### PR TITLE
dts: Add support for QSPI signals

### DIFF
--- a/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)tx-pinctrl.dtsi
@@ -310,6 +310,68 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yx-pinctrl.dtsi
@@ -310,6 +310,68 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412r(e-g)yxp-pinctrl.dtsi
@@ -310,6 +310,68 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)hx-pinctrl.dtsi
@@ -386,6 +386,113 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412v(e-g)tx-pinctrl.dtsi
@@ -380,6 +380,113 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)jx-pinctrl.dtsi
@@ -416,6 +416,148 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f412z(e-g)tx-pinctrl.dtsi
@@ -416,6 +416,148 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413m(g-h)yx-pinctrl.dtsi
@@ -382,6 +382,78 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413r(g-h)tx-pinctrl.dtsi
@@ -351,6 +351,68 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)hx-pinctrl.dtsi
@@ -427,6 +427,113 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413v(g-h)tx-pinctrl.dtsi
@@ -421,6 +421,113 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)jx-pinctrl.dtsi
@@ -457,6 +457,148 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f413z(g-h)tx-pinctrl.dtsi
@@ -457,6 +457,148 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423mhyx-pinctrl.dtsi
@@ -382,6 +382,78 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423rhtx-pinctrl.dtsi
@@ -351,6 +351,68 @@
 				pinmux = <STM32_PINMUX('B', 1, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhhx-pinctrl.dtsi
@@ -427,6 +427,113 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423vhtx-pinctrl.dtsi
@@ -421,6 +421,113 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhjx-pinctrl.dtsi
@@ -457,6 +457,148 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f423zhtx-pinctrl.dtsi
@@ -457,6 +457,148 @@
 				pinmux = <STM32_PINMUX('E', 11, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pa6: quadspi_bk2_io0_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pa7: quadspi_bk2_io1_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb1: quadspi_clk_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc4: quadspi_bk2_io2_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc5: quadspi_bk2_io3_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pc8: quadspi_bk1_io2_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446m(c-e)yx-pinctrl.dtsi
@@ -393,6 +393,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446r(c-e)tx-pinctrl.dtsi
@@ -400,6 +400,38 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446v(c-e)tx-pinctrl.dtsi
@@ -668,6 +668,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)hx-pinctrl.dtsi
@@ -862,6 +862,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)jx-pinctrl.dtsi
@@ -862,6 +862,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f446z(c-e)tx-pinctrl.dtsi
@@ -862,6 +862,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pd3: quadspi_clk_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)hx-pinctrl.dtsi
@@ -871,6 +871,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469a(e-g-i)yx-pinctrl.dtsi
@@ -871,6 +871,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469b(e-g-i)tx-pinctrl.dtsi
@@ -1169,6 +1169,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g)tx-pinctrl.dtsi
@@ -1105,6 +1105,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469i(e-g-i)hx-pinctrl.dtsi
@@ -1105,6 +1105,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469iitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469iitx-pinctrl.dtsi
@@ -1105,6 +1105,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469n(e-g)hx-pinctrl.dtsi
@@ -1169,6 +1169,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469nihx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469nihx-pinctrl.dtsi
@@ -1169,6 +1169,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469v(e-g)tx-pinctrl.dtsi
@@ -513,6 +513,68 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469vitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469vitx-pinctrl.dtsi
@@ -513,6 +513,68 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469z(e-g)tx-pinctrl.dtsi
@@ -755,6 +755,88 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f469zitx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f469zitx-pinctrl.dtsi
@@ -755,6 +755,88 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)hx-pinctrl.dtsi
@@ -871,6 +871,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479a(g-i)yx-pinctrl.dtsi
@@ -871,6 +871,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479b(g-i)tx-pinctrl.dtsi
@@ -1169,6 +1169,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)hx-pinctrl.dtsi
@@ -1105,6 +1105,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479i(g-i)tx-pinctrl.dtsi
@@ -1105,6 +1105,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479n(g-i)hx-pinctrl.dtsi
@@ -1169,6 +1169,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479v(g-i)tx-pinctrl.dtsi
@@ -513,6 +513,68 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f4/stm32f479z(g-i)tx-pinctrl.dtsi
@@ -755,6 +755,88 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)kx-pinctrl.dtsi
@@ -1012,6 +1012,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722i(c-e)tx-pinctrl.dtsi
@@ -1012,6 +1012,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722r(c-e)tx-pinctrl.dtsi
@@ -349,6 +349,38 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722v(c-e)tx-pinctrl.dtsi
@@ -617,6 +617,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f722z(c-e)tx-pinctrl.dtsi
@@ -823,6 +823,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)kx-pinctrl.dtsi
@@ -1002,6 +1002,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723i(c-e)tx-pinctrl.dtsi
@@ -1002,6 +1002,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)tx-pinctrl.dtsi
@@ -595,6 +595,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723v(c-e)yx-pinctrl.dtsi
@@ -595,6 +595,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)ix-pinctrl.dtsi
@@ -813,6 +813,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f723z(c-e)tx-pinctrl.dtsi
@@ -813,6 +813,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730i8kx-pinctrl.dtsi
@@ -1002,6 +1002,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730r8tx-pinctrl.dtsi
@@ -349,6 +349,38 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730v8tx-pinctrl.dtsi
@@ -617,6 +617,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f730z8tx-pinctrl.dtsi
@@ -813,6 +813,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732iekx-pinctrl.dtsi
@@ -1012,6 +1012,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732ietx-pinctrl.dtsi
@@ -1012,6 +1012,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732retx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732retx-pinctrl.dtsi
@@ -349,6 +349,38 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732vetx-pinctrl.dtsi
@@ -617,6 +617,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f732zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f732zetx-pinctrl.dtsi
@@ -823,6 +823,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733iekx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733iekx-pinctrl.dtsi
@@ -1002,6 +1002,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733ietx-pinctrl.dtsi
@@ -1002,6 +1002,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733vetx-pinctrl.dtsi
@@ -595,6 +595,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733veyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733veyx-pinctrl.dtsi
@@ -595,6 +595,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733zeix-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zeix-pinctrl.dtsi
@@ -813,6 +813,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f733zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f733zetx-pinctrl.dtsi
@@ -813,6 +813,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)kx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745i(e-g)tx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)hx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745v(e-g)tx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f745z(e-g)tx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746b(e-g)tx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746i(e-g)kx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746ietx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746ietx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746igtx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746nehx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nehx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746nghx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746v(e-g)hx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746vetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vetx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746vgtx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746z(e-g)yx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746zetx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zetx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f746zgtx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750n8hx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750v8tx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f750z8tx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756bgtx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756igkx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igkx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756igtx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756nghx-pinctrl.dtsi
@@ -1245,6 +1245,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vghx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756vgtx-pinctrl.dtsi
@@ -792,6 +792,78 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgtx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f756zgyx-pinctrl.dtsi
@@ -1024,6 +1024,108 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765b(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)kx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765i(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765n(g-i)hx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)hx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765v(g-i)tx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f765z(g-i)tx-pinctrl.dtsi
@@ -1118,6 +1118,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767b(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)kx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767i(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767n(g-i)hx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vghx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vgtx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vihx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767vitx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zgtx-pinctrl.dtsi
@@ -1118,6 +1118,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f767zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f767zitx-pinctrl.dtsi
@@ -1118,6 +1118,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f768aiyx-pinctrl.dtsi
@@ -1046,6 +1046,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769a(g-i)yx-pinctrl.dtsi
@@ -1046,6 +1046,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769b(g-i)tx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769igtx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769igtx-pinctrl.dtsi
@@ -1263,6 +1263,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769iitx-pinctrl.dtsi
@@ -1263,6 +1263,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769nghx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nghx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f769nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f769nihx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777bitx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777iikx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iikx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777iitx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777nihx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777vihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vihx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777vitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777vitx-pinctrl.dtsi
@@ -871,6 +871,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f777zitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f777zitx-pinctrl.dtsi
@@ -1118,6 +1118,118 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f778aiyx-pinctrl.dtsi
@@ -1046,6 +1046,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779aiyx-pinctrl.dtsi
@@ -1046,6 +1046,103 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779bitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779bitx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779iitx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779iitx-pinctrl.dtsi
@@ -1263,6 +1263,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/f7/stm32f779nihx-pinctrl.dtsi
+++ b/dts/st/f7/stm32f779nihx-pinctrl.dtsi
@@ -1344,6 +1344,128 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742a(g-i)ix-pinctrl.dtsi
@@ -1253,6 +1253,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742b(g-i)tx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)kx-pinctrl.dtsi
@@ -1332,6 +1332,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742i(g-i)tx-pinctrl.dtsi
@@ -1332,6 +1332,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)hx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742v(g-i)tx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742x(g-i)hx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h742z(g-i)tx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743a(g-i)ix-pinctrl.dtsi
@@ -1253,6 +1253,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bgtx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743bitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igkx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743igtx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iikx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743iitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743v(g-i)hx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vgtx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743vitx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xghx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743xihx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zgtx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h743zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h743zitx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bgtx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745bitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745igkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igkx-pinctrl.dtsi
@@ -1344,6 +1344,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745igtx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iikx-pinctrl.dtsi
@@ -1344,6 +1344,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745iitx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xghx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745xihx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zgtx-pinctrl.dtsi
@@ -980,6 +980,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h745zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h745zitx-pinctrl.dtsi
@@ -980,6 +980,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747a(g-i)ix-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bgtx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747bitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747igtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747igtx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747iitx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747xghx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xghx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747xihx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h747ziyx-pinctrl.dtsi
@@ -1001,6 +1001,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibkx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750ibtx-pinctrl.dtsi
@@ -1332,6 +1332,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750vbtx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750xbhx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h750zbtx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753aiix-pinctrl.dtsi
@@ -1253,6 +1253,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753bitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iikx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753iitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753vihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vihx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753vitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753vitx-pinctrl.dtsi
@@ -818,6 +818,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753xihx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h753zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h753zitx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755bitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755iikx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iikx-pinctrl.dtsi
@@ -1344,6 +1344,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755iitx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755xihx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h755zitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h755zitx-pinctrl.dtsi
@@ -980,6 +980,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757aiix-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757aiix-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757bitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757bitx-pinctrl.dtsi
@@ -1358,6 +1358,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757iitx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757iitx-pinctrl.dtsi
@@ -1110,6 +1110,123 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757xihx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757xihx-pinctrl.dtsi
@@ -1422,6 +1422,133 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pg6: quadspi_bk1_ncs_pg6 {
+				pinmux = <STM32_PINMUX('G', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
+++ b/dts/st/h7/stm32h757ziyx-pinctrl.dtsi
@@ -1001,6 +1001,83 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_ckin_pb8: sdmmc1_ckin_pb8 {

--- a/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8tx-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412c8ux-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtx-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbtxp-pinctrl.dtsi
@@ -148,6 +148,43 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbux-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412cbuxp-pinctrl.dtsi
@@ -148,6 +148,43 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8tx-pinctrl.dtsi
@@ -124,6 +124,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412k8ux-pinctrl.dtsi
@@ -124,6 +124,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbtx-pinctrl.dtsi
@@ -124,6 +124,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412kbux-pinctrl.dtsi
@@ -124,6 +124,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8ix-pinctrl.dtsi
@@ -220,6 +220,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412r8tx-pinctrl.dtsi
@@ -220,6 +220,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbix-pinctrl.dtsi
@@ -220,6 +220,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbixp-pinctrl.dtsi
@@ -212,6 +212,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtx-pinctrl.dtsi
@@ -220,6 +220,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412rbtxp-pinctrl.dtsi
@@ -212,6 +212,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412t8yx-pinctrl.dtsi
@@ -130,6 +130,43 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyx-pinctrl.dtsi
@@ -130,6 +130,43 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l412tbyxp-pinctrl.dtsi
@@ -124,6 +124,43 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbtx-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422cbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422cbux-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbtx-pinctrl.dtsi
@@ -124,6 +124,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422kbux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422kbux-pinctrl.dtsi
@@ -124,6 +124,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422rbix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbix-pinctrl.dtsi
@@ -220,6 +220,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422rbtx-pinctrl.dtsi
@@ -220,6 +220,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l422tbyx-pinctrl.dtsi
@@ -130,6 +130,43 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)tx-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)ux-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431c(b-c)yx-pinctrl.dtsi
@@ -164,6 +164,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431k(b-c)ux-pinctrl.dtsi
@@ -115,6 +115,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)ix-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)tx-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431r(b-c)yx-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vcix-pinctrl.dtsi
@@ -205,6 +205,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l431vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l431vctx-pinctrl.dtsi
@@ -205,6 +205,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l432k(b-c)ux-pinctrl.dtsi
@@ -115,6 +115,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)tx-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)ux-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433c(b-c)yx-pinctrl.dtsi
@@ -164,6 +164,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)ix-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)tx-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433r(b-c)yx-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433rctxp-pinctrl.dtsi
@@ -192,6 +192,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l433vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vcix-pinctrl.dtsi
@@ -205,6 +205,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l433vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l433vctx-pinctrl.dtsi
@@ -205,6 +205,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l442kcux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l442kcux-pinctrl.dtsi
@@ -115,6 +115,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443cctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443cctx-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443ccux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccux-pinctrl.dtsi
@@ -160,6 +160,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443ccyx-pinctrl.dtsi
@@ -164,6 +164,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l443rcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcix-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443rctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rctx-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443rcyx-pinctrl.dtsi
@@ -196,6 +196,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443vcix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vcix-pinctrl.dtsi
@@ -205,6 +205,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l443vctx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l443vctx-pinctrl.dtsi
@@ -205,6 +205,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451c(c-e)ux-pinctrl.dtsi
@@ -198,6 +198,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l451cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451cetx-pinctrl.dtsi
@@ -198,6 +198,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)ix-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)tx-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451r(c-e)yx-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)ix-pinctrl.dtsi
@@ -267,6 +267,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l451v(c-e)tx-pinctrl.dtsi
@@ -267,6 +267,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452c(c-e)ux-pinctrl.dtsi
@@ -198,6 +198,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452cetx-pinctrl.dtsi
@@ -198,6 +198,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)ix-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)tx-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452r(c-e)yx-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452retxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452retxp-pinctrl.dtsi
@@ -242,6 +242,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)ix-pinctrl.dtsi
@@ -267,6 +267,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l452v(c-e)tx-pinctrl.dtsi
@@ -267,6 +267,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462cetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462cetx-pinctrl.dtsi
@@ -198,6 +198,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l462ceux-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462ceux-pinctrl.dtsi
@@ -198,6 +198,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l462reix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reix-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462retx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462retx-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462reyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462reyx-pinctrl.dtsi
@@ -246,6 +246,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462veix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462veix-pinctrl.dtsi
@@ -267,6 +267,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l462vetx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l462vetx-pinctrl.dtsi
@@ -267,6 +267,103 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471q(e-g)ix-pinctrl.dtsi
@@ -629,6 +629,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471r(e-g)tx-pinctrl.dtsi
@@ -252,6 +252,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471v(e-g)tx-pinctrl.dtsi
@@ -455,6 +455,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)jx-pinctrl.dtsi
@@ -649,6 +649,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l471z(e-g)tx-pinctrl.dtsi
@@ -649,6 +649,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475r(c-e-g)tx-pinctrl.dtsi
@@ -252,6 +252,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l475v(c-e-g)tx-pinctrl.dtsi
@@ -455,6 +455,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476j(e-g)yx-pinctrl.dtsi
@@ -264,6 +264,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476jgyxp-pinctrl.dtsi
@@ -256,6 +256,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476m(e-g)yx-pinctrl.dtsi
@@ -264,6 +264,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476q(e-g)ix-pinctrl.dtsi
@@ -629,6 +629,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476r(c-e-g)tx-pinctrl.dtsi
@@ -252,6 +252,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476v(c-e-g)tx-pinctrl.dtsi
@@ -455,6 +455,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476z(e-g)tx-pinctrl.dtsi
@@ -649,6 +649,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgjx-pinctrl.dtsi
@@ -649,6 +649,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l476zgtxp-pinctrl.dtsi
@@ -643,6 +643,63 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l485j(c-e)yx-pinctrl.dtsi
@@ -264,6 +264,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486jgyx-pinctrl.dtsi
@@ -264,6 +264,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486qgix-pinctrl.dtsi
@@ -629,6 +629,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486rgtx-pinctrl.dtsi
@@ -252,6 +252,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486vgtx-pinctrl.dtsi
@@ -455,6 +455,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l486zgtx-pinctrl.dtsi
@@ -649,6 +649,68 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pb11: quadspi_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_ncs_pe11: quadspi_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496a(e-g)ix-pinctrl.dtsi
@@ -774,6 +774,143 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496agixp-pinctrl.dtsi
@@ -774,6 +774,143 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496q(e-g)ix-pinctrl.dtsi
@@ -737,6 +737,133 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496qgixp-pinctrl.dtsi
@@ -713,6 +713,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496r(e-g)tx-pinctrl.dtsi
@@ -324,6 +324,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496rgtxp-pinctrl.dtsi
@@ -316,6 +316,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496v(e-g)tx-pinctrl.dtsi
@@ -539,6 +539,133 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgtxp-pinctrl.dtsi
@@ -521,6 +521,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyx-pinctrl.dtsi
@@ -497,6 +497,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496vgyxp-pinctrl.dtsi
@@ -489,6 +489,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496wgyxp-pinctrl.dtsi
@@ -582,6 +582,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d5_pb9: sdmmc1_d5_pb9 {

--- a/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496z(e-g)tx-pinctrl.dtsi
@@ -757,6 +757,158 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l496zgtxp-pinctrl.dtsi
@@ -745,6 +745,153 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agix-pinctrl.dtsi
@@ -774,6 +774,143 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6agixp-pinctrl.dtsi
@@ -774,6 +774,143 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgix-pinctrl.dtsi
@@ -737,6 +737,133 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6qgixp-pinctrl.dtsi
@@ -713,6 +713,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtx-pinctrl.dtsi
@@ -324,6 +324,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6rgtxp-pinctrl.dtsi
@@ -316,6 +316,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtx-pinctrl.dtsi
@@ -539,6 +539,133 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgtxp-pinctrl.dtsi
@@ -521,6 +521,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyx-pinctrl.dtsi
@@ -497,6 +497,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6vgyxp-pinctrl.dtsi
@@ -489,6 +489,128 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtx-pinctrl.dtsi
@@ -757,6 +757,158 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
+++ b/dts/st/l4/stm32l4a6zgtxp-pinctrl.dtsi
@@ -745,6 +745,153 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb0: quadspi_bk1_io1_pb0 {
+				pinmux = <STM32_PINMUX('B', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb1: quadspi_bk1_io0_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pc1: quadspi_bk2_io0_pc1 {
+				pinmux = <STM32_PINMUX('C', 1, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pc2: quadspi_bk2_io1_pc2 {
+				pinmux = <STM32_PINMUX('C', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pc3: quadspi_bk2_io2_pc3 {
+				pinmux = <STM32_PINMUX('C', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pc4: quadspi_bk2_io3_pc4 {
+				pinmux = <STM32_PINMUX('C', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pd3: quadspi_bk2_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pd4: quadspi_bk2_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd5: quadspi_bk2_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pd6: quadspi_bk2_io1_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF5)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pd6: quadspi_bk2_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pd7: quadspi_bk2_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pe10: quadspi_clk_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pe11: quadspi_bk1_ncs_pe11 {
+				pinmux = <STM32_PINMUX('E', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pe12: quadspi_bk1_io0_pe12 {
+				pinmux = <STM32_PINMUX('E', 12, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pe13: quadspi_bk1_io1_pe13 {
+				pinmux = <STM32_PINMUX('E', 13, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe14: quadspi_bk1_io2_pe14 {
+				pinmux = <STM32_PINMUX('E', 14, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pe15: quadspi_bk1_io3_pe15 {
+				pinmux = <STM32_PINMUX('E', 15, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF3)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_d4_pb8: sdmmc1_d4_pb8 {

--- a/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aaax-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aabx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aacx-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151aadx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151caax-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cabx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cacx-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151cadx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151daax-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dabx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dacx-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151dadx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151faax-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fabx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151facx-pinctrl.dtsi
@@ -1025,6 +1025,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp151fadx-pinctrl.dtsi
@@ -663,6 +663,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aaax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aacx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153aadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153caax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cacx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153cadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153daax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dacx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153dadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153faax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153facx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp153fadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aaax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aacx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157aadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157caax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cacx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157cadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157daax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dacx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157dadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157faax-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fabx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157facx-pinctrl.dtsi
@@ -1081,6 +1081,153 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_ph2: quadspi_bk2_io0_ph2 {
+				pinmux = <STM32_PINMUX('H', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_ph3: quadspi_bk2_io1_ph3 {
+				pinmux = <STM32_PINMUX('H', 3, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
+++ b/dts/st/mp1/stm32mp157fadx-pinctrl.dtsi
@@ -707,6 +707,143 @@
 				pinmux = <STM32_PINMUX('A', 15, AF6)>;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_io3_pa1: quadspi_bk1_io3_pa1 {
+				pinmux = <STM32_PINMUX('A', 1, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa7: quadspi_clk_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb2: quadspi_clk_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb6: quadspi_bk1_ncs_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb10: quadspi_bk1_ncs_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc0: quadspi_bk2_ncs_pc0 {
+				pinmux = <STM32_PINMUX('C', 0, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pc9: quadspi_bk1_io0_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pc10: quadspi_bk1_io1_pc10 {
+				pinmux = <STM32_PINMUX('C', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_ncs_pc11: quadspi_bk2_ncs_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd11: quadspi_bk1_io0_pd11 {
+				pinmux = <STM32_PINMUX('D', 11, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd12: quadspi_bk1_io1_pd12 {
+				pinmux = <STM32_PINMUX('D', 12, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd13: quadspi_bk1_io3_pd13 {
+				pinmux = <STM32_PINMUX('D', 13, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pe2: quadspi_bk1_io2_pe2 {
+				pinmux = <STM32_PINMUX('E', 2, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io0_pe7: quadspi_bk2_io0_pe7 {
+				pinmux = <STM32_PINMUX('E', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io1_pe8: quadspi_bk2_io1_pe8 {
+				pinmux = <STM32_PINMUX('E', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pe9: quadspi_bk2_io2_pe9 {
+				pinmux = <STM32_PINMUX('E', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pe10: quadspi_bk2_io3_pe10 {
+				pinmux = <STM32_PINMUX('E', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pf6: quadspi_bk1_io3_pf6 {
+				pinmux = <STM32_PINMUX('F', 6, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pf7: quadspi_bk1_io2_pf7 {
+				pinmux = <STM32_PINMUX('F', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pf8: quadspi_bk1_io0_pf8 {
+				pinmux = <STM32_PINMUX('F', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pf9: quadspi_bk1_io1_pf9 {
+				pinmux = <STM32_PINMUX('F', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pf10: quadspi_clk_pf10 {
+				pinmux = <STM32_PINMUX('F', 10, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg7: quadspi_bk2_io3_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pg7: quadspi_clk_pg7 {
+				pinmux = <STM32_PINMUX('G', 7, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg9: quadspi_bk2_io2_pg9 {
+				pinmux = <STM32_PINMUX('G', 9, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io2_pg10: quadspi_bk2_io2_pg10 {
+				pinmux = <STM32_PINMUX('G', 10, AF11)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk2_io3_pg14: quadspi_bk2_io3_pg14 {
+				pinmux = <STM32_PINMUX('G', 14, AF9)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SDMMC */
 
 			sdmmc1_cdir_pa15: sdmmc1_cdir_pa15 {

--- a/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb35c(c-e)uxa-pinctrl.dtsi
@@ -104,6 +104,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ccux-pinctrl.dtsi
@@ -104,6 +104,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55ceux-pinctrl.dtsi
@@ -104,6 +104,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55cgux-pinctrl.dtsi
@@ -104,6 +104,38 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rcvx-pinctrl.dtsi
@@ -164,6 +164,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55revx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55revx-pinctrl.dtsi
@@ -164,6 +164,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55rgvx-pinctrl.dtsi
@@ -164,6 +164,48 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcqx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vcyx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veqx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55veyx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgqx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vgyx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb55vyyx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
+++ b/dts/st/wb/stm32wb5mmghx-pinctrl.dtsi
@@ -164,6 +164,73 @@
 				drive-open-drain;
 			};
 
+			/* QUADSPI */
+
+			quadspi_bk1_ncs_pa2: quadspi_bk1_ncs_pa2 {
+				pinmux = <STM32_PINMUX('A', 2, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pa3: quadspi_clk_pa3 {
+				pinmux = <STM32_PINMUX('A', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pa6: quadspi_bk1_io3_pa6 {
+				pinmux = <STM32_PINMUX('A', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pa7: quadspi_bk1_io2_pa7 {
+				pinmux = <STM32_PINMUX('A', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pb8: quadspi_bk1_io1_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pb9: quadspi_bk1_io0_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_clk_pb10: quadspi_clk_pb10 {
+				pinmux = <STM32_PINMUX('B', 10, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pb11: quadspi_bk1_ncs_pb11 {
+				pinmux = <STM32_PINMUX('B', 11, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_ncs_pd3: quadspi_bk1_ncs_pd3 {
+				pinmux = <STM32_PINMUX('D', 3, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io0_pd4: quadspi_bk1_io0_pd4 {
+				pinmux = <STM32_PINMUX('D', 4, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io1_pd5: quadspi_bk1_io1_pd5 {
+				pinmux = <STM32_PINMUX('D', 5, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io2_pd6: quadspi_bk1_io2_pd6 {
+				pinmux = <STM32_PINMUX('D', 6, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
+			quadspi_bk1_io3_pd7: quadspi_bk1_io3_pd7 {
+				pinmux = <STM32_PINMUX('D', 7, AF10)>;
+				slew-rate = "very-high-speed";
+			};
+
 			/* SPI_MISO */
 
 			spi1_miso_pa6: spi1_miso_pa6 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -157,6 +157,10 @@
 - name: I2S_SD
   match: "^I2S\\d+_SD$"
 
+- name: QUADSPI
+  match: "^QUADSPI_(?:CLK|NCS|BK1_NCS|BK1_IO[0-3]|BK2_NCS|BK2_IO[0-3])$"
+  slew-rate: very-high-speed
+
 - name: SDMMC
   match: "^SDMMC\\d+_(?:CK)?(?:CKIN)?(?:CDIR)?(?:CMD)?(?:D\\d+)?(?:D0DIR)?(?:D123DIR)?$"
   slew-rate: very-high-speed


### PR DESCRIPTION
Required configuration and new batch of pinctrl.dtsi files including QUADSPI signals