### PR TITLE
dts: add support for FMC signals

### DIFF
--- a/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)hx-pinctrl.dtsi
@@ -141,6 +141,206 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302v(d-e)tx-pinctrl.dtsi
@@ -141,6 +141,206 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f302z(d-e)tx-pinctrl.dtsi
@@ -145,6 +145,326 @@
 				pinmux = <STM32_PINMUX('A', 4, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_ph0: fmc_a0_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_ph1: fmc_a1_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)hx-pinctrl.dtsi
@@ -257,6 +257,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303v(d-e)tx-pinctrl.dtsi
@@ -257,6 +257,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f303z(d-e)tx-pinctrl.dtsi
@@ -261,6 +261,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_ph0: fmc_a0_ph0 {
+				pinmux = <STM32_PINMUX('H', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_ph1: fmc_a1_ph1 {
+				pinmux = <STM32_PINMUX('H', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f398vetx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f398vetx-pinctrl.dtsi
@@ -253,6 +253,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427a(g-i)hx-pinctrl.dtsi
@@ -436,6 +436,488 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)hx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427i(g-i)tx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427v(g-i)tx-pinctrl.dtsi
@@ -376,6 +376,230 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f427z(g-i)tx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429a(g-i)hx-pinctrl.dtsi
@@ -436,6 +436,488 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429b(e-g-i)tx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g)tx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429i(e-g-i)hx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429iitx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429n(e-g)hx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429nihx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429v(e-g)tx-pinctrl.dtsi
@@ -376,6 +376,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429vitx-pinctrl.dtsi
@@ -376,6 +376,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429z(e-g)tx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zgyx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429zitx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f429ziyx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437aihx-pinctrl.dtsi
@@ -436,6 +436,488 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)hx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437i(g-i)tx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437v(g-i)tx-pinctrl.dtsi
@@ -376,6 +376,230 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f437z(g-i)tx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439aihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439aihx-pinctrl.dtsi
@@ -436,6 +436,488 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439b(g-i)tx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)hx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439i(g-i)tx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439n(g-i)hx-pinctrl.dtsi
@@ -462,6 +462,512 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439v(g-i)tx-pinctrl.dtsi
@@ -376,6 +376,200 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)tx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f439z(g-i)yx-pinctrl.dtsi
@@ -428,6 +428,374 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -231,6 +231,248 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -263,6 +263,392 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -263,6 +263,392 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -263,6 +263,392 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -216,6 +216,494 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -216,6 +216,494 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -462,6 +462,536 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -458,6 +458,482 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -458,6 +458,482 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -458,6 +458,482 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -462,6 +462,536 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -462,6 +462,536 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -215,6 +215,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -215,6 +215,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -247,6 +247,374 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -247,6 +247,374 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -216,6 +216,494 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -216,6 +216,494 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -462,6 +462,536 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -458,6 +458,482 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -458,6 +458,482 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -462,6 +462,536 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -215,6 +215,176 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -247,6 +247,374 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -259,6 +259,548 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -259,6 +259,548 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -213,6 +213,248 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -245,6 +245,410 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -259,6 +259,542 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -259,6 +259,542 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -213,6 +213,230 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -245,6 +245,404 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -245,6 +245,404 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -259,6 +259,542 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -213,6 +213,248 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -245,6 +245,404 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -259,6 +259,548 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -259,6 +259,548 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -213,6 +213,248 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -245,6 +245,410 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -259,6 +259,542 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -259,6 +259,542 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -213,6 +213,230 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -245,6 +245,404 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -245,6 +245,404 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg11: fmc_int_pg11 {
+				pinmux = <STM32_PINMUX('G', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -462,6 +462,542 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -376,6 +376,248 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -428,6 +428,404 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -446,6 +446,434 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -446,6 +446,434 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -446,6 +446,434 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -239,6 +239,530 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -239,6 +239,530 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -476,6 +476,518 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -476,6 +476,518 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -394,6 +394,272 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -446,6 +446,434 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -239,6 +239,530 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -239,6 +239,530 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -476,6 +476,518 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -485,6 +485,572 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473q(b-c-e)tx-pinctrl.dtsi
@@ -382,6 +382,350 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf7: fmc_a1_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pf8: fmc_a24_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pf11: fmc_ne4_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg6: fmc_int_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg8: fmc_ne3_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)hx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)ix-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g473v(b-c-e)tx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -382,6 +382,350 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf7: fmc_a1_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pf8: fmc_a24_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pf11: fmc_ne4_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg6: fmc_int_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg8: fmc_ne3_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g483qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483qetx-pinctrl.dtsi
@@ -382,6 +382,350 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf7: fmc_a1_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pf8: fmc_a24_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pf11: fmc_ne4_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg6: fmc_int_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg8: fmc_ne3_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g483vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vehx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g483veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483veix-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g483vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g483vetx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -382,6 +382,350 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf7: fmc_a1_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pf8: fmc_a24_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pf11: fmc_ne4_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg6: fmc_int_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg8: fmc_ne3_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -382,6 +382,224 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pf9: fmc_a25_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf10: fmc_a0_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -518,6 +518,506 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -531,6 +531,560 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -531,6 +531,560 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -518,6 +518,506 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -600,6 +600,512 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -600,6 +600,512 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -452,6 +452,344 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -452,6 +452,344 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -428,6 +428,386 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -531,6 +531,560 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -518,6 +518,506 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -383,6 +383,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -600,6 +600,512 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -452,6 +452,344 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -545,6 +545,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -480,6 +480,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -609,6 +609,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -428,6 +428,386 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3a(g-i)ixq-pinctrl.dtsi
@@ -286,6 +286,488 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)kxq-pinctrl.dtsi
@@ -286,6 +286,524 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)tx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3i(g-i)txq-pinctrl.dtsi
@@ -234,6 +234,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3l(g-i)hxq-pinctrl.dtsi
@@ -290,6 +290,584 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3n(g-i)hx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3qiyxq-pinctrl.dtsi
@@ -238,6 +238,302 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hx-pinctrl.dtsi
@@ -210,6 +210,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)hxq-pinctrl.dtsi
@@ -210,6 +210,242 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)tx-pinctrl.dtsi
@@ -210,6 +210,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3v(g-i)txq-pinctrl.dtsi
@@ -210,6 +210,200 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)tx-pinctrl.dtsi
@@ -234,6 +234,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7a3z(g-i)txq-pinctrl.dtsi
@@ -222,6 +222,344 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0abixq-pinctrl.dtsi
@@ -286,6 +286,488 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibkxq-pinctrl.dtsi
@@ -286,6 +286,524 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0ibtx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0vbtx-pinctrl.dtsi
@@ -210,6 +210,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b0zbtx-pinctrl.dtsi
@@ -234,6 +234,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3aiixq-pinctrl.dtsi
@@ -286,6 +286,488 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iikxq-pinctrl.dtsi
@@ -286,6 +286,524 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3iitxq-pinctrl.dtsi
@@ -234,6 +234,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3lihxq-pinctrl.dtsi
@@ -290,6 +290,584 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3nihx-pinctrl.dtsi
@@ -246,6 +246,572 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_ph2: fmc_sdcke0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_ph3: fmc_sdne0_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_ph5: fmc_sdnwe_ph5 {
+				pinmux = <STM32_PINMUX('H', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_ph6: fmc_sdne1_ph6 {
+				pinmux = <STM32_PINMUX('H', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_ph7: fmc_sdcke1_ph7 {
+				pinmux = <STM32_PINMUX('H', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d16_ph8: fmc_d16_ph8 {
+				pinmux = <STM32_PINMUX('H', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d17_ph9: fmc_d17_ph9 {
+				pinmux = <STM32_PINMUX('H', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d18_ph10: fmc_d18_ph10 {
+				pinmux = <STM32_PINMUX('H', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d19_ph11: fmc_d19_ph11 {
+				pinmux = <STM32_PINMUX('H', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d20_ph12: fmc_d20_ph12 {
+				pinmux = <STM32_PINMUX('H', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d21_ph13: fmc_d21_ph13 {
+				pinmux = <STM32_PINMUX('H', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d22_ph14: fmc_d22_ph14 {
+				pinmux = <STM32_PINMUX('H', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d23_ph15: fmc_d23_ph15 {
+				pinmux = <STM32_PINMUX('H', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d24_pi0: fmc_d24_pi0 {
+				pinmux = <STM32_PINMUX('I', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d25_pi1: fmc_d25_pi1 {
+				pinmux = <STM32_PINMUX('I', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d26_pi2: fmc_d26_pi2 {
+				pinmux = <STM32_PINMUX('I', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d27_pi3: fmc_d27_pi3 {
+				pinmux = <STM32_PINMUX('I', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl2_pi4: fmc_nbl2_pi4 {
+				pinmux = <STM32_PINMUX('I', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl3_pi5: fmc_nbl3_pi5 {
+				pinmux = <STM32_PINMUX('I', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d28_pi6: fmc_d28_pi6 {
+				pinmux = <STM32_PINMUX('I', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d29_pi7: fmc_d29_pi7 {
+				pinmux = <STM32_PINMUX('I', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d30_pi9: fmc_d30_pi9 {
+				pinmux = <STM32_PINMUX('I', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d31_pi10: fmc_d31_pi10 {
+				pinmux = <STM32_PINMUX('I', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3qiyxq-pinctrl.dtsi
@@ -238,6 +238,302 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc2: fmc_sdne0_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc3: fmc_sdcke0_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihx-pinctrl.dtsi
@@ -210,6 +210,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vihxq-pinctrl.dtsi
@@ -210,6 +210,242 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitx-pinctrl.dtsi
@@ -210,6 +210,272 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3vitxq-pinctrl.dtsi
@@ -210,6 +210,200 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitx-pinctrl.dtsi
@@ -234,6 +234,434 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdncas_pg15: fmc_sdncas_pg15 {
+				pinmux = <STM32_PINMUX('G', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
+++ b/dts/st/h7/stm32h7b3zitxq-pinctrl.dtsi
@@ -222,6 +222,344 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_sdnwe_pa7: fmc_sdnwe_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke1_pb5: fmc_sdcke1_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne1_pb6: fmc_sdne1_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pc0: fmc_a25_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnwe_pc0: fmc_sdnwe_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdne0_pc4: fmc_sdne0_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdcke0_pc5: fmc_sdcke0_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pc6: fmc_nwait_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pc7: fmc_ne1_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pc8: fmc_int_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF10)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pc8: fmc_nce_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pc8: fmc_ne2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdnras_pf11: fmc_sdnras_pf11 {
+				pinmux = <STM32_PINMUX('F', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg6: fmc_ne3_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_sdclk_pg8: fmc_sdclk_pg8 {
+				pinmux = <STM32_PINMUX('G', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -209,6 +209,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -197,6 +197,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -229,6 +229,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -229,6 +229,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -197,6 +197,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -209,6 +209,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -197,6 +197,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -229,6 +229,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -229,6 +229,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -229,6 +229,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -209,6 +209,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -197,6 +197,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -229,6 +229,326 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -240,6 +240,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -240,6 +240,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -227,6 +227,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -227,6 +227,332 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -215,6 +215,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -215,6 +215,170 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -207,6 +207,170 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -247,6 +247,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -247,6 +247,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -240,6 +240,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -240,6 +240,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -227,6 +227,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -227,6 +227,332 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -215,6 +215,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -215,6 +215,170 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -207,6 +207,170 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -247,6 +247,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -247,6 +247,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5a(g-e)ix-pinctrl.dtsi
@@ -190,6 +190,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5agixp-pinctrl.dtsi
@@ -190,6 +190,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5q(g-e)ix-pinctrl.dtsi
@@ -181,6 +181,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5qgixp-pinctrl.dtsi
@@ -181,6 +181,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)tx-pinctrl.dtsi
@@ -181,6 +181,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5v(g-e)yx-pinctrl.dtsi
@@ -181,6 +181,194 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgtxp-pinctrl.dtsi
@@ -181,6 +181,200 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5vgyxp-pinctrl.dtsi
@@ -173,6 +173,194 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5z(g-e)tx-pinctrl.dtsi
@@ -181,6 +181,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4p5zgtxp-pinctrl.dtsi
@@ -181,6 +181,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5agix-pinctrl.dtsi
@@ -126,6 +126,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5qgix-pinctrl.dtsi
@@ -181,6 +181,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgtx-pinctrl.dtsi
@@ -181,6 +181,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5vgyx-pinctrl.dtsi
@@ -181,6 +181,194 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4q5zgtx-pinctrl.dtsi
@@ -181,6 +181,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5a(g-i)ix-pinctrl.dtsi
@@ -126,6 +126,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5q(g-i)ix-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5v(g-i)tx-pinctrl.dtsi
@@ -117,6 +117,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)tx-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5z(g-i)yx-pinctrl.dtsi
@@ -117,6 +117,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r5zitxp-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7aiix-pinctrl.dtsi
@@ -126,6 +126,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7vitx-pinctrl.dtsi
@@ -117,6 +117,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r7zitx-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9a(g-i)ix-pinctrl.dtsi
@@ -122,6 +122,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9v(g-i)tx-pinctrl.dtsi
@@ -113,6 +113,170 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)jx-pinctrl.dtsi
@@ -117,6 +117,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)tx-pinctrl.dtsi
@@ -113,6 +113,332 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9z(g-i)yx-pinctrl.dtsi
@@ -117,6 +117,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4r9ziyxp-pinctrl.dtsi
@@ -117,6 +117,332 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5aiix-pinctrl.dtsi
@@ -126,6 +126,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5qiix-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5vitx-pinctrl.dtsi
@@ -117,6 +117,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5zitx-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s5ziyx-pinctrl.dtsi
@@ -117,6 +117,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7aiix-pinctrl.dtsi
@@ -126,6 +126,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7vitx-pinctrl.dtsi
@@ -117,6 +117,206 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s7zitx-pinctrl.dtsi
@@ -117,6 +117,344 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9aiix-pinctrl.dtsi
@@ -122,6 +122,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9vitx-pinctrl.dtsi
@@ -113,6 +113,170 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zijx-pinctrl.dtsi
@@ -117,6 +117,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9zitx-pinctrl.dtsi
@@ -113,6 +113,332 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4s9ziyx-pinctrl.dtsi
@@ -117,6 +117,338 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552q(c-e)ixq-pinctrl.dtsi
@@ -178,6 +178,332 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeix-pinctrl.dtsi
@@ -178,6 +178,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552qeixp-pinctrl.dtsi
@@ -178,6 +178,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552v(c-e)txq-pinctrl.dtsi
@@ -162,6 +162,200 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552vetx-pinctrl.dtsi
@@ -178,6 +178,206 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552z(c-e)txq-pinctrl.dtsi
@@ -162,6 +162,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l552zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l552zetx-pinctrl.dtsi
@@ -178,6 +178,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562qeix-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeix-pinctrl.dtsi
@@ -178,6 +178,206 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixp-pinctrl.dtsi
@@ -178,6 +178,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562qeixq-pinctrl.dtsi
@@ -178,6 +178,332 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562vetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetx-pinctrl.dtsi
@@ -178,6 +178,206 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562vetxq-pinctrl.dtsi
@@ -162,6 +162,200 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562zetx-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetx-pinctrl.dtsi
@@ -178,6 +178,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
+++ b/dts/st/l5/stm32l562zetxq-pinctrl.dtsi
@@ -162,6 +162,344 @@
 				pinmux = <STM32_PINMUX('D', 1, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_nl_pb7: fmc_nl_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_clk_pd3: fmc_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pd7: fmc_nce_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne1_pd7: fmc_ne1_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a16_pd11: fmc_a16_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a17_pd12: fmc_a17_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a18_pd13: fmc_a18_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl0_pe0: fmc_nbl0_pe0 {
+				pinmux = <STM32_PINMUX('E', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nbl1_pe1: fmc_nbl1_pe1 {
+				pinmux = <STM32_PINMUX('E', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a23_pe2: fmc_a23_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a19_pe3: fmc_a19_pe3 {
+				pinmux = <STM32_PINMUX('E', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a20_pe4: fmc_a20_pe4 {
+				pinmux = <STM32_PINMUX('E', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a21_pe5: fmc_a21_pe5 {
+				pinmux = <STM32_PINMUX('E', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a22_pe6: fmc_a22_pe6 {
+				pinmux = <STM32_PINMUX('E', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a0_pf0: fmc_a0_pf0 {
+				pinmux = <STM32_PINMUX('F', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a1_pf1: fmc_a1_pf1 {
+				pinmux = <STM32_PINMUX('F', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a2_pf2: fmc_a2_pf2 {
+				pinmux = <STM32_PINMUX('F', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a3_pf3: fmc_a3_pf3 {
+				pinmux = <STM32_PINMUX('F', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a4_pf4: fmc_a4_pf4 {
+				pinmux = <STM32_PINMUX('F', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a5_pf5: fmc_a5_pf5 {
+				pinmux = <STM32_PINMUX('F', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a6_pf12: fmc_a6_pf12 {
+				pinmux = <STM32_PINMUX('F', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a7_pf13: fmc_a7_pf13 {
+				pinmux = <STM32_PINMUX('F', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a8_pf14: fmc_a8_pf14 {
+				pinmux = <STM32_PINMUX('F', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a9_pf15: fmc_a9_pf15 {
+				pinmux = <STM32_PINMUX('F', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a10_pg0: fmc_a10_pg0 {
+				pinmux = <STM32_PINMUX('G', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a11_pg1: fmc_a11_pg1 {
+				pinmux = <STM32_PINMUX('G', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a12_pg2: fmc_a12_pg2 {
+				pinmux = <STM32_PINMUX('G', 2, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a13_pg3: fmc_a13_pg3 {
+				pinmux = <STM32_PINMUX('G', 3, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a14_pg4: fmc_a14_pg4 {
+				pinmux = <STM32_PINMUX('G', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a15_pg5: fmc_a15_pg5 {
+				pinmux = <STM32_PINMUX('G', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_int_pg7: fmc_int_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne2_pg9: fmc_ne2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne3_pg10: fmc_ne3_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_ne4_pg12: fmc_ne4_pg12 {
+				pinmux = <STM32_PINMUX('G', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a24_pg13: fmc_a24_pg13 {
+				pinmux = <STM32_PINMUX('G', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_a25_pg14: fmc_a25_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -202,6 +202,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -182,6 +182,128 @@
 				pinmux = <STM32_PINMUX('A', 5, ANALOG)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -258,6 +258,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -226,6 +226,128 @@
 				pinmux = <STM32_PINMUX('B', 13, AF9)>;
 			};
 
+			/* FMC */
+
+			fmc_d2_pd0: fmc_d2_pd0 {
+				pinmux = <STM32_PINMUX('D', 0, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d3_pd1: fmc_d3_pd1 {
+				pinmux = <STM32_PINMUX('D', 1, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_noe_pd4: fmc_noe_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwe_pd5: fmc_nwe_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nwait_pd6: fmc_nwait_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d13_pd8: fmc_d13_pd8 {
+				pinmux = <STM32_PINMUX('D', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d14_pd9: fmc_d14_pd9 {
+				pinmux = <STM32_PINMUX('D', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d15_pd10: fmc_d15_pd10 {
+				pinmux = <STM32_PINMUX('D', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d0_pd14: fmc_d0_pd14 {
+				pinmux = <STM32_PINMUX('D', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d1_pd15: fmc_d1_pd15 {
+				pinmux = <STM32_PINMUX('D', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d4_pe7: fmc_d4_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d5_pe8: fmc_d5_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d6_pe9: fmc_d6_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d7_pe10: fmc_d7_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d8_pe11: fmc_d8_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d9_pe12: fmc_d9_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d10_pe13: fmc_d10_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d11_pe14: fmc_d11_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_d12_pe15: fmc_d12_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
+			fmc_nce_pg9: fmc_nce_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF12)>;
+				bias-pull-up;
+				slew-rate = "very-high-speed";
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pb6: i2c1_scl_pb6 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -132,6 +132,12 @@
 - name: FDCAN_TX
   match: "^FDCAN\\d+_TX$"
 
+- name: FMC
+  match: "^FMC_(?:NL|NADV|CLK|NBL[0-3]|A\\d+|D\\d+|NE[1-4]|NOE|NWE|NWAIT|NCE|INT|SDCLK|SDNWE|SDCKE[0-1]|SDNE[0-1]|SDNRAS|SDNCAS)$"
+  mode: alternate
+  bias: pull-up
+  slew-rate: very-high-speed
+
 - name: I2C_SCL
   match: "^I2C\\d+_SCL$"
   drive: open-drain


### PR DESCRIPTION
Add Flexible Memory Controller (FMC) signals. Only available on some non-F1 series.