### PR TITLE
stm32cube: update stm32g0 to version V1.4.0

### DIFF
--- a/stm32cube/common_ll/README.rst
+++ b/stm32cube/common_ll/README.rst
@@ -16,7 +16,7 @@ stm32f2xx       1.9.1
 stm32f3xx       1.11.1
 stm32f4xx       1.25.1
 stm32f7xx       1.16.0
-stm32g0xx       1.3.0
+stm32g0xx       1.4.0
 stm32g4xx       1.3.0
 stm32h7xx       1.8.0
 stm32l0xx       1.11.3

--- a/stm32cube/common_ll/include/stm32_ll_crs.h
+++ b/stm32cube/common_ll/include/stm32_ll_crs.h
@@ -8,6 +8,8 @@
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X)
 #include <stm32f0xx_ll_crs.h>
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+#include <stm32g0xx_ll_crs.h>
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)
 #include <stm32g4xx_ll_crs.h>
 #elif defined(CONFIG_SOC_SERIES_STM32H7X)

--- a/stm32cube/common_ll/include/stm32_ll_utils.h
+++ b/stm32cube/common_ll/include/stm32_ll_utils.h
@@ -20,6 +20,8 @@
 #include <stm32f7xx_ll_utils.h>
 #elif defined(CONFIG_SOC_SERIES_STM32G0X)
 #include <stm32g0xx_ll_utils.h>
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+#include <stm32g0xx_ll_utils.h>
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)
 #include <stm32g4xx_ll_utils.h>
 #elif defined(CONFIG_SOC_SERIES_STM32H7X)

--- a/stm32cube/stm32g0xx/CMakeLists.txt
+++ b/stm32cube/stm32g0xx/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2018 Endre Karlson <endre.karlson@gmail.com>
-# Copyright (c) 2019 STMicroelectronics.
+# Copyright (c) 2020 STMicroelectronics
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,15 +21,19 @@ zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_DAC_EX drivers/src/stm32g0xx_h
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_DMA drivers/src/stm32g0xx_hal_dma.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_DMA_EX drivers/src/stm32g0xx_hal_dma_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_EXTI drivers/src/stm32g0xx_hal_exti.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_FDCAN drivers/src/stm32g0xx_hal_fdcan.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_FLASH drivers/src/stm32g0xx_hal_flash.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_FLASH_EX drivers/src/stm32g0xx_hal_flash_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_GPIO drivers/src/stm32g0xx_hal_gpio.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_HCD drivers/src/stm32g0xx_hal_hcd.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_I2C drivers/src/stm32g0xx_hal_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_I2C_EX drivers/src/stm32g0xx_hal_i2c_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_I2S drivers/src/stm32g0xx_hal_i2s.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_IRDA drivers/src/stm32g0xx_hal_irda.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_IWDG drivers/src/stm32g0xx_hal_iwdg.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_LPTIM drivers/src/stm32g0xx_hal_lptim.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_PCD drivers/src/stm32g0xx_hal_pcd.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_PCD_EX drivers/src/stm32g0xx_hal_pcd_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_PWR drivers/src/stm32g0xx_hal_pwr.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_PWR_EX drivers/src/stm32g0xx_hal_pwr_ex.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_RNG drivers/src/stm32g0xx_hal_rng.c)
@@ -50,6 +54,7 @@ zephyr_library_sources_ifdef(CONFIG_USE_STM32_HAL_WWDG drivers/src/stm32g0xx_hal
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_ADC drivers/src/stm32g0xx_ll_adc.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_COMP drivers/src/stm32g0xx_ll_comp.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_CRC drivers/src/stm32g0xx_ll_crc.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_CRS drivers/src/stm32g0xx_ll_crs.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_DAC drivers/src/stm32g0xx_ll_dac.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_DMA drivers/src/stm32g0xx_ll_dma.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_EXTI drivers/src/stm32g0xx_ll_exti.c)
@@ -65,4 +70,5 @@ zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_SPI drivers/src/stm32g0xx_ll_sp
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_TIM drivers/src/stm32g0xx_ll_tim.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_UCPD drivers/src/stm32g0xx_ll_ucpd.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_USART drivers/src/stm32g0xx_ll_usart.c)
+zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_USB drivers/src/stm32g0xx_ll_usb.c)
 zephyr_library_sources_ifdef(CONFIG_USE_STM32_LL_UTILS drivers/src/stm32g0xx_ll_utils.c)

--- a/stm32cube/stm32g0xx/README
+++ b/stm32cube/stm32g0xx/README
@@ -39,5 +39,6 @@ Patch List:
    *Changes from official delivery:
     -dos2unix applied
     -trailing white spaces removed
+    -added include guards to stm32g0xx_hal_hcd.h(STM32CubeG0 GH issue: 13)
 
    See release_note.html from STM32Cube

--- a/stm32cube/stm32g0xx/README
+++ b/stm32cube/stm32g0xx/README
@@ -6,7 +6,7 @@ Origin:
    http://www.st.com/en/embedded-software/stm32cubeg0.html
 
 Status:
-   version v1.3.0
+   version v1.4.0
 
 Purpose:
    ST Microelectronics official MCU package for STM32G0 series.
@@ -23,7 +23,7 @@ URL:
    https://github.com/STMicroelectronics/STM32CubeG0
 
 Commit:
-   2447e18b9505b881c926e8d6c6fc60d065d85ebc
+   c6cb8664ae0542c33f81046d735ee9492d5df0f3
 
 Maintained-by:
    External
@@ -36,12 +36,8 @@ License Link:
 
 Patch List:
 
-    *Extend public SetFlashLatency API to all families
-     The LL_SetFlashLatency public API is now defined for families
-     beyond G4, L4 and L5. The private function has been made public.
-    Impacted files:
-     drivers/include/stm32g0xx_ll_utils.h
-     drivers/src/stm32g0xx_ll_utils.c
-    ST Bug tracker ID: 76033
+   *Changes from official delivery:
+    -dos2unix applied
+    -trailing white spaces removed
 
    See release_note.html from STM32Cube

--- a/stm32cube/stm32g0xx/drivers/include/Legacy/stm32_hal_legacy.h
+++ b/stm32cube/stm32g0xx/drivers/include/Legacy/stm32_hal_legacy.h
@@ -38,7 +38,6 @@
 #define AES_CLEARFLAG_CCF               CRYP_CLEARFLAG_CCF
 #define AES_CLEARFLAG_RDERR             CRYP_CLEARFLAG_RDERR
 #define AES_CLEARFLAG_WRERR             CRYP_CLEARFLAG_WRERR
-
 /**
   * @}
   */
@@ -236,12 +235,12 @@
 #define DAC_WAVEGENERATION_NOISE                        DAC_WAVE_NOISE
 #define DAC_WAVEGENERATION_TRIANGLE                     DAC_WAVE_TRIANGLE
 
-#if defined(STM32G4)
-#define DAC_CHIPCONNECT_DISABLE       (DAC_CHIPCONNECT_EXTERNAL | DAC_CHIPCONNECT_BOTH)
-#define DAC_CHIPCONNECT_ENABLE        (DAC_CHIPCONNECT_INTERNAL | DAC_CHIPCONNECT_BOTH)
+#if defined(STM32G4) || defined(STM32H7)
+#define DAC_CHIPCONNECT_DISABLE       DAC_CHIPCONNECT_EXTERNAL
+#define DAC_CHIPCONNECT_ENABLE        DAC_CHIPCONNECT_INTERNAL
 #endif
 
-#if defined(STM32L1) || defined(STM32L4) || defined(STM32G0)
+#if defined(STM32L1) || defined(STM32L4) || defined(STM32G0) || defined(STM32L5) || defined(STM32H7) || defined(STM32F4) || defined(STM32G4)
 #define HAL_DAC_MSP_INIT_CB_ID       HAL_DAC_MSPINIT_CB_ID
 #define HAL_DAC_MSP_DEINIT_CB_ID     HAL_DAC_MSPDEINIT_CB_ID
 #endif
@@ -306,7 +305,21 @@
 #define HAL_DMAMUX_REQUEST_GEN_FALLING           HAL_DMAMUX_REQ_GEN_FALLING
 #define HAL_DMAMUX_REQUEST_GEN_RISING_FALLING    HAL_DMAMUX_REQ_GEN_RISING_FALLING
 
+#if defined(STM32L4R5xx) || defined(STM32L4R9xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
+#define DMA_REQUEST_DCMI_PSSI                    DMA_REQUEST_DCMI
+#endif
+
 #endif /* STM32L4 */
+
+#if defined(STM32G0)
+#define DMA_REQUEST_DAC1_CHANNEL1                DMA_REQUEST_DAC1_CH1
+#define DMA_REQUEST_DAC1_CHANNEL2                DMA_REQUEST_DAC1_CH2
+#define DMA_REQUEST_TIM16_TRIG_COM               DMA_REQUEST_TIM16_COM
+#define DMA_REQUEST_TIM17_TRIG_COM               DMA_REQUEST_TIM17_COM
+
+#define LL_DMAMUX_REQ_TIM16_TRIG_COM             LL_DMAMUX_REQ_TIM16_COM
+#define LL_DMAMUX_REQ_TIM17_TRIG_COM             LL_DMAMUX_REQ_TIM17_COM
+#endif
 
 #if defined(STM32H7)
 
@@ -364,6 +377,9 @@
 #define DFSDM_FILTER_EXT_TRIG_LPTIM1               DFSDM_FILTER_EXT_TRIG_LPTIM1_OUT
 #define DFSDM_FILTER_EXT_TRIG_LPTIM2               DFSDM_FILTER_EXT_TRIG_LPTIM2_OUT
 #define DFSDM_FILTER_EXT_TRIG_LPTIM3               DFSDM_FILTER_EXT_TRIG_LPTIM3_OUT
+
+#define DAC_TRIGGER_LP1_OUT                        DAC_TRIGGER_LPTIM1_OUT
+#define DAC_TRIGGER_LP2_OUT                        DAC_TRIGGER_LPTIM2_OUT
 
 #endif /* STM32H7 */
 
@@ -460,7 +476,9 @@
 #define FLASH_FLAG_SNECCE_BANK2RR FLASH_FLAG_SNECCERR_BANK2
 #define FLASH_FLAG_DBECCE_BANK2RR FLASH_FLAG_DBECCERR_BANK2
 #define FLASH_FLAG_STRBER_BANK2R  FLASH_FLAG_STRBERR_BANK2
-#endif
+#define FLASH_FLAG_WDW            FLASH_FLAG_WBNE
+#define OB_WRP_SECTOR_All         OB_WRP_SECTOR_ALL
+#endif /* STM32H7 */
 
 /**
   * @}
@@ -564,7 +582,14 @@
 #define GPIO_AF9_SDIO2                            GPIO_AF9_SDMMC2
 #define GPIO_AF10_SDIO2                           GPIO_AF10_SDMMC2
 #define GPIO_AF11_SDIO2                           GPIO_AF11_SDMMC2
-#endif
+
+#if defined (STM32H743xx) || defined (STM32H753xx)  || defined (STM32H750xx) || defined (STM32H742xx) || \
+    defined (STM32H745xx) || defined (STM32H755xx)  || defined (STM32H747xx) || defined (STM32H757xx)
+#define GPIO_AF10_OTG2_HS  GPIO_AF10_OTG2_FS
+#define GPIO_AF10_OTG1_FS  GPIO_AF10_OTG1_HS
+#define GPIO_AF12_OTG2_FS  GPIO_AF12_OTG1_FS
+#endif /*STM32H743xx || STM32H753xx || STM32H750xx || STM32H742xx || STM32H745xx || STM32H755xx || STM32H747xx || STM32H757xx */
+#endif /* STM32H7 */
 
 #define GPIO_AF0_LPTIM                            GPIO_AF0_LPTIM1
 #define GPIO_AF1_LPTIM                            GPIO_AF1_LPTIM1
@@ -622,6 +647,10 @@
 #define HAL_HRTIM_ExternalEventCounterEnable    HAL_HRTIM_ExtEventCounterEnable
 #define HAL_HRTIM_ExternalEventCounterDisable   HAL_HRTIM_ExtEventCounterDisable
 #define HAL_HRTIM_ExternalEventCounterReset     HAL_HRTIM_ExtEventCounterReset
+#define HRTIM_TIMEEVENT_A                       HRTIM_EVENTCOUNTER_A
+#define HRTIM_TIMEEVENT_B                       HRTIM_EVENTCOUNTER_B
+#define HRTIM_TIMEEVENTRESETMODE_UNCONDITIONAL  HRTIM_EVENTCOUNTER_RSTMODE_UNCONDITIONAL
+#define HRTIM_TIMEEVENTRESETMODE_CONDITIONAL    HRTIM_EVENTCOUNTER_RSTMODE_CONDITIONAL
 #endif /* STM32G4 */
 
 #if defined(STM32H7)
@@ -735,6 +764,66 @@
 #define HRTIM_OUTPUTRESET_TIMFEV8_TIMECMP2 HRTIM_OUTPUTSET_TIMEV_8
 #define HRTIM_OUTPUTRESET_TIMFEV9_TIMECMP3 HRTIM_OUTPUTSET_TIMEV_9
 #endif /* STM32H7 */
+
+#if defined(STM32F3)
+/** @brief Constants defining available sources associated to external events.
+  */
+#define HRTIM_EVENTSRC_1              (0x00000000U)
+#define HRTIM_EVENTSRC_2              (HRTIM_EECR1_EE1SRC_0)
+#define HRTIM_EVENTSRC_3              (HRTIM_EECR1_EE1SRC_1)
+#define HRTIM_EVENTSRC_4              (HRTIM_EECR1_EE1SRC_1 | HRTIM_EECR1_EE1SRC_0)
+
+/** @brief Constants defining the events that can be selected to configure the
+  *        set/reset crossbar of a timer output
+  */
+#define HRTIM_OUTPUTSET_TIMEV_1       (HRTIM_SET1R_TIMEVNT1)
+#define HRTIM_OUTPUTSET_TIMEV_2       (HRTIM_SET1R_TIMEVNT2)
+#define HRTIM_OUTPUTSET_TIMEV_3       (HRTIM_SET1R_TIMEVNT3)
+#define HRTIM_OUTPUTSET_TIMEV_4       (HRTIM_SET1R_TIMEVNT4)
+#define HRTIM_OUTPUTSET_TIMEV_5       (HRTIM_SET1R_TIMEVNT5)
+#define HRTIM_OUTPUTSET_TIMEV_6       (HRTIM_SET1R_TIMEVNT6)
+#define HRTIM_OUTPUTSET_TIMEV_7       (HRTIM_SET1R_TIMEVNT7)
+#define HRTIM_OUTPUTSET_TIMEV_8       (HRTIM_SET1R_TIMEVNT8)
+#define HRTIM_OUTPUTSET_TIMEV_9       (HRTIM_SET1R_TIMEVNT9)
+
+#define HRTIM_OUTPUTRESET_TIMEV_1     (HRTIM_RST1R_TIMEVNT1)
+#define HRTIM_OUTPUTRESET_TIMEV_2     (HRTIM_RST1R_TIMEVNT2)
+#define HRTIM_OUTPUTRESET_TIMEV_3     (HRTIM_RST1R_TIMEVNT3)
+#define HRTIM_OUTPUTRESET_TIMEV_4     (HRTIM_RST1R_TIMEVNT4)
+#define HRTIM_OUTPUTRESET_TIMEV_5     (HRTIM_RST1R_TIMEVNT5)
+#define HRTIM_OUTPUTRESET_TIMEV_6     (HRTIM_RST1R_TIMEVNT6)
+#define HRTIM_OUTPUTRESET_TIMEV_7     (HRTIM_RST1R_TIMEVNT7)
+#define HRTIM_OUTPUTRESET_TIMEV_8     (HRTIM_RST1R_TIMEVNT8)
+#define HRTIM_OUTPUTRESET_TIMEV_9     (HRTIM_RST1R_TIMEVNT9)
+
+/** @brief Constants defining the event filtering applied to external events
+  *        by a timer
+  */
+#define HRTIM_TIMEVENTFILTER_NONE             (0x00000000U)
+#define HRTIM_TIMEVENTFILTER_BLANKINGCMP1     (HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_BLANKINGCMP2     (HRTIM_EEFR1_EE1FLTR_1)
+#define HRTIM_TIMEVENTFILTER_BLANKINGCMP3     (HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_BLANKINGCMP4     (HRTIM_EEFR1_EE1FLTR_2)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR1    (HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR2    (HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR3    (HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR4    (HRTIM_EEFR1_EE1FLTR_3)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR5    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR6    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_1)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR7    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR8    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2)
+#define HRTIM_TIMEVENTFILTER_WINDOWINGCMP2    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_0)
+#define HRTIM_TIMEVENTFILTER_WINDOWINGCMP3    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1)
+#define HRTIM_TIMEVENTFILTER_WINDOWINGTIM     (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
+
+/** @brief Constants defining the DLL calibration periods (in micro seconds)
+  */
+#define HRTIM_CALIBRATIONRATE_7300             0x00000000U
+#define HRTIM_CALIBRATIONRATE_910              (HRTIM_DLLCR_CALRTE_0)
+#define HRTIM_CALIBRATIONRATE_114              (HRTIM_DLLCR_CALRTE_1)
+#define HRTIM_CALIBRATIONRATE_14               (HRTIM_DLLCR_CALRTE_1 | HRTIM_DLLCR_CALRTE_0)
+
+#endif /* STM32F3 */
 /**
   * @}
   */
@@ -874,7 +963,7 @@
 #define OPAMP_PGACONNECT_VM0                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0
 #define OPAMP_PGACONNECT_VM1                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO1
 
-#if defined(STM32L1) || defined(STM32L4)
+#if defined(STM32L1) || defined(STM32L4) || defined(STM32L5) || defined(STM32H7) || defined(STM32G4)
 #define HAL_OPAMP_MSP_INIT_CB_ID       HAL_OPAMP_MSPINIT_CB_ID
 #define HAL_OPAMP_MSP_DEINIT_CB_ID     HAL_OPAMP_MSPDEINIT_CB_ID
 #endif
@@ -964,6 +1053,16 @@
 #define RTC_TAMPERPIN_PC13 RTC_TAMPERPIN_DEFAULT
 #define RTC_TAMPERPIN_PA0  RTC_TAMPERPIN_POS1
 #define RTC_TAMPERPIN_PI8  RTC_TAMPERPIN_POS1
+
+#if defined(STM32H7)
+#define RTC_TAMPCR_TAMPXE          RTC_TAMPER_X
+#define RTC_TAMPCR_TAMPXIE         RTC_TAMPER_X_INTERRUPT
+
+#define RTC_TAMPER1_INTERRUPT      RTC_IT_TAMP1
+#define RTC_TAMPER2_INTERRUPT      RTC_IT_TAMP2
+#define RTC_TAMPER3_INTERRUPT      RTC_IT_TAMP3
+#define RTC_ALL_TAMPER_INTERRUPT   RTC_IT_TAMPALL
+#endif /* STM32H7 */
 
 /**
   * @}
@@ -1358,6 +1457,30 @@
 
 #define HASH_HMACKeyType_ShortKey  HASH_HMAC_KEYTYPE_SHORTKEY
 #define HASH_HMACKeyType_LongKey   HASH_HMAC_KEYTYPE_LONGKEY
+
+#if defined(STM32L4) || defined(STM32L5) || defined(STM32F2) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7)
+
+#define HAL_HASH_MD5_Accumulate                HAL_HASH_MD5_Accmlt
+#define HAL_HASH_MD5_Accumulate_End            HAL_HASH_MD5_Accmlt_End
+#define HAL_HASH_MD5_Accumulate_IT             HAL_HASH_MD5_Accmlt_IT
+#define HAL_HASH_MD5_Accumulate_End_IT         HAL_HASH_MD5_Accmlt_End_IT
+
+#define HAL_HASH_SHA1_Accumulate               HAL_HASH_SHA1_Accmlt
+#define HAL_HASH_SHA1_Accumulate_End           HAL_HASH_SHA1_Accmlt_End
+#define HAL_HASH_SHA1_Accumulate_IT            HAL_HASH_SHA1_Accmlt_IT
+#define HAL_HASH_SHA1_Accumulate_End_IT        HAL_HASH_SHA1_Accmlt_End_IT
+
+#define HAL_HASHEx_SHA224_Accumulate           HAL_HASHEx_SHA224_Accmlt
+#define HAL_HASHEx_SHA224_Accumulate_End       HAL_HASHEx_SHA224_Accmlt_End
+#define HAL_HASHEx_SHA224_Accumulate_IT        HAL_HASHEx_SHA224_Accmlt_IT
+#define HAL_HASHEx_SHA224_Accumulate_End_IT    HAL_HASHEx_SHA224_Accmlt_End_IT
+
+#define HAL_HASHEx_SHA256_Accumulate           HAL_HASHEx_SHA256_Accmlt
+#define HAL_HASHEx_SHA256_Accumulate_End       HAL_HASHEx_SHA256_Accmlt_End
+#define HAL_HASHEx_SHA256_Accumulate_IT        HAL_HASHEx_SHA256_Accmlt_IT
+#define HAL_HASHEx_SHA256_Accumulate_End_IT    HAL_HASHEx_SHA256_Accmlt_End_IT
+
+#endif  /* STM32L4 || STM32L5 || STM32F2 || STM32F4 || STM32F7 || STM32H7 */
 /**
   * @}
   */
@@ -1380,6 +1503,13 @@
 #endif
 #define HAL_ADC_EnableBuffer_Cmd(cmd)  (((cmd)==ENABLE) ? HAL_ADCEx_EnableVREFINT() : HAL_ADCEx_DisableVREFINT())
 #define HAL_ADC_EnableBufferSensor_Cmd(cmd) (((cmd)==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : HAL_ADCEx_DisableVREFINTTempSensor())
+#if defined(STM32H7A3xx) || defined(STM32H7B3xx) || defined(STM32H7B0xx) || defined(STM32H7A3xxQ) || defined(STM32H7B3xxQ) || defined(STM32H7B0xxQ)
+#define HAL_EnableSRDomainDBGStopMode      HAL_EnableDomain3DBGStopMode
+#define HAL_DisableSRDomainDBGStopMode     HAL_DisableDomain3DBGStopMode
+#define HAL_EnableSRDomainDBGStandbyMode   HAL_EnableDomain3DBGStandbyMode
+#define HAL_DisableSRDomainDBGStandbyMode  HAL_DisableDomain3DBGStandbyMode
+#endif /* STM32H7A3xx || STM32H7B3xx || STM32H7B0xx || STM32H7A3xxQ || STM32H7B3xxQ  || STM32H7B0xxQ */
+
 /**
   * @}
   */
@@ -1409,16 +1539,18 @@
 
 #define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd)==ENABLE)? HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
 
-#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32G4)
+#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4) || defined(STM32L1)
 #define HAL_I2C_Master_Sequential_Transmit_IT  HAL_I2C_Master_Seq_Transmit_IT
 #define HAL_I2C_Master_Sequential_Receive_IT   HAL_I2C_Master_Seq_Receive_IT
 #define HAL_I2C_Slave_Sequential_Transmit_IT   HAL_I2C_Slave_Seq_Transmit_IT
 #define HAL_I2C_Slave_Sequential_Receive_IT    HAL_I2C_Slave_Seq_Receive_IT
+#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F0 || STM32F1 || STM32F2 || STM32F3 || STM32F4 || STM32F7 || STM32L0 || STM32L4 || STM32L5 || STM32G4 || STM32L1 */
+#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4)|| defined(STM32L1)
 #define HAL_I2C_Master_Sequential_Transmit_DMA HAL_I2C_Master_Seq_Transmit_DMA
 #define HAL_I2C_Master_Sequential_Receive_DMA  HAL_I2C_Master_Seq_Receive_DMA
 #define HAL_I2C_Slave_Sequential_Transmit_DMA  HAL_I2C_Slave_Seq_Transmit_DMA
 #define HAL_I2C_Slave_Sequential_Receive_DMA   HAL_I2C_Slave_Seq_Receive_DMA
-#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F4 || STM32F7 || STM32L0 || STM32L4 */
+#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F4 || STM32F7 || STM32L0 || STM32L4 || STM32L5 || STM32G4 || STM32L1 */
 
 #if defined(STM32F4)
 #define HAL_FMPI2C_Master_Sequential_Transmit_IT  HAL_FMPI2C_Master_Seq_Transmit_IT
@@ -1437,6 +1569,13 @@
 /** @defgroup HAL_PWR_Aliased HAL PWR Aliased maintained for legacy purpose
   * @{
   */
+
+#if defined(STM32G0)
+#define HAL_PWR_ConfigPVD                             HAL_PWREx_ConfigPVD
+#define HAL_PWR_EnablePVD                             HAL_PWREx_EnablePVD
+#define HAL_PWR_DisablePVD                            HAL_PWREx_DisablePVD
+#define HAL_PWR_PVD_IRQHandler                        HAL_PWREx_PVD_IRQHandler
+#endif
 #define HAL_PWR_PVDConfig                             HAL_PWR_ConfigPVD
 #define HAL_PWR_DisableBkUpReg                        HAL_PWREx_DisableBkUpReg
 #define HAL_PWR_DisableFlashPowerDown                 HAL_PWREx_DisableFlashPowerDown
@@ -1509,14 +1648,14 @@
 #define HAL_TIM_DMAError                                TIM_DMAError
 #define HAL_TIM_DMACaptureCplt                          TIM_DMACaptureCplt
 #define HAL_TIMEx_DMACommutationCplt                    TIMEx_DMACommutationCplt
-#if defined(STM32H7) || defined(STM32G0) || defined(STM32F7) || defined(STM32F4) || defined(STM32L0) || defined(STM32L4)
+#if defined(STM32H7) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4)
 #define HAL_TIM_SlaveConfigSynchronization              HAL_TIM_SlaveConfigSynchro
 #define HAL_TIM_SlaveConfigSynchronization_IT           HAL_TIM_SlaveConfigSynchro_IT
 #define HAL_TIMEx_CommutationCallback                   HAL_TIMEx_CommutCallback
 #define HAL_TIMEx_ConfigCommutationEvent                HAL_TIMEx_ConfigCommutEvent
 #define HAL_TIMEx_ConfigCommutationEvent_IT             HAL_TIMEx_ConfigCommutEvent_IT
 #define HAL_TIMEx_ConfigCommutationEvent_DMA            HAL_TIMEx_ConfigCommutEvent_DMA
-#endif /* STM32H7 || STM32G0 || STM32F7 || STM32F4  || STM32L0 */
+#endif /* STM32H7 || STM32G0 || STM32F0 || STM32F1 || STM32F2 || STM32F3 || STM32F4 || STM32F7 || STM32L0 */
 /**
   * @}
   */
@@ -3112,9 +3251,8 @@
 #define RCC_MCOSOURCE_PLLCLK_NODIV  RCC_MCO1SOURCE_PLLCLK
 #define RCC_MCOSOURCE_PLLCLK_DIV2   RCC_MCO1SOURCE_PLLCLK_DIV2
 
-#if defined(STM32L4)
+#if defined(STM32L4) || defined(STM32WB) || defined(STM32G0) || defined(STM32G4) || defined(STM32L5)
 #define RCC_RTCCLKSOURCE_NO_CLK     RCC_RTCCLKSOURCE_NONE
-#elif defined(STM32WB) || defined(STM32G0) || defined(STM32G4)
 #else
 #define RCC_RTCCLKSOURCE_NONE       RCC_RTCCLKSOURCE_NO_CLK
 #endif
@@ -3242,7 +3380,7 @@
 /** @defgroup HAL_RTC_Aliased_Macros HAL RTC Aliased Macros maintained for legacy purpose
   * @{
   */
-#if defined (STM32G0) || defined (STM32L412xx) || defined (STM32L422xx) || defined (STM32L4P5xx) || defined (STM32L4Q5xx) || defined (STM32G4)
+#if defined (STM32G0) || defined (STM32L5) || defined (STM32L412xx) || defined (STM32L422xx) || defined (STM32L4P5xx) || defined (STM32L4Q5xx) || defined (STM32G4)
 #else
 #define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
 #endif
@@ -3350,22 +3488,22 @@
 #define  __HAL_SD_SDIO_CLEAR_FLAG   __HAL_SD_SDMMC_CLEAR_FLAG
 #define  __HAL_SD_SDIO_GET_IT       __HAL_SD_SDMMC_GET_IT
 #define  __HAL_SD_SDIO_CLEAR_IT     __HAL_SD_SDMMC_CLEAR_IT
-#define  SDIO_STATIC_FLAGS	        SDMMC_STATIC_FLAGS
-#define  SDIO_CMD0TIMEOUT	          SDMMC_CMD0TIMEOUT
-#define  SD_SDIO_SEND_IF_COND	      SD_SDMMC_SEND_IF_COND
+#define  SDIO_STATIC_FLAGS          SDMMC_STATIC_FLAGS
+#define  SDIO_CMD0TIMEOUT           SDMMC_CMD0TIMEOUT
+#define  SD_SDIO_SEND_IF_COND       SD_SDMMC_SEND_IF_COND
 /* alias CMSIS for compatibilities */
 #define  SDIO_IRQn                  SDMMC1_IRQn
 #define  SDIO_IRQHandler            SDMMC1_IRQHandler
 #endif
 
-#if defined(STM32F7) || defined(STM32F4) || defined(STM32F2) || defined(STM32L4)
+#if defined(STM32F7) || defined(STM32F4) || defined(STM32F2) || defined(STM32L4) || defined(STM32H7)
 #define  HAL_SD_CardCIDTypedef       HAL_SD_CardCIDTypeDef
 #define  HAL_SD_CardCSDTypedef       HAL_SD_CardCSDTypeDef
 #define  HAL_SD_CardStatusTypedef    HAL_SD_CardStatusTypeDef
 #define  HAL_SD_CardStateTypedef     HAL_SD_CardStateTypeDef
 #endif
 
-#if defined(STM32H7)
+#if defined(STM32H7) || defined(STM32L5)
 #define HAL_MMCEx_Read_DMADoubleBuffer0CpltCallback   HAL_MMCEx_Read_DMADoubleBuf0CpltCallback
 #define HAL_MMCEx_Read_DMADoubleBuffer1CpltCallback   HAL_MMCEx_Read_DMADoubleBuf1CpltCallback
 #define HAL_MMCEx_Write_DMADoubleBuffer0CpltCallback  HAL_MMCEx_Write_DMADoubleBuf0CpltCallback
@@ -3606,12 +3744,12 @@
   * @{
   */
 #if defined (STM32H7) || defined (STM32G4) || defined (STM32F3)
-#define HAL_HRTIM_WaveformCounterStart_IT HAL_HRTIM_WaveformCountStart_IT
-#define HAL_HRTIM_WaveformCounterStart_DMA HAL_HRTIM_WaveformCountStart_DMA
-#define HAL_HRTIM_WaveformCounterStart HAL_HRTIM_WaveformCountStart
-#define HAL_HRTIM_WaveformCounterStop_IT HAL_HRTIM_WaveformCountStop_IT
-#define HAL_HRTIM_WaveformCounterStop_DMA HAL_HRTIM_WaveformCountStop_DMA
-#define HAL_HRTIM_WaveformCounterStop HAL_HRTIM_WaveformCountStop
+#define HAL_HRTIM_WaveformCounterStart_IT      HAL_HRTIM_WaveformCountStart_IT
+#define HAL_HRTIM_WaveformCounterStart_DMA     HAL_HRTIM_WaveformCountStart_DMA
+#define HAL_HRTIM_WaveformCounterStart         HAL_HRTIM_WaveformCountStart
+#define HAL_HRTIM_WaveformCounterStop_IT       HAL_HRTIM_WaveformCountStop_IT
+#define HAL_HRTIM_WaveformCounterStop_DMA      HAL_HRTIM_WaveformCountStop_DMA
+#define HAL_HRTIM_WaveformCounterStop          HAL_HRTIM_WaveformCountStop
 #endif
 /**
   * @}
@@ -3620,9 +3758,9 @@
 /** @defgroup HAL_QSPI_Aliased_Macros HAL QSPI Aliased Macros maintained for legacy purpose
   * @{
   */
-#if defined (STM32L4)
+#if defined (STM32L4) || defined (STM32F4) || defined (STM32F7) || defined(STM32H7)
 #define HAL_QPSI_TIMEOUT_DEFAULT_VALUE HAL_QSPI_TIMEOUT_DEFAULT_VALUE
-#endif
+#endif /* STM32L4 || STM32F4 || STM32F7 */
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal.h
@@ -38,26 +38,23 @@ extern "C" {
   */
 
 /* Exported types ------------------------------------------------------------*/
-/* Exported constants --------------------------------------------------------*/
-
-/** @defgroup HAL_Exported_Constants HAL Exported Constants
-  * @{
-  */
-
 /** @defgroup HAL_TICK_FREQ Tick Frequency
   * @{
   */
-#define  HAL_TICK_FREQ_10HZ         100U
-#define  HAL_TICK_FREQ_100HZ        10U
-#define  HAL_TICK_FREQ_1KHZ         1U
-#define  HAL_TICK_FREQ_DEFAULT      HAL_TICK_FREQ_1KHZ
-
+typedef enum
+{
+  HAL_TICK_FREQ_10HZ         = 100U,
+  HAL_TICK_FREQ_100HZ        = 10U,
+  HAL_TICK_FREQ_1KHZ         = 1U,
+  HAL_TICK_FREQ_DEFAULT      = HAL_TICK_FREQ_1KHZ
+} HAL_TickFreqTypeDef;
 /**
   * @}
   */
 
-/**
-  * @}
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup HAL_Exported_Constants HAL Exported Constants
+  * @{
   */
 
 /** @defgroup SYSCFG_Exported_Constants SYSCFG Exported Constants
@@ -81,14 +78,14 @@ extern "C" {
 #define SYSCFG_BREAK_SP                SYSCFG_CFGR2_SPL    /*!< Enables and locks the SRAM Parity error signal with Break Input of TIM1/15/16/17 */
 #if defined(SYSCFG_CFGR2_PVDL)
 #define SYSCFG_BREAK_PVD               SYSCFG_CFGR2_PVDL   /*!< Enables and locks the PVD connection with TIM1/15/16/17 Break Input and also the PVDE and PLS bits of the Power Control Interface */
-#endif
+#endif /* SYSCFG_CFGR2_PVDL */
 #define SYSCFG_BREAK_LOCKUP            SYSCFG_CFGR2_CLL    /*!< Enables and locks the LOCKUP output of CortexM0+ with Break Input of TIM1/15/16/17 */
 #define SYSCFG_BREAK_ECC               SYSCFG_CFGR2_ECCL   /*!< Enables and locks the ECC of CortexM0+ with Break Input of TIM1/15/16/17 */
 /**
   * @}
   */
 
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 /** @defgroup SYSCFG_ClampingDiode Clamping Diode
   * @{
   */
@@ -104,7 +101,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 
 /** @defgroup HAL_Pin_remapping Pin remapping
   * @{
@@ -121,11 +118,11 @@ extern "C" {
   */
 #define HAL_SYSCFG_IRDA_ENV_SEL_TIM16     (SYSCFG_CFGR1_IR_MOD_0 & SYSCFG_CFGR1_IR_MOD_1)    /*!< 00: Timer16 is selected as IR Modulation envelope source */
 #define HAL_SYSCFG_IRDA_ENV_SEL_USART1    (SYSCFG_CFGR1_IR_MOD_0)                            /*!< 01: USART1 is selected as IR Modulation envelope source */
-#if defined (STM32G081xx) || defined (STM32G071xx) || defined (STM32G070xx)
+#if defined(USART4)
 #define HAL_SYSCFG_IRDA_ENV_SEL_USART4    (SYSCFG_CFGR1_IR_MOD_1)                            /*!< 10: USART4 is selected as IR Modulation envelope source */
-#elif defined (STM32G041xx) || defined (STM32G031xx) || defined (STM32G030xx)
+#else
 #define HAL_SYSCFG_IRDA_ENV_SEL_USART2    (SYSCFG_CFGR1_IR_MOD_1)                            /*!< 10: USART2 is selected as IR Modulation envelope source */
-#endif
+#endif /* USART4 */
 
 /**
   * @}
@@ -190,20 +187,23 @@ extern "C" {
   */
 #define SYSCFG_FASTMODEPLUS_I2C1       SYSCFG_CFGR1_I2C1_FMP /*!< Enable Fast mode Plus on I2C1 */
 #define SYSCFG_FASTMODEPLUS_I2C2       SYSCFG_CFGR1_I2C2_FMP /*!< Enable Fast mode Plus on I2C2 */
+#if  defined (I2C3)
+#define SYSCFG_FASTMODEPLUS_I2C3       SYSCFG_CFGR1_I2C3_FMP /*!< Enable Fast mode Plus on I2C3 */
+#endif /* I2C3 */
 
 /**
  * @}
  */
-#if defined (STM32G081xx) || defined (STM32G071xx) || defined (STM32G070xx)
+#if defined (SYSCFG_CFGR1_UCPD1_STROBE) || defined (SYSCFG_CFGR1_UCPD2_STROBE)
 /** @defgroup SYSCFG_UCPDx_STROBE SYSCFG Dead Battery feature configuration
   * @{
   */
 #define SYSCFG_UCPD1_STROBE          SYSCFG_CFGR1_UCPD1_STROBE /*!< UCPD1 Dead battery sw configuration */
 #define SYSCFG_UCPD2_STROBE          SYSCFG_CFGR1_UCPD2_STROBE /*!< UCPD2 Dead battery sw configuration */
-#endif
 /**
   * @}
   */
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE) || SYSCFG_CFGR1_UCPD2_STROBE */
 
 /** @defgroup HAL_ISR_Wrapper HAL ISR Wrapper
   * @brief ISR Wrapper
@@ -242,15 +242,21 @@ extern "C" {
 #define HAL_SYSCFG_ITLINE30                          0x0000001EU /*!< Internal define for macro handling */
 #define HAL_SYSCFG_ITLINE31                          0x0000001FU /*!< Internal define for macro handling */
 
-#define HAL_ITLINE_WWDG           ((HAL_SYSCFG_ITLINE0 << 0x18U) | SYSCFG_ITLINE0_SR_WWDG)          /*!< WWDG has expired .... */
-#if defined (SYSCFG_ITLINE1_SR_PVDOUT)
+#define HAL_ITLINE_WWDG           ((HAL_SYSCFG_ITLINE0 << 0x18U) | SYSCFG_ITLINE0_SR_EWDG)          /*!< WWDG has expired .... */
+#if defined (PWR_PVD_SUPPORT)
 #define HAL_ITLINE_PVDOUT         ((HAL_SYSCFG_ITLINE1 << 0x18U) | SYSCFG_ITLINE1_SR_PVDOUT)        /*!< Power voltage detection Interrupt .... */
-#endif
+#endif /* PWR_PVD_SUPPORT */
+#if defined (PWR_PVM_SUPPORT)
+#define HAL_ITLINE_PVMOUT         ((HAL_SYSCFG_ITLINE1 << 0x18U) | SYSCFG_ITLINE1_SR_PVMOUT)        /*!< Power voltage monitor Interrupt .... */
+#endif /* PWR_PVM_SUPPORT */
 #define HAL_ITLINE_RTC            ((HAL_SYSCFG_ITLINE2 << 0x18U) | SYSCFG_ITLINE2_SR_RTC)           /*!< RTC -> exti[19] Interrupt */
 #define HAL_ITLINE_TAMPER         ((HAL_SYSCFG_ITLINE2 << 0x18U) | SYSCFG_ITLINE2_SR_TAMPER)        /*!< TAMPER -> exti[21] interrupt .... */
 #define HAL_ITLINE_FLASH_ECC      ((HAL_SYSCFG_ITLINE3 << 0x18U) | SYSCFG_ITLINE3_SR_FLASH_ECC)     /*!< Flash ECC Interrupt */
 #define HAL_ITLINE_FLASH_ITF      ((HAL_SYSCFG_ITLINE3 << 0x18U) | SYSCFG_ITLINE3_SR_FLASH_ITF)     /*!< Flash ITF Interrupt */
 #define HAL_ITLINE_CLK_CTRL       ((HAL_SYSCFG_ITLINE4 << 0x18U) | SYSCFG_ITLINE4_SR_CLK_CTRL)      /*!< CLK Control Interrupt */
+#if defined (CRS)
+#define HAL_ITLINE_CRS            ((HAL_SYSCFG_ITLINE4 << 0x18U) | SYSCFG_ITLINE4_SR_CRS)           /*!< CRS Interrupt */
+#endif /*CRS  */
 #define HAL_ITLINE_EXTI0          ((HAL_SYSCFG_ITLINE5 << 0x18U) | SYSCFG_ITLINE5_SR_EXTI0)         /*!< External Interrupt 0 */
 #define HAL_ITLINE_EXTI1          ((HAL_SYSCFG_ITLINE5 << 0x18U) | SYSCFG_ITLINE5_SR_EXTI1)         /*!< External Interrupt 1 */
 #define HAL_ITLINE_EXTI2          ((HAL_SYSCFG_ITLINE6 << 0x18U) | SYSCFG_ITLINE6_SR_EXTI2)         /*!< External Interrupt 2 */
@@ -269,27 +275,40 @@ extern "C" {
 #define HAL_ITLINE_EXTI15         ((HAL_SYSCFG_ITLINE7 << 0x18U) | SYSCFG_ITLINE7_SR_EXTI15)        /*!< EXTI15 Interrupt */
 #if defined (UCPD1)
 #define HAL_ITLINE_UCPD1          ((HAL_SYSCFG_ITLINE8 << 0x18U) | SYSCFG_ITLINE8_SR_UCPD1)         /*!< UCPD1 Interrupt */
-#endif
+#endif /* UCPD1 */
 #if defined (UCPD2)
 #define HAL_ITLINE_UCPD2          ((HAL_SYSCFG_ITLINE8 << 0x18U) | SYSCFG_ITLINE8_SR_UCPD2)         /*!< UCPD2 Interrupt */
-#endif
+#endif /* UCPD2 */
+#if defined (STM32G0C1xx) || defined (STM32G0B1xx) || defined (STM32G0B0xx)
+#define HAL_ITLINE_USB            ((HAL_SYSCFG_ITLINE8 << 0x18U) | SYSCFG_ITLINE8_SR_USB)           /*!< USB Interrupt */
+#endif /* STM32G0C1xx) || STM32G0B1xx) || STM32G0B0xx */
 #define HAL_ITLINE_DMA1_CH1       ((HAL_SYSCFG_ITLINE9 << 0x18U) | SYSCFG_ITLINE9_SR_DMA1_CH1)      /*!< DMA1 Channel 1 Interrupt */
 #define HAL_ITLINE_DMA1_CH2       ((HAL_SYSCFG_ITLINE10 << 0x18U) | SYSCFG_ITLINE10_SR_DMA1_CH2)    /*!< DMA1 Channel 2 Interrupt */
 #define HAL_ITLINE_DMA1_CH3       ((HAL_SYSCFG_ITLINE10 << 0x18U) | SYSCFG_ITLINE10_SR_DMA1_CH3)    /*!< DMA1 Channel 3 Interrupt */
-#define HAL_ITLINE_DMAMUX         ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMAMUX)      /*!< DMAMUX Interrupt */
+#define HAL_ITLINE_DMAMUX1        ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMAMUX1)     /*!< DMAMUX1 Interrupt */
 #define HAL_ITLINE_DMA1_CH4       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA1_CH4)    /*!< DMA1 Channel 4 Interrupt */
 #define HAL_ITLINE_DMA1_CH5       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA1_CH5)    /*!< DMA1 Channel 5 Interrupt */
-#if defined (STM32G081xx) || defined (STM32G071xx) || defined (STM32G070xx)
+#if defined(DMA1_Channel7)
 #define HAL_ITLINE_DMA1_CH6       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA1_CH6)    /*!< DMA1 Channel 6 Interrupt */
 #define HAL_ITLINE_DMA1_CH7       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA1_CH7)    /*!< DMA1 Channel 7 Interrupt */
-#endif
+#endif /* DMA1_Channel7 */
+#if defined (DMA2)
+#define HAL_ITLINE_DMA2_CH1       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA2_CH1)    /*!< DMA2 Channel 1 Interrupt */
+#define HAL_ITLINE_DMA2_CH2       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA2_CH2)    /*!< DMA2 Channel 2 Interrupt */
+#define HAL_ITLINE_DMA2_CH3       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA2_CH3)    /*!< DMA2 Channel 3 Interrupt */
+#define HAL_ITLINE_DMA2_CH4       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA2_CH4)    /*!< DMA2 Channel 4 Interrupt */
+#define HAL_ITLINE_DMA2_CH5       ((HAL_SYSCFG_ITLINE11 << 0x18U) | SYSCFG_ITLINE11_SR_DMA2_CH5)    /*!< DMA2 Channel 5 Interrupt */
+#endif /* DMA2 */
 #define HAL_ITLINE_ADC            ((HAL_SYSCFG_ITLINE12 << 0x18U) | SYSCFG_ITLINE12_SR_ADC)         /*!< ADC Interrupt */
 #if defined (COMP1)
 #define HAL_ITLINE_COMP1          ((HAL_SYSCFG_ITLINE12 << 0x18U) | SYSCFG_ITLINE12_SR_COMP1)       /*!< COMP1 Interrupt -> exti[17] */
-#endif
+#endif /* COMP1 */
 #if defined (COMP2)
 #define HAL_ITLINE_COMP2          ((HAL_SYSCFG_ITLINE12 << 0x18U) | SYSCFG_ITLINE12_SR_COMP2)       /*!< COMP2 Interrupt -> exti[18] */
-#endif
+#endif /* COMP2 */
+#if defined (COMP3)
+#define HAL_ITLINE_COMP3          ((HAL_SYSCFG_ITLINE12 << 0x18U) | SYSCFG_ITLINE12_SR_COMP3)       /*!< COMP3 Interrupt -> exti[1x] */
+#endif /* COMP3 */
 #define HAL_ITLINE_TIM1_BRK       ((HAL_SYSCFG_ITLINE13 << 0x18U) | SYSCFG_ITLINE13_SR_TIM1_BRK)    /*!< TIM1 BRK Interrupt */
 #define HAL_ITLINE_TIM1_UPD       ((HAL_SYSCFG_ITLINE13 << 0x18U) | SYSCFG_ITLINE13_SR_TIM1_UPD)    /*!< TIM1 UPD Interrupt */
 #define HAL_ITLINE_TIM1_TRG       ((HAL_SYSCFG_ITLINE13 << 0x18U) | SYSCFG_ITLINE13_SR_TIM1_TRG)    /*!< TIM1 TRG Interrupt */
@@ -297,53 +316,83 @@ extern "C" {
 #define HAL_ITLINE_TIM1_CC        ((HAL_SYSCFG_ITLINE14 << 0x18U) | SYSCFG_ITLINE14_SR_TIM1_CC)     /*!< TIM1 CC Interrupt */
 #if defined (TIM2)
 #define HAL_ITLINE_TIM2           ((HAL_SYSCFG_ITLINE15 << 0x18U) | SYSCFG_ITLINE15_SR_TIM2_GLB)    /*!< TIM2 Interrupt */
-#endif
+#endif /* TIM2 */
 #define HAL_ITLINE_TIM3           ((HAL_SYSCFG_ITLINE16 << 0x18U) | SYSCFG_ITLINE16_SR_TIM3_GLB)    /*!< TIM3 Interrupt */
+#if defined (TIM4)
+#define HAL_ITLINE_TIM4           ((HAL_SYSCFG_ITLINE16 << 0x18U) | SYSCFG_ITLINE16_SR_TIM4_GLB)    /*!< TIM4 Interrupt */
+#endif /* TIM4 */
 #if defined(TIM6)
 #define HAL_ITLINE_TIM6           ((HAL_SYSCFG_ITLINE17 << 0x18U) | SYSCFG_ITLINE17_SR_TIM6_GLB)    /*!< TIM6 Interrupt */
-#endif
+#endif /* TIM6 */
 #if defined(DAC1)
-#define HAL_ITLINE_DAC            ((HAL_SYSCFG_ITLINE17 << 0x18U) | SYSCFG_ITLINE17_SR_DAC_GLB)     /*!< DAC Interrupt */
-#endif
+#define HAL_ITLINE_DAC            ((HAL_SYSCFG_ITLINE17 << 0x18U) | SYSCFG_ITLINE17_SR_DAC)         /*!< DAC Interrupt */
+#endif /* DAC1 */
 #if defined(LPTIM1)
 #define HAL_ITLINE_LPTIM1         ((HAL_SYSCFG_ITLINE17 << 0x18U) | SYSCFG_ITLINE17_SR_LPTIM1_GLB)  /*!< LPTIM1 Interrupt -> exti[29] */
-#endif
-#if defined(TIM6)
+#endif /* LPTIM1 */
+#if defined(TIM7)
 #define HAL_ITLINE_TIM7           ((HAL_SYSCFG_ITLINE18 << 0x18U) | SYSCFG_ITLINE18_SR_TIM7_GLB)    /*!< TIM7 Interrupt */
-#endif
+#endif /* TIM7 */
 #if defined(LPTIM2)
 #define HAL_ITLINE_LPTIM2         ((HAL_SYSCFG_ITLINE18 << 0x18U) | SYSCFG_ITLINE18_SR_LPTIM2_GLB)  /*!< LPTIM2 Interrupt -> exti[30] */
-#endif
+#endif /* LPTIM2 */
 #define HAL_ITLINE_TIM14          ((HAL_SYSCFG_ITLINE19 << 0x18U) | SYSCFG_ITLINE19_SR_TIM14_GLB)   /*!< TIM14 Interrupt */
 #if defined(TIM15)
 #define HAL_ITLINE_TIM15          ((HAL_SYSCFG_ITLINE20 << 0x18U) | SYSCFG_ITLINE20_SR_TIM15_GLB)   /*!< TIM15 Interrupt */
-#endif
+#endif /* TIM15 */
 #define HAL_ITLINE_TIM16          ((HAL_SYSCFG_ITLINE21 << 0x18U) | SYSCFG_ITLINE21_SR_TIM16_GLB)   /*!< TIM16 Interrupt */
+#if defined (FDCAN1) || defined (FDCAN2)
+#define HAL_ITLINE_FDCAN1_IT0     ((HAL_SYSCFG_ITLINE21 << 0x18U) | SYSCFG_ITLINE21_SR_FDCAN1_IT0)  /*!< FDCAN1_IT0 Interrupt */
+#define HAL_ITLINE_FDCAN2_IT0     ((HAL_SYSCFG_ITLINE21 << 0x18U) | SYSCFG_ITLINE21_SR_FDCAN2_IT0)  /*!< FDCAN2_IT0 Interrupt */
+#endif /* FDCAN1 || FDCAN2 */
 #define HAL_ITLINE_TIM17          ((HAL_SYSCFG_ITLINE22 << 0x18U) | SYSCFG_ITLINE22_SR_TIM17_GLB)   /*!< TIM17 Interrupt */
+#if defined (FDCAN1) || defined (FDCAN2)
+#define HAL_ITLINE_FDCAN1_IT1     ((HAL_SYSCFG_ITLINE22 << 0x18U) | SYSCFG_ITLINE22_SR_FDCAN1_IT1)  /*!< FDCAN1_IT1 Interrupt */
+#define HAL_ITLINE_FDCAN2_IT1     ((HAL_SYSCFG_ITLINE22 << 0x18U) | SYSCFG_ITLINE22_SR_FDCAN2_IT1)  /*!< FDCAN2_IT1 Interrupt */
+#endif /* FDCAN1 || FDCAN2 */
 #define HAL_ITLINE_I2C1           ((HAL_SYSCFG_ITLINE23 << 0x18U) | SYSCFG_ITLINE23_SR_I2C1_GLB)    /*!< I2C1 Interrupt -> exti[23] */
-#define HAL_ITLINE_I2C2           ((HAL_SYSCFG_ITLINE24 << 0x18U) | SYSCFG_ITLINE24_SR_I2C2_GLB)    /*!< I2C2 Interrupt */
+#define HAL_ITLINE_I2C2           ((HAL_SYSCFG_ITLINE24 << 0x18U) | SYSCFG_ITLINE24_SR_I2C2_GLB)    /*!< I2C2 Interrupt -> exti[24] */
+#if defined (I2C3)
+#define HAL_ITLINE_I2C3           ((HAL_SYSCFG_ITLINE24 << 0x18U) | SYSCFG_ITLINE24_SR_I2C3_GLB)    /*!< I2C3 Interrupt -> exti[22] */
+#endif /* I2C3 */
 #define HAL_ITLINE_SPI1           ((HAL_SYSCFG_ITLINE25 << 0x18U) | SYSCFG_ITLINE25_SR_SPI1)        /*!< SPI1 Interrupt  */
 #define HAL_ITLINE_SPI2           ((HAL_SYSCFG_ITLINE26 << 0x18U) | SYSCFG_ITLINE26_SR_SPI2)        /*!< SPI2 Interrupt */
+#if defined (SPI3)
+#define HAL_ITLINE_SPI3           ((HAL_SYSCFG_ITLINE26 << 0x18U) | SYSCFG_ITLINE26_SR_SPI3)        /*!< SPI3 Interrupt */
+#endif /* SPI3 */
 #define HAL_ITLINE_USART1         ((HAL_SYSCFG_ITLINE27 << 0x18U) | SYSCFG_ITLINE27_SR_USART1_GLB)  /*!< USART1 GLB Interrupt -> exti[25] */
 #define HAL_ITLINE_USART2         ((HAL_SYSCFG_ITLINE28 << 0x18U) | SYSCFG_ITLINE28_SR_USART2_GLB)  /*!< USART2 GLB Interrupt -> exti[26] */
+#if defined (LPUART2)
+#define HAL_ITLINE_LPUART2        ((HAL_SYSCFG_ITLINE28 << 0x18U) | SYSCFG_ITLINE28_SR_LPUART2_GLB)  /*!< LPUART2 GLB Interrupt -> exti[26] */
+#endif /* LPUART2 */
 #if defined(USART3)
 #define HAL_ITLINE_USART3         ((HAL_SYSCFG_ITLINE29 << 0x18U) | SYSCFG_ITLINE29_SR_USART3_GLB)  /*!< USART3 Interrupt .... */
-#endif
+#endif /* USART3 */
 #if defined(USART4)
 #define HAL_ITLINE_USART4         ((HAL_SYSCFG_ITLINE29 << 0x18U) | SYSCFG_ITLINE29_SR_USART4_GLB)  /*!< USART4 Interrupt .... */
-#endif
+#endif /* USART4 */
 #if defined (LPUART1)
 #define HAL_ITLINE_LPUART1        ((HAL_SYSCFG_ITLINE29 << 0x18U) | SYSCFG_ITLINE29_SR_LPUART1_GLB) /*!< LPUART1 Interrupt -> exti[28]*/
-#endif
+#endif /* LPUART1 */
+#if defined (USART5)
+#define HAL_ITLINE_USART5         ((HAL_SYSCFG_ITLINE29 << 0x18U) | SYSCFG_ITLINE29_SR_USART5_GLB)  /*!< USART5 Interrupt .... */
+#endif /* USART5 */
+#if defined (USART6)
+#define HAL_ITLINE_USART6         ((HAL_SYSCFG_ITLINE29 << 0x18U) | SYSCFG_ITLINE29_SR_USART6_GLB)  /*!< USART6 Interrupt .... */
+#endif /* USART6 */
 #if defined (CEC)
 #define HAL_ITLINE_CEC            ((HAL_SYSCFG_ITLINE30 << 0x18U) | SYSCFG_ITLINE30_SR_CEC)         /*!< CEC Interrupt -> exti[27] */
-#endif
+#endif /* CEC */
 #if defined (RNG)
 #define HAL_ITLINE_RNG            ((HAL_SYSCFG_ITLINE31 << 0x18U) | SYSCFG_ITLINE31_SR_RNG)         /*!< RNG Interrupt */
-#endif
+#endif /* RNG */
 #if defined (AES)
 #define HAL_ITLINE_AES            ((HAL_SYSCFG_ITLINE31 << 0x18U) | SYSCFG_ITLINE31_SR_AES)         /*!< AES Interrupt */
-#endif
+#endif /* AES */
+/**
+  * @}
+  */
+
 /**
   * @}
   */
@@ -366,77 +415,87 @@ extern "C" {
 #if defined(DBG_APB_FZ1_DBG_TIM2_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM2()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM2_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM2()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM2_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_TIM2_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_TIM3_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM3()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM3_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM3()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM3_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_TIM3_STOP */
+
+#if defined(DBG_APB_FZ1_DBG_TIM4_STOP)
+#define __HAL_DBGMCU_FREEZE_TIM4()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM4_STOP)
+#define __HAL_DBGMCU_UNFREEZE_TIM4()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM4_STOP)
+#endif /* DBG_APB_FZ1_DBG_TIM4_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_TIM6_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM6()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM6_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM6()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM6_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_TIM6_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_TIM7_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM7()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM7_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM7()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_TIM7_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_TIM7_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_RTC_STOP)
 #define __HAL_DBGMCU_FREEZE_RTC()            SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_RTC_STOP)
 #define __HAL_DBGMCU_UNFREEZE_RTC()          CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_RTC_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_RTC_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_WWDG_STOP)
 #define __HAL_DBGMCU_FREEZE_WWDG()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_WWDG_STOP)
 #define __HAL_DBGMCU_UNFREEZE_WWDG()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_WWDG_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_WWDG_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_IWDG_STOP)
 #define __HAL_DBGMCU_FREEZE_IWDG()           SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_IWDG_STOP)
 #define __HAL_DBGMCU_UNFREEZE_IWDG()         CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_IWDG_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_IWDG_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP)
 #define __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT()   SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP)
 #define __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT() CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP */
+
+#if defined(DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP)
+#define __HAL_DBGMCU_FREEZE_I2C2_TIMEOUT()   SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP)
+#define __HAL_DBGMCU_UNFREEZE_I2C2_TIMEOUT() CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP)
+#endif /* DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_LPTIM1_STOP)
 #define __HAL_DBGMCU_FREEZE_LPTIM1()         SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_LPTIM1_STOP)
 #define __HAL_DBGMCU_UNFREEZE_LPTIM1()       CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_LPTIM1_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_LPTIM1_STOP */
 
 #if defined(DBG_APB_FZ1_DBG_LPTIM2_STOP)
 #define __HAL_DBGMCU_FREEZE_LPTIM2()         SET_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_LPTIM2_STOP)
 #define __HAL_DBGMCU_UNFREEZE_LPTIM2()       CLEAR_BIT(DBG->APBFZ1, DBG_APB_FZ1_DBG_LPTIM2_STOP)
-#endif
+#endif /* DBG_APB_FZ1_DBG_LPTIM2_STOP */
 
 #if defined(DBG_APB_FZ2_DBG_TIM1_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM1()           SET_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM1_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM1()         CLEAR_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM1_STOP)
-#endif
+#endif /* DBG_APB_FZ2_DBG_TIM1_STOP */
 
 #if defined(DBG_APB_FZ2_DBG_TIM14_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM14()          SET_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM14_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM14()        CLEAR_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM14_STOP)
-#endif
+#endif /* DBG_APB_FZ2_DBG_TIM14_STOP */
 
 #if defined(DBG_APB_FZ2_DBG_TIM15_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM15()          SET_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM15_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM15()        CLEAR_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM15_STOP)
-#endif
+#endif /* DBG_APB_FZ2_DBG_TIM15_STOP */
 
 #if defined(DBG_APB_FZ2_DBG_TIM16_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM16()          SET_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM16_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM16()        CLEAR_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM16_STOP)
-#endif
+#endif /* DBG_APB_FZ2_DBG_TIM16_STOP */
 
 #if defined(DBG_APB_FZ2_DBG_TIM17_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM17()          SET_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM17_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM17()        CLEAR_BIT(DBG->APBFZ2, DBG_APB_FZ2_DBG_TIM17_STOP)
-#endif
+#endif /* DBG_APB_FZ2_DBG_TIM17_STOP */
 
 /**
   * @}
@@ -446,9 +505,15 @@ extern "C" {
   * @{
   */
 
+/**
+  * @brief ISR wrapper check
+  * @note Allow to determine interrupt source per line.
+  */
+#define __HAL_GET_PENDING_IT(__SOURCE__)     (SYSCFG->IT_LINE_SR[((__SOURCE__) >> 0x18U)] & ((__SOURCE__) & 0x00FFFFFF))
+
 /** @brief  Main Flash memory mapped at 0x00000000
   */
-#define __HAL_SYSCFG_REMAPMEMORY_FLASH()       CLEAR_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_MEM_MODE)
+#define __HAL_SYSCFG_REMAPMEMORY_FLASH()     CLEAR_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_MEM_MODE)
 
 /** @brief  System Flash memory mapped at 0x00000000
   */
@@ -456,7 +521,8 @@ extern "C" {
 
 /** @brief  Embedded SRAM mapped at 0x00000000
   */
-#define __HAL_SYSCFG_REMAPMEMORY_SRAM()        MODIFY_REG(SYSCFG->CFGR1, SYSCFG_CFGR1_MEM_MODE, (SYSCFG_CFGR1_MEM_MODE_1|SYSCFG_CFGR1_MEM_MODE_0))
+#define __HAL_SYSCFG_REMAPMEMORY_SRAM() \
+  MODIFY_REG(SYSCFG->CFGR1, SYSCFG_CFGR1_MEM_MODE, (SYSCFG_CFGR1_MEM_MODE_1|SYSCFG_CFGR1_MEM_MODE_0))
 
 /**
   * @brief  Return the boot mode as configured by user.
@@ -484,7 +550,7 @@ extern "C" {
   * @note   The selected configuration is locked and can be unlocked only by system reset
   */
 #define __HAL_SYSCFG_BREAK_PVD_LOCK()           SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_PVDL)
-#endif
+#endif /* SYSCFG_CFGR2_PVDL */
 
 /** @brief  SYSCFG Break SRAM PARITY lock
   *         Enables and locks the SRAM_PARITY error signal with Break Input of TIMER1/15/16/17
@@ -513,7 +579,7 @@ extern "C" {
                                                                 CLEAR_BIT(SYSCFG->CFGR1, (__FASTMODEPLUS__));\
                                                                }while(0U)
 
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 /** @brief  Clamping Diode on specific pins enable/disable macros
   * @param __PIN__ This parameter can be a combination of values @ref SYSCFG_ClampingDiode
   */
@@ -524,12 +590,13 @@ extern "C" {
 #define __HAL_SYSCFG_CLAMPINGDIODE_DISABLE(__PIN__) do {assert_param(IS_SYSCFG_CLAMPINGDIODE((__PIN__)));\
                                                                 CLEAR_BIT(SYSCFG->CFGR2, (__PIN__));\
                                                                }while(0U)
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 
 /** @brief  ISR wrapper check
   * @note Allow to determine interrupt source per line.
   */
-#define __HAL_SYSCFG_GET_PENDING_IT(__SOURCE__)       (SYSCFG->IT_LINE_SR[((__SOURCE__) >> 0x18U)] & ((__SOURCE__) & 0x00FFFFFFU))
+#define __HAL_SYSCFG_GET_PENDING_IT(__SOURCE__)  \
+  (SYSCFG->IT_LINE_SR[((__SOURCE__) >> 0x18U)] & ((__SOURCE__) & 0x00FFFFFFU))
 
 /** @brief  selection of the modulation envelope signal macro, using bits [7:6] of SYSCFG_CFGR1 register
   * @param __SOURCE__ This parameter can be a value of @ref HAL_IR_ENV_SEL
@@ -589,9 +656,9 @@ extern "C" {
 #define IS_SYSCFG_BREAK_CONFIG(__CONFIG__) (((__CONFIG__) == SYSCFG_BREAK_SP)        || \
                                             ((__CONFIG__) == SYSCFG_BREAK_ECC)       || \
                                             ((__CONFIG__) == SYSCFG_BREAK_LOCKUP))
-#endif
+#endif /* PWR_PVD_SUPPORT */
 
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 #define IS_SYSCFG_CLAMPINGDIODE(__PIN__) ((((__PIN__) & SYSCFG_CDEN_PA1)  == SYSCFG_CDEN_PA1)  || \
                                           (((__PIN__) & SYSCFG_CDEN_PA3)  == SYSCFG_CDEN_PA3)  || \
                                           (((__PIN__) & SYSCFG_CDEN_PA5)  == SYSCFG_CDEN_PA5)  || \
@@ -600,17 +667,17 @@ extern "C" {
                                           (((__PIN__) & SYSCFG_CDEN_PB0)  == SYSCFG_CDEN_PB0)  || \
                                           (((__PIN__) & SYSCFG_CDEN_PB1)  == SYSCFG_CDEN_PB1)  || \
                                           (((__PIN__) & SYSCFG_CDEN_PB2)  == SYSCFG_CDEN_PB2))
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 
-#if defined (STM32G081xx) || defined (STM32G071xx) || defined (STM32G070xx)
+#if defined (USART4)
 #define IS_HAL_SYSCFG_IRDA_ENV_SEL(SEL)   (((SEL) == HAL_SYSCFG_IRDA_ENV_SEL_TIM16)   || \
                                            ((SEL) == HAL_SYSCFG_IRDA_ENV_SEL_USART1)  || \
                                            ((SEL) == HAL_SYSCFG_IRDA_ENV_SEL_USART4))
-#elif defined (STM32G041xx) || defined (STM32G031xx) || defined (STM32G030xx)
+#else
 #define IS_HAL_SYSCFG_IRDA_ENV_SEL(SEL)   (((SEL) == HAL_SYSCFG_IRDA_ENV_SEL_TIM16)   || \
                                            ((SEL) == HAL_SYSCFG_IRDA_ENV_SEL_USART1)  || \
                                            ((SEL) == HAL_SYSCFG_IRDA_ENV_SEL_USART2))
-#endif
+#endif /* USART4 */
 #define IS_HAL_SYSCFG_IRDA_POL_SEL(SEL)   (((SEL) == HAL_SYSCFG_IRDA_POLARITY_NOT_INVERTED)   || \
                                            ((SEL) == HAL_SYSCFG_IRDA_POLARITY_INVERTED))
 
@@ -618,7 +685,7 @@ extern "C" {
 #define IS_SYSCFG_DBATT_CONFIG(__CONFIG__) (((__CONFIG__) == SYSCFG_UCPD1_STROBE) || \
                                             ((__CONFIG__) == SYSCFG_UCPD2_STROBE) || \
                                             ((__CONFIG__) == (SYSCFG_UCPD1_STROBE | SYSCFG_UCPD2_STROBE)))
-#endif
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE || SYSCFG_CFGR1_UCPD2_STROBE */
 #if defined(VREFBUF)
 #define IS_SYSCFG_VREFBUF_VOLTAGE_SCALE(__SCALE__)  (((__SCALE__) == SYSCFG_VREFBUF_VOLTAGE_SCALE0) || \
                                                      ((__SCALE__) == SYSCFG_VREFBUF_VOLTAGE_SCALE1))
@@ -682,8 +749,8 @@ void HAL_IncTick(void);
 void HAL_Delay(uint32_t Delay);
 uint32_t HAL_GetTick(void);
 uint32_t HAL_GetTickPrio(void);
-HAL_StatusTypeDef HAL_SetTickFreq(uint32_t Freq);
-uint32_t HAL_GetTickFreq(void);
+HAL_StatusTypeDef HAL_SetTickFreq(HAL_TickFreqTypeDef Freq);
+HAL_TickFreqTypeDef HAL_GetTickFreq(void);
 void HAL_SuspendTick(void);
 void HAL_ResumeTick(void);
 uint32_t HAL_GetHalVersion(void);
@@ -717,7 +784,7 @@ void HAL_DBGMCU_DisableDBGStandbyMode(void);
   */
 extern __IO uint32_t uwTick;
 extern uint32_t uwTickPrio;
-extern uint32_t uwTickFreq;
+extern HAL_TickFreqTypeDef uwTickFreq;
 /**
   * @}
   */
@@ -740,13 +807,13 @@ void HAL_SYSCFG_EnableIOAnalogSwitchBooster(void);
 void HAL_SYSCFG_DisableIOAnalogSwitchBooster(void);
 void HAL_SYSCFG_EnableRemap(uint32_t PinRemap);
 void HAL_SYSCFG_DisableRemap(uint32_t PinRemap);
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 void HAL_SYSCFG_EnableClampingDiode(uint32_t PinConfig);
 void HAL_SYSCFG_DisableClampingDiode(uint32_t PinConfig);
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 #if defined (SYSCFG_CFGR1_UCPD1_STROBE) || defined (SYSCFG_CFGR1_UCPD2_STROBE)
 void HAL_SYSCFG_StrobeDBattpinsConfig(uint32_t ConfigDeadBattery);
-#endif
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE || SYSCFG_CFGR1_UCPD2_STROBE */
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_adc.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_adc.h
@@ -22,7 +22,7 @@
 #define STM32G0xx_HAL_ADC_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -58,7 +58,7 @@ typedef struct
   uint32_t TriggeredMode;                 /*!< Selects the regular triggered oversampling mode.
                                                This parameter can be a value of @ref ADC_HAL_EC_OVS_DISCONT_MODE */
 
-}ADC_OversamplingTypeDef;
+} ADC_OversamplingTypeDef;
 
 /**
   * @brief  Structure definition of ADC instance and ADC group regular.
@@ -94,7 +94,7 @@ typedef struct
                                        This parameter can be a value of @ref ADC_HAL_EC_DATA_ALIGN */
 
   uint32_t ScanConvMode;          /*!< Configure the sequencer of ADC group regular.
-                                       On this STM32 serie, ADC group regular sequencer both modes "fully configurable" or "not fully configurable" are
+                                       On this STM32 series, ADC group regular sequencer both modes "fully configurable" or "not fully configurable" are
                                        available:
                                         - sequencer configured to fully configurable:
                                           sequencer length and each rank affectation to a channel are configurable.
@@ -125,8 +125,8 @@ typedef struct
                                        This feature automatically adapts the frequency of ADC conversions triggers to the speed of the system that reads the data. Moreover, this avoids risk of overrun
                                        for low frequency applications.
                                        This parameter can be set to ENABLE or DISABLE.
-                                       Note: Do not use with interruption or DMA (HAL_ADC_Start_IT(), HAL_ADC_Start_DMA()) since they clear immediately the EOC flag
-                                             to free the IRQ vector sequencer.
+                                       Note: It is not recommended to use with interruption or DMA (HAL_ADC_Start_IT(), HAL_ADC_Start_DMA()) since these modes have to clear immediately the EOC flag (by CPU to free the IRQ pending event or by DMA).
+                                             Auto wait will work but fort a very short time, discarding its intended benefit (except specific case of high load of CPU or DMA transfers which can justify usage of auto wait).
                                              Do use with polling: 1. Start conversion with HAL_ADC_Start(), 2. Later on, when ADC conversion data is needed:
                                              use HAL_ADC_PollForConversion() to ensure that conversion is completed and HAL_ADC_GetValue() to retrieve conversion result and trig another conversion start. */
 
@@ -156,7 +156,7 @@ typedef struct
                                        Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
                                        Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
                                        This parameter can be set to ENABLE or DISABLE.
-                                       Note: On this STM32 serie, ADC group regular number of discontinuous ranks increment is fixed to one-by-one. */
+                                       Note: On this STM32 series, ADC group regular number of discontinuous ranks increment is fixed to one-by-one. */
 
   uint32_t ExternalTrigConv;      /*!< Select the external event source used to trigger ADC group regular conversion start.
                                        If set to ADC_SOFTWARE_START, external triggers are disabled and software trigger is used instead.
@@ -218,7 +218,7 @@ typedef struct
                                              some rearm cycles are inserted before performing ADC conversion
                                              start, inducing a delay of 2 ADC clock cycles. */
 
-}ADC_InitTypeDef;
+} ADC_InitTypeDef;
 
 /**
   * @brief  Structure definition of ADC channel for regular group
@@ -257,7 +257,7 @@ typedef struct
                                               sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
                                               Refer to device datasheet for timings values. */
 
-}ADC_ChannelConfTypeDef;
+} ADC_ChannelConfTypeDef;
 
 /**
   * @brief  Structure definition of ADC analog watchdog
@@ -305,7 +305,7 @@ typedef struct
                                          impacted: the comparison of analog watchdog thresholds is done on
                                          oversampling final computation (after ratio and shift application):
                                          ADC data register bitfield [15:4] (12 most significant bits). */
-}ADC_AnalogWDGConfTypeDef;
+} ADC_AnalogWDGConfTypeDef;
 
 /** @defgroup ADC_States ADC States
   * @{
@@ -335,13 +335,13 @@ typedef struct
                                                               external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available)) */
 #define HAL_ADC_STATE_REG_EOC           (0x00000200UL)   /*!< Conversion data available on group regular */
 #define HAL_ADC_STATE_REG_OVR           (0x00000400UL)   /*!< Overrun occurrence */
-#define HAL_ADC_STATE_REG_EOSMP         (0x00000800UL)   /*!< Not available on this STM32 serie: End Of Sampling flag raised  */
+#define HAL_ADC_STATE_REG_EOSMP         (0x00000800UL)   /*!< Not available on this STM32 series: End Of Sampling flag raised  */
 
 /* States of ADC group injected */
-#define HAL_ADC_STATE_INJ_BUSY          (0x00001000UL)  /*!< Not available on this STM32 serie: A conversion on group injected is ongoing or can occur (either by auto-injection mode,
+#define HAL_ADC_STATE_INJ_BUSY          (0x00001000UL)  /*!< Not available on this STM32 series: A conversion on group injected is ongoing or can occur (either by auto-injection mode,
                                                              external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available))*/
-#define HAL_ADC_STATE_INJ_EOC           (0x00002000UL)  /*!< Not available on this STM32 serie: Conversion data available on group injected */
-#define HAL_ADC_STATE_INJ_JQOVF         (0x00004000UL)  /*!< Not available on this STM32 serie: Injected queue overflow occurrence */
+#define HAL_ADC_STATE_INJ_EOC           (0x00002000UL)  /*!< Not available on this STM32 series: Conversion data available on group injected */
+#define HAL_ADC_STATE_INJ_JQOVF         (0x00004000UL)  /*!< Not available on this STM32 series: Injected queue overflow occurrence */
 
 /* States of ADC analog watchdogs */
 #define HAL_ADC_STATE_AWD1              (0x00010000UL)   /*!< Out-of-window occurrence of ADC analog watchdog 1 */
@@ -349,7 +349,7 @@ typedef struct
 #define HAL_ADC_STATE_AWD3              (0x00040000UL)   /*!< Out-of-window occurrence of ADC analog watchdog 3 */
 
 /* States of ADC multi-mode */
-#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000UL)   /*!< Not available on this STM32 serie: ADC in multimode slave state, controlled by another ADC master (when feature available) */
+#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000UL)   /*!< Not available on this STM32 series: ADC in multimode slave state, controlled by another ADC master (when feature available) */
 
 
 /**
@@ -363,7 +363,7 @@ typedef struct
 typedef struct __ADC_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
 {
   ADC_TypeDef                   *Instance;              /*!< Register base address */
   ADC_InitTypeDef               Init;                   /*!< ADC initialization parameters and regular conversions setting */
@@ -384,7 +384,7 @@ typedef struct
   void (* MspInitCallback)(struct __ADC_HandleTypeDef *hadc);               /*!< ADC Msp Init callback */
   void (* MspDeInitCallback)(struct __ADC_HandleTypeDef *hadc);             /*!< ADC Msp DeInit callback */
 #endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
-}ADC_HandleTypeDef;
+} ADC_HandleTypeDef;
 
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
 /**
@@ -474,7 +474,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @{
   */
 #define ADC_DATAALIGN_RIGHT                (LL_ADC_DATA_ALIGN_RIGHT)/*!< ADC conversion data alignment: right aligned (alignment on data register LSB bit 0)*/
-#define ADC_DATAALIGN_LEFT                 (LL_ADC_DATA_ALIGN_LEFT)       /*!< ADC conversion data alignment: left aligned (aligment on data register MSB bit 15)*/
+#define ADC_DATAALIGN_LEFT                 (LL_ADC_DATA_ALIGN_LEFT)       /*!< ADC conversion data alignment: left aligned (alignment on data register MSB bit 15)*/
 /**
   * @}
   */
@@ -518,6 +518,9 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_EXTERNALTRIG_T2_TRGO      (LL_ADC_REG_TRIG_EXT_TIM2_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM2 TRGO. Trigger edge set to rising edge (default setting). */
 #endif
 #define ADC_EXTERNALTRIG_T3_TRGO      (LL_ADC_REG_TRIG_EXT_TIM3_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM3 TRGO. Trigger edge set to rising edge (default setting). */
+#if defined(TIM4)
+#define ADC_EXTERNALTRIG_T4_TRGO      (LL_ADC_REG_TRIG_EXT_TIM4_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM4 TRGO. Trigger edge set to rising edge (default setting). */
+#endif
 #if defined(TIM6)
 #define ADC_EXTERNALTRIG_T6_TRGO      (LL_ADC_REG_TRIG_EXT_TIM6_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM6 TRGO. Trigger edge set to rising edge (default setting). */
 #endif
@@ -823,7 +826,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /**
   * @brief Enable ADC overrun mode.
   * @param _OVERRUN_MODE_ Overrun mode.
-  * @retval Overun bit setting to be programmed into CFGR register
+  * @retval Overrun bit setting to be programmed into CFGR register
   */
 /* Note: Bit ADC_CFGR1_OVRMOD not used directly in constant                   */
 /* "ADC_OVR_DATA_OVERWRITTEN" to have this case defined to 0x00, to set it    */
@@ -846,9 +849,9 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_SCAN_SEQ_MODE(_SCAN_MODE_)                                         \
   ( (((_SCAN_MODE_) & ADC_SCAN_SEQ_FIXED_INT) != 0UL                           \
     )?                                                                         \
-     ((_SCAN_MODE_) & (~ADC_SCAN_SEQ_FIXED_INT))                               \
-     :                                                                         \
-     (ADC_CFGR1_CHSELRMOD)                                                     \
+    ((_SCAN_MODE_) & (~ADC_SCAN_SEQ_FIXED_INT))                                \
+    :                                                                          \
+    (ADC_CFGR1_CHSELRMOD)                                                      \
   )
 
 /**
@@ -1062,14 +1065,14 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
 #define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__)                               \
   do{                                                                          \
-     (__HANDLE__)->State = HAL_ADC_STATE_RESET;                               \
-     (__HANDLE__)->MspInitCallback = NULL;                                     \
-     (__HANDLE__)->MspDeInitCallback = NULL;                                   \
-    } while(0)
+    (__HANDLE__)->State = HAL_ADC_STATE_RESET;                                 \
+    (__HANDLE__)->MspInitCallback = NULL;                                      \
+    (__HANDLE__)->MspDeInitCallback = NULL;                                    \
+  } while(0)
 #else
 #define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__)                               \
   ((__HANDLE__)->State = HAL_ADC_STATE_RESET)
-#endif
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
 
 /**
   * @brief Enable ADC interrupt.
@@ -1213,7 +1216,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @retval Value between Min_Data=0 and Max_Data=18
   */
 #define __HAL_ADC_CHANNEL_TO_DECIMAL_NB(__CHANNEL__)                           \
-         __LL_ADC_CHANNEL_TO_DECIMAL_NB((__CHANNEL__))
+  __LL_ADC_CHANNEL_TO_DECIMAL_NB((__CHANNEL__))
 
 /**
   * @brief  Helper macro to get ADC channel in literal format ADC_CHANNEL_x
@@ -1254,7 +1257,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *             using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
   */
 #define __HAL_ADC_DECIMAL_NB_TO_CHANNEL(__DECIMAL_NB__)                        \
-         __LL_ADC_DECIMAL_NB_TO_CHANNEL((__DECIMAL_NB__))
+  __LL_ADC_DECIMAL_NB_TO_CHANNEL((__DECIMAL_NB__))
 
 /**
   * @brief  Helper macro to determine whether the selected channel
@@ -1304,7 +1307,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *         Value "1" if the channel corresponds to a parameter definition of a ADC internal channel.
   */
 #define __HAL_ADC_IS_CHANNEL_INTERNAL(__CHANNEL__)                             \
-         __LL_ADC_IS_CHANNEL_INTERNAL((__CHANNEL__))
+  __LL_ADC_IS_CHANNEL_INTERNAL((__CHANNEL__))
 
 /**
   * @brief  Helper macro to convert a channel defined from parameter
@@ -1368,7 +1371,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *         @arg @ref ADC_CHANNEL_18
   */
 #define __HAL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL(__CHANNEL__)                    \
-         __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL((__CHANNEL__))
+  __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL((__CHANNEL__))
 
 /**
   * @brief  Helper macro to determine whether the internal channel
@@ -1392,7 +1395,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *         Value "1" if the internal channel selected is available on the ADC instance selected.
   */
 #define __HAL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE(__ADC_INSTANCE__, __CHANNEL__)  \
-         __LL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE((__ADC_INSTANCE__), (__CHANNEL__))
+  __LL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE((__ADC_INSTANCE__), (__CHANNEL__))
 
 /**
   * @brief  Helper macro to select the ADC common instance
@@ -1405,7 +1408,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @retval ADC common register instance
   */
 #define __HAL_ADC_COMMON_INSTANCE(__ADCx__)                                    \
-         __LL_ADC_COMMON_INSTANCE((__ADCx__))
+  __LL_ADC_COMMON_INSTANCE((__ADCx__))
 
 /**
   * @brief  Helper macro to check if all ADC instances sharing the same
@@ -1425,7 +1428,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *         is enabled.
   */
 #define __HAL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__ADCXY_COMMON__)              \
-         __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE((__ADCXY_COMMON__))
+  __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE((__ADCXY_COMMON__))
 
 /**
   * @brief  Helper macro to define the ADC conversion data full-scale digital
@@ -1441,7 +1444,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @retval ADC conversion data full-scale digital value
   */
 #define __HAL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                             \
-         __LL_ADC_DIGITAL_SCALE((__ADC_RESOLUTION__))
+  __LL_ADC_DIGITAL_SCALE((__ADC_RESOLUTION__))
 
 /**
   * @brief  Helper macro to convert the ADC conversion data from
@@ -1463,10 +1466,10 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   */
 #define __HAL_ADC_CONVERT_DATA_RESOLUTION(__DATA__,\
                                           __ADC_RESOLUTION_CURRENT__,\
-                                          __ADC_RESOLUTION_TARGET__)            \
-         __LL_ADC_CONVERT_DATA_RESOLUTION((__DATA__),\
-                                          (__ADC_RESOLUTION_CURRENT__),\
-                                          (__ADC_RESOLUTION_TARGET__))
+                                          __ADC_RESOLUTION_TARGET__) \
+__LL_ADC_CONVERT_DATA_RESOLUTION((__DATA__),\
+                                 (__ADC_RESOLUTION_CURRENT__),\
+                                 (__ADC_RESOLUTION_TARGET__))
 
 /**
   * @brief  Helper macro to calculate the voltage (unit: mVolt)
@@ -1486,10 +1489,10 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   */
 #define __HAL_ADC_CALC_DATA_TO_VOLTAGE(__VREFANALOG_VOLTAGE__,\
                                        __ADC_DATA__,\
-                                       __ADC_RESOLUTION__)                     \
-         __LL_ADC_CALC_DATA_TO_VOLTAGE((__VREFANALOG_VOLTAGE__),\
-                                       (__ADC_DATA__),\
-                                       (__ADC_RESOLUTION__))
+                                       __ADC_RESOLUTION__) \
+__LL_ADC_CALC_DATA_TO_VOLTAGE((__VREFANALOG_VOLTAGE__),\
+                              (__ADC_DATA__),\
+                              (__ADC_RESOLUTION__))
 
 /**
   * @brief  Helper macro to calculate analog reference voltage (Vref+)
@@ -1501,7 +1504,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *         connected to pin Vref+.
   *         On devices with small package, the pin Vref+ is not present
   *         and internally bonded to pin Vdda.
-  * @note   On this STM32 serie, calibration data of internal voltage reference
+  * @note   On this STM32 series, calibration data of internal voltage reference
   *         VrefInt corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         internal voltage reference VrefInt.
@@ -1517,9 +1520,9 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @retval Analog reference voltage (unit: mV)
   */
 #define __HAL_ADC_CALC_VREFANALOG_VOLTAGE(__VREFINT_ADC_DATA__,\
-                                          __ADC_RESOLUTION__)                  \
-         __LL_ADC_CALC_VREFANALOG_VOLTAGE((__VREFINT_ADC_DATA__),\
-                                          (__ADC_RESOLUTION__))
+                                          __ADC_RESOLUTION__) \
+__LL_ADC_CALC_VREFANALOG_VOLTAGE((__VREFINT_ADC_DATA__),\
+                                 (__ADC_RESOLUTION__))
 
 /**
   * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
@@ -1548,7 +1551,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @note   Analog reference voltage (Vref+) must be either known from
   *         user board environment or can be calculated using ADC measurement
   *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
-  * @note   On this STM32 serie, calibration data of temperature sensor
+  * @note   On this STM32 series, calibration data of temperature sensor
   *         corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         temperature sensor.
@@ -1568,10 +1571,10 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   */
 #define __HAL_ADC_CALC_TEMPERATURE(__VREFANALOG_VOLTAGE__,\
                                    __TEMPSENSOR_ADC_DATA__,\
-                                   __ADC_RESOLUTION__)                         \
-         __LL_ADC_CALC_TEMPERATURE((__VREFANALOG_VOLTAGE__),\
-                                   (__TEMPSENSOR_ADC_DATA__),\
-                                   (__ADC_RESOLUTION__))
+                                   __ADC_RESOLUTION__) \
+__LL_ADC_CALC_TEMPERATURE((__VREFANALOG_VOLTAGE__),\
+                          (__TEMPSENSOR_ADC_DATA__),\
+                          (__ADC_RESOLUTION__))
 
 /**
   * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
@@ -1622,13 +1625,13 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
                                               __TEMPSENSOR_CALX_TEMP__,\
                                               __VREFANALOG_VOLTAGE__,\
                                               __TEMPSENSOR_ADC_DATA__,\
-                                              __ADC_RESOLUTION__)              \
-         __LL_ADC_CALC_TEMPERATURE_TYP_PARAMS((__TEMPSENSOR_TYP_AVGSLOPE__),\
-                                              (__TEMPSENSOR_TYP_CALX_V__),\
-                                              (__TEMPSENSOR_CALX_TEMP__),\
-                                              (__VREFANALOG_VOLTAGE__),\
-                                              (__TEMPSENSOR_ADC_DATA__),\
-                                              (__ADC_RESOLUTION__))
+                                              __ADC_RESOLUTION__) \
+__LL_ADC_CALC_TEMPERATURE_TYP_PARAMS((__TEMPSENSOR_TYP_AVGSLOPE__),\
+                                     (__TEMPSENSOR_TYP_CALX_V__),\
+                                     (__TEMPSENSOR_CALX_TEMP__),\
+                                     (__VREFANALOG_VOLTAGE__),\
+                                     (__TEMPSENSOR_ADC_DATA__),\
+                                     (__ADC_RESOLUTION__))
 
 /**
   * @}
@@ -1651,14 +1654,15 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @{
   */
 /* Initialization and de-initialization functions  ****************************/
-HAL_StatusTypeDef       HAL_ADC_Init(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Init(ADC_HandleTypeDef *hadc);
 HAL_StatusTypeDef       HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
-void                    HAL_ADC_MspInit(ADC_HandleTypeDef* hadc);
-void                    HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_MspInit(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_MspDeInit(ADC_HandleTypeDef *hadc);
 
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
 /* Callbacks Register/UnRegister functions  ***********************************/
-HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID,
+                                           pADC_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
 /**
@@ -1672,39 +1676,39 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
 /* IO operation functions  *****************************************************/
 
 /* Blocking mode: Polling */
-HAL_StatusTypeDef       HAL_ADC_Start(ADC_HandleTypeDef* hadc);
-HAL_StatusTypeDef       HAL_ADC_Stop(ADC_HandleTypeDef* hadc);
-HAL_StatusTypeDef       HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);
-HAL_StatusTypeDef       HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout);
+HAL_StatusTypeDef       HAL_ADC_Start(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Timeout);
+HAL_StatusTypeDef       HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventType, uint32_t Timeout);
 
 /* Non-blocking mode: Interruption */
-HAL_StatusTypeDef       HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc);
-HAL_StatusTypeDef       HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Start_IT(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop_IT(ADC_HandleTypeDef *hadc);
 
 /* Non-blocking mode: DMA */
-HAL_StatusTypeDef       HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
-HAL_StatusTypeDef       HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc);
 
 /* ADC retrieve conversion value intended to be used with polling or interruption */
-uint32_t                HAL_ADC_GetValue(ADC_HandleTypeDef* hadc);
+uint32_t                HAL_ADC_GetValue(ADC_HandleTypeDef *hadc);
 
 /* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption and DMA) */
-void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc);
-void                    HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc);
-void                    HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
-void                    HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef *hadc);
 void                    HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
 /**
   * @}
   */
 
 /** @addtogroup ADC_Exported_Functions_Group3 Peripheral Control functions
- *  @brief    Peripheral Control functions
- * @{
- */
+  *  @brief    Peripheral Control functions
+  * @{
+  */
 /* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig);
-HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig);
+HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConfTypeDef *sConfig);
+HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDGConfTypeDef *AnalogWDGConfig);
 
 /**
   * @}
@@ -1714,7 +1718,7 @@ HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_Ana
 /** @addtogroup ADC_Exported_Functions_Group4
   * @{
   */
-uint32_t                HAL_ADC_GetState(ADC_HandleTypeDef* hadc);
+uint32_t                HAL_ADC_GetState(ADC_HandleTypeDef *hadc);
 uint32_t                HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
 
 /**
@@ -1726,9 +1730,9 @@ uint32_t                HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
   */
 
 /* Private functions ---------------------------------------------------------*/
-HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc);
-HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc);
-HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef *hadc);
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_adc_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_adc_ex.h
@@ -22,7 +22,7 @@
 #define STM32G0xx_HAL_ADC_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -143,15 +143,15 @@
 /* IO operation functions *****************************************************/
 
 /* ADC calibration */
-HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc);
-uint32_t                HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc);
-HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32_t CalibrationFactor);
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc);
+uint32_t                HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t CalibrationFactor);
 
 /* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption) */
-void                    HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef* hadc);
-void                    HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef* hadc);
-void                    HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef* hadc);
-void                    HAL_ADCEx_ChannelConfigReadyCallback(ADC_HandleTypeDef* hadc);
+void                    HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_ChannelConfigReadyCallback(ADC_HandleTypeDef *hadc);
 
 /**
   * @}
@@ -161,7 +161,7 @@ void                    HAL_ADCEx_ChannelConfigReadyCallback(ADC_HandleTypeDef* 
   * @{
   */
 /* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef       HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef       HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef *hadc);
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_cec.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_cec.h
@@ -121,7 +121,7 @@ typedef struct
   *          b6  Error information
   *             0  : No Error
   *             1  : Error
-  *          b5     CEC peripheral initilisation status
+  *          b5     CEC peripheral initialization status
   *             0  : Reset (peripheral not initialized)
   *             1  : Init done (peripheral initialized. HAL CEC Init function already called)
   *          b4-b3  (not used)
@@ -138,7 +138,7 @@ typedef struct
   *          RxState value coding follow below described bitmap :
   *          b7-b6  (not used)
   *             xx : Should be set to 00
-  *          b5     CEC peripheral initilisation status
+  *          b5     CEC peripheral initialization status
   *             0  : Reset (peripheral not initialized)
   *             1  : Init done (peripheral initialized)
   *          b4-b2  (not used)

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_comp.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_comp.h
@@ -51,7 +51,7 @@ typedef struct
 
   uint32_t WindowMode;         /*!< Set window mode of a pair of comparators instances
                                     (2 consecutive instances odd and even COMP<x> and COMP<x+1>).
-                                    Note: HAL COMP driver allows to set window mode from any COMP instance of the pair of COMP instances composing window mode.
+                                    Note: HAL COMP driver allows to set window mode from any COMP instance of the pair of COMP instances composing window mode, except for window mode with COMP2 and COMP3 (for devices featuring COMP3): it must be set from COMP3 instance.
                                     This parameter can be a value of @ref COMP_WindowMode */
 
   uint32_t WindowOutput;       /*!< Set window mode output.
@@ -160,7 +160,7 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   */
 #define COMP_WINDOWMODE_DISABLE                 (0x00000000UL)         /*!< Window mode disable: Comparators instances pair COMP1 and COMP2 are independent */
 #define COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON (COMP_CSR_WINMODE)     /*!< Window mode enable: Comparators instances pair COMP1 and COMP2 have their input plus connected together. The common input is COMP1 input plus (COMP2 input plus is no more accessible). */
-#define COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (COMP_CSR_WINMODE | COMP_WINDOWMODE_COMP2) /*!< Window mode enable: Comparators instances pair COMP1 and COMP2 have their input plus connected together. The common input is COMP2 input plus (COMP1 input plus is no more accessible). */
+#define COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (COMP_CSR_WINMODE | COMP_WINDOWMODE_COMP2) /*!< Window mode enable: if used from COMP1 or COMP2 instance, comparators instances pair COMP1 and COMP2 have their input plus connected together, the common input is COMP2 input plus (COMP1 input plus is no more accessible). If used from COMP3 instance (when available), comparators instances pair COMP2 and COMP3 have their input plus connected together, the common input is COMP2 input plus (COMP3 input plus is no more accessible). */
 /**
   * @}
   */
@@ -171,7 +171,10 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 #define COMP_WINDOWOUTPUT_EACH_COMP             (0x00000000UL)                            /*!< Window output default mode: Comparators output are indicating each their own state. To know window mode state: each comparator output must be read, if "((COMPx exclusive or COMPy) == 1)" then monitored signal is within comparators window.  */
 #define COMP_WINDOWOUTPUT_COMP1                 (COMP_CSR_WINOUT)                         /*!< Window output synthetized on COMP1 output: COMP1 output is no more indicating its own state, but global window mode state (logical high means monitored signal is within comparators window). */
 #define COMP_WINDOWOUTPUT_COMP2                 (COMP_CSR_WINOUT | COMP_WINDOWMODE_COMP2) /*!< Window output synthetized on COMP2 output: COMP2 output is no more indicating its own state, but global window mode state (logical high means monitored signal is within comparators window). */
-#define COMP_WINDOWOUTPUT_BOTH                  (0x00000001UL)                            /*!< Window output synthetized on both COMP1 and COMP2 output: COMP1 and COMP2 outputs are no more indicating their own state, but global window mode state (logical high means monitored signal is within comparators window). This is a specific configuraton (technically possible but not relevant from application point of view: 2 comparators output used for the same signal level), standard configuraton for window mode is one of the 3 settings above. */
+#if defined(COMP3)
+#define COMP_WINDOWOUTPUT_COMP3                 (COMP_CSR_WINOUT)                         /*!< Window output synthetized on COMP3 output: COMP3 output is no more indicating its own state, but global window mode state (logical high means monitored signal is within comparators window). */
+#endif
+#define COMP_WINDOWOUTPUT_BOTH                  (0x00000001UL)                            /*!< Window output synthetized on both comparators output of pair of comparator selected (COMP1 and COMP2, or COMP2 and COMP3 for devices featuring COMP3 instance): both comparators outputs are no more indicating their own state, but global window mode state (logical high means monitored signal is within comparators window). This is a specific configuration (technically possible but not relevant from application point of view: 2 comparators output used for the same signal level), standard configuration for window mode is one of the settings above. */
 /**
   * @}
   */
@@ -191,9 +194,9 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 /** @defgroup COMP_InputPlus COMP input plus (non-inverting input)
   * @{
   */
-#define COMP_INPUT_PLUS_IO1            (0x00000000UL)         /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1, pin PB4 for COMP2) */
-#define COMP_INPUT_PLUS_IO2            (COMP_CSR_INPSEL_0)    /*!< Comparator input plus connected to IO2 (pin PB2 for COMP1, pin PB6 for COMP2) */
-#define COMP_INPUT_PLUS_IO3            (COMP_CSR_INPSEL_1)    /*!< Comparator input plus connected to IO3 (pin PA1 for COMP1, pin PA3 for COMP2) */
+#define COMP_INPUT_PLUS_IO1            (0x00000000UL)         /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1, pin PB4 for COMP2, pin PB0 for COMP3 (for devices featuring COMP3 instance)) */
+#define COMP_INPUT_PLUS_IO2            (COMP_CSR_INPSEL_0)    /*!< Comparator input plus connected to IO2 (pin PB2 for COMP1, pin PB6 for COMP2, pin PC1 for COMP3 (for devices featuring COMP3 instance)) */
+#define COMP_INPUT_PLUS_IO3            (COMP_CSR_INPSEL_1)    /*!< Comparator input plus connected to IO3 (pin PA1 for COMP1, pin PA3 for COMP2, pin PE7 for COMP3 (for devices featuring COMP3 instance)) */
 /**
   * @}
   */
@@ -207,9 +210,9 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 #define COMP_INPUT_MINUS_VREFINT       (                                        COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to VrefInt */
 #define COMP_INPUT_MINUS_DAC1_CH1      (                    COMP_CSR_INMSEL_2                                        ) /*!< Comparator input minus connected to DAC1 channel 1 (DAC_OUT1)  */
 #define COMP_INPUT_MINUS_DAC1_CH2      (                    COMP_CSR_INMSEL_2                     | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to DAC1 channel 2 (DAC_OUT2)  */
-#define COMP_INPUT_MINUS_IO1           (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1                    ) /*!< Comparator input minus connected to IO1 (pin PA9 for COMP1, pin PB3 for COMP2) */
-#define COMP_INPUT_MINUS_IO2           (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1, pin PB7 for COMP2) */
-#define COMP_INPUT_MINUS_IO3           (COMP_CSR_INMSEL_3                                                            ) /*!< Comparator input minus connected to IO3 (pin PA0 for COMP1, pin PA2 for COMP2) */
+#define COMP_INPUT_MINUS_IO1           (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1                    ) /*!< Comparator input minus connected to IO1 (pin PB1 for COMP1, pin PB3 for COMP2, pin PB2 for COMP3 (for devices featuring COMP3 instance)) */
+#define COMP_INPUT_MINUS_IO2           (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1, pin PB7 for COMP2, pin PC0 for COMP3 (for devices featuring COMP3 instance)) */
+#define COMP_INPUT_MINUS_IO3           (COMP_CSR_INMSEL_3                                                            ) /*!< Comparator input minus connected to IO3 (pin PA0 for COMP1, pin PA2 for COMP2, pin PE8 for COMP3 (for devices featuring COMP3 instance)) */
 /**
   * @}
   */
@@ -239,11 +242,11 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   */
 #define COMP_BLANKINGSRC_NONE            (0x00000000UL)          /*!<Comparator output without blanking */
 /* Note: Output blanking source common to all COMP instances */
-#define COMP_BLANKINGSRC_TIM1_OC4        (COMP_CSR_BLANKING_0)   /*!< Comparator output blanking source TIM1 OC4 (common to all COMP instances: COMP1, COMP2) */
-#define COMP_BLANKINGSRC_TIM1_OC5        (COMP_CSR_BLANKING_1)   /*!< Comparator output blanking source TIM1 OC5 (common to all COMP instances: COMP1, COMP2) */
-#define COMP_BLANKINGSRC_TIM2_OC3        (COMP_CSR_BLANKING_2)   /*!< Comparator output blanking source TIM2 OC3 (common to all COMP instances: COMP1, COMP2) */
-#define COMP_BLANKINGSRC_TIM3_OC3        (COMP_CSR_BLANKING_3)   /*!< Comparator output blanking source TIM3 OC3 (common to all COMP instances: COMP1, COMP2) */
-#define COMP_BLANKINGSRC_TIM15_OC2       (COMP_CSR_BLANKING_4)   /*!< Comparator output blanking source TIM15 OC2 (common to all COMP instances: COMP1, COMP2) */
+#define COMP_BLANKINGSRC_TIM1_OC4        (COMP_CSR_BLANKING_0)   /*!< Comparator output blanking source TIM1 OC4 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define COMP_BLANKINGSRC_TIM1_OC5        (COMP_CSR_BLANKING_1)   /*!< Comparator output blanking source TIM1 OC5 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define COMP_BLANKINGSRC_TIM2_OC3        (COMP_CSR_BLANKING_2)   /*!< Comparator output blanking source TIM2 OC3 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define COMP_BLANKINGSRC_TIM3_OC3        (COMP_CSR_BLANKING_3)   /*!< Comparator output blanking source TIM3 OC3 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define COMP_BLANKINGSRC_TIM15_OC2       (COMP_CSR_BLANKING_4)   /*!< Comparator output blanking source TIM15 OC2 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
 /**
   * @}
   */
@@ -546,6 +549,102 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 #define __HAL_COMP_COMP2_EXTI_CLEAR_FALLING_FLAG()    LL_EXTI_ClearFallingFlag_0_31(COMP_EXTI_LINE_COMP2)
 
 /**
+  * @brief  Enable the COMP3 EXTI line rising edge trigger.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_ENABLE_RISING_EDGE()    LL_EXTI_EnableRisingTrig_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Disable the COMP3 EXTI line rising edge trigger.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_DISABLE_RISING_EDGE()   LL_EXTI_DisableRisingTrig_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Enable the COMP3 EXTI line falling edge trigger.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_ENABLE_FALLING_EDGE()   LL_EXTI_EnableFallingTrig_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Disable the COMP3 EXTI line falling edge trigger.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_DISABLE_FALLING_EDGE()  LL_EXTI_DisableFallingTrig_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Enable the COMP3 EXTI line rising & falling edge trigger.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_ENABLE_RISING_FALLING_EDGE()   do { \
+                                                               LL_EXTI_EnableRisingTrig_0_31(COMP_EXTI_LINE_COMP3); \
+                                                               LL_EXTI_EnableFallingTrig_0_31(COMP_EXTI_LINE_COMP3); \
+                                                             } while(0)
+
+/**
+  * @brief  Disable the COMP3 EXTI line rising & falling edge trigger.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
+                                                               LL_EXTI_DisableRisingTrig_0_31(COMP_EXTI_LINE_COMP3); \
+                                                               LL_EXTI_DisableFallingTrig_0_31(COMP_EXTI_LINE_COMP3); \
+                                                             } while(0)
+
+/**
+  * @brief  Enable the COMP3 EXTI line in interrupt mode.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_ENABLE_IT()             LL_EXTI_EnableIT_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Disable the COMP3 EXTI line in interrupt mode.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_DISABLE_IT()            LL_EXTI_DisableIT_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Generate a software interrupt on the COMP3 EXTI line.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_GENERATE_SWIT()         LL_EXTI_GenerateSWI_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Enable the COMP3 EXTI line in event mode.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_ENABLE_EVENT()          LL_EXTI_EnableEvent_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Disable the COMP3 EXTI line in event mode.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_DISABLE_EVENT()         LL_EXTI_DisableEvent_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Check whether the COMP3 EXTI line rising flag is set.
+  * @retval RESET or SET
+  */
+#define __HAL_COMP_COMP3_EXTI_GET_RISING_FLAG()       LL_EXTI_IsActiveRisingFlag_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Clear the COMP3 EXTI rising flag.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_CLEAR_RISING_FLAG()     LL_EXTI_ClearRisingFlag_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Check whether the COMP3 EXTI line falling flag is set.
+  * @retval RESET or SET
+  */
+#define __HAL_COMP_COMP3_EXTI_GET_FALLING_FLAG()      LL_EXTI_IsActiveFallingFlag_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
+  * @brief  Clear the COMP3 EXTI falling flag.
+  * @retval None
+  */
+#define __HAL_COMP_COMP3_EXTI_CLEAR_FALLING_FLAG()    LL_EXTI_ClearFallingFlag_0_31(COMP_EXTI_LINE_COMP3)
+
+/**
   * @}
   */
 
@@ -573,6 +672,9 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   */
 #define COMP_EXTI_LINE_COMP1           (EXTI_IMR1_IM17)  /*!< EXTI line 17 connected to COMP1 output */
 #define COMP_EXTI_LINE_COMP2           (EXTI_IMR1_IM18)  /*!< EXTI line 18 connected to COMP2 output */
+#if defined(COMP3)
+#define COMP_EXTI_LINE_COMP3           (EXTI_IMR1_IM20)  /*!< EXTI line 20 connected to COMP3 output */
+#endif
 /**
   * @}
   */
@@ -605,18 +707,38 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   * @param  __INSTANCE__  specifies the COMP instance.
   * @retval value of @ref COMP_ExtiLine
   */
+#if defined(COMP3)
+#define COMP_GET_EXTI_LINE(__INSTANCE__)    (((__INSTANCE__) == COMP1) ? COMP_EXTI_LINE_COMP1  \
+                                             :((__INSTANCE__) == COMP2) ? COMP_EXTI_LINE_COMP2 \
+                                             : COMP_EXTI_LINE_COMP3)
+#else
 #define COMP_GET_EXTI_LINE(__INSTANCE__)    (((__INSTANCE__) == COMP1) ? COMP_EXTI_LINE_COMP1  \
                                              : COMP_EXTI_LINE_COMP2)
+#endif
 /**
   * @}
   */
 
-/** @defgroup COMP_IS_COMP_Definitions COMP private macros to check input parameters
+/** @defgroup COMP_IS_COMP_Private_Definitions COMP private macros to check input parameters
   * @{
   */
-#define IS_COMP_WINDOWMODE(__WINDOWMODE__)  (((__WINDOWMODE__) == COMP_WINDOWMODE_DISABLE)                || \
-                                             ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)|| \
-                                             ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON)  )
+#if defined(COMP3)
+#define IS_COMP_WINDOWMODE(__INSTANCE__, __WINDOWMODE__) \
+(((__INSTANCE__) == COMP3) \
+  ? \
+  (((__WINDOWMODE__) == COMP_WINDOWMODE_DISABLE)                ||  \
+   ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON)  ) \
+  :\
+  (((__WINDOWMODE__) == COMP_WINDOWMODE_DISABLE)                ||  \
+   ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)||  \
+   ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON)  ) \
+)
+#else
+#define IS_COMP_WINDOWMODE(__INSTANCE__, __WINDOWMODE__) \
+(((__WINDOWMODE__) == COMP_WINDOWMODE_DISABLE)                || \
+ ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)|| \
+ ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON)  )
+#endif
 
 #define IS_COMP_WINDOWOUTPUT(__WINDOWOUTPUT__) (((__WINDOWOUTPUT__) == COMP_WINDOWOUTPUT_EACH_COMP) || \
                                                 ((__WINDOWOUTPUT__) == COMP_WINDOWOUTPUT_COMP1)     || \

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_conf.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_conf.h
@@ -45,12 +45,15 @@ extern "C" {
 #define HAL_DMA_MODULE_ENABLED
 #define HAL_EXTI_MODULE_ENABLED
 #define HAL_FLASH_MODULE_ENABLED
+#define HAL_FDCAN_MODULE_ENABLED
 #define HAL_GPIO_MODULE_ENABLED
 #define HAL_I2C_MODULE_ENABLED
 #define HAL_I2S_MODULE_ENABLED
 #define HAL_IRDA_MODULE_ENABLED
 #define HAL_IWDG_MODULE_ENABLED
 #define HAL_LPTIM_MODULE_ENABLED
+#define HAL_HCD_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED
 #define HAL_PWR_MODULE_ENABLED
 #define HAL_RCC_MODULE_ENABLED
 #define HAL_RNG_MODULE_ENABLED
@@ -67,23 +70,27 @@ extern "C" {
 /**
   * @brief This is the list of modules where register callback can be used
   */
-#define USE_HAL_ADC_REGISTER_CALLBACKS    0u
-#define USE_HAL_CEC_REGISTER_CALLBACKS    0u
-#define USE_HAL_COMP_REGISTER_CALLBACKS   0u
-#define USE_HAL_CRYP_REGISTER_CALLBACKS   0u
-#define USE_HAL_DAC_REGISTER_CALLBACKS    0u
-#define USE_HAL_I2C_REGISTER_CALLBACKS    0u
-#define USE_HAL_I2S_REGISTER_CALLBACKS    0u
-#define USE_HAL_IRDA_REGISTER_CALLBACKS   0u
-#define USE_HAL_LPTIM_REGISTER_CALLBACKS  0u
-#define USE_HAL_RNG_REGISTER_CALLBACKS    0u
-#define USE_HAL_RTC_REGISTER_CALLBACKS    0u
-#define USE_HAL_SMBUS_REGISTER_CALLBACKS  0u
-#define USE_HAL_SPI_REGISTER_CALLBACKS    0u
-#define USE_HAL_TIM_REGISTER_CALLBACKS    0u
-#define USE_HAL_UART_REGISTER_CALLBACKS   0u
-#define USE_HAL_USART_REGISTER_CALLBACKS  0u
-#define USE_HAL_WWDG_REGISTER_CALLBACKS   0u
+#define USE_HAL_ADC_REGISTER_CALLBACKS        0u
+#define USE_HAL_CEC_REGISTER_CALLBACKS        0u
+#define USE_HAL_COMP_REGISTER_CALLBACKS       0u
+#define USE_HAL_CRYP_REGISTER_CALLBACKS       0u
+#define USE_HAL_DAC_REGISTER_CALLBACKS        0u
+#define USE_HAL_FDCAN_REGISTER_CALLBACKS      0u
+#define USE_HAL_I2C_REGISTER_CALLBACKS        0u
+#define USE_HAL_I2S_REGISTER_CALLBACKS        0u
+#define USE_HAL_IRDA_REGISTER_CALLBACKS       0u
+#define USE_HAL_LPTIM_REGISTER_CALLBACKS      0u
+#define USE_HAL_HCD_REGISTER_CALLBACKS        0u
+#define USE_HAL_PCD_REGISTER_CALLBACKS        0u
+#define USE_HAL_RNG_REGISTER_CALLBACKS        0u
+#define USE_HAL_RTC_REGISTER_CALLBACKS        0u
+#define USE_HAL_SMARTCARD_REGISTER_CALLBACKS  0u
+#define USE_HAL_SMBUS_REGISTER_CALLBACKS      0u
+#define USE_HAL_SPI_REGISTER_CALLBACKS        0u
+#define USE_HAL_TIM_REGISTER_CALLBACKS        0u
+#define USE_HAL_UART_REGISTER_CALLBACKS       0u
+#define USE_HAL_USART_REGISTER_CALLBACKS      0u
+#define USE_HAL_WWDG_REGISTER_CALLBACKS       0u
 
 /* ########################## Oscillator Values adaptation ####################*/
 /**
@@ -108,6 +115,19 @@ extern "C" {
 #define HSI_VALUE    (16000000UL)           /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief Internal High Speed oscillator (HSI48) value for USB FS, SDMMC and RNG.
+  *        This internal oscillator is mainly dedicated to provide a high precision clock to
+  *        the USB peripheral by means of a special Clock Recovery System (CRS) circuitry.
+  *        When the CRS is not used, the HSI48 RC oscillator runs on it default frequency
+  *        which is subject to manufacturing process variations.
+  */
+#if !defined  (HSI48_VALUE)
+  #define HSI48_VALUE   48000000U             /*!< Value of the Internal High Speed oscillator for USB FS/SDMMC/RNG in Hz.
+                                               The real value my vary depending on manufacturing process variations.*/
+#endif /* HSI48_VALUE */
+#endif
 
 /**
   * @brief Internal Low Speed oscillator (LSI) value.
@@ -138,6 +158,16 @@ in voltage and temperature.*/
 #define EXTERNAL_I2S1_CLOCK_VALUE    (48000UL) /*!< Value of the I2S1 External clock source in Hz*/
 #endif /* EXTERNAL_I2S1_CLOCK_VALUE */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief External clock source for I2S2 peripheral
+  *        This value is used by the RCC HAL module to compute the I2S2 clock source
+  *        frequency.
+  */
+#if !defined  (EXTERNAL_I2S2_CLOCK_VALUE)
+  #define EXTERNAL_I2S2_CLOCK_VALUE    48000U /*!< Value of the I2S2 External clock source in Hz*/
+#endif /* EXTERNAL_I2S2_CLOCK_VALUE */
+#endif
 
 /* Tip: To avoid modifying this file each time you need to use different HSE,
    ===  you can define the HSE value in your toolchain compiler preprocessor. */
@@ -223,6 +253,10 @@ in voltage and temperature.*/
 #include "stm32g0xx_hal_exti.h"
 #endif /* HAL_EXTI_MODULE_ENABLED */
 
+#ifdef HAL_FDCAN_MODULE_ENABLED
+#include "stm32g0xx_hal_fdcan.h"
+#endif /* HAL_FDCAN_MODULE_ENABLED */
+
 #ifdef HAL_FLASH_MODULE_ENABLED
 #include "stm32g0xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
@@ -246,6 +280,14 @@ in voltage and temperature.*/
 #ifdef HAL_LPTIM_MODULE_ENABLED
 #include "stm32g0xx_hal_lptim.h"
 #endif /* HAL_LPTIM_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+#include "stm32g0xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+#include "stm32g0xx_hal_hcd.h"
+#endif /* HAL_HCD_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
 #include "stm32g0xx_hal_pwr.h"

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_cryp.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_cryp.h
@@ -64,9 +64,10 @@ typedef struct
   uint32_t *Header;                    /*!< used only in AES GCM and CCM Algorithm for authentication,
                                         GCM : also known as Additional Authentication Data
                                         CCM : named B1 composed of the associated data length and Associated Data. */
-  uint32_t HeaderSize;                 /*!< The size of header buffer in word  */
+  uint32_t HeaderSize;                 /*!< The size of header buffer */
   uint32_t *B0;                        /*!< B0 is first authentication block used only  in AES CCM mode */
-  uint32_t DataWidthUnit;              /*!< Data With Unit, this parameter can be value of @ref CRYP_Data_Width_Unit*/
+  uint32_t DataWidthUnit;              /*!< Payload Data Width Unit, this parameter can be value of @ref CRYP_Data_Width_Unit*/
+  uint32_t HeaderWidthUnit;            /*!< Header Width Unit, this parameter can be value of @ref CRYP_Header_Width_Unit*/
   uint32_t KeyIVConfigSkip;            /*!< CRYP peripheral Key and IV configuration skip, to config Key and Initialization
                                            Vector only once and to skip configuration for consecutive processings.
                                            This parameter can be a value of @ref CRYP_Configuration_Skip */
@@ -108,7 +109,7 @@ typedef struct __CRYP_HandleTypeDef
 typedef struct
 #endif
 {
-  AES_TypeDef                       *Instance;            /*!< AES Register base address */
+  AES_TypeDef                       *Instance;        /*!< AES Register base address */
 
   CRYP_ConfigTypeDef                Init;             /*!< CRYP required parameters */
 
@@ -119,13 +120,13 @@ typedef struct
 
   uint32_t                          *pCrypOutBuffPtr; /*!< Pointer to CRYP processing (encryption, decryption,...) buffer */
 
-  __IO uint16_t                     CrypHeaderCount;   /*!< Counter of header data */
+  __IO uint16_t                     CrypHeaderCount;  /*!< Counter of header data in words */
 
-  __IO uint16_t                     CrypInCount;      /*!< Counter of input data */
+  __IO uint16_t                     CrypInCount;      /*!< Counter of input data in words */
 
-  __IO uint16_t                     CrypOutCount;     /*!< Counter of output data */
+  __IO uint16_t                     CrypOutCount;     /*!< Counter of output data in words */
 
-  uint16_t                          Size;             /*!< length of input data in words */
+  uint16_t                          Size;             /*!< Length of input data */
 
   uint32_t                          Phase;            /*!< CRYP peripheral phase */
 
@@ -182,9 +183,11 @@ typedef struct
 
   uint32_t                    Key_saved[8];            /*!< copy of key registers */
 
-  uint32_t                    Size_saved;              /*!< copy of input buffer size */
+  uint16_t                    Size_saved;              /*!< copy of input buffer size */
 
   uint16_t                    CrypHeaderCount_saved;   /*!< copy of CRYP header data counter when processing is suspended */
+
+  uint32_t                    SizesSum_saved;          /*!< copy of SizesSum when processing is suspended */
 
   uint32_t                    ResumingFlag;            /*!< resumption flag to bypass steps already carried out */
 
@@ -258,6 +261,17 @@ typedef  void (*pCRYP_CallbackTypeDef)(CRYP_HandleTypeDef *hcryp);    /*!< point
 
 #define CRYP_DATAWIDTHUNIT_WORD   0x00000000U  /*!< By default, size unit is word */
 #define CRYP_DATAWIDTHUNIT_BYTE   0x00000001U  /*!< By default, size unit is byte */
+
+/**
+  * @}
+  */
+
+/** @defgroup CRYP_Header_Width_Unit CRYP Header Width Unit
+  * @{
+  */
+
+#define CRYP_HEADERWIDTHUNIT_WORD   0x00000000U  /*!< By default, header size unit is word */
+#define CRYP_HEADERWIDTHUNIT_BYTE   0x00000001U  /*!< By default, header size unit is byte */
 
 /**
   * @}
@@ -564,6 +578,13 @@ uint32_t HAL_CRYP_GetError(CRYP_HandleTypeDef *hcryp);
 
 #define IS_CRYP_INIT(CONFIG)(((CONFIG) == CRYP_KEYIVCONFIG_ALWAYS) || \
                              ((CONFIG) == CRYP_KEYIVCONFIG_ONCE))
+
+#define IS_CRYP_BUFFERSIZE(ALGO, DATAWIDTH, SIZE)                                             \
+       (((((ALGO) == CRYP_AES_CTR)) &&                                             \
+            ((((DATAWIDTH) == CRYP_DATAWIDTHUNIT_WORD) && (((SIZE) % 4U) == 0U))           || \
+             (((DATAWIDTH) == CRYP_DATAWIDTHUNIT_BYTE) && (((SIZE) % 16U) == 0U))))        || \
+         (((ALGO) == CRYP_AES_ECB) || ((ALGO) == CRYP_AES_CBC)                  || \
+          ((ALGO)== CRYP_AES_GCM_GMAC) || ((ALGO) == CRYP_AES_CCM)))
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_def.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_def.h
@@ -107,7 +107,14 @@ typedef enum
                                     }while (0U)
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #ifndef __weak
+    #define __weak  __attribute__((weak))
+  #endif
+  #ifndef __packed
+    #define __packed  __attribute__((packed))
+  #endif
+#elif  defined ( __GNUC__ ) && !defined (__CC_ARM) /* GNU Compiler */
 #ifndef __weak
 #define __weak   __attribute__((weak))
 #endif /* __weak */
@@ -119,7 +126,14 @@ typedef enum
 
 /* Macro to get variable aligned on 4-bytes, for __ICCARM__ the directive "#pragma data_alignment=4" must be used instead */
 /* GNU Compiler */
-#if defined   (__GNUC__)
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) /* ARM Compiler V6 */
+  #ifndef __ALIGN_BEGIN
+    #define __ALIGN_BEGIN
+  #endif
+  #ifndef __ALIGN_END
+    #define __ALIGN_END      __attribute__ ((aligned (4)))
+  #endif
+#elif defined   (__GNUC__) && !defined (__CC_ARM)  /* GNU Compiler */
 #ifndef __ALIGN_END
 #define __ALIGN_END    __attribute__ ((aligned (4U)))
 #endif /* __ALIGN_END */
@@ -132,7 +146,7 @@ typedef enum
 #endif /* __ALIGN_END */
 #ifndef __ALIGN_BEGIN
 /* ARM Compiler */
-#if defined   (__CC_ARM)
+#if defined   (__CC_ARM)                           /* ARM Compiler V5 */
 #define __ALIGN_BEGIN    __align(4U)
 /* IAR Compiler */
 #elif defined (__ICCARM__)
@@ -144,9 +158,9 @@ typedef enum
 /**
   * @brief  __RAM_FUNC definition
   */
-#if defined ( __CC_ARM   )
-/* ARM Compiler
-   ------------
+#if defined ( __CC_ARM   ) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+/* ARM Compiler V4/V5 and V6
+   --------------------------
    RAM functions are defined using the toolchain options.
    Functions that are executed in RAM should reside in a separate source module.
    Using the 'Options for File' dialog you can simply change the 'Code / Const'
@@ -176,9 +190,9 @@ typedef enum
 /**
   * @brief  __NOINLINE definition
   */
-#if defined ( __CC_ARM   ) || defined   (  __GNUC__  )
-/* ARM & GNUCompiler
-   ----------------
+#if defined ( __CC_ARM   ) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)) || defined   (  __GNUC__  )
+/* ARM V4/V5 and V6 & GNU Compiler
+   -------------------------------
 */
 #define __NOINLINE __attribute__ ( (noinline) )
 

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_dma.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_dma.h
@@ -27,6 +27,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g0xx_hal_def.h"
+#include "stm32g0xx_ll_dma.h"
 
 /** @addtogroup STM32G0xx_HAL_Driver
   * @{
@@ -132,6 +133,10 @@ typedef struct __DMA_HandleTypeDef
 
   __IO uint32_t                   ErrorCode;                          /*!< DMA Error code                        */
 
+#if defined(DMA2)
+  DMA_TypeDef            *DmaBaseAddress;                             /*!< DMA Channel Base Address              */
+
+#endif
   uint32_t                        ChannelIndex;                       /*!< DMA Channel Index                     */
 
   DMAMUX_Channel_TypeDef           *DMAmuxChannel;                    /*!< Register base address                 */
@@ -163,9 +168,11 @@ typedef struct __DMA_HandleTypeDef
 #define HAL_DMA_ERROR_TE             0x00000001U       /*!< Transfer error                          */
 #define HAL_DMA_ERROR_NO_XFER        0x00000004U       /*!< Abort requested with no Xfer ongoing    */
 #define HAL_DMA_ERROR_TIMEOUT        0x00000020U       /*!< Timeout error                           */
+#define HAL_DMA_ERROR_PARAM          0x00000040U       /*!< Parameter error                         */
+#define HAL_DMA_ERROR_BUSY           0x00000080U       /*!< DMA Busy error                          */
 #define HAL_DMA_ERROR_NOT_SUPPORTED  0x00000100U       /*!< Not supported mode                      */
-#define HAL_DMA_ERROR_SYNC           0x00000200U       /*!< DMAMUX sync overrun  error              */
-#define HAL_DMA_ERROR_REQGEN         0x00000400U       /*!< DMAMUX request generator overrun  error */
+#define HAL_DMA_ERROR_SYNC           0x00000200U       /*!< DMAMUX sync overrun error               */
+#define HAL_DMA_ERROR_REQGEN         0x00000400U       /*!< DMAMUX request generator overrun error  */
 
 /**
   * @}
@@ -174,110 +181,127 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_request DMA request
   * @{
   */
-#define DMA_REQUEST_MEM2MEM           0U               /*!< memory to memory transfer     */
-
-
-#define DMA_REQUEST_GENERATOR0        1U               /*!< DMAMUX request generator 0    */
-#define DMA_REQUEST_GENERATOR1        2U               /*!< DMAMUX request generator 1    */
-#define DMA_REQUEST_GENERATOR2        3U               /*!< DMAMUX request generator 2    */
-#define DMA_REQUEST_GENERATOR3        4U               /*!< DMAMUX request generator 3    */
-
-
-#define DMA_REQUEST_ADC1              5U               /*!< DMAMUX ADC1 request           */
-
+#define DMA_REQUEST_MEM2MEM          LL_DMAMUX_REQ_MEM2MEM        /*!< memory to memory transfer  */
+#define DMA_REQUEST_GENERATOR0       LL_DMAMUX_REQ_GENERATOR0     /*!< DMAMUX request generator 0 */
+#define DMA_REQUEST_GENERATOR1       LL_DMAMUX_REQ_GENERATOR1     /*!< DMAMUX request generator 1 */
+#define DMA_REQUEST_GENERATOR2       LL_DMAMUX_REQ_GENERATOR2     /*!< DMAMUX request generator 2 */
+#define DMA_REQUEST_GENERATOR3       LL_DMAMUX_REQ_GENERATOR3     /*!< DMAMUX request generator 3 */
+#define DMA_REQUEST_ADC1             LL_DMAMUX_REQ_ADC1           /*!< DMAMUX ADC1 request        */
 #if defined(AES)
-#define DMA_REQUEST_AES_IN            6U               /*!< DMAMUX AES IN request         */
-#define DMA_REQUEST_AES_OUT           7U               /*!< DMAMUX AES OUT request        */
+#define DMA_REQUEST_AES_IN           LL_DMAMUX_REQ_AES_IN         /*!< DMAMUX AES_IN request      */
+#define DMA_REQUEST_AES_OUT          LL_DMAMUX_REQ_AES_OUT        /*!< DMAMUX AES_OUT request     */
 #endif
-
 #if defined(DAC1)
-#define DMA_REQUEST_DAC1_CHANNEL1     8U               /*!< DMAMUX SPI2 RX request        */
-#define DMA_REQUEST_DAC1_CHANNEL2     9U               /*!< DMAMUX SPI2 TX request        */
+#define DMA_REQUEST_DAC1_CH1         LL_DMAMUX_REQ_DAC1_CH1       /*!< DMAMUX DAC_CH1 request     */
+#define DMA_REQUEST_DAC1_CH2         LL_DMAMUX_REQ_DAC1_CH2       /*!< DMAMUX DAC_CH2 request     */
 #endif
-
-#define DMA_REQUEST_I2C1_RX          10U               /*!< DMAMUX I2C1 RX request        */
-#define DMA_REQUEST_I2C1_TX          11U               /*!< DMAMUX I2C1 TX request        */
-#define DMA_REQUEST_I2C2_RX          12U               /*!< DMAMUX I2C2 RX request        */
-#define DMA_REQUEST_I2C2_TX          13U               /*!< DMAMUX I2C2 TX request        */
-
+#define DMA_REQUEST_I2C1_RX          LL_DMAMUX_REQ_I2C1_RX        /*!< DMAMUX I2C1 RX request     */
+#define DMA_REQUEST_I2C1_TX          LL_DMAMUX_REQ_I2C1_TX        /*!< DMAMUX I2C1 TX request     */
+#define DMA_REQUEST_I2C2_RX          LL_DMAMUX_REQ_I2C2_RX        /*!< DMAMUX I2C2 RX request     */
+#define DMA_REQUEST_I2C2_TX          LL_DMAMUX_REQ_I2C2_TX        /*!< DMAMUX I2C2 TX request     */
 #if defined(LPUART1)
-#define DMA_REQUEST_LPUART1_RX       14U               /*!< DMAMUX LPUART1 RX request     */
-#define DMA_REQUEST_LPUART1_TX       15U               /*!< DMAMUX LPUART1 TX request     */
+#define DMA_REQUEST_LPUART1_RX       LL_DMAMUX_REQ_LPUART1_RX     /*!< DMAMUX LPUART1 RX request  */
+#define DMA_REQUEST_LPUART1_TX       LL_DMAMUX_REQ_LPUART1_TX     /*!< DMAMUX LPUART1 TX request  */
 #endif
-
-#define DMA_REQUEST_SPI1_RX          16U               /*!< DMAMUX SPI1 RX request        */
-#define DMA_REQUEST_SPI1_TX          17U               /*!< DMAMUX SPI1 TX request        */
-#define DMA_REQUEST_SPI2_RX          18U               /*!< DMAMUX SPI2 RX request        */
-#define DMA_REQUEST_SPI2_TX          19U               /*!< DMAMUX SPI2 TX request        */
-
-
-#define DMA_REQUEST_TIM1_CH1         20U               /*!< DMAMUX TIM1 CH1 request       */
-#define DMA_REQUEST_TIM1_CH2         21U               /*!< DMAMUX TIM1 CH2 request       */
-#define DMA_REQUEST_TIM1_CH3         22U               /*!< DMAMUX TIM1 CH3 request       */
-#define DMA_REQUEST_TIM1_CH4         23U               /*!< DMAMUX TIM1 CH4 request       */
-#define DMA_REQUEST_TIM1_TRIG_COM    24U               /*!< DMAMUX TIM1 TRIG COM request  */
-#define DMA_REQUEST_TIM1_UP          25U               /*!< DMAMUX TIM1 UP request        */
-
+#define DMA_REQUEST_SPI1_RX          LL_DMAMUX_REQ_SPI1_RX        /*!< DMAMUX SPI1 RX request     */
+#define DMA_REQUEST_SPI1_TX          LL_DMAMUX_REQ_SPI1_TX        /*!< DMAMUX SPI1 TX request     */
+#define DMA_REQUEST_SPI2_RX          LL_DMAMUX_REQ_SPI2_RX        /*!< DMAMUX SPI2 RX request     */
+#define DMA_REQUEST_SPI2_TX          LL_DMAMUX_REQ_SPI2_TX        /*!< DMAMUX SPI2 TX request     */
+#define DMA_REQUEST_TIM1_CH1         LL_DMAMUX_REQ_TIM1_CH1       /*!< DMAMUX TIM1 CH1 request    */
+#define DMA_REQUEST_TIM1_CH2         LL_DMAMUX_REQ_TIM1_CH2       /*!< DMAMUX TIM1 CH2 request    */
+#define DMA_REQUEST_TIM1_CH3         LL_DMAMUX_REQ_TIM1_CH3       /*!< DMAMUX TIM1 CH3 request    */
+#define DMA_REQUEST_TIM1_CH4         LL_DMAMUX_REQ_TIM1_CH4       /*!< DMAMUX TIM1 CH4 request    */
+#define DMA_REQUEST_TIM1_TRIG_COM    LL_DMAMUX_REQ_TIM1_TRIG_COM  /*!< DMAMUX TIM1 TRIG COM request */
+#define DMA_REQUEST_TIM1_UP          LL_DMAMUX_REQ_TIM1_UP        /*!< DMAMUX TIM1 UP request     */
 #if defined(TIM2)
-#define DMA_REQUEST_TIM2_CH1         26U               /*!< DMAMUX TIM2 CH1 request       */
-#define DMA_REQUEST_TIM2_CH2         27U               /*!< DMAMUX TIM2 CH2 request       */
-#define DMA_REQUEST_TIM2_CH3         28U               /*!< DMAMUX TIM2 CH3 request       */
-#define DMA_REQUEST_TIM2_CH4         29U               /*!< DMAMUX TIM2 CH4 request       */
-#define DMA_REQUEST_TIM2_TRIG        30U               /*!< DMAMUX TIM2 TRIG request      */
-#define DMA_REQUEST_TIM2_UP          31U               /*!< DMAMUX TIM2 UP request        */
+#define DMA_REQUEST_TIM2_CH1         LL_DMAMUX_REQ_TIM2_CH1       /*!< DMAMUX TIM2 CH1 request    */
+#define DMA_REQUEST_TIM2_CH2         LL_DMAMUX_REQ_TIM2_CH2       /*!< DMAMUX TIM2 CH2 request    */
+#define DMA_REQUEST_TIM2_CH3         LL_DMAMUX_REQ_TIM2_CH3       /*!< DMAMUX TIM2 CH3 request    */
+#define DMA_REQUEST_TIM2_CH4         LL_DMAMUX_REQ_TIM2_CH4       /*!< DMAMUX TIM2 CH4 request    */
+#define DMA_REQUEST_TIM2_TRIG        LL_DMAMUX_REQ_TIM2_TRIG      /*!< DMAMUX TIM2 TRIG request   */
+#define DMA_REQUEST_TIM2_UP          LL_DMAMUX_REQ_TIM2_UP        /*!< DMAMUX TIM2 UP request     */
 #endif
-
-#define DMA_REQUEST_TIM3_CH1         32U               /*!< DMAMUX TIM3 CH1 request       */
-#define DMA_REQUEST_TIM3_CH2         33U               /*!< DMAMUX TIM3 CH2 request       */
-#define DMA_REQUEST_TIM3_CH3         34U               /*!< DMAMUX TIM3 CH3 request       */
-#define DMA_REQUEST_TIM3_CH4         35U               /*!< DMAMUX TIM3 CH4 request       */
-#define DMA_REQUEST_TIM3_TRIG        36U               /*!< DMAMUX TIM3 TRIG request      */
-#define DMA_REQUEST_TIM3_UP          37U               /*!< DMAMUX TIM3 UP request        */
-
+#define DMA_REQUEST_TIM3_CH1         LL_DMAMUX_REQ_TIM3_CH1       /*!< DMAMUX TIM3 CH1 request    */
+#define DMA_REQUEST_TIM3_CH2         LL_DMAMUX_REQ_TIM3_CH2       /*!< DMAMUX TIM3 CH2 request    */
+#define DMA_REQUEST_TIM3_CH3         LL_DMAMUX_REQ_TIM3_CH3       /*!< DMAMUX TIM3 CH3 request    */
+#define DMA_REQUEST_TIM3_CH4         LL_DMAMUX_REQ_TIM3_CH4       /*!< DMAMUX TIM3 CH4 request    */
+#define DMA_REQUEST_TIM3_TRIG        LL_DMAMUX_REQ_TIM3_TRIG      /*!< DMAMUX TIM3 TRIG request   */
+#define DMA_REQUEST_TIM3_UP          LL_DMAMUX_REQ_TIM3_UP        /*!< DMAMUX TIM3 UP request     */
 #if defined(TIM6)
-#define DMA_REQUEST_TIM6_UP          38U               /*!< DMAMUX TIM6 UP request        */
+#define DMA_REQUEST_TIM6_UP          LL_DMAMUX_REQ_TIM6_UP        /*!< DMAMUX TIM6 UP request     */
 #endif
 #if defined(TIM7)
-#define DMA_REQUEST_TIM7_UP          39U               /*!< DMAMUX TIM7 UP request        */
+#define DMA_REQUEST_TIM7_UP          LL_DMAMUX_REQ_TIM7_UP        /*!< DMAMUX TIM7 UP request     */
 #endif
-
 #if defined(TIM15)
-#define DMA_REQUEST_TIM15_CH1        40U               /*!< DMAMUX TIM15 CH1 request      */
-#define DMA_REQUEST_TIM15_CH2        41U               /*!< DMAMUX TIM15 CH2 request      */
-#define DMA_REQUEST_TIM15_TRIG_COM   42U               /*!< DMAMUX TIM15 TRIG COM request */
-#define DMA_REQUEST_TIM15_UP         43U               /*!< DMAMUX TIM15 UP request       */
+#define DMA_REQUEST_TIM15_CH1        LL_DMAMUX_REQ_TIM15_CH1      /*!< DMAMUX TIM15 CH1 request   */
+#define DMA_REQUEST_TIM15_CH2        LL_DMAMUX_REQ_TIM15_CH2      /*!< DMAMUX TIM15 CH2 request   */
+#define DMA_REQUEST_TIM15_TRIG_COM   LL_DMAMUX_REQ_TIM15_TRIG_COM /*!< DMAMUX TIM15 TRIG COM request */
+#define DMA_REQUEST_TIM15_UP         LL_DMAMUX_REQ_TIM15_UP       /*!< DMAMUX TIM15 UP request    */
 #endif
-
-#define DMA_REQUEST_TIM16_CH1        44U               /*!< DMAMUX TIM16 CH1 request      */
-#define DMA_REQUEST_TIM16_TRIG_COM   45U               /*!< DMAMUX TIM16 TRIG COM request */
-#define DMA_REQUEST_TIM16_UP         46U               /*!< DMAMUX TIM16 UP request       */
-
-#define DMA_REQUEST_TIM17_CH1        47U               /*!< DMAMUX TIM17 CH2 request      */
-#define DMA_REQUEST_TIM17_TRIG_COM   48U               /*!< DMAMUX TIM17 TRIG COM request */
-#define DMA_REQUEST_TIM17_UP         49U               /*!< DMAMUX TIM17 UP request       */
-
-#define DMA_REQUEST_USART1_RX        50U               /*!< DMAMUX USART1 RX request      */
-#define DMA_REQUEST_USART1_TX        51U               /*!< DMAMUX USART1 TX request      */
-#define DMA_REQUEST_USART2_RX        52U               /*!< DMAMUX USART2 RX request      */
-#define DMA_REQUEST_USART2_TX        53U               /*!< DMAMUX USART2 TX request      */
+#define DMA_REQUEST_TIM16_CH1        LL_DMAMUX_REQ_TIM16_CH1      /*!< DMAMUX TIM16 CH1 request   */
+#define DMA_REQUEST_TIM16_COM        LL_DMAMUX_REQ_TIM16_COM      /*!< DMAMUX TIM16 COM request   */
+#define DMA_REQUEST_TIM16_UP         LL_DMAMUX_REQ_TIM16_UP       /*!< DMAMUX TIM16 UP request    */
+#define DMA_REQUEST_TIM17_CH1        LL_DMAMUX_REQ_TIM17_CH1      /*!< DMAMUX TIM17 CH1 request   */
+#define DMA_REQUEST_TIM17_COM        LL_DMAMUX_REQ_TIM17_COM      /*!< DMAMUX TIM17 COM request   */
+#define DMA_REQUEST_TIM17_UP         LL_DMAMUX_REQ_TIM17_UP       /*!< DMAMUX TIM17 UP request    */
+#define DMA_REQUEST_USART1_RX        LL_DMAMUX_REQ_USART1_RX      /*!< DMAMUX USART1 RX request  */
+#define DMA_REQUEST_USART1_TX        LL_DMAMUX_REQ_USART1_TX      /*!< DMAMUX USART1 TX request  */
+#define DMA_REQUEST_USART2_RX        LL_DMAMUX_REQ_USART2_RX      /*!< DMAMUX USART2 RX request  */
+#define DMA_REQUEST_USART2_TX        LL_DMAMUX_REQ_USART2_TX      /*!< DMAMUX USART2 TX request  */
 #if defined(USART3)
-#define DMA_REQUEST_USART3_RX        54U               /*!< DMAMUX USART3 RX request      */
-#define DMA_REQUEST_USART3_TX        55U               /*!< DMAMUX USART3 TX request      */
+#define DMA_REQUEST_USART3_RX        LL_DMAMUX_REQ_USART3_RX      /*!< DMAMUX USART3 RX request  */
+#define DMA_REQUEST_USART3_TX        LL_DMAMUX_REQ_USART3_TX      /*!< DMAMUX USART3 TX request  */
 #endif
 #if defined(USART4)
-#define DMA_REQUEST_USART4_RX        56U               /*!< DMAMUX USART4 RX request      */
-#define DMA_REQUEST_USART4_TX        57U               /*!< DMAMUX USART4 TX request      */
+#define DMA_REQUEST_USART4_RX        LL_DMAMUX_REQ_USART4_RX      /*!< DMAMUX USART4 RX request  */
+#define DMA_REQUEST_USART4_TX        LL_DMAMUX_REQ_USART4_TX      /*!< DMAMUX USART4 TX request  */
 #endif
-
 #if defined(UCPD1)
-#define DMA_REQUEST_UCPD1_RX         58U               /*!< DMAMUX UCPD1 RX request       */
-#define DMA_REQUEST_UCPD1_TX         59U               /*!< DMAMUX UCPD1 TX request       */
+#define DMA_REQUEST_UCPD1_RX         LL_DMAMUX_REQ_UCPD1_RX       /*!< DMAMUX UCPD1 RX request  */
+#define DMA_REQUEST_UCPD1_TX         LL_DMAMUX_REQ_UCPD1_TX       /*!< DMAMUX UCPD1 TX request  */
 #endif
 #if defined(UCPD2)
-#define DMA_REQUEST_UCPD2_RX         60U               /*!< DMAMUX UCPD2 RX request       */
-#define DMA_REQUEST_UCPD2_TX         61U               /*!< DMAMUX UCPD2 TX request       */
+#define DMA_REQUEST_UCPD2_RX         LL_DMAMUX_REQ_UCPD2_RX       /*!< DMAMUX UCPD2 RX request  */
+#define DMA_REQUEST_UCPD2_TX         LL_DMAMUX_REQ_UCPD2_TX       /*!< DMAMUX UCPD2 TX request  */
 #endif
 
+#if defined(I2C3)
+#define DMA_REQUEST_I2C3_RX          LL_DMAMUX_REQ_I2C3_RX        /*!< DMAMUX I2C3 RX request  */
+#define DMA_REQUEST_I2C3_TX          LL_DMAMUX_REQ_I2C3_TX        /*!< DMAMUX I2C3 TX request  */
+#endif
+
+#if defined(LPUART2)
+#define DMA_REQUEST_LPUART2_RX       LL_DMAMUX_REQ_LPUART2_RX     /*!< DMAMUX LPUART2 RX request  */
+#define DMA_REQUEST_LPUART2_TX       LL_DMAMUX_REQ_LPUART2_TX     /*!< DMAMUX LPUART2 TX request  */
+#endif
+
+#if defined(SPI3)
+#define DMA_REQUEST_SPI3_RX          LL_DMAMUX_REQ_SPI3_RX        /*!< DMAMUX SPI3 RX request     */
+#define DMA_REQUEST_SPI3_TX          LL_DMAMUX_REQ_SPI3_TX        /*!< DMAMUX SPI3 TX request     */
+#endif
+
+#if defined(TIM4)
+#define DMA_REQUEST_TIM4_CH1         LL_DMAMUX_REQ_TIM4_CH1       /*!< DMAMUX TIM4 CH1 request    */
+#define DMA_REQUEST_TIM4_CH2         LL_DMAMUX_REQ_TIM4_CH2       /*!< DMAMUX TIM4 CH2 request    */
+#define DMA_REQUEST_TIM4_CH3         LL_DMAMUX_REQ_TIM4_CH3       /*!< DMAMUX TIM4 CH3 request    */
+#define DMA_REQUEST_TIM4_CH4         LL_DMAMUX_REQ_TIM4_CH4       /*!< DMAMUX TIM4 CH4 request    */
+#define DMA_REQUEST_TIM4_TRIG        LL_DMAMUX_REQ_TIM4_TRIG      /*!< DMAMUX TIM4 TRIG request   */
+#define DMA_REQUEST_TIM4_UP          LL_DMAMUX_REQ_TIM4_UP        /*!< DMAMUX TIM4 UP request     */
+#endif
+
+#if defined(USART5)
+#define DMA_REQUEST_USART5_RX        LL_DMAMUX_REQ_USART5_RX      /*!< DMAMUX USART5 RX request  */
+#define DMA_REQUEST_USART5_TX        LL_DMAMUX_REQ_USART5_TX      /*!< DMAMUX USART5 TX request  */
+#endif
+
+#if defined(USART6)
+#define DMA_REQUEST_USART6_RX        LL_DMAMUX_REQ_USART6_RX      /*!< DMAMUX USART6 RX request  */
+#define DMA_REQUEST_USART6_TX        LL_DMAMUX_REQ_USART6_TX      /*!< DMAMUX USART6 TX request  */
+#endif
+
+
+#define DMA_MAX_REQUEST              LL_DMAMUX_MAX_REQ
 /**
   * @}
   */
@@ -285,9 +309,9 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Data_transfer_direction DMA Data transfer direction
   * @{
   */
-#define DMA_PERIPH_TO_MEMORY         0x00000000U       /*!< Peripheral to memory direction */
-#define DMA_MEMORY_TO_PERIPH         DMA_CCR_DIR       /*!< Memory to peripheral direction */
-#define DMA_MEMORY_TO_MEMORY         DMA_CCR_MEM2MEM   /*!< Memory to memory direction     */
+#define DMA_PERIPH_TO_MEMORY         LL_DMA_DIRECTION_PERIPH_TO_MEMORY  /*!< Peripheral to memory direction */
+#define DMA_MEMORY_TO_PERIPH         LL_DMA_DIRECTION_MEMORY_TO_PERIPH  /*!< Memory to peripheral direction */
+#define DMA_MEMORY_TO_MEMORY         LL_DMA_DIRECTION_MEMORY_TO_MEMORY  /*!< Memory to memory direction     */
 
 /**
   * @}
@@ -296,8 +320,8 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Peripheral_incremented_mode DMA Peripheral incremented mode
   * @{
   */
-#define DMA_PINC_ENABLE              DMA_CCR_PINC      /*!< Peripheral increment mode Enable  */
-#define DMA_PINC_DISABLE             0x00000000U       /*!< Peripheral increment mode Disable */
+#define DMA_PINC_ENABLE              LL_DMA_PERIPH_INCREMENT            /*!< Peripheral increment mode Enable  */
+#define DMA_PINC_DISABLE             LL_DMA_PERIPH_NOINCREMENT          /*!< Peripheral increment mode Disable */
 /**
   * @}
   */
@@ -305,8 +329,8 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Memory_incremented_mode DMA Memory incremented mode
   * @{
   */
-#define DMA_MINC_ENABLE              DMA_CCR_MINC      /*!< Memory increment mode Enable  */
-#define DMA_MINC_DISABLE             0x00000000U       /*!< Memory increment mode Disable */
+#define DMA_MINC_ENABLE              LL_DMA_MEMORY_INCREMENT            /*!< Memory increment mode Enable  */
+#define DMA_MINC_DISABLE             LL_DMA_MEMORY_NOINCREMENT          /*!< Memory increment mode Disable */
 /**
   * @}
   */
@@ -314,9 +338,9 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Peripheral_data_size DMA Peripheral data size
   * @{
   */
-#define DMA_PDATAALIGN_BYTE          0x00000000U       /*!< Peripheral data alignment : Byte     */
-#define DMA_PDATAALIGN_HALFWORD      DMA_CCR_PSIZE_0   /*!< Peripheral data alignment : HalfWord */
-#define DMA_PDATAALIGN_WORD          DMA_CCR_PSIZE_1   /*!< Peripheral data alignment : Word     */
+#define DMA_PDATAALIGN_BYTE          LL_DMA_PDATAALIGN_BYTE             /*!< Peripheral data alignment : Byte     */
+#define DMA_PDATAALIGN_HALFWORD      LL_DMA_PDATAALIGN_HALFWORD         /*!< Peripheral data alignment : HalfWord */
+#define DMA_PDATAALIGN_WORD          LL_DMA_PDATAALIGN_WORD             /*!< Peripheral data alignment : Word     */
 /**
   * @}
   */
@@ -324,9 +348,9 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Memory_data_size DMA Memory data size
   * @{
   */
-#define DMA_MDATAALIGN_BYTE          0x00000000U       /*!< Memory data alignment : Byte     */
-#define DMA_MDATAALIGN_HALFWORD      DMA_CCR_MSIZE_0   /*!< Memory data alignment : HalfWord */
-#define DMA_MDATAALIGN_WORD          DMA_CCR_MSIZE_1   /*!< Memory data alignment : Word     */
+#define DMA_MDATAALIGN_BYTE          LL_DMA_MDATAALIGN_BYTE             /*!< Memory data alignment : Byte     */
+#define DMA_MDATAALIGN_HALFWORD      LL_DMA_MDATAALIGN_HALFWORD         /*!< Memory data alignment : HalfWord */
+#define DMA_MDATAALIGN_WORD          LL_DMA_MDATAALIGN_WORD             /*!< Memory data alignment : Word     */
 /**
   * @}
   */
@@ -334,8 +358,8 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_mode DMA mode
   * @{
   */
-#define DMA_NORMAL                   0x00000000U       /*!< Normal mode    */
-#define DMA_CIRCULAR                 DMA_CCR_CIRC      /*!< Circular mode  */
+#define DMA_NORMAL                   LL_DMA_MODE_NORMAL                 /*!< Normal mode    */
+#define DMA_CIRCULAR                 LL_DMA_MODE_CIRCULAR               /*!< Circular mode  */
 /**
   * @}
   */
@@ -343,10 +367,10 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Priority_level DMA Priority level
   * @{
   */
-#define DMA_PRIORITY_LOW             0x00000000U       /*!< Priority level : Low       */
-#define DMA_PRIORITY_MEDIUM          DMA_CCR_PL_0      /*!< Priority level : Medium    */
-#define DMA_PRIORITY_HIGH            DMA_CCR_PL_1      /*!< Priority level : High      */
-#define DMA_PRIORITY_VERY_HIGH       DMA_CCR_PL        /*!< Priority level : Very_High */
+#define DMA_PRIORITY_LOW             LL_DMA_PRIORITY_LOW                /*!< Priority level : Low       */
+#define DMA_PRIORITY_MEDIUM          LL_DMA_PRIORITY_MEDIUM             /*!< Priority level : Medium    */
+#define DMA_PRIORITY_HIGH            LL_DMA_PRIORITY_HIGH               /*!< Priority level : High      */
+#define DMA_PRIORITY_VERY_HIGH       LL_DMA_PRIORITY_VERYHIGH           /*!< Priority level : Very_High */
 /**
   * @}
   */
@@ -354,9 +378,9 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_interrupt_enable_definitions DMA interrupt enable definitions
   * @{
   */
-#define DMA_IT_TC                    DMA_CCR_TCIE
-#define DMA_IT_HT                    DMA_CCR_HTIE
-#define DMA_IT_TE                    DMA_CCR_TEIE
+#define DMA_IT_TC                    DMA_CCR_TCIE                       /*!< Transfer Complete interrupt      */
+#define DMA_IT_HT                    DMA_CCR_HTIE                       /*!< Half Transfer Complete interrupt */
+#define DMA_IT_TE                    DMA_CCR_TEIE                       /*!< Transfer Error interrupt         */
 /**
   * @}
   */
@@ -365,38 +389,38 @@ typedef struct __DMA_HandleTypeDef
   * @{
   */
 
-#define DMA_FLAG_GI1                 DMA_ISR_GIF1
-#define DMA_FLAG_TC1                 DMA_ISR_TCIF1
-#define DMA_FLAG_HT1                 DMA_ISR_HTIF1
-#define DMA_FLAG_TE1                 DMA_ISR_TEIF1
-#define DMA_FLAG_GI2                 DMA_ISR_GIF2
-#define DMA_FLAG_TC2                 DMA_ISR_TCIF2
-#define DMA_FLAG_HT2                 DMA_ISR_HTIF2
-#define DMA_FLAG_TE2                 DMA_ISR_TEIF2
-#define DMA_FLAG_GI3                 DMA_ISR_GIF3
-#define DMA_FLAG_TC3                 DMA_ISR_TCIF3
-#define DMA_FLAG_HT3                 DMA_ISR_HTIF3
-#define DMA_FLAG_TE3                 DMA_ISR_TEIF3
-#define DMA_FLAG_GI4                 DMA_ISR_GIF4
-#define DMA_FLAG_TC4                 DMA_ISR_TCIF4
-#define DMA_FLAG_HT4                 DMA_ISR_HTIF4
-#define DMA_FLAG_TE4                 DMA_ISR_TEIF4
-#define DMA_FLAG_GI5                 DMA_ISR_GIF5
-#define DMA_FLAG_TC5                 DMA_ISR_TCIF5
-#define DMA_FLAG_HT5                 DMA_ISR_HTIF5
-#define DMA_FLAG_TE5                 DMA_ISR_TEIF5
-#if defined (DMA1_Channel6)
-#define DMA_FLAG_GI6                 DMA_ISR_GIF6
-#define DMA_FLAG_TC6                 DMA_ISR_TCIF6
-#define DMA_FLAG_HT6                 DMA_ISR_HTIF6
-#define DMA_FLAG_TE6                 DMA_ISR_TEIF6
-#endif /* DMA1_Channel6 */
-#if defined (DMA1_Channel7)
-#define DMA_FLAG_GI7                 DMA_ISR_GIF7
-#define DMA_FLAG_TC7                 DMA_ISR_TCIF7
-#define DMA_FLAG_HT7                 DMA_ISR_HTIF7
-#define DMA_FLAG_TE7                 DMA_ISR_TEIF7
-#endif /* DMA1_Channel7 */
+#define DMA_FLAG_GI1                 DMA_ISR_GIF1                       /*!< Global Interrupt flag for Channel 1  */
+#define DMA_FLAG_TC1                 DMA_ISR_TCIF1                      /*!< Transfer Complete flag for Channel 1 */
+#define DMA_FLAG_HT1                 DMA_ISR_HTIF1                      /*!< Half Transfer flag for Channel 1      */
+#define DMA_FLAG_TE1                 DMA_ISR_TEIF1                      /*!< Transfer Error flag for Channel 1     */
+#define DMA_FLAG_GI2                 DMA_ISR_GIF2                       /*!< Global Interrupt flag for Channel 2  */
+#define DMA_FLAG_TC2                 DMA_ISR_TCIF2                      /*!< Transfer Complete flag for Channel 2 */
+#define DMA_FLAG_HT2                 DMA_ISR_HTIF2                      /*!< Half Transfer flag for Channel 2      */
+#define DMA_FLAG_TE2                 DMA_ISR_TEIF2                      /*!< Transfer Error flag for Channel 2     */
+#define DMA_FLAG_GI3                 DMA_ISR_GIF3                       /*!< Global Interrupt flag for Channel 3  */
+#define DMA_FLAG_TC3                 DMA_ISR_TCIF3                      /*!< Transfer Complete flag for Channel 3 */
+#define DMA_FLAG_HT3                 DMA_ISR_HTIF3                      /*!< Half Transfer flag for Channel 3      */
+#define DMA_FLAG_TE3                 DMA_ISR_TEIF3                      /*!< Transfer Error flag for Channel 3     */
+#define DMA_FLAG_GI4                 DMA_ISR_GIF4                       /*!< Global Interrupt flag for Channel 4  */
+#define DMA_FLAG_TC4                 DMA_ISR_TCIF4                      /*!< Transfer Complete flag for Channel 4 */
+#define DMA_FLAG_HT4                 DMA_ISR_HTIF4                      /*!< Half Transfer flag for Channel 4      */
+#define DMA_FLAG_TE4                 DMA_ISR_TEIF4                      /*!< Transfer Error flag for Channel 4     */
+#define DMA_FLAG_GI5                 DMA_ISR_GIF5                       /*!< Global Interrupt flag for Channel 5  */
+#define DMA_FLAG_TC5                 DMA_ISR_TCIF5                      /*!< Transfer Complete flag for Channel 5 */
+#define DMA_FLAG_HT5                 DMA_ISR_HTIF5                      /*!< Half Transfer flag for Channel 5      */
+#define DMA_FLAG_TE5                 DMA_ISR_TEIF5                      /*!< Transfer Error for Channel 5          */
+#if defined(DMA1_Channel6)
+#define DMA_FLAG_GI6                 DMA_ISR_GIF6                       /*!< Global Interrupt flag for Channel 6  */
+#define DMA_FLAG_TC6                 DMA_ISR_TCIF6                      /*!< Transfer Complete flag for Channel 6 */
+#define DMA_FLAG_HT6                 DMA_ISR_HTIF6                      /*!< Half Transfer flag for Channel 6      */
+#define DMA_FLAG_TE6                 DMA_ISR_TEIF6                      /*!< Transfer Error flag for Channel 6     */
+#endif
+#if defined(DMA1_Channel7)
+#define DMA_FLAG_GI7                 DMA_ISR_GIF7                       /*!< Global Interrupt flag for Channel 7  */
+#define DMA_FLAG_TC7                 DMA_ISR_TCIF7                      /*!< Transfer Complete flag for Channel 7 */
+#define DMA_FLAG_HT7                 DMA_ISR_HTIF7                      /*!< Half Transfer flag for Channel 7      */
+#define DMA_FLAG_TE7                 DMA_ISR_TEIF7                      /*!< Transfer Error flag for Channel 7     */
+#endif
 /**
   * @}
   */
@@ -430,15 +454,27 @@ typedef struct __DMA_HandleTypeDef
   */
 #define __HAL_DMA_DISABLE(__HANDLE__)       ((__HANDLE__)->Instance->CCR &=  ~DMA_CCR_EN)
 
-/* Interrupt & Flag management */
-
 /**
   * @brief  Return the current DMA Channel transfer complete flag.
   * @param __HANDLE__ DMA handle
   * @retval The specified transfer complete flag index.
   */
-
-#if defined (DMA1_Channel7)
+#if defined(DMA2)
+#define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TC1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TC2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TC3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TC4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TC5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
+   DMA_FLAG_TC7)
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
 #define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
@@ -447,22 +483,38 @@ typedef struct __DMA_HandleTypeDef
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
    DMA_FLAG_TC7)
-#elif defined (DMA1_Channel5)
+#else
 #define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
    DMA_FLAG_TC5)
-#endif /* DMA1_Channel7 */
+#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Return the current DMA Channel half transfer complete flag.
   * @param __HANDLE__ DMA handle
   * @retval The specified half transfer complete flag index.
   */
-#if defined (DMA1_Channel7)
-#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
+#if defined(DMA2)
+#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_HT1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_HT2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_HT3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_HT4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_HT5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
+   DMA_FLAG_HT7)
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
+#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
@@ -470,22 +522,38 @@ typedef struct __DMA_HandleTypeDef
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
    DMA_FLAG_HT7)
-#elif defined(DMA1_Channel5)
-#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
+#else
+#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
    DMA_FLAG_HT5)
-#endif /* DMA1_Channel7 */
+#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Return the current DMA Channel transfer error flag.
   * @param  __HANDLE__ DMA handle
   * @retval The specified transfer error flag index.
   */
-#if defined (DMA1_Channel7)
-#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
+#if defined(DMA2)
+#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TE1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TE2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TE3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TE4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TE5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
+   DMA_FLAG_TE7)
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
+#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
@@ -493,65 +561,92 @@ typedef struct __DMA_HandleTypeDef
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
    DMA_FLAG_TE7)
-#elif defined(DMA1_Channel5)
-#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
+#else
+#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
    DMA_FLAG_TE5)
-#endif /* DMA1_Channel7 */
+#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Return the current DMA Channel Global interrupt flag.
   * @param  __HANDLE__ DMA handle
   * @retval The specified transfer error flag index.
   */
-#if defined (DMA1_Channel7)
-#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__)\
+#if defined(DMA2)
+#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_GI1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_GI1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_GI2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_GI2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_GI3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_GI3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_GI4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_GI4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_GI5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_GI5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_GI6 :\
+   DMA_FLAG_GI7)
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
+#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_GI1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_GI2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_GI3 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_GI4 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_GI5 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_GI6 :\
-   DMA_ISR_GIF7)
-#elif defined(DMA1_Channel5)
-#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__)\
+   DMA_FLAG_GI7)
+#else
+#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__) \
 (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_GI1 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_GI2 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_GI3 :\
  ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_GI4 :\
-   DMA_ISR_GIF5)
-#endif /* DMA1_Channel7 */
+   DMA_FLAG_GI5)
+#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Get the DMA Channel pending flags.
   * @param  __HANDLE__ DMA handle
   * @param  __FLAG__ Get the specified flag.
   *          This parameter can be any combination of the following values:
-  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
-  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
-  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
-  *            @arg DMA_FLAG_GIFx: Global interrupt flag
-  *         Where x can be 1_7 to select the DMA Channel flag.
+  *            @arg DMA_FLAG_TCx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEx:  Transfer error flag
+  *            @arg DMA_FLAG_GIx:  Global interrupt flag
+  *         Where x can be 1 to max Channel supported by the product to select the DMA Channel flag.
   * @retval The state of FLAG (SET or RESET).
   */
+#if defined(DMA2)
+#define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__) (((uint32_t)((__HANDLE__)->Instance) > ((uint32_t)DMA1_Channel7))? \
+ (DMA2->ISR & (__FLAG__)) : (DMA1->ISR & (__FLAG__)))
+#else /* DMA1 */
 #define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__)  (DMA1->ISR & (__FLAG__))
+#endif /* DMA2 */
 
 /**
   * @brief  Clear the DMA Channel pending flags.
   * @param  __HANDLE__ DMA handle
   * @param  __FLAG__ specifies the flag to clear.
   *          This parameter can be any combination of the following values:
-  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
-  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
-  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
-  *            @arg DMA_FLAG_GIFx: Global interrupt flag
-  *         Where x can be 1_7 to select the DMA Channel flag.
+  *            @arg DMA_FLAG_TCx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEx:  Transfer error flag
+  *            @arg DMA_FLAG_GIx:  Global interrupt flag
+  *         Where x can be 1 to max Channel supported by the product to select the DMA Channel flag.
   * @retval None
   */
+#if defined(DMA2)
+#define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (((uint32_t)((__HANDLE__)->Instance) > ((uint32_t)DMA1_Channel7))? \
+ (DMA2->IFCR = (__FLAG__)) : (DMA1->IFCR = (__FLAG__)))
+#else /* DMA1 */
 #define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (DMA1->IFCR |= (__FLAG__))
+#endif /* DMA2 */
 
 /**
   * @brief  Enable the specified DMA Channel interrupts.
@@ -655,39 +750,35 @@ uint32_t             HAL_DMA_GetError(DMA_HandleTypeDef *hdma);
   * @{
   */
 
-#define IS_DMA_DIRECTION(DIRECTION) (((DIRECTION) == DMA_PERIPH_TO_MEMORY ) || \
-                                     ((DIRECTION) == DMA_MEMORY_TO_PERIPH)  || \
-                                     ((DIRECTION) == DMA_MEMORY_TO_MEMORY))
+#define IS_DMA_DIRECTION(DIRECTION)             (((DIRECTION) == DMA_PERIPH_TO_MEMORY ) || \
+                                                 ((DIRECTION) == DMA_MEMORY_TO_PERIPH)  || \
+                                                 ((DIRECTION) == DMA_MEMORY_TO_MEMORY))
 
-#define IS_DMA_BUFFER_SIZE(SIZE) (((SIZE) >= 0x1U) && ((SIZE) < 0x10000U))
+#define IS_DMA_BUFFER_SIZE(SIZE)                (((SIZE) >= 0x1U) && ((SIZE) < DMA_CNDTR_NDT))
 
-#define IS_DMA_PERIPHERAL_INC_STATE(STATE) (((STATE) == DMA_PINC_ENABLE) || \
-                                            ((STATE) == DMA_PINC_DISABLE))
+#define IS_DMA_PERIPHERAL_INC_STATE(STATE)      (((STATE) == DMA_PINC_ENABLE) || \
+                                                 ((STATE) == DMA_PINC_DISABLE))
 
-#define IS_DMA_MEMORY_INC_STATE(STATE) (((STATE) == DMA_MINC_ENABLE)  || \
-                                        ((STATE) == DMA_MINC_DISABLE))
+#define IS_DMA_MEMORY_INC_STATE(STATE)          (((STATE) == DMA_MINC_ENABLE)  || \
+                                                 ((STATE) == DMA_MINC_DISABLE))
 
-#if defined(STM32G081xx)||defined(STM32G071xx)||defined(STM32G070xx)
-#define IS_DMA_ALL_REQUEST(REQUEST) ((REQUEST) <= DMA_REQUEST_UCPD2_TX)
-#elif defined(STM32G041xx)||defined(STM32G031xx)||defined(STM32G030xx)
-#define IS_DMA_ALL_REQUEST(REQUEST) ((REQUEST) <= DMA_REQUEST_USART2_TX)
-#endif
+#define IS_DMA_ALL_REQUEST(REQUEST)             ((REQUEST) <= DMA_MAX_REQUEST)
 
-#define IS_DMA_PERIPHERAL_DATA_SIZE(SIZE) (((SIZE) == DMA_PDATAALIGN_BYTE)     || \
-                                           ((SIZE) == DMA_PDATAALIGN_HALFWORD) || \
-                                           ((SIZE) == DMA_PDATAALIGN_WORD))
+#define IS_DMA_PERIPHERAL_DATA_SIZE(SIZE)       (((SIZE) == DMA_PDATAALIGN_BYTE)     || \
+                                                 ((SIZE) == DMA_PDATAALIGN_HALFWORD) || \
+                                                 ((SIZE) == DMA_PDATAALIGN_WORD))
 
-#define IS_DMA_MEMORY_DATA_SIZE(SIZE) (((SIZE) == DMA_MDATAALIGN_BYTE)     || \
-                                       ((SIZE) == DMA_MDATAALIGN_HALFWORD) || \
-                                       ((SIZE) == DMA_MDATAALIGN_WORD ))
+#define IS_DMA_MEMORY_DATA_SIZE(SIZE)           (((SIZE) == DMA_MDATAALIGN_BYTE)     || \
+                                                 ((SIZE) == DMA_MDATAALIGN_HALFWORD) || \
+                                                 ((SIZE) == DMA_MDATAALIGN_WORD ))
 
-#define IS_DMA_MODE(MODE) (((MODE) == DMA_NORMAL )  || \
-                           ((MODE) == DMA_CIRCULAR))
+#define IS_DMA_MODE(MODE)                       (((MODE) == DMA_NORMAL )  || \
+                                                 ((MODE) == DMA_CIRCULAR))
 
-#define IS_DMA_PRIORITY(PRIORITY) (((PRIORITY) == DMA_PRIORITY_LOW )   || \
-                                   ((PRIORITY) == DMA_PRIORITY_MEDIUM) || \
-                                   ((PRIORITY) == DMA_PRIORITY_HIGH)   || \
-                                   ((PRIORITY) == DMA_PRIORITY_VERY_HIGH))
+#define IS_DMA_PRIORITY(PRIORITY)               (((PRIORITY) == DMA_PRIORITY_LOW )   || \
+                                                 ((PRIORITY) == DMA_PRIORITY_MEDIUM) || \
+                                                 ((PRIORITY) == DMA_PRIORITY_HIGH)   || \
+                                                 ((PRIORITY) == DMA_PRIORITY_VERY_HIGH))
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_dma_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_dma_ex.h
@@ -27,6 +27,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g0xx_hal_def.h"
+#include "stm32g0xx_ll_dmamux.h"
 
 /** @addtogroup STM32G0xx_HAL_Driver
   * @{
@@ -42,29 +43,24 @@ extern "C" {
   */
 
 /**
-  * @brief  HAL DMA Synchro definition
-  */
-
-
-/**
   * @brief  HAL DMAMUX Synchronization configuration structure definition
   */
 typedef struct
 {
-  uint32_t SyncSignalID;  /*!< Specifies the synchronization signal gating the DMA request in periodic mode.
-                              This parameter can be a value of @ref DMAEx_DMAMUX_SyncSignalID_selection */
+  uint32_t SyncSignalID;        /*!< Specifies the synchronization signal gating the DMA request in periodic mode.
+                                  This parameter can be a value of @ref DMAEx_DMAMUX_SyncSignalID_selection */
 
-  uint32_t SyncPolarity;  /*!< Specifies the polarity of the signal on which the DMA request is synchronized.
-                              This parameter can be a value of @ref DMAEx_DMAMUX_SyncPolarity_selection */
+  uint32_t SyncPolarity;        /*!< Specifies the polarity of the signal on which the DMA request is synchronized.
+                                  This parameter can be a value of @ref DMAEx_DMAMUX_SyncPolarity_selection */
 
-  FunctionalState SyncEnable;  /*!< Specifies if the synchronization shall be enabled or disabled
-                                    This parameter can take the value ENABLE or DISABLE*/
+  FunctionalState SyncEnable;   /*!< Specifies if the synchronization shall be enabled or disabled
+                                  This parameter can take the value ENABLE or DISABLE */
 
-  FunctionalState EventEnable;    /*!< Specifies if an event shall be generated once the RequestNumber is reached.
-                                       This parameter can take the value ENABLE or DISABLE */
+  FunctionalState EventEnable;  /*!< Specifies if an event shall be generated once the RequestNumber is reached.
+                                  This parameter can take the value ENABLE or DISABLE */
 
-  uint32_t RequestNumber; /*!< Specifies the number of DMA request that will be authorized after a sync event
-                               This parameter must be a number between Min_Data = 1 and Max_Data = 32 */
+  uint32_t RequestNumber;       /*!< Specifies the number of DMA request that will be authorized after a sync event
+                                  This parameter must be a number between Min_Data = 1 and Max_Data = 32 */
 
 
 } HAL_DMA_MuxSyncConfigTypeDef;
@@ -75,14 +71,14 @@ typedef struct
   */
 typedef struct
 {
-  uint32_t SignalID;      /*!< Specifies the ID of the signal used for DMAMUX request generator
-                              This parameter can be a value of @ref DMAEx_DMAMUX_SignalGeneratorID_selection */
+  uint32_t SignalID;            /*!< Specifies the ID of the signal used for DMAMUX request generator
+                                  This parameter can be a value of @ref DMAEx_DMAMUX_SignalGeneratorID_selection */
 
-  uint32_t Polarity;       /*!< Specifies the polarity of the signal on which the request is generated.
-                             This parameter can be a value of @ref DMAEx_DMAMUX_RequestGeneneratorPolarity_selection */
+  uint32_t Polarity;            /*!< Specifies the polarity of the signal on which the request is generated.
+                                  This parameter can be a value of @ref DMAEx_DMAMUX_RequestGeneneratorPolarity_selection */
 
-  uint32_t RequestNumber;  /*!< Specifies the number of DMA request that will be generated after a signal event
-                                This parameter must be a number between Min_Data = 1 and Max_Data = 32 */
+  uint32_t RequestNumber;       /*!< Specifies the number of DMA request that will be generated after a signal event
+                                  This parameter must be a number between Min_Data = 1 and Max_Data = 32 */
 
 } HAL_DMA_MuxRequestGeneratorConfigTypeDef;
 
@@ -98,30 +94,35 @@ typedef struct
 /** @defgroup DMAEx_DMAMUX_SyncSignalID_selection DMAMUX SyncSignalID selection
   * @{
   */
-#define HAL_DMAMUX1_SYNC_EXTI0                      0U     /*!<  Synchronization Signal is EXTI0  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI1                      1U     /*!<  Synchronization Signal is EXTI1  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI2                      2U     /*!<  Synchronization Signal is EXTI2  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI3                      3U     /*!<  Synchronization Signal is EXTI3  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI4                      4U     /*!<  Synchronization Signal is EXTI4  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI5                      5U     /*!<  Synchronization Signal is EXTI5  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI6                      6U     /*!<  Synchronization Signal is EXTI6  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI7                      7U     /*!<  Synchronization Signal is EXTI7  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI8                      8U     /*!<  Synchronization Signal is EXTI8  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI9                      9U     /*!<  Synchronization Signal is EXTI9  IT   */
-#define HAL_DMAMUX1_SYNC_EXTI10                    10U     /*!<  Synchronization Signal is EXTI10 IT   */
-#define HAL_DMAMUX1_SYNC_EXTI11                    11U     /*!<  Synchronization Signal is EXTI11 IT   */
-#define HAL_DMAMUX1_SYNC_EXTI12                    12U     /*!<  Synchronization Signal is EXTI12 IT   */
-#define HAL_DMAMUX1_SYNC_EXTI13                    13U     /*!<  Synchronization Signal is EXTI13 IT   */
-#define HAL_DMAMUX1_SYNC_EXTI14                    14U     /*!<  Synchronization Signal is EXTI14 IT   */
-#define HAL_DMAMUX1_SYNC_EXTI15                    15U     /*!<  Synchronization Signal is EXTI15 IT   */
-#define HAL_DMAMUX1_SYNC_DMAMUX1_CH0_EVT           16U     /*!<  Synchronization Signal is DMAMUX1 Channel0 Event  */
-#define HAL_DMAMUX1_SYNC_DMAMUX1_CH1_EVT           17U     /*!<  Synchronization Signal is DMAMUX1 Channel1 Event  */
-#define HAL_DMAMUX1_SYNC_DMAMUX1_CH2_EVT           18U     /*!<  Synchronization Signal is DMAMUX1 Channel2 Event  */
-#define HAL_DMAMUX1_SYNC_DMAMUX1_CH3_EVT           19U     /*!<  Synchronization Signal is DMAMUX1 Channel3 Event  */
-#define HAL_DMAMUX1_SYNC_LPTIM1_OUT                20U     /*!<  Synchronization Signal is LPTIM1 OUT */
-#define HAL_DMAMUX1_SYNC_LPTIM2_OUT                21U     /*!<  Synchronization Signal is LPTIM2 OUT */
-#define HAL_DMAMUX1_SYNC_TIM14_OC                  22U     /*!<  Synchronization Signal is TIM14 OC */
+#define HAL_DMAMUX1_SYNC_EXTI0            LL_DMAMUX_SYNC_EXTI_LINE0      /*!< Synchronization signal from EXTI Line0  */
+#define HAL_DMAMUX1_SYNC_EXTI1            LL_DMAMUX_SYNC_EXTI_LINE1      /*!< Synchronization signal from EXTI Line1  */
+#define HAL_DMAMUX1_SYNC_EXTI2            LL_DMAMUX_SYNC_EXTI_LINE2      /*!< Synchronization signal from EXTI Line2  */
+#define HAL_DMAMUX1_SYNC_EXTI3            LL_DMAMUX_SYNC_EXTI_LINE3      /*!< Synchronization signal from EXTI Line3  */
+#define HAL_DMAMUX1_SYNC_EXTI4            LL_DMAMUX_SYNC_EXTI_LINE4      /*!< Synchronization signal from EXTI Line4  */
+#define HAL_DMAMUX1_SYNC_EXTI5            LL_DMAMUX_SYNC_EXTI_LINE5      /*!< Synchronization signal from EXTI Line5  */
+#define HAL_DMAMUX1_SYNC_EXTI6            LL_DMAMUX_SYNC_EXTI_LINE6      /*!< Synchronization signal from EXTI Line6  */
+#define HAL_DMAMUX1_SYNC_EXTI7            LL_DMAMUX_SYNC_EXTI_LINE7      /*!< Synchronization signal from EXTI Line7  */
+#define HAL_DMAMUX1_SYNC_EXTI8            LL_DMAMUX_SYNC_EXTI_LINE8      /*!< Synchronization signal from EXTI Line8  */
+#define HAL_DMAMUX1_SYNC_EXTI9            LL_DMAMUX_SYNC_EXTI_LINE9      /*!< Synchronization signal from EXTI Line9  */
+#define HAL_DMAMUX1_SYNC_EXTI10           LL_DMAMUX_SYNC_EXTI_LINE10     /*!< Synchronization signal from EXTI Line10  */
+#define HAL_DMAMUX1_SYNC_EXTI11           LL_DMAMUX_SYNC_EXTI_LINE11     /*!< Synchronization signal from EXTI Line11  */
+#define HAL_DMAMUX1_SYNC_EXTI12           LL_DMAMUX_SYNC_EXTI_LINE12     /*!< Synchronization signal from EXTI Line12  */
+#define HAL_DMAMUX1_SYNC_EXTI13           LL_DMAMUX_SYNC_EXTI_LINE13     /*!< Synchronization signal from EXTI Line1 3 */
+#define HAL_DMAMUX1_SYNC_EXTI14           LL_DMAMUX_SYNC_EXTI_LINE14     /*!< Synchronization signal from EXTI Line1 4 */
+#define HAL_DMAMUX1_SYNC_EXTI15           LL_DMAMUX_SYNC_EXTI_LINE15     /*!< Synchronization signal from EXTI Line1 5 */
+#define HAL_DMAMUX1_SYNC_DMAMUX1_CH0_EVT  LL_DMAMUX_SYNC_DMAMUX_CH0      /*!< Synchronization signal from DMAMUX channel0 Event */
+#define HAL_DMAMUX1_SYNC_DMAMUX1_CH1_EVT  LL_DMAMUX_SYNC_DMAMUX_CH1      /*!< Synchronization signal from DMAMUX channel1 Event */
+#define HAL_DMAMUX1_SYNC_DMAMUX1_CH2_EVT  LL_DMAMUX_SYNC_DMAMUX_CH2      /*!< Synchronization signal from DMAMUX channel2 Event */
+#define HAL_DMAMUX1_SYNC_DMAMUX1_CH3_EVT  LL_DMAMUX_SYNC_DMAMUX_CH3      /*!< Synchronization signal from DMAMUX channel3 Event */
+#if defined(LPTIM1)
+#define HAL_DMAMUX1_SYNC_LPTIM1_OUT       LL_DMAMUX_SYNC_LPTIM1_OUT      /*!< Synchronization signal from LPTIM1 Output */
+#endif
+#if defined(LPTIM2)
+#define HAL_DMAMUX1_SYNC_LPTIM2_OUT       LL_DMAMUX_SYNC_LPTIM2_OUT      /*!< Synchronization signal from LPTIM2 Output */
+#endif
+#define HAL_DMAMUX1_SYNC_TIM14_OC         LL_DMAMUX_SYNC_TIM14_OC        /*!< Synchronization signal from TIM14 OC */
 
+#define HAL_DMAMUX1_MAX_SYNC              HAL_DMAMUX1_SYNC_TIM14_OC
 /**
   * @}
   */
@@ -129,10 +130,10 @@ typedef struct
 /** @defgroup DMAEx_DMAMUX_SyncPolarity_selection DMAMUX SyncPolarity selection
   * @{
   */
-#define HAL_DMAMUX_SYNC_NO_EVENT                   0U                          /*!< block synchronization events        */
-#define HAL_DMAMUX_SYNC_RISING                     DMAMUX_CxCR_SPOL_0          /*!< synchronize with rising edge events */
-#define HAL_DMAMUX_SYNC_FALLING                    DMAMUX_CxCR_SPOL_1          /*!< synchronize with falling edge events */
-#define HAL_DMAMUX_SYNC_RISING_FALLING             DMAMUX_CxCR_SPOL            /*!< synchronize with rising and falling edge events */
+#define HAL_DMAMUX_SYNC_NO_EVENT          LL_DMAMUX_SYNC_NO_EVENT               /*!< block synchronization events                       */
+#define HAL_DMAMUX_SYNC_RISING            LL_DMAMUX_SYNC_POL_RISING             /*!< synchronize with rising edge events                */
+#define HAL_DMAMUX_SYNC_FALLING           LL_DMAMUX_SYNC_POL_FALLING            /*!< synchronize with falling edge events               */
+#define HAL_DMAMUX_SYNC_RISING_FALLING    LL_DMAMUX_SYNC_POL_RISING_FALLING     /*!< synchronize with rising and falling edge events    */
 
 /**
   * @}
@@ -141,30 +142,35 @@ typedef struct
 /** @defgroup DMAEx_DMAMUX_SignalGeneratorID_selection DMAMUX SignalGeneratorID selection
   * @{
   */
-#define HAL_DMAMUX1_REQ_GEN_EXTI0               0U     /*!< Request generator Signal is EXTI0 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI1               1U     /*!< Request generator Signal is EXTI1 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI2               2U     /*!< Request generator Signal is EXTI2 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI3               3U     /*!< Request generator Signal is EXTI3 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI4               4U     /*!< Request generator Signal is EXTI4 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI5               5U     /*!< Request generator Signal is EXTI5 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI6               6U     /*!< Request generator Signal is EXTI6 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI7               7U     /*!< Request generator Signal is EXTI7 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI8               8U     /*!< Request generator Signal is EXTI8 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI9               9U     /*!< Request generator Signal is EXTI9 IT    */
-#define HAL_DMAMUX1_REQ_GEN_EXTI10             10U     /*!< Request generator Signal is EXTI10 IT   */
-#define HAL_DMAMUX1_REQ_GEN_EXTI11             11U     /*!< Request generator Signal is EXTI11 IT   */
-#define HAL_DMAMUX1_REQ_GEN_EXTI12             12U     /*!< Request generator Signal is EXTI12 IT   */
-#define HAL_DMAMUX1_REQ_GEN_EXTI13             13U     /*!< Request generator Signal is EXTI13 IT   */
-#define HAL_DMAMUX1_REQ_GEN_EXTI14             14U     /*!< Request generator Signal is EXTI14 IT   */
-#define HAL_DMAMUX1_REQ_GEN_EXTI15             15U     /*!< Request generator Signal is EXTI15 IT   */
-#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH0_EVT    16U     /*!< Request generator Signal is DMAMUX1 Channel0 Event */
-#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH1_EVT    17U     /*!< Request generator Signal is DMAMUX1 Channel1 Event */
-#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH2_EVT    18U     /*!< Request generator Signal is DMAMUX1 Channel2 Event  */
-#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH3_EVT    19U     /*!< Request generator Signal is DMAMUX1 Channel3 Event  */
-#define HAL_DMAMUX1_REQ_GEN_LPTIM1_OUT         20U     /*!< Request generator Signal is LPTIM1 OUT */
-#define HAL_DMAMUX1_REQ_GEN_LPTIM2_OUT         21U     /*!< Request generator Signal is LPTIM2 OUT */
-#define HAL_DMAMUX1_REQ_GEN_TIM14_OC           22U     /*!< Request generator Signal is TIM14 OC */
+#define HAL_DMAMUX1_REQ_GEN_EXTI0            LL_DMAMUX_REQ_GEN_EXTI_LINE0    /*!< Request signal generation from EXTI Line0  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI1            LL_DMAMUX_REQ_GEN_EXTI_LINE1    /*!< Request signal generation from EXTI Line1  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI2            LL_DMAMUX_REQ_GEN_EXTI_LINE2    /*!< Request signal generation from EXTI Line2  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI3            LL_DMAMUX_REQ_GEN_EXTI_LINE3    /*!< Request signal generation from EXTI Line3  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI4            LL_DMAMUX_REQ_GEN_EXTI_LINE4    /*!< Request signal generation from EXTI Line4  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI5            LL_DMAMUX_REQ_GEN_EXTI_LINE5    /*!< Request signal generation from EXTI Line5  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI6            LL_DMAMUX_REQ_GEN_EXTI_LINE6    /*!< Request signal generation from EXTI Line6  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI7            LL_DMAMUX_REQ_GEN_EXTI_LINE7    /*!< Request signal generation from EXTI Line7  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI8            LL_DMAMUX_REQ_GEN_EXTI_LINE8    /*!< Request signal generation from EXTI Line8  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI9            LL_DMAMUX_REQ_GEN_EXTI_LINE9    /*!< Request signal generation from EXTI Line9  */
+#define HAL_DMAMUX1_REQ_GEN_EXTI10           LL_DMAMUX_REQ_GEN_EXTI_LINE10   /*!< Request signal generation from EXTI Line10 */
+#define HAL_DMAMUX1_REQ_GEN_EXTI11           LL_DMAMUX_REQ_GEN_EXTI_LINE11   /*!< Request signal generation from EXTI Line11 */
+#define HAL_DMAMUX1_REQ_GEN_EXTI12           LL_DMAMUX_REQ_GEN_EXTI_LINE12   /*!< Request signal generation from EXTI Line12 */
+#define HAL_DMAMUX1_REQ_GEN_EXTI13           LL_DMAMUX_REQ_GEN_EXTI_LINE13   /*!< Request signal generation from EXTI Line13 */
+#define HAL_DMAMUX1_REQ_GEN_EXTI14           LL_DMAMUX_REQ_GEN_EXTI_LINE14   /*!< Request signal generation from EXTI Line14 */
+#define HAL_DMAMUX1_REQ_GEN_EXTI15           LL_DMAMUX_REQ_GEN_EXTI_LINE15   /*!< Request signal generation from EXTI Line15 */
+#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH0_EVT  LL_DMAMUX_REQ_GEN_DMAMUX_CH0    /*!< Request signal generation from DMAMUX channel0 Event */
+#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH1_EVT  LL_DMAMUX_REQ_GEN_DMAMUX_CH1    /*!< Request signal generation from DMAMUX channel1 Event */
+#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH2_EVT  LL_DMAMUX_REQ_GEN_DMAMUX_CH2    /*!< Request signal generation from DMAMUX channel2 Event */
+#define HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH3_EVT  LL_DMAMUX_REQ_GEN_DMAMUX_CH3    /*!< Request signal generation from DMAMUX channel3 Event */
+#if defined(LPTIM1)
+#define HAL_DMAMUX1_REQ_GEN_LPTIM1_OUT       LL_DMAMUX_REQ_GEN_LPTIM1_OUT    /*!< Request signal generation from LPTIM1 Output */
+#endif
+#if defined(LPTIM2)
+#define HAL_DMAMUX1_REQ_GEN_LPTIM2_OUT       LL_DMAMUX_REQ_GEN_LPTIM2_OUT    /*!< Request signal generation from LPTIM2 Output */
+#endif
+#define HAL_DMAMUX1_REQ_GEN_TIM14_OC         LL_DMAMUX_REQ_GEN_TIM14_OC      /*!< Request signal generation from TIM14 OC */
 
+#define HAL_DMAMUX1_MAX_REQ_GEN              HAL_DMAMUX1_REQ_GEN_TIM14_OC
 /**
   * @}
   */
@@ -172,10 +178,10 @@ typedef struct
 /** @defgroup DMAEx_DMAMUX_RequestGeneneratorPolarity_selection DMAMUX RequestGeneneratorPolarity selection
   * @{
   */
-#define HAL_DMAMUX_REQ_GEN_NO_EVENT            0U                          /*!< block request generator events        */
-#define HAL_DMAMUX_REQ_GEN_RISING              DMAMUX_RGxCR_GPOL_0         /*!< generate request on rising edge events */
-#define HAL_DMAMUX_REQ_GEN_FALLING             DMAMUX_RGxCR_GPOL_1         /*!< generate request on falling edge events */
-#define HAL_DMAMUX_REQ_GEN_RISING_FALLING      DMAMUX_RGxCR_GPOL           /*!< generate request on rising and falling edge events */
+#define HAL_DMAMUX_REQ_GEN_NO_EVENT       LL_DMAMUX_REQ_GEN_NO_EVENT            /*!< block request generator events                     */
+#define HAL_DMAMUX_REQ_GEN_RISING         LL_DMAMUX_REQ_GEN_POL_RISING          /*!< generate request on rising edge events             */
+#define HAL_DMAMUX_REQ_GEN_FALLING        LL_DMAMUX_REQ_GEN_POL_FALLING         /*!< generate request on falling edge events            */
+#define HAL_DMAMUX_REQ_GEN_RISING_FALLING LL_DMAMUX_REQ_GEN_POL_RISING_FALLING  /*!< generate request on rising and falling edge events */
 
 /**
   * @}
@@ -225,28 +231,32 @@ void              HAL_DMAEx_MUX_IRQHandler(DMA_HandleTypeDef *hdma);
  * @{
  */
 
-#define IS_DMAMUX_SYNC_SIGNAL_ID(SIGNAL_ID) ((SIGNAL_ID) <= HAL_DMAMUX1_SYNC_TIM14_OC)
+#define IS_DMAMUX_SYNC_SIGNAL_ID(SIGNAL_ID)             (((SIGNAL_ID) == HAL_DMAMUX1_SYNC_EXTI0) || \
+                                                         (((SIGNAL_ID) >= HAL_DMAMUX1_SYNC_EXTI1) && \
+                                                          ((SIGNAL_ID) <= HAL_DMAMUX1_MAX_SYNC)))
 
-#define IS_DMAMUX_SYNC_REQUEST_NUMBER(REQUEST_NUMBER) (((REQUEST_NUMBER) > 0U) && ((REQUEST_NUMBER) <= 32U))
+#define IS_DMAMUX_SYNC_REQUEST_NUMBER(REQUEST_NUMBER)   (((REQUEST_NUMBER) > 0U) && ((REQUEST_NUMBER) <= 32U))
 
-#define IS_DMAMUX_SYNC_POLARITY(POLARITY) (((POLARITY) == HAL_DMAMUX_SYNC_NO_EVENT)    || \
-                                           ((POLARITY) == HAL_DMAMUX_SYNC_RISING)   || \
-                                           ((POLARITY) == HAL_DMAMUX_SYNC_FALLING)  || \
-                                           ((POLARITY) == HAL_DMAMUX_SYNC_RISING_FALLING))
+#define IS_DMAMUX_SYNC_POLARITY(POLARITY)               (((POLARITY) == HAL_DMAMUX_SYNC_NO_EVENT) || \
+                                                         ((POLARITY) == HAL_DMAMUX_SYNC_RISING)   || \
+                                                         ((POLARITY) == HAL_DMAMUX_SYNC_FALLING)  || \
+                                                         ((POLARITY) == HAL_DMAMUX_SYNC_RISING_FALLING))
 
-#define IS_DMAMUX_SYNC_STATE(SYNC) (((SYNC) == DISABLE)   || ((SYNC) == ENABLE))
+#define IS_DMAMUX_SYNC_STATE(SYNC)                      (((SYNC) == DISABLE)   || ((SYNC) == ENABLE))
 
-#define IS_DMAMUX_SYNC_EVENT(EVENT) (((EVENT) == DISABLE)   || \
-                                     ((EVENT) == ENABLE))
+#define IS_DMAMUX_SYNC_EVENT(EVENT)                     (((EVENT) == DISABLE)   || \
+                                                         ((EVENT) == ENABLE))
 
-#define IS_DMAMUX_REQUEST_GEN_SIGNAL_ID(SIGNAL_ID) ((SIGNAL_ID) <= HAL_DMAMUX1_REQ_GEN_TIM14_OC)
+#define IS_DMAMUX_REQUEST_GEN_SIGNAL_ID(SIGNAL_ID)      (((SIGNAL_ID) == HAL_DMAMUX1_REQ_GEN_EXTI0) || \
+                                                         (((SIGNAL_ID) >= HAL_DMAMUX1_REQ_GEN_EXTI1) && \
+                                                          ((SIGNAL_ID) <= HAL_DMAMUX1_MAX_REQ_GEN)))
 
 #define IS_DMAMUX_REQUEST_GEN_REQUEST_NUMBER(REQUEST_NUMBER) (((REQUEST_NUMBER) > 0U) && ((REQUEST_NUMBER) <= 32U))
 
-#define IS_DMAMUX_REQUEST_GEN_POLARITY(POLARITY) (((POLARITY) == HAL_DMAMUX_REQ_GEN_NO_EVENT)   || \
-                                                  ((POLARITY) == HAL_DMAMUX_REQ_GEN_RISING)  || \
-                                                  ((POLARITY) == HAL_DMAMUX_REQ_GEN_FALLING) || \
-                                                  ((POLARITY) == HAL_DMAMUX_REQ_GEN_RISING_FALLING))
+#define IS_DMAMUX_REQUEST_GEN_POLARITY(POLARITY)        (((POLARITY) == HAL_DMAMUX_REQ_GEN_NO_EVENT)|| \
+                                                         ((POLARITY) == HAL_DMAMUX_REQ_GEN_RISING)  || \
+                                                         ((POLARITY) == HAL_DMAMUX_REQ_GEN_FALLING) || \
+                                                         ((POLARITY) == HAL_DMAMUX_REQ_GEN_RISING_FALLING))
 
 /**
   * @}
@@ -265,6 +275,6 @@ void              HAL_DMAEx_MUX_IRQHandler(DMA_HandleTypeDef *hdma);
 }
 #endif
 
-#endif /* STM32G0xx_HAL_DMA_H */
+#endif /* STM32G0xx_HAL_DMA_EX_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_exti.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_exti.h
@@ -116,11 +116,23 @@ typedef struct
 #define EXTI_LINE_18                        (EXTI_RESERVED | EXTI_REG1 | 0x12u)
 #endif
 #define EXTI_LINE_19                        (EXTI_DIRECT   | EXTI_REG1 | 0x13u)
+#if defined(COMP3)
+#define EXTI_LINE_20                        (EXTI_CONFIG   | EXTI_REG1 | 0x14u)
+#else
 #define EXTI_LINE_20                        (EXTI_RESERVED | EXTI_REG1 | 0x14u)
+#endif
 #define EXTI_LINE_21                        (EXTI_DIRECT   | EXTI_REG1 | 0x15u)
+#if defined(RCC_CCIPR_I2C2SEL)
+#define EXTI_LINE_22                        (EXTI_DIRECT   | EXTI_REG1 | 0x16u)
+#else
 #define EXTI_LINE_22                        (EXTI_RESERVED | EXTI_REG1 | 0x16u)
+#endif
 #define EXTI_LINE_23                        (EXTI_DIRECT   | EXTI_REG1 | 0x17u)
+#if defined(RCC_CCIPR_USART3SEL)
+#define EXTI_LINE_24                        (EXTI_DIRECT   | EXTI_REG1 | 0x18u)
+#else
 #define EXTI_LINE_24                        (EXTI_RESERVED | EXTI_REG1 | 0x18u)
+#endif
 #define EXTI_LINE_25                        (EXTI_DIRECT   | EXTI_REG1 | 0x19u)
 #if defined(RCC_CCIPR_USART2SEL)
 #define EXTI_LINE_26                        (EXTI_DIRECT   | EXTI_REG1 | 0x1Au)
@@ -150,9 +162,26 @@ typedef struct
 #define EXTI_LINE_31                        (EXTI_DIRECT   | EXTI_REG1 | 0x1Fu)
 #if defined(UCPD1)
 #define EXTI_LINE_32                        (EXTI_DIRECT   | EXTI_REG2 | 0x00u)
+#else
+#define EXTI_LINE_32                        (EXTI_RESERVED | EXTI_REG2 | 0x00u)
 #endif
 #if defined(UCPD2)
 #define EXTI_LINE_33                        (EXTI_DIRECT   | EXTI_REG2 | 0x01u)
+#else
+#define EXTI_LINE_33                        (EXTI_RESERVED | EXTI_REG2 | 0x01u)
+#endif
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+#define EXTI_LINE_34                        (EXTI_CONFIG   | EXTI_REG2 | 0x02u)
+#else
+#define EXTI_LINE_34                        (EXTI_RESERVED | EXTI_REG2 | 0x02u)
+#endif
+#if defined(LPUART2)
+#define EXTI_LINE_35                        (EXTI_DIRECT   | EXTI_REG2 | 0x03u)
+#else
+#define EXTI_LINE_35                        (EXTI_RESERVED | EXTI_REG2 | 0x03u)
+#endif
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define EXTI_LINE_36                        (EXTI_DIRECT | EXTI_REG2 | 0x04u)
 #endif
 /**
   * @}
@@ -187,6 +216,9 @@ typedef struct
 #define EXTI_GPIOB                          0x00000001u
 #define EXTI_GPIOC                          0x00000002u
 #define EXTI_GPIOD                          0x00000003u
+#if defined(GPIOE)
+#define EXTI_GPIOE                          0x00000004u
+#endif
 #define EXTI_GPIOF                          0x00000005u
 /**
   * @}
@@ -241,8 +273,16 @@ typedef struct
 /**
   * @brief  EXTI Line number
   */
-#if defined(EXTI_IMR2_IM33)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+#define EXTI_LINE_NB                        37uL
+#elif defined(STM32G0B0xx)
+#define EXTI_LINE_NB                        37uL
+#elif defined(STM32G081xx) || defined(STM32G071xx)
 #define EXTI_LINE_NB                        34uL
+#elif defined(STM32G070xx)
+#define EXTI_LINE_NB                        34uL
+#elif defined(STM32G041xx) || defined(STM32G031xx)
+#define EXTI_LINE_NB                        32uL
 #else
 #define EXTI_LINE_NB                        32uL
 #endif
@@ -255,28 +295,37 @@ typedef struct
 /** @defgroup EXTI_Private_Macros EXTI Private Macros
   * @{
   */
-#define IS_EXTI_LINE(__LINE__)          ((((__LINE__) & ~(EXTI_PROPERTY_MASK | EXTI_REG_MASK | EXTI_PIN_MASK)) == 0x00u) && \
-                                        ((((__LINE__) & EXTI_PROPERTY_MASK) == EXTI_DIRECT)   || \
-                                         (((__LINE__) & EXTI_PROPERTY_MASK) == EXTI_CONFIG)   || \
-                                         (((__LINE__) & EXTI_PROPERTY_MASK) == EXTI_GPIO))    && \
-                                         (((__LINE__) & (EXTI_REG_MASK | EXTI_PIN_MASK))      < \
+#define IS_EXTI_LINE(__EXTI_LINE__)     ((((__EXTI_LINE__) & ~(EXTI_PROPERTY_MASK | EXTI_REG_MASK | EXTI_PIN_MASK)) == 0x00u) && \
+                                        ((((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_DIRECT)   || \
+                                         (((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_CONFIG)   || \
+                                         (((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_GPIO))    && \
+                                         (((__EXTI_LINE__) & (EXTI_REG_MASK | EXTI_PIN_MASK))      < \
                                          (((EXTI_LINE_NB / 32u) << EXTI_REG_SHIFT) | (EXTI_LINE_NB % 32u))))
 
-#define IS_EXTI_MODE(__LINE__)          ((((__LINE__) & EXTI_MODE_MASK) != 0x00u) && \
-                                         (((__LINE__) & ~EXTI_MODE_MASK) == 0x00u))
+#define IS_EXTI_MODE(__MODE__)          ((((__MODE__) & EXTI_MODE_MASK) != 0x00u) && \
+                                         (((__MODE__) & ~EXTI_MODE_MASK) == 0x00u))
 
-#define IS_EXTI_TRIGGER(__LINE__)       (((__LINE__) & ~EXTI_TRIGGER_MASK) == 0x00u)
+#define IS_EXTI_TRIGGER(__EXTI_LINE__)  (((__EXTI_LINE__) & ~EXTI_TRIGGER_MASK) == 0x00u)
 
-#define IS_EXTI_PENDING_EDGE(__LINE__)  (((__LINE__) == EXTI_TRIGGER_RISING) || \
-                                         ((__LINE__) == EXTI_TRIGGER_FALLING))
+#define IS_EXTI_PENDING_EDGE(__EXTI_LINE__)  (((__EXTI_LINE__) == EXTI_TRIGGER_RISING) || \
+                                              ((__EXTI_LINE__) == EXTI_TRIGGER_FALLING))
 
-#define IS_EXTI_CONFIG_LINE(__LINE__)   (((__LINE__) & EXTI_CONFIG) != 0x00u)
+#define IS_EXTI_CONFIG_LINE(__EXTI_LINE__)   (((__EXTI_LINE__) & EXTI_CONFIG) != 0x00u)
 
+#if defined(GPIOE)
+#define IS_EXTI_GPIO_PORT(__PORT__)     (((__PORT__) == EXTI_GPIOA) || \
+                                         ((__PORT__) == EXTI_GPIOB) || \
+                                         ((__PORT__) == EXTI_GPIOC) || \
+                                         ((__PORT__) == EXTI_GPIOD) || \
+                                         ((__PORT__) == EXTI_GPIOE) || \
+                                         ((__PORT__) == EXTI_GPIOF))
+#else
 #define IS_EXTI_GPIO_PORT(__PORT__)     (((__PORT__) == EXTI_GPIOA) || \
                                          ((__PORT__) == EXTI_GPIOB) || \
                                          ((__PORT__) == EXTI_GPIOC) || \
                                          ((__PORT__) == EXTI_GPIOD) || \
                                          ((__PORT__) == EXTI_GPIOF))
+#endif
 
 #define IS_EXTI_GPIO_PIN(__PIN__)       ((__PIN__) < 16u)
 

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_fdcan.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_fdcan.h
@@ -1,0 +1,1438 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_fdcan.h
+  * @author  MCD Application Team
+  * @brief   Header file of FDCAN HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32G0xx_HAL_FDCAN_H
+#define STM32G0xx_HAL_FDCAN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal_def.h"
+
+#if defined(FDCAN1)
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FDCAN
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup FDCAN_Exported_Types FDCAN Exported Types
+  * @{
+  */
+
+/**
+  * @brief HAL State structures definition
+  */
+typedef enum
+{
+  HAL_FDCAN_STATE_RESET      = 0x00U, /*!< FDCAN not yet initialized or disabled */
+  HAL_FDCAN_STATE_READY      = 0x01U, /*!< FDCAN initialized and ready for use   */
+  HAL_FDCAN_STATE_BUSY       = 0x02U, /*!< FDCAN process is ongoing              */
+  HAL_FDCAN_STATE_ERROR      = 0x03U  /*!< FDCAN error state                     */
+} HAL_FDCAN_StateTypeDef;
+
+/**
+  * @brief FDCAN Init structure definition
+  */
+typedef struct
+{
+  uint32_t ClockDivider;                 /*!< Specifies the FDCAN kernel clock divider.
+                                              The clock is common to all FDCAN instances.
+                                              This parameter is applied only at initialisation of
+                                              first FDCAN instance.
+                                              This parameter can be a value of @ref FDCAN_clock_divider.   */
+
+  uint32_t FrameFormat;                  /*!< Specifies the FDCAN frame format.
+                                              This parameter can be a value of @ref FDCAN_frame_format     */
+
+  uint32_t Mode;                         /*!< Specifies the FDCAN mode.
+                                              This parameter can be a value of @ref FDCAN_operating_mode   */
+
+  FunctionalState AutoRetransmission;    /*!< Enable or disable the automatic retransmission mode.
+                                              This parameter can be set to ENABLE or DISABLE               */
+
+  FunctionalState TransmitPause;         /*!< Enable or disable the Transmit Pause feature.
+                                              This parameter can be set to ENABLE or DISABLE               */
+
+  FunctionalState ProtocolException;      /*!< Enable or disable the Protocol Exception Handling.
+                                              This parameter can be set to ENABLE or DISABLE               */
+
+  uint32_t NominalPrescaler;             /*!< Specifies the value by which the oscillator frequency is
+                                              divided for generating the nominal bit time quanta.
+                                              This parameter must be a number between 1 and 512            */
+
+  uint32_t NominalSyncJumpWidth;         /*!< Specifies the maximum number of time quanta the FDCAN
+                                              hardware is allowed to lengthen or shorten a bit to perform
+                                              resynchronization.
+                                              This parameter must be a number between 1 and 128            */
+
+  uint32_t NominalTimeSeg1;              /*!< Specifies the number of time quanta in Bit Segment 1.
+                                              This parameter must be a number between 2 and 256            */
+
+  uint32_t NominalTimeSeg2;              /*!< Specifies the number of time quanta in Bit Segment 2.
+                                              This parameter must be a number between 2 and 128            */
+
+  uint32_t DataPrescaler;                /*!< Specifies the value by which the oscillator frequency is
+                                              divided for generating the data bit time quanta.
+                                              This parameter must be a number between 1 and 32             */
+
+  uint32_t DataSyncJumpWidth;            /*!< Specifies the maximum number of time quanta the FDCAN
+                                              hardware is allowed to lengthen or shorten a data bit to
+                                              perform resynchronization.
+                                              This parameter must be a number between 1 and 16             */
+
+  uint32_t DataTimeSeg1;                 /*!< Specifies the number of time quanta in Data Bit Segment 1.
+                                              This parameter must be a number between 1 and 32             */
+
+  uint32_t DataTimeSeg2;                 /*!< Specifies the number of time quanta in Data Bit Segment 2.
+                                              This parameter must be a number between 1 and 16             */
+
+  uint32_t StdFiltersNbr;                /*!< Specifies the number of standard Message ID filters.
+                                              This parameter must be a number between 0 and 28             */
+
+  uint32_t ExtFiltersNbr;                /*!< Specifies the number of extended Message ID filters.
+                                              This parameter must be a number between 0 and 8             */
+
+  uint32_t TxFifoQueueMode;              /*!< Tx FIFO/Queue Mode selection.
+                                              This parameter can be a value of @ref FDCAN_txFifoQueue_Mode */
+
+} FDCAN_InitTypeDef;
+
+/**
+  * @brief  FDCAN filter structure definition
+  */
+typedef struct
+{
+  uint32_t IdType;           /*!< Specifies the identifier type.
+                                  This parameter can be a value of @ref FDCAN_id_type       */
+
+  uint32_t FilterIndex;      /*!< Specifies the filter which will be initialized.
+                                  This parameter must be a number between:
+                                   - 0 and (SRAMCAN_FLS_NBR-1), if IdType is FDCAN_STANDARD_ID
+                                   - 0 and (SRAMCAN_FLE_NBR-1), if IdType is FDCAN_EXTENDED_ID */
+
+  uint32_t FilterType;       /*!< Specifies the filter type.
+                                  This parameter can be a value of @ref FDCAN_filter_type.
+                                  The value FDCAN_FILTER_RANGE_NO_EIDM is permitted
+                                  only when IdType is FDCAN_EXTENDED_ID.                    */
+
+  uint32_t FilterConfig;     /*!< Specifies the filter configuration.
+                                  This parameter can be a value of @ref FDCAN_filter_config */
+
+  uint32_t FilterID1;        /*!< Specifies the filter identification 1.
+                                  This parameter must be a number between:
+                                   - 0 and 0x7FF, if IdType is FDCAN_STANDARD_ID
+                                   - 0 and 0x1FFFFFFF, if IdType is FDCAN_EXTENDED_ID       */
+
+  uint32_t FilterID2;        /*!< Specifies the filter identification 2.
+                                  This parameter must be a number between:
+                                   - 0 and 0x7FF, if IdType is FDCAN_STANDARD_ID
+                                   - 0 and 0x1FFFFFFF, if IdType is FDCAN_EXTENDED_ID       */
+
+} FDCAN_FilterTypeDef;
+
+/**
+  * @brief  FDCAN Tx header structure definition
+  */
+typedef struct
+{
+  uint32_t Identifier;          /*!< Specifies the identifier.
+                                     This parameter must be a number between:
+                                      - 0 and 0x7FF, if IdType is FDCAN_STANDARD_ID
+                                      - 0 and 0x1FFFFFFF, if IdType is FDCAN_EXTENDED_ID               */
+
+  uint32_t IdType;              /*!< Specifies the identifier type for the message that will be
+                                     transmitted.
+                                     This parameter can be a value of @ref FDCAN_id_type               */
+
+  uint32_t TxFrameType;         /*!< Specifies the frame type of the message that will be transmitted.
+                                     This parameter can be a value of @ref FDCAN_frame_type            */
+
+  uint32_t DataLength;          /*!< Specifies the length of the frame that will be transmitted.
+                                      This parameter can be a value of @ref FDCAN_data_length_code     */
+
+  uint32_t ErrorStateIndicator; /*!< Specifies the error state indicator.
+                                     This parameter can be a value of @ref FDCAN_error_state_indicator */
+
+  uint32_t BitRateSwitch;       /*!< Specifies whether the Tx frame will be transmitted with or without
+                                     bit rate switching.
+                                     This parameter can be a value of @ref FDCAN_bit_rate_switching    */
+
+  uint32_t FDFormat;            /*!< Specifies whether the Tx frame will be transmitted in classic or
+                                     FD format.
+                                     This parameter can be a value of @ref FDCAN_format                */
+
+  uint32_t TxEventFifoControl;  /*!< Specifies the event FIFO control.
+                                     This parameter can be a value of @ref FDCAN_EFC                   */
+
+  uint32_t MessageMarker;       /*!< Specifies the message marker to be copied into Tx Event FIFO
+                                     element for identification of Tx message status.
+                                     This parameter must be a number between 0 and 0xFF                */
+
+} FDCAN_TxHeaderTypeDef;
+
+/**
+  * @brief  FDCAN Rx header structure definition
+  */
+typedef struct
+{
+  uint32_t Identifier;            /*!< Specifies the identifier.
+                                       This parameter must be a number between:
+                                        - 0 and 0x7FF, if IdType is FDCAN_STANDARD_ID
+                                        - 0 and 0x1FFFFFFF, if IdType is FDCAN_EXTENDED_ID               */
+
+  uint32_t IdType;                /*!< Specifies the identifier type of the received message.
+                                       This parameter can be a value of @ref FDCAN_id_type               */
+
+  uint32_t RxFrameType;           /*!< Specifies the the received message frame type.
+                                       This parameter can be a value of @ref FDCAN_frame_type            */
+
+  uint32_t DataLength;            /*!< Specifies the received frame length.
+                                        This parameter can be a value of @ref FDCAN_data_length_code     */
+
+  uint32_t ErrorStateIndicator;   /*!< Specifies the error state indicator.
+                                       This parameter can be a value of @ref FDCAN_error_state_indicator */
+
+  uint32_t BitRateSwitch;         /*!< Specifies whether the Rx frame is received with or without bit
+                                       rate switching.
+                                       This parameter can be a value of @ref FDCAN_bit_rate_switching    */
+
+  uint32_t FDFormat;              /*!< Specifies whether the Rx frame is received in classic or FD
+                                       format.
+                                       This parameter can be a value of @ref FDCAN_format                */
+
+  uint32_t RxTimestamp;           /*!< Specifies the timestamp counter value captured on start of frame
+                                       reception.
+                                       This parameter must be a number between 0 and 0xFFFF              */
+
+  uint32_t FilterIndex;           /*!< Specifies the index of matching Rx acceptance filter element.
+                                       This parameter must be a number between:
+                                        - 0 and (SRAMCAN_FLS_NBR-1), if IdType is FDCAN_STANDARD_ID
+                                        - 0 and (SRAMCAN_FLE_NBR-1), if IdType is FDCAN_EXTENDED_ID */
+
+  uint32_t IsFilterMatchingFrame; /*!< Specifies whether the accepted frame did not match any Rx filter.
+                                         Acceptance of non-matching frames may be enabled via
+                                         HAL_FDCAN_ConfigGlobalFilter().
+                                         This parameter can be 0 or 1                                    */
+
+} FDCAN_RxHeaderTypeDef;
+
+/**
+  * @brief  FDCAN Tx event FIFO structure definition
+  */
+typedef struct
+{
+  uint32_t Identifier;          /*!< Specifies the identifier.
+                                     This parameter must be a number between:
+                                      - 0 and 0x7FF, if IdType is FDCAN_STANDARD_ID
+                                      - 0 and 0x1FFFFFFF, if IdType is FDCAN_EXTENDED_ID               */
+
+  uint32_t IdType;              /*!< Specifies the identifier type for the transmitted message.
+                                     This parameter can be a value of @ref FDCAN_id_type               */
+
+  uint32_t TxFrameType;         /*!< Specifies the frame type of the transmitted message.
+                                     This parameter can be a value of @ref FDCAN_frame_type            */
+
+  uint32_t DataLength;          /*!< Specifies the length of the transmitted frame.
+                                     This parameter can be a value of @ref FDCAN_data_length_code      */
+
+  uint32_t ErrorStateIndicator; /*!< Specifies the error state indicator.
+                                     This parameter can be a value of @ref FDCAN_error_state_indicator */
+
+  uint32_t BitRateSwitch;       /*!< Specifies whether the Tx frame is transmitted with or without bit
+                                     rate switching.
+                                     This parameter can be a value of @ref FDCAN_bit_rate_switching    */
+
+  uint32_t FDFormat;            /*!< Specifies whether the Tx frame is transmitted in classic or FD
+                                     format.
+                                     This parameter can be a value of @ref FDCAN_format                */
+
+  uint32_t TxTimestamp;         /*!< Specifies the timestamp counter value captured on start of frame
+                                     transmission.
+                                     This parameter must be a number between 0 and 0xFFFF              */
+
+  uint32_t MessageMarker;       /*!< Specifies the message marker copied into Tx Event FIFO element
+                                     for identification of Tx message status.
+                                     This parameter must be a number between 0 and 0xFF                */
+
+  uint32_t EventType;           /*!< Specifies the event type.
+                                     This parameter can be a value of @ref FDCAN_event_type            */
+
+} FDCAN_TxEventFifoTypeDef;
+
+/**
+  * @brief  FDCAN High Priority Message Status structure definition
+  */
+typedef struct
+{
+  uint32_t FilterList;     /*!< Specifies the filter list of the matching filter element.
+                                This parameter can be:
+                                 - 0 : Standard Filter List
+                                 - 1 : Extended Filter List                                */
+
+  uint32_t FilterIndex;    /*!< Specifies the index of matching filter element.
+                                This parameter can be a number between:
+                                - 0 and (SRAMCAN_FLS_NBR-1), if FilterList is 0 (Standard)
+                                - 0 and (SRAMCAN_FLE_NBR-1), if FilterList is 1 (Extended) */
+
+  uint32_t MessageStorage; /*!< Specifies the HP Message Storage.
+                                This parameter can be a value of @ref FDCAN_hp_msg_storage */
+
+  uint32_t MessageIndex;   /*!< Specifies the Index of Rx FIFO element to which the
+                                message was stored.
+                                This parameter is valid only when MessageStorage is:
+                                  FDCAN_HP_STORAGE_RXFIFO0
+                                 or
+                                  FDCAN_HP_STORAGE_RXFIFO1                                 */
+
+} FDCAN_HpMsgStatusTypeDef;
+
+/**
+  * @brief FDCAN Protocol Status structure definition
+  */
+typedef struct
+{
+  uint32_t LastErrorCode;     /*!< Specifies the type of the last error that occurred on the FDCAN bus.
+                                   This parameter can be a value of @ref FDCAN_protocol_error_code                           */
+
+  uint32_t DataLastErrorCode; /*!< Specifies the type of the last error that occurred in the data phase of a CAN FD format
+                                   frame with its BRS flag set.
+                                   This parameter can be a value of @ref FDCAN_protocol_error_code                           */
+
+  uint32_t Activity;          /*!< Specifies the FDCAN module communication state.
+                                   This parameter can be a value of @ref FDCAN_communication_state                           */
+
+  uint32_t ErrorPassive;      /*!< Specifies the FDCAN module error status.
+                                   This parameter can be:
+                                    - 0 : The FDCAN is in Error_Active state
+                                    - 1 : The FDCAN is in Error_Passive state                                                */
+
+  uint32_t Warning;           /*!< Specifies the FDCAN module warning status.
+                                   This parameter can be:
+                                    - 0 : error counters (RxErrorCnt and TxErrorCnt) are below the Error_Warning limit of 96
+                                    - 1 : at least one of error counters has reached the Error_Warning limit of 96           */
+
+  uint32_t BusOff;            /*!< Specifies the FDCAN module Bus_Off status.
+                                   This parameter can be:
+                                    - 0 : The FDCAN is not in Bus_Off state
+                                    - 1 : The FDCAN is in Bus_Off state                                                      */
+
+  uint32_t RxESIflag;         /*!< Specifies ESI flag of last received CAN FD message.
+                                   This parameter can be:
+                                    - 0 : Last received CAN FD message did not have its ESI flag set
+                                    - 1 : Last received CAN FD message had its ESI flag set                                  */
+
+  uint32_t RxBRSflag;         /*!< Specifies BRS flag of last received CAN FD message.
+                                   This parameter can be:
+                                    - 0 : Last received CAN FD message did not have its BRS flag set
+                                    - 1 : Last received CAN FD message had its BRS flag set                                  */
+
+  uint32_t RxFDFflag;         /*!< Specifies if CAN FD message (FDF flag set) has been received since last protocol status
+                                   This parameter can be:
+                                    - 0 : No CAN FD message received
+                                    - 1 : CAN FD message received                                                            */
+
+  uint32_t ProtocolException; /*!< Specifies the FDCAN module Protocol Exception status.
+                                   This parameter can be:
+                                    - 0 : No protocol exception event occurred since last read access
+                                    - 1 : Protocol exception event occurred                                                  */
+
+  uint32_t TDCvalue;          /*!< Specifies the Transmitter Delay Compensation Value.
+                                   This parameter can be a number between 0 and 127                                          */
+
+} FDCAN_ProtocolStatusTypeDef;
+
+/**
+  * @brief FDCAN Error Counters structure definition
+  */
+typedef struct
+{
+  uint32_t TxErrorCnt;     /*!< Specifies the Transmit Error Counter Value.
+                                This parameter can be a number between 0 and 255                                         */
+
+  uint32_t RxErrorCnt;     /*!< Specifies the Receive Error Counter Value.
+                                This parameter can be a number between 0 and 127                                         */
+
+  uint32_t RxErrorPassive; /*!< Specifies the Receive Error Passive status.
+                                This parameter can be:
+                                 - 0 : The Receive Error Counter (RxErrorCnt) is below the error passive level of 128
+                                 - 1 : The Receive Error Counter (RxErrorCnt) has reached the error passive level of 128 */
+
+  uint32_t ErrorLogging;   /*!< Specifies the Transmit/Receive error logging counter value.
+                                This parameter can be a number between 0 and 255.
+                                This counter is incremented each time when a FDCAN protocol error causes the TxErrorCnt
+                                or the RxErrorCnt to be incremented. The counter stops at 255; the next increment of
+                                TxErrorCnt or RxErrorCnt sets interrupt flag FDCAN_FLAG_ERROR_LOGGING_OVERFLOW           */
+
+} FDCAN_ErrorCountersTypeDef;
+
+/**
+  * @brief  FDCAN Message RAM blocks
+  */
+typedef struct
+{
+  uint32_t StandardFilterSA; /*!< Specifies the Standard Filter List Start Address.
+                                  This parameter must be a 32-bit word address      */
+
+  uint32_t ExtendedFilterSA; /*!< Specifies the Extended Filter List Start Address.
+                                  This parameter must be a 32-bit word address      */
+
+  uint32_t RxFIFO0SA;        /*!< Specifies the Rx FIFO 0 Start Address.
+                                  This parameter must be a 32-bit word address      */
+
+  uint32_t RxFIFO1SA;        /*!< Specifies the Rx FIFO 1 Start Address.
+                                  This parameter must be a 32-bit word address      */
+
+  uint32_t TxEventFIFOSA;    /*!< Specifies the Tx Event FIFO Start Address.
+                                  This parameter must be a 32-bit word address      */
+
+  uint32_t TxFIFOQSA;        /*!< Specifies the Tx FIFO/Queue Start Address.
+                                  This parameter must be a 32-bit word address      */
+
+} FDCAN_MsgRamAddressTypeDef;
+
+/**
+  * @brief  FDCAN handle structure definition
+  */
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+typedef struct __FDCAN_HandleTypeDef
+#else
+typedef struct
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+{
+  FDCAN_GlobalTypeDef         *Instance;        /*!< Register base address     */
+
+  FDCAN_InitTypeDef           Init;             /*!< FDCAN required parameters */
+
+  FDCAN_MsgRamAddressTypeDef  msgRam;           /*!< FDCAN Message RAM blocks  */
+
+  uint32_t                    LatestTxFifoQRequest; /*!< FDCAN Tx buffer index
+                                               of latest Tx FIFO/Queue request */
+
+  __IO HAL_FDCAN_StateTypeDef State;            /*!< FDCAN communication state */
+
+  HAL_LockTypeDef             Lock;             /*!< FDCAN locking object      */
+
+  __IO uint32_t               ErrorCode;        /*!< FDCAN Error code          */
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+  void (* TxEventFifoCallback)(struct __FDCAN_HandleTypeDef *hfdcan, uint32_t TxEventFifoITs);     /*!< FDCAN Tx Event Fifo callback         */
+  void (* RxFifo0Callback)(struct __FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs);             /*!< FDCAN Rx Fifo 0 callback             */
+  void (* RxFifo1Callback)(struct __FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo1ITs);             /*!< FDCAN Rx Fifo 1 callback             */
+  void (* TxFifoEmptyCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                              /*!< FDCAN Tx Fifo Empty callback         */
+  void (* TxBufferCompleteCallback)(struct __FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes); /*!< FDCAN Tx Buffer complete callback    */
+  void (* TxBufferAbortCallback)(struct __FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes);    /*!< FDCAN Tx Buffer abort callback       */
+  void (* HighPriorityMessageCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                      /*!< FDCAN High priority message callback */
+  void (* TimestampWraparoundCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                      /*!< FDCAN Timestamp wraparound callback  */
+  void (* TimeoutOccurredCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                          /*!< FDCAN Timeout occurred callback      */
+  void (* ErrorCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                                    /*!< FDCAN Error callback                 */
+  void (* ErrorStatusCallback)(struct __FDCAN_HandleTypeDef *hfdcan, uint32_t ErrorStatusITs);     /*!< FDCAN Error status callback          */
+
+  void (* MspInitCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                                  /*!< FDCAN Msp Init callback              */
+  void (* MspDeInitCallback)(struct __FDCAN_HandleTypeDef *hfdcan);                                /*!< FDCAN Msp DeInit callback            */
+
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+
+} FDCAN_HandleTypeDef;
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+/**
+  * @brief  HAL FDCAN common Callback ID enumeration definition
+  */
+typedef enum
+{
+  HAL_FDCAN_TX_FIFO_EMPTY_CB_ID        = 0x00U,    /*!< FDCAN Tx Fifo Empty callback ID         */
+  HAL_FDCAN_HIGH_PRIO_MESSAGE_CB_ID    = 0x01U,    /*!< FDCAN High priority message callback ID */
+  HAL_FDCAN_TIMESTAMP_WRAPAROUND_CB_ID = 0x02U,    /*!< FDCAN Timestamp wraparound callback ID  */
+  HAL_FDCAN_TIMEOUT_OCCURRED_CB_ID     = 0x03U,    /*!< FDCAN Timeout occurred callback ID      */
+  HAL_FDCAN_ERROR_CALLBACK_CB_ID       = 0x04U,    /*!< FDCAN Error callback ID                 */
+
+  HAL_FDCAN_MSPINIT_CB_ID              = 0x05U,    /*!< FDCAN MspInit callback ID               */
+  HAL_FDCAN_MSPDEINIT_CB_ID            = 0x06U,    /*!< FDCAN MspDeInit callback ID             */
+
+} HAL_FDCAN_CallbackIDTypeDef;
+
+/**
+  * @brief  HAL FDCAN Callback pointer definition
+  */
+typedef  void (*pFDCAN_CallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan);                                         /*!< pointer to a common FDCAN callback function           */
+typedef  void (*pFDCAN_TxEventFifoCallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, uint32_t TxEventFifoITs);     /*!< pointer to Tx event Fifo FDCAN callback function      */
+typedef  void (*pFDCAN_RxFifo0CallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs);             /*!< pointer to Rx Fifo 0 FDCAN callback function          */
+typedef  void (*pFDCAN_RxFifo1CallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo1ITs);             /*!< pointer to Rx Fifo 1 FDCAN callback function          */
+typedef  void (*pFDCAN_TxBufferCompleteCallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes); /*!< pointer to Tx Buffer complete FDCAN callback function */
+typedef  void (*pFDCAN_TxBufferAbortCallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes);    /*!< pointer to Tx Buffer abort FDCAN callback function    */
+typedef  void (*pFDCAN_ErrorStatusCallbackTypeDef)(FDCAN_HandleTypeDef *hfdcan, uint32_t ErrorStatusITs);     /*!< pointer to Error Status callback function             */
+
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup FDCAN_Exported_Constants FDCAN Exported Constants
+  * @{
+  */
+
+/** @defgroup HAL_FDCAN_Error_Code HAL FDCAN Error Code
+  * @{
+  */
+#define HAL_FDCAN_ERROR_NONE            ((uint32_t)0x00000000U) /*!< No error                                                               */
+#define HAL_FDCAN_ERROR_TIMEOUT         ((uint32_t)0x00000001U) /*!< Timeout error                                                          */
+#define HAL_FDCAN_ERROR_NOT_INITIALIZED ((uint32_t)0x00000002U) /*!< Peripheral not initialized                                             */
+#define HAL_FDCAN_ERROR_NOT_READY       ((uint32_t)0x00000004U) /*!< Peripheral not ready                                                   */
+#define HAL_FDCAN_ERROR_NOT_STARTED     ((uint32_t)0x00000008U) /*!< Peripheral not started                                                 */
+#define HAL_FDCAN_ERROR_NOT_SUPPORTED   ((uint32_t)0x00000010U) /*!< Mode not supported                                                     */
+#define HAL_FDCAN_ERROR_PARAM           ((uint32_t)0x00000020U) /*!< Parameter error                                                        */
+#define HAL_FDCAN_ERROR_PENDING         ((uint32_t)0x00000040U) /*!< Pending operation                                                      */
+#define HAL_FDCAN_ERROR_RAM_ACCESS      ((uint32_t)0x00000080U) /*!< Message RAM Access Failure                                             */
+#define HAL_FDCAN_ERROR_FIFO_EMPTY      ((uint32_t)0x00000100U) /*!< Put element in full FIFO                                               */
+#define HAL_FDCAN_ERROR_FIFO_FULL       ((uint32_t)0x00000200U) /*!< Get element from empty FIFO                                            */
+#define HAL_FDCAN_ERROR_LOG_OVERFLOW    FDCAN_IR_ELO            /*!< Overflow of CAN Error Logging Counter                                  */
+#define HAL_FDCAN_ERROR_RAM_WDG         FDCAN_IR_WDI            /*!< Message RAM Watchdog event occurred                                    */
+#define HAL_FDCAN_ERROR_PROTOCOL_ARBT   FDCAN_IR_PEA            /*!< Protocol Error in Arbitration Phase (Nominal Bit Time is used)         */
+#define HAL_FDCAN_ERROR_PROTOCOL_DATA   FDCAN_IR_PED            /*!< Protocol Error in Data Phase (Data Bit Time is used)                   */
+#define HAL_FDCAN_ERROR_RESERVED_AREA   FDCAN_IR_ARA            /*!< Access to Reserved Address                                             */
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+#define HAL_FDCAN_ERROR_INVALID_CALLBACK ((uint32_t)0x00000100U) /*!< Invalid Callback error                                                */
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_frame_format FDCAN Frame Format
+  * @{
+  */
+#define FDCAN_FRAME_CLASSIC   ((uint32_t)0x00000000U)                         /*!< Classic mode                      */
+#define FDCAN_FRAME_FD_NO_BRS ((uint32_t)FDCAN_CCCR_FDOE)                     /*!< FD mode without BitRate Switching */
+#define FDCAN_FRAME_FD_BRS    ((uint32_t)(FDCAN_CCCR_FDOE | FDCAN_CCCR_BRSE)) /*!< FD mode with BitRate Switching    */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_operating_mode FDCAN Operating Mode
+  * @{
+  */
+#define FDCAN_MODE_NORMAL               ((uint32_t)0x00000000U) /*!< Normal mode               */
+#define FDCAN_MODE_RESTRICTED_OPERATION ((uint32_t)0x00000001U) /*!< Restricted Operation mode */
+#define FDCAN_MODE_BUS_MONITORING       ((uint32_t)0x00000002U) /*!< Bus Monitoring mode       */
+#define FDCAN_MODE_INTERNAL_LOOPBACK    ((uint32_t)0x00000003U) /*!< Internal LoopBack mode    */
+#define FDCAN_MODE_EXTERNAL_LOOPBACK    ((uint32_t)0x00000004U) /*!< External LoopBack mode    */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_clock_divider FDCAN Clock Divider
+  * @{
+  */
+#define FDCAN_CLOCK_DIV1  ((uint32_t)0x00000000U) /*!< Divide kernel clock by 1  */
+#define FDCAN_CLOCK_DIV2  ((uint32_t)0x00000001U) /*!< Divide kernel clock by 2  */
+#define FDCAN_CLOCK_DIV4  ((uint32_t)0x00000002U) /*!< Divide kernel clock by 4  */
+#define FDCAN_CLOCK_DIV6  ((uint32_t)0x00000003U) /*!< Divide kernel clock by 6  */
+#define FDCAN_CLOCK_DIV8  ((uint32_t)0x00000004U) /*!< Divide kernel clock by 8  */
+#define FDCAN_CLOCK_DIV10 ((uint32_t)0x00000005U) /*!< Divide kernel clock by 10 */
+#define FDCAN_CLOCK_DIV12 ((uint32_t)0x00000006U) /*!< Divide kernel clock by 12 */
+#define FDCAN_CLOCK_DIV14 ((uint32_t)0x00000007U) /*!< Divide kernel clock by 14 */
+#define FDCAN_CLOCK_DIV16 ((uint32_t)0x00000008U) /*!< Divide kernel clock by 16 */
+#define FDCAN_CLOCK_DIV18 ((uint32_t)0x00000009U) /*!< Divide kernel clock by 18 */
+#define FDCAN_CLOCK_DIV20 ((uint32_t)0x0000000AU) /*!< Divide kernel clock by 20 */
+#define FDCAN_CLOCK_DIV22 ((uint32_t)0x0000000BU) /*!< Divide kernel clock by 22 */
+#define FDCAN_CLOCK_DIV24 ((uint32_t)0x0000000CU) /*!< Divide kernel clock by 24 */
+#define FDCAN_CLOCK_DIV26 ((uint32_t)0x0000000DU) /*!< Divide kernel clock by 26 */
+#define FDCAN_CLOCK_DIV28 ((uint32_t)0x0000000EU) /*!< Divide kernel clock by 28 */
+#define FDCAN_CLOCK_DIV30 ((uint32_t)0x0000000FU) /*!< Divide kernel clock by 30 */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_txFifoQueue_Mode FDCAN Tx FIFO/Queue Mode
+  * @{
+  */
+#define FDCAN_TX_FIFO_OPERATION  ((uint32_t)0x00000000U)     /*!< FIFO mode  */
+#define FDCAN_TX_QUEUE_OPERATION ((uint32_t)FDCAN_TXBC_TFQM) /*!< Queue mode */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_id_type FDCAN ID Type
+  * @{
+  */
+#define FDCAN_STANDARD_ID ((uint32_t)0x00000000U) /*!< Standard ID element */
+#define FDCAN_EXTENDED_ID ((uint32_t)0x40000000U) /*!< Extended ID element */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_frame_type FDCAN Frame Type
+  * @{
+  */
+#define FDCAN_DATA_FRAME   ((uint32_t)0x00000000U)  /*!< Data frame   */
+#define FDCAN_REMOTE_FRAME ((uint32_t)0x20000000U)  /*!< Remote frame */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_data_length_code FDCAN Data Length Code
+  * @{
+  */
+#define FDCAN_DLC_BYTES_0  ((uint32_t)0x00000000U) /*!< 0 bytes data field  */
+#define FDCAN_DLC_BYTES_1  ((uint32_t)0x00010000U) /*!< 1 bytes data field  */
+#define FDCAN_DLC_BYTES_2  ((uint32_t)0x00020000U) /*!< 2 bytes data field  */
+#define FDCAN_DLC_BYTES_3  ((uint32_t)0x00030000U) /*!< 3 bytes data field  */
+#define FDCAN_DLC_BYTES_4  ((uint32_t)0x00040000U) /*!< 4 bytes data field  */
+#define FDCAN_DLC_BYTES_5  ((uint32_t)0x00050000U) /*!< 5 bytes data field  */
+#define FDCAN_DLC_BYTES_6  ((uint32_t)0x00060000U) /*!< 6 bytes data field  */
+#define FDCAN_DLC_BYTES_7  ((uint32_t)0x00070000U) /*!< 7 bytes data field  */
+#define FDCAN_DLC_BYTES_8  ((uint32_t)0x00080000U) /*!< 8 bytes data field  */
+#define FDCAN_DLC_BYTES_12 ((uint32_t)0x00090000U) /*!< 12 bytes data field */
+#define FDCAN_DLC_BYTES_16 ((uint32_t)0x000A0000U) /*!< 16 bytes data field */
+#define FDCAN_DLC_BYTES_20 ((uint32_t)0x000B0000U) /*!< 20 bytes data field */
+#define FDCAN_DLC_BYTES_24 ((uint32_t)0x000C0000U) /*!< 24 bytes data field */
+#define FDCAN_DLC_BYTES_32 ((uint32_t)0x000D0000U) /*!< 32 bytes data field */
+#define FDCAN_DLC_BYTES_48 ((uint32_t)0x000E0000U) /*!< 48 bytes data field */
+#define FDCAN_DLC_BYTES_64 ((uint32_t)0x000F0000U) /*!< 64 bytes data field */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_error_state_indicator FDCAN Error State Indicator
+  * @{
+  */
+#define FDCAN_ESI_ACTIVE  ((uint32_t)0x00000000U) /*!< Transmitting node is error active  */
+#define FDCAN_ESI_PASSIVE ((uint32_t)0x80000000U) /*!< Transmitting node is error passive */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_bit_rate_switching FDCAN Bit Rate Switching
+  * @{
+  */
+#define FDCAN_BRS_OFF ((uint32_t)0x00000000U) /*!< FDCAN frames transmitted/received without bit rate switching */
+#define FDCAN_BRS_ON  ((uint32_t)0x00100000U) /*!< FDCAN frames transmitted/received with bit rate switching    */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_format FDCAN format
+  * @{
+  */
+#define FDCAN_CLASSIC_CAN ((uint32_t)0x00000000U) /*!< Frame transmitted/received in Classic CAN format */
+#define FDCAN_FD_CAN      ((uint32_t)0x00200000U) /*!< Frame transmitted/received in FDCAN format       */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_EFC FDCAN Event FIFO control
+  * @{
+  */
+#define FDCAN_NO_TX_EVENTS    ((uint32_t)0x00000000U) /*!< Do not store Tx events */
+#define FDCAN_STORE_TX_EVENTS ((uint32_t)0x00800000U) /*!< Store Tx events        */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_filter_type FDCAN Filter Type
+  * @{
+  */
+#define FDCAN_FILTER_RANGE         ((uint32_t)0x00000000U) /*!< Range filter from FilterID1 to FilterID2                        */
+#define FDCAN_FILTER_DUAL          ((uint32_t)0x00000001U) /*!< Dual ID filter for FilterID1 or FilterID2                       */
+#define FDCAN_FILTER_MASK          ((uint32_t)0x00000002U) /*!< Classic filter: FilterID1 = filter, FilterID2 = mask            */
+#define FDCAN_FILTER_RANGE_NO_EIDM ((uint32_t)0x00000003U) /*!< Range filter from FilterID1 to FilterID2, EIDM mask not applied */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_filter_config FDCAN Filter Configuration
+  * @{
+  */
+#define FDCAN_FILTER_DISABLE       ((uint32_t)0x00000000U) /*!< Disable filter element                                    */
+#define FDCAN_FILTER_TO_RXFIFO0    ((uint32_t)0x00000001U) /*!< Store in Rx FIFO 0 if filter matches                      */
+#define FDCAN_FILTER_TO_RXFIFO1    ((uint32_t)0x00000002U) /*!< Store in Rx FIFO 1 if filter matches                      */
+#define FDCAN_FILTER_REJECT        ((uint32_t)0x00000003U) /*!< Reject ID if filter matches                               */
+#define FDCAN_FILTER_HP            ((uint32_t)0x00000004U) /*!< Set high priority if filter matches                       */
+#define FDCAN_FILTER_TO_RXFIFO0_HP ((uint32_t)0x00000005U) /*!< Set high priority and store in FIFO 0 if filter matches   */
+#define FDCAN_FILTER_TO_RXFIFO1_HP ((uint32_t)0x00000006U) /*!< Set high priority and store in FIFO 1 if filter matches   */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Tx_location FDCAN Tx Location
+  * @{
+  */
+#define FDCAN_TX_BUFFER0  ((uint32_t)0x00000001U) /*!< Add message to Tx Buffer 0  */
+#define FDCAN_TX_BUFFER1  ((uint32_t)0x00000002U) /*!< Add message to Tx Buffer 1  */
+#define FDCAN_TX_BUFFER2  ((uint32_t)0x00000004U) /*!< Add message to Tx Buffer 2  */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Rx_location FDCAN Rx Location
+  * @{
+  */
+#define FDCAN_RX_FIFO0    ((uint32_t)0x00000040U) /*!< Get received message from Rx FIFO 0    */
+#define FDCAN_RX_FIFO1    ((uint32_t)0x00000041U) /*!< Get received message from Rx FIFO 1    */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_event_type FDCAN Event Type
+  * @{
+  */
+#define FDCAN_TX_EVENT             ((uint32_t)0x00400000U) /*!< Tx event                              */
+#define FDCAN_TX_IN_SPITE_OF_ABORT ((uint32_t)0x00800000U) /*!< Transmission in spite of cancellation */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_hp_msg_storage FDCAN High Priority Message Storage
+  * @{
+  */
+#define FDCAN_HP_STORAGE_NO_FIFO  ((uint32_t)0x00000000U) /*!< No FIFO selected         */
+#define FDCAN_HP_STORAGE_MSG_LOST ((uint32_t)0x00000040U) /*!< FIFO message lost        */
+#define FDCAN_HP_STORAGE_RXFIFO0  ((uint32_t)0x00000080U) /*!< Message stored in FIFO 0 */
+#define FDCAN_HP_STORAGE_RXFIFO1  ((uint32_t)0x000000C0U) /*!< Message stored in FIFO 1 */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_protocol_error_code FDCAN protocol error code
+  * @{
+  */
+#define FDCAN_PROTOCOL_ERROR_NONE      ((uint32_t)0x00000000U) /*!< No error occurred         */
+#define FDCAN_PROTOCOL_ERROR_STUFF     ((uint32_t)0x00000001U) /*!< Stuff error               */
+#define FDCAN_PROTOCOL_ERROR_FORM      ((uint32_t)0x00000002U) /*!< Form error                */
+#define FDCAN_PROTOCOL_ERROR_ACK       ((uint32_t)0x00000003U) /*!< Acknowledge error         */
+#define FDCAN_PROTOCOL_ERROR_BIT1      ((uint32_t)0x00000004U) /*!< Bit 1 (recessive) error   */
+#define FDCAN_PROTOCOL_ERROR_BIT0      ((uint32_t)0x00000005U) /*!< Bit 0 (dominant) error    */
+#define FDCAN_PROTOCOL_ERROR_CRC       ((uint32_t)0x00000006U) /*!< CRC check sum error       */
+#define FDCAN_PROTOCOL_ERROR_NO_CHANGE ((uint32_t)0x00000007U) /*!< No change since last read */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_communication_state FDCAN communication state
+  * @{
+  */
+#define FDCAN_COM_STATE_SYNC ((uint32_t)0x00000000U) /*!< Node is synchronizing on CAN communication */
+#define FDCAN_COM_STATE_IDLE ((uint32_t)0x00000008U) /*!< Node is neither receiver nor transmitter   */
+#define FDCAN_COM_STATE_RX   ((uint32_t)0x00000010U) /*!< Node is operating as receiver              */
+#define FDCAN_COM_STATE_TX   ((uint32_t)0x00000018U) /*!< Node is operating as transmitter           */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Rx_FIFO_operation_mode FDCAN FIFO operation mode
+  * @{
+  */
+#define FDCAN_RX_FIFO_BLOCKING  ((uint32_t)0x00000000U) /*!< Rx FIFO blocking mode  */
+#define FDCAN_RX_FIFO_OVERWRITE ((uint32_t)0x00000001U) /*!< Rx FIFO overwrite mode */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Non_Matching_Frames FDCAN non-matching frames
+  * @{
+  */
+#define FDCAN_ACCEPT_IN_RX_FIFO0 ((uint32_t)0x00000000U) /*!< Accept in Rx FIFO 0 */
+#define FDCAN_ACCEPT_IN_RX_FIFO1 ((uint32_t)0x00000001U) /*!< Accept in Rx FIFO 1 */
+#define FDCAN_REJECT             ((uint32_t)0x00000002U) /*!< Reject              */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Reject_Remote_Frames FDCAN reject remote frames
+  * @{
+  */
+#define FDCAN_FILTER_REMOTE ((uint32_t)0x00000000U) /*!< Filter remote frames */
+#define FDCAN_REJECT_REMOTE ((uint32_t)0x00000001U) /*!< Reject all remote frames */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Interrupt_Line FDCAN interrupt line
+  * @{
+  */
+#define FDCAN_INTERRUPT_LINE0 ((uint32_t)0x00000001U) /*!< Interrupt Line 0 */
+#define FDCAN_INTERRUPT_LINE1 ((uint32_t)0x00000002U) /*!< Interrupt Line 1 */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Timestamp FDCAN timestamp
+  * @{
+  */
+#define FDCAN_TIMESTAMP_INTERNAL ((uint32_t)0x00000001U) /*!< Timestamp counter value incremented according to TCP */
+#define FDCAN_TIMESTAMP_EXTERNAL ((uint32_t)0x00000002U) /*!< External timestamp counter value used                */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Timestamp_Prescaler FDCAN timestamp prescaler
+  * @{
+  */
+#define FDCAN_TIMESTAMP_PRESC_1  ((uint32_t)0x00000000U) /*!< Timestamp counter time unit in equal to CAN bit time                 */
+#define FDCAN_TIMESTAMP_PRESC_2  ((uint32_t)0x00010000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 2  */
+#define FDCAN_TIMESTAMP_PRESC_3  ((uint32_t)0x00020000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 3  */
+#define FDCAN_TIMESTAMP_PRESC_4  ((uint32_t)0x00030000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 4  */
+#define FDCAN_TIMESTAMP_PRESC_5  ((uint32_t)0x00040000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 5  */
+#define FDCAN_TIMESTAMP_PRESC_6  ((uint32_t)0x00050000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 6  */
+#define FDCAN_TIMESTAMP_PRESC_7  ((uint32_t)0x00060000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 7  */
+#define FDCAN_TIMESTAMP_PRESC_8  ((uint32_t)0x00070000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 8  */
+#define FDCAN_TIMESTAMP_PRESC_9  ((uint32_t)0x00080000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 9  */
+#define FDCAN_TIMESTAMP_PRESC_10 ((uint32_t)0x00090000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 10 */
+#define FDCAN_TIMESTAMP_PRESC_11 ((uint32_t)0x000A0000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 11 */
+#define FDCAN_TIMESTAMP_PRESC_12 ((uint32_t)0x000B0000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 12 */
+#define FDCAN_TIMESTAMP_PRESC_13 ((uint32_t)0x000C0000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 13 */
+#define FDCAN_TIMESTAMP_PRESC_14 ((uint32_t)0x000D0000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 14 */
+#define FDCAN_TIMESTAMP_PRESC_15 ((uint32_t)0x000E0000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 15 */
+#define FDCAN_TIMESTAMP_PRESC_16 ((uint32_t)0x000F0000U) /*!< Timestamp counter time unit in equal to CAN bit time multiplied by 16 */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Timeout_Operation FDCAN timeout operation
+  * @{
+  */
+#define FDCAN_TIMEOUT_CONTINUOUS    ((uint32_t)0x00000000U) /*!< Timeout continuous operation        */
+#define FDCAN_TIMEOUT_TX_EVENT_FIFO ((uint32_t)0x00000002U) /*!< Timeout controlled by Tx Event FIFO */
+#define FDCAN_TIMEOUT_RX_FIFO0      ((uint32_t)0x00000004U) /*!< Timeout controlled by Rx FIFO 0     */
+#define FDCAN_TIMEOUT_RX_FIFO1      ((uint32_t)0x00000006U) /*!< Timeout controlled by Rx FIFO 1     */
+/**
+  * @}
+  */
+
+/** @defgroup Interrupt_Masks Interrupt masks
+  * @{
+  */
+#define FDCAN_IR_MASK ((uint32_t)0x00FFFFFFU) /*!< FDCAN interrupts mask */
+#define FDCAN_ILS_MASK ((uint32_t)0x0000007FU) /*!< FDCAN interrupts group mask */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_flags FDCAN Flags
+  * @{
+  */
+#define FDCAN_FLAG_TX_COMPLETE             FDCAN_IR_TC             /*!< Transmission Completed                                */
+#define FDCAN_FLAG_TX_ABORT_COMPLETE       FDCAN_IR_TCF            /*!< Transmission Cancellation Finished                    */
+#define FDCAN_FLAG_TX_FIFO_EMPTY           FDCAN_IR_TFE            /*!< Tx FIFO Empty                                         */
+#define FDCAN_FLAG_RX_HIGH_PRIORITY_MSG    FDCAN_IR_HPM            /*!< High priority message received                        */
+#define FDCAN_FLAG_TX_EVT_FIFO_ELT_LOST    FDCAN_IR_TEFL           /*!< Tx Event FIFO element lost                            */
+#define FDCAN_FLAG_TX_EVT_FIFO_FULL        FDCAN_IR_TEFF           /*!< Tx Event FIFO full                                    */
+#define FDCAN_FLAG_TX_EVT_FIFO_NEW_DATA    FDCAN_IR_TEFN           /*!< Tx Handler wrote Tx Event FIFO element                */
+#define FDCAN_FLAG_RX_FIFO0_MESSAGE_LOST   FDCAN_IR_RF0L           /*!< Rx FIFO 0 message lost                                */
+#define FDCAN_FLAG_RX_FIFO0_FULL           FDCAN_IR_RF0F           /*!< Rx FIFO 0 full                                        */
+#define FDCAN_FLAG_RX_FIFO0_NEW_MESSAGE    FDCAN_IR_RF0N           /*!< New message written to Rx FIFO 0                      */
+#define FDCAN_FLAG_RX_FIFO1_MESSAGE_LOST   FDCAN_IR_RF1L           /*!< Rx FIFO 1 message lost                                */
+#define FDCAN_FLAG_RX_FIFO1_FULL           FDCAN_IR_RF1F           /*!< Rx FIFO 1 full                                        */
+#define FDCAN_FLAG_RX_FIFO1_NEW_MESSAGE    FDCAN_IR_RF1N           /*!< New message written to Rx FIFO 1                      */
+#define FDCAN_FLAG_RAM_ACCESS_FAILURE      FDCAN_IR_MRAF           /*!< Message RAM access failure occurred                   */
+#define FDCAN_FLAG_ERROR_LOGGING_OVERFLOW  FDCAN_IR_ELO            /*!< Overflow of FDCAN Error Logging Counter occurred      */
+#define FDCAN_FLAG_ERROR_PASSIVE           FDCAN_IR_EP             /*!< Error_Passive status changed                          */
+#define FDCAN_FLAG_ERROR_WARNING           FDCAN_IR_EW             /*!< Error_Warning status changed                          */
+#define FDCAN_FLAG_BUS_OFF                 FDCAN_IR_BO             /*!< Bus_Off status changed                                */
+#define FDCAN_FLAG_RAM_WATCHDOG            FDCAN_IR_WDI            /*!< Message RAM Watchdog event due to missing READY       */
+#define FDCAN_FLAG_ARB_PROTOCOL_ERROR      FDCAN_IR_PEA            /*!< Protocol error in arbitration phase detected          */
+#define FDCAN_FLAG_DATA_PROTOCOL_ERROR     FDCAN_IR_PED            /*!< Protocol error in data phase detected                 */
+#define FDCAN_FLAG_RESERVED_ADDRESS_ACCESS FDCAN_IR_ARA            /*!< Access to reserved address occurred                   */
+#define FDCAN_FLAG_TIMESTAMP_WRAPAROUND    FDCAN_IR_TSW            /*!< Timestamp counter wrapped around                      */
+#define FDCAN_FLAG_TIMEOUT_OCCURRED        FDCAN_IR_TOO            /*!< Timeout reached                                       */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Interrupts FDCAN Interrupts
+  * @{
+  */
+
+/** @defgroup FDCAN_Tx_Interrupts FDCAN Tx Interrupts
+  * @{
+  */
+#define FDCAN_IT_TX_COMPLETE           FDCAN_IE_TCE   /*!< Transmission Completed                                */
+#define FDCAN_IT_TX_ABORT_COMPLETE     FDCAN_IE_TCFE  /*!< Transmission Cancellation Finished                    */
+#define FDCAN_IT_TX_FIFO_EMPTY         FDCAN_IE_TFEE  /*!< Tx FIFO Empty                                         */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Rx_Interrupts FDCAN Rx Interrupts
+  * @{
+  */
+#define FDCAN_IT_RX_HIGH_PRIORITY_MSG  FDCAN_IE_HPME  /*!< High priority message received                        */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Counter_Interrupts FDCAN Counter Interrupts
+  * @{
+  */
+#define FDCAN_IT_TIMESTAMP_WRAPAROUND  FDCAN_IE_TSWE  /*!< Timestamp counter wrapped around                      */
+#define FDCAN_IT_TIMEOUT_OCCURRED      FDCAN_IE_TOOE  /*!< Timeout reached                                       */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Tx_Event_Fifo_Interrupts FDCAN Tx Event FIFO Interrupts
+  * @{
+  */
+#define FDCAN_IT_TX_EVT_FIFO_ELT_LOST  FDCAN_IE_TEFLE /*!< Tx Event FIFO element lost                 */
+#define FDCAN_IT_TX_EVT_FIFO_FULL      FDCAN_IE_TEFFE /*!< Tx Event FIFO full                         */
+#define FDCAN_IT_TX_EVT_FIFO_NEW_DATA  FDCAN_IE_TEFNE /*!< Tx Handler wrote Tx Event FIFO element     */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Rx_Fifo0_Interrupts FDCAN Rx FIFO 0 Interrupts
+  * @{
+  */
+#define FDCAN_IT_RX_FIFO0_MESSAGE_LOST FDCAN_IE_RF0LE /*!< Rx FIFO 0 message lost                 */
+#define FDCAN_IT_RX_FIFO0_FULL         FDCAN_IE_RF0FE /*!< Rx FIFO 0 full                         */
+#define FDCAN_IT_RX_FIFO0_NEW_MESSAGE  FDCAN_IE_RF0NE /*!< New message written to Rx FIFO 0       */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Rx_Fifo1_Interrupts FDCAN Rx FIFO 1 Interrupts
+  * @{
+  */
+#define FDCAN_IT_RX_FIFO1_MESSAGE_LOST FDCAN_IE_RF1LE /*!< Rx FIFO 1 message lost                 */
+#define FDCAN_IT_RX_FIFO1_FULL         FDCAN_IE_RF1FE /*!< Rx FIFO 1 full                         */
+#define FDCAN_IT_RX_FIFO1_NEW_MESSAGE  FDCAN_IE_RF1NE /*!< New message written to Rx FIFO 1       */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Error_Interrupts FDCAN Error Interrupts
+  * @{
+  */
+#define FDCAN_IT_RAM_ACCESS_FAILURE      FDCAN_IE_MRAFE /*!< Message RAM access failure occurred              */
+#define FDCAN_IT_ERROR_LOGGING_OVERFLOW  FDCAN_IE_ELOE  /*!< Overflow of FDCAN Error Logging Counter occurred */
+#define FDCAN_IT_RAM_WATCHDOG            FDCAN_IE_WDIE  /*!< Message RAM Watchdog event due to missing READY  */
+#define FDCAN_IT_ARB_PROTOCOL_ERROR      FDCAN_IE_PEAE  /*!< Protocol error in arbitration phase detected     */
+#define FDCAN_IT_DATA_PROTOCOL_ERROR     FDCAN_IE_PEDE  /*!< Protocol error in data phase detected            */
+#define FDCAN_IT_RESERVED_ADDRESS_ACCESS FDCAN_IE_ARAE  /*!< Access to reserved address occurred              */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Error_Status_Interrupts FDCAN Error Status Interrupts
+  * @{
+  */
+#define FDCAN_IT_ERROR_PASSIVE           FDCAN_IE_EPE   /*!< Error_Passive status changed      */
+#define FDCAN_IT_ERROR_WARNING           FDCAN_IE_EWE   /*!< Error_Warning status changed      */
+#define FDCAN_IT_BUS_OFF                 FDCAN_IE_BOE   /*!< Bus_Off status changed            */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Interrupts_List FDCAN Interrupts List
+  * @{
+  */
+#define FDCAN_IT_LIST_RX_FIFO0         (FDCAN_IT_RX_FIFO0_MESSAGE_LOST | \
+                                        FDCAN_IT_RX_FIFO0_FULL         | \
+                                        FDCAN_IT_RX_FIFO0_NEW_MESSAGE)       /*!< RX FIFO 0 Interrupts List          */
+#define FDCAN_IT_LIST_RX_FIFO1         (FDCAN_IT_RX_FIFO1_MESSAGE_LOST | \
+                                        FDCAN_IT_RX_FIFO1_FULL         | \
+                                        FDCAN_IT_RX_FIFO1_NEW_MESSAGE)       /*!< RX FIFO 1 Interrupts List          */
+#define FDCAN_IT_LIST_SMSG             (FDCAN_IT_TX_ABORT_COMPLETE | \
+                                        FDCAN_IT_TX_COMPLETE | \
+                                        FDCAN_IT_RX_HIGH_PRIORITY_MSG)       /*!< Status Message Interrupts List     */
+#define FDCAN_IT_LIST_TX_FIFO_ERROR    (FDCAN_IT_TX_EVT_FIFO_ELT_LOST | \
+                                        FDCAN_IT_TX_EVT_FIFO_FULL | \
+                                        FDCAN_IT_TX_EVT_FIFO_NEW_DATA | \
+                                        FDCAN_IT_TX_FIFO_EMPTY)              /*!< TX FIFO Error Interrupts List      */
+#define FDCAN_IT_LIST_MISC             (FDCAN_IT_TIMEOUT_OCCURRED | \
+                                        FDCAN_IT_RAM_ACCESS_FAILURE | \
+                                        FDCAN_IT_TIMESTAMP_WRAPAROUND)       /*!< Misc. Interrupts List              */
+#define FDCAN_IT_LIST_BIT_LINE_ERROR   (FDCAN_IT_ERROR_PASSIVE | \
+                                        FDCAN_IT_ERROR_LOGGING_OVERFLOW)     /*!< Bit and Line Error Interrupts List */
+#define FDCAN_IT_LIST_PROTOCOL_ERROR   (FDCAN_IT_RESERVED_ADDRESS_ACCESS | \
+                                        FDCAN_IT_DATA_PROTOCOL_ERROR | \
+                                        FDCAN_IT_ARB_PROTOCOL_ERROR | \
+                                        FDCAN_IT_RAM_WATCHDOG | \
+                                        FDCAN_IT_BUS_OFF | \
+                                        FDCAN_IT_ERROR_WARNING)              /*!< Protocol Error Interrupts List     */
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Interrupts_Group FDCAN Interrupts Group
+  * @{
+  */
+#define FDCAN_IT_GROUP_RX_FIFO0          FDCAN_ILS_RXFIFO0 /*!< RX FIFO 0 Interrupts Group:
+                                                                  RF0LL: Rx FIFO 0 Message Lost
+                                                                  RF0FL: Rx FIFO 0 is Full
+                                                                  RF0NL: Rx FIFO 0 Has New Message            */
+#define FDCAN_IT_GROUP_RX_FIFO1          FDCAN_ILS_RXFIFO1 /*!< RX FIFO 1 Interrupts Group:
+                                                                  RF1LL: Rx FIFO 1 Message Lost
+                                                                  RF1FL: Rx FIFO 1 is Full
+                                                                  RF1NL: Rx FIFO 1 Has New Message            */
+#define FDCAN_IT_GROUP_SMSG              FDCAN_ILS_SMSG    /*!< Status Message Interrupts Group:
+                                                                  TCFL: Transmission Cancellation Finished
+                                                                  TCL: Transmission Completed
+                                                                  HPML: High Priority Message                 */
+#define FDCAN_IT_GROUP_TX_FIFO_ERROR     FDCAN_ILS_TFERR   /*!< TX FIFO Error Interrupts Group:
+                                                                  TEFLL: Tx Event FIFO Element Lost
+                                                                  TEFFL: Tx Event FIFO Full
+                                                                  TEFNL: Tx Event FIFO New Entry
+                                                                  TFEL: Tx FIFO Empty Interrupt Line          */
+#define FDCAN_IT_GROUP_MISC              FDCAN_ILS_MISC    /*!< Misc. Interrupts Group:
+                                                                  TOOL: Timeout Occurred
+                                                                  MRAFL: Message RAM Access Failure
+                                                                  TSWL: Timestamp Wraparound                  */
+#define FDCAN_IT_GROUP_BIT_LINE_ERROR    FDCAN_ILS_BERR    /*!< Bit and Line Error Interrupts Group:
+                                                                  EPL: Error Passive
+                                                                  ELOL: Error Logging Overflow                */
+#define FDCAN_IT_GROUP_PROTOCOL_ERROR    FDCAN_ILS_PERR    /*!< Protocol Error Group:
+                                                                  ARAL: Access to Reserved Address Line
+                                                                  PEDL: Protocol Error in Data Phase Line
+                                                                  PEAL: Protocol Error in Arbitration Phase Line
+                                                                  WDIL: Watchdog Interrupt Line
+                                                                  BOL: Bus_Off Status
+                                                                  EWL: Warning Status                         */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup FDCAN_Exported_Macros FDCAN Exported Macros
+  * @{
+  */
+
+/** @brief  Reset FDCAN handle state.
+  * @param  __HANDLE__ FDCAN handle.
+  * @retval None
+  */
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+#define __HAL_FDCAN_RESET_HANDLE_STATE(__HANDLE__) do{                                                \
+                                                      (__HANDLE__)->State = HAL_FDCAN_STATE_RESET;    \
+                                                      (__HANDLE__)->MspInitCallback = NULL;           \
+                                                      (__HANDLE__)->MspDeInitCallback = NULL;         \
+                                                     } while(0)
+#else
+#define __HAL_FDCAN_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_FDCAN_STATE_RESET)
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+
+/**
+  * @brief  Enable the specified FDCAN interrupts.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __INTERRUPT__ FDCAN interrupt.
+  *         This parameter can be any combination of @arg FDCAN_Interrupts
+  * @retval None
+  */
+#define __HAL_FDCAN_ENABLE_IT(__HANDLE__, __INTERRUPT__)             \
+  (__HANDLE__)->Instance->IE |= (__INTERRUPT__)
+
+/**
+  * @brief  Disable the specified FDCAN interrupts.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __INTERRUPT__ FDCAN interrupt.
+  *         This parameter can be any combination of @arg FDCAN_Interrupts
+  * @retval None
+  */
+#define __HAL_FDCAN_DISABLE_IT(__HANDLE__, __INTERRUPT__)               \
+  ((__HANDLE__)->Instance->IE) &= ~(__INTERRUPT__)
+
+/**
+  * @brief  Check whether the specified FDCAN interrupt is set or not.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __INTERRUPT__ FDCAN interrupt.
+  *         This parameter can be one of @arg FDCAN_Interrupts
+  * @retval ITStatus
+  */
+#define __HAL_FDCAN_GET_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->IR & (__INTERRUPT__))
+
+/**
+  * @brief  Clear the specified FDCAN interrupts.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __INTERRUPT__ specifies the interrupts to clear.
+  *         This parameter can be any combination of @arg FDCAN_Interrupts
+  * @retval None
+  */
+#define __HAL_FDCAN_CLEAR_IT(__HANDLE__, __INTERRUPT__)             \
+  ((__HANDLE__)->Instance->IR) = (__INTERRUPT__)
+
+/**
+  * @brief  Check whether the specified FDCAN flag is set or not.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __FLAG__ FDCAN flag.
+  *         This parameter can be one of @arg FDCAN_flags
+  * @retval FlagStatus
+  */
+#define __HAL_FDCAN_GET_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->IR & (__FLAG__))
+
+/**
+  * @brief  Clear the specified FDCAN flags.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __FLAG__ specifies the flags to clear.
+  *         This parameter can be any combination of @arg FDCAN_flags
+  * @retval None
+  */
+#define __HAL_FDCAN_CLEAR_FLAG(__HANDLE__, __FLAG__)             \
+  ((__HANDLE__)->Instance->IR) = (__FLAG__)
+
+/** @brief  Check if the specified FDCAN interrupt source is enabled or disabled.
+  * @param  __HANDLE__ FDCAN handle.
+  * @param  __INTERRUPT__ specifies the FDCAN interrupt source to check.
+  *         This parameter can be a value of @arg FDCAN_Interrupts
+  * @retval ITStatus
+  */
+#define __HAL_FDCAN_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->IE & (__INTERRUPT__))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup FDCAN_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup FDCAN_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions *****************************/
+HAL_StatusTypeDef HAL_FDCAN_Init(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_DeInit(FDCAN_HandleTypeDef *hfdcan);
+void              HAL_FDCAN_MspInit(FDCAN_HandleTypeDef *hfdcan);
+void              HAL_FDCAN_MspDeInit(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_EnterPowerDownMode(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_ExitPowerDownMode(FDCAN_HandleTypeDef *hfdcan);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+/* Callbacks Register/UnRegister functions  ***********************************/
+HAL_StatusTypeDef HAL_FDCAN_RegisterCallback(FDCAN_HandleTypeDef *hfdcan, HAL_FDCAN_CallbackIDTypeDef CallbackID, pFDCAN_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterCallback(FDCAN_HandleTypeDef *hfdcan, HAL_FDCAN_CallbackIDTypeDef CallbackID);
+HAL_StatusTypeDef HAL_FDCAN_RegisterTxEventFifoCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_TxEventFifoCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterTxEventFifoCallback(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_RegisterRxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_RxFifo0CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterRxFifo0Callback(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_RegisterRxFifo1Callback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_RxFifo1CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterRxFifo1Callback(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_RegisterTxBufferCompleteCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_TxBufferCompleteCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterTxBufferCompleteCallback(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_RegisterTxBufferAbortCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_TxBufferAbortCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterTxBufferAbortCallback(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_RegisterErrorStatusCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_ErrorStatusCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterErrorStatusCallback(FDCAN_HandleTypeDef *hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @addtogroup FDCAN_Exported_Functions_Group2
+  * @{
+  */
+/* Configuration functions ****************************************************/
+HAL_StatusTypeDef HAL_FDCAN_ConfigFilter(FDCAN_HandleTypeDef *hfdcan, FDCAN_FilterTypeDef *sFilterConfig);
+HAL_StatusTypeDef HAL_FDCAN_ConfigGlobalFilter(FDCAN_HandleTypeDef *hfdcan, uint32_t NonMatchingStd, uint32_t NonMatchingExt, uint32_t RejectRemoteStd, uint32_t RejectRemoteExt);
+HAL_StatusTypeDef HAL_FDCAN_ConfigExtendedIdMask(FDCAN_HandleTypeDef *hfdcan, uint32_t Mask);
+HAL_StatusTypeDef HAL_FDCAN_ConfigRxFifoOverwrite(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo, uint32_t OperationMode);
+HAL_StatusTypeDef HAL_FDCAN_ConfigRamWatchdog(FDCAN_HandleTypeDef *hfdcan, uint32_t CounterStartValue);
+HAL_StatusTypeDef HAL_FDCAN_ConfigTimestampCounter(FDCAN_HandleTypeDef *hfdcan, uint32_t TimestampPrescaler);
+HAL_StatusTypeDef HAL_FDCAN_EnableTimestampCounter(FDCAN_HandleTypeDef *hfdcan, uint32_t TimestampOperation);
+HAL_StatusTypeDef HAL_FDCAN_DisableTimestampCounter(FDCAN_HandleTypeDef *hfdcan);
+uint16_t          HAL_FDCAN_GetTimestampCounter(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_ResetTimestampCounter(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_ConfigTimeoutCounter(FDCAN_HandleTypeDef *hfdcan, uint32_t TimeoutOperation, uint32_t TimeoutPeriod);
+HAL_StatusTypeDef HAL_FDCAN_EnableTimeoutCounter(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_DisableTimeoutCounter(FDCAN_HandleTypeDef *hfdcan);
+uint16_t          HAL_FDCAN_GetTimeoutCounter(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_ResetTimeoutCounter(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_ConfigTxDelayCompensation(FDCAN_HandleTypeDef *hfdcan, uint32_t TdcOffset, uint32_t TdcFilter);
+HAL_StatusTypeDef HAL_FDCAN_EnableTxDelayCompensation(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_DisableTxDelayCompensation(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_EnableISOMode(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_DisableISOMode(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_EnableEdgeFiltering(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_DisableEdgeFiltering(FDCAN_HandleTypeDef *hfdcan);
+/**
+  * @}
+  */
+
+/** @addtogroup FDCAN_Exported_Functions_Group3
+  * @{
+  */
+/* Control functions **********************************************************/
+HAL_StatusTypeDef HAL_FDCAN_Start(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_Stop(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_AddMessageToTxFifoQ(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxHeaderTypeDef *pTxHeader, uint8_t *pTxData);
+uint32_t HAL_FDCAN_GetLatestTxFifoQRequestBuffer(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_AbortTxRequest(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndex);
+HAL_StatusTypeDef HAL_FDCAN_GetRxMessage(FDCAN_HandleTypeDef *hfdcan, uint32_t RxLocation, FDCAN_RxHeaderTypeDef *pRxHeader, uint8_t *pRxData);
+HAL_StatusTypeDef HAL_FDCAN_GetTxEvent(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxEventFifoTypeDef *pTxEvent);
+HAL_StatusTypeDef HAL_FDCAN_GetHighPriorityMessageStatus(FDCAN_HandleTypeDef *hfdcan, FDCAN_HpMsgStatusTypeDef *HpMsgStatus);
+HAL_StatusTypeDef HAL_FDCAN_GetProtocolStatus(FDCAN_HandleTypeDef *hfdcan, FDCAN_ProtocolStatusTypeDef *ProtocolStatus);
+HAL_StatusTypeDef HAL_FDCAN_GetErrorCounters(FDCAN_HandleTypeDef *hfdcan, FDCAN_ErrorCountersTypeDef *ErrorCounters);
+uint32_t HAL_FDCAN_IsTxBufferMessagePending(FDCAN_HandleTypeDef *hfdcan, uint32_t TxBufferIndex);
+uint32_t HAL_FDCAN_GetRxFifoFillLevel(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo);
+uint32_t HAL_FDCAN_GetTxFifoFreeLevel(FDCAN_HandleTypeDef *hfdcan);
+uint32_t HAL_FDCAN_IsRestrictedOperationMode(FDCAN_HandleTypeDef *hfdcan);
+HAL_StatusTypeDef HAL_FDCAN_ExitRestrictedOperationMode(FDCAN_HandleTypeDef *hfdcan);
+/**
+  * @}
+  */
+
+/** @addtogroup FDCAN_Exported_Functions_Group4
+  * @{
+  */
+/* Interrupts management ******************************************************/
+HAL_StatusTypeDef HAL_FDCAN_ConfigInterruptLines(FDCAN_HandleTypeDef *hfdcan, uint32_t ITList, uint32_t InterruptLine);
+HAL_StatusTypeDef HAL_FDCAN_ActivateNotification(FDCAN_HandleTypeDef *hfdcan, uint32_t ActiveITs, uint32_t BufferIndexes);
+HAL_StatusTypeDef HAL_FDCAN_DeactivateNotification(FDCAN_HandleTypeDef *hfdcan, uint32_t InactiveITs);
+void              HAL_FDCAN_IRQHandler(FDCAN_HandleTypeDef *hfdcan);
+/**
+  * @}
+  */
+
+/** @addtogroup FDCAN_Exported_Functions_Group5
+  * @{
+  */
+/* Callback functions *********************************************************/
+void HAL_FDCAN_TxEventFifoCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t TxEventFifoITs);
+void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs);
+void HAL_FDCAN_RxFifo1Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo1ITs);
+void HAL_FDCAN_TxFifoEmptyCallback(FDCAN_HandleTypeDef *hfdcan);
+void HAL_FDCAN_TxBufferCompleteCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes);
+void HAL_FDCAN_TxBufferAbortCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes);
+void HAL_FDCAN_HighPriorityMessageCallback(FDCAN_HandleTypeDef *hfdcan);
+void HAL_FDCAN_TimestampWraparoundCallback(FDCAN_HandleTypeDef *hfdcan);
+void HAL_FDCAN_TimeoutOccurredCallback(FDCAN_HandleTypeDef *hfdcan);
+void HAL_FDCAN_ErrorCallback(FDCAN_HandleTypeDef *hfdcan);
+void HAL_FDCAN_ErrorStatusCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t ErrorStatusITs);
+/**
+  * @}
+  */
+
+/** @addtogroup FDCAN_Exported_Functions_Group6
+  * @{
+  */
+/* Peripheral State functions *************************************************/
+uint32_t HAL_FDCAN_GetError(FDCAN_HandleTypeDef *hfdcan);
+HAL_FDCAN_StateTypeDef HAL_FDCAN_GetState(FDCAN_HandleTypeDef *hfdcan);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/** @defgroup FDCAN_Private_Types FDCAN Private Types
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup FDCAN_Private_Variables FDCAN Private Variables
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup FDCAN_Private_Constants FDCAN Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup FDCAN_Private_Macros FDCAN Private Macros
+  * @{
+  */
+#define IS_FDCAN_FRAME_FORMAT(FORMAT) (((FORMAT) == FDCAN_FRAME_CLASSIC  ) || \
+                                       ((FORMAT) == FDCAN_FRAME_FD_NO_BRS) || \
+                                       ((FORMAT) == FDCAN_FRAME_FD_BRS   ))
+#define IS_FDCAN_MODE(MODE) (((MODE) == FDCAN_MODE_NORMAL              ) || \
+                             ((MODE) == FDCAN_MODE_RESTRICTED_OPERATION) || \
+                             ((MODE) == FDCAN_MODE_BUS_MONITORING      ) || \
+                             ((MODE) == FDCAN_MODE_INTERNAL_LOOPBACK   ) || \
+                             ((MODE) == FDCAN_MODE_EXTERNAL_LOOPBACK   ))
+#define IS_FDCAN_CKDIV(CKDIV) (((CKDIV) == FDCAN_CLOCK_DIV1 ) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV2 ) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV4 ) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV6 ) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV8 ) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV10) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV12) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV14) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV16) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV18) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV20) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV22) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV24) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV26) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV28) || \
+                               ((CKDIV) == FDCAN_CLOCK_DIV30))
+#define IS_FDCAN_NOMINAL_PRESCALER(PRESCALER) (((PRESCALER) >= 1U) && ((PRESCALER) <= 512U))
+#define IS_FDCAN_NOMINAL_SJW(SJW) (((SJW) >= 1U) && ((SJW) <= 128U))
+#define IS_FDCAN_NOMINAL_TSEG1(TSEG1) (((TSEG1) >= 1U) && ((TSEG1) <= 256U))
+#define IS_FDCAN_NOMINAL_TSEG2(TSEG2) (((TSEG2) >= 1U) && ((TSEG2) <= 128U))
+#define IS_FDCAN_DATA_PRESCALER(PRESCALER) (((PRESCALER) >= 1U) && ((PRESCALER) <= 32U))
+#define IS_FDCAN_DATA_SJW(SJW) (((SJW) >= 1U) && ((SJW) <= 16U))
+#define IS_FDCAN_DATA_TSEG1(TSEG1) (((TSEG1) >= 1U) && ((TSEG1) <= 32U))
+#define IS_FDCAN_DATA_TSEG2(TSEG2) (((TSEG2) >= 1U) && ((TSEG2) <= 16U))
+#define IS_FDCAN_MAX_VALUE(VALUE, MAX) ((VALUE) <= (MAX))
+#define IS_FDCAN_MIN_VALUE(VALUE, MIN) ((VALUE) >= (MIN))
+#define IS_FDCAN_TX_FIFO_QUEUE_MODE(MODE) (((MODE) == FDCAN_TX_FIFO_OPERATION ) || \
+                                           ((MODE) == FDCAN_TX_QUEUE_OPERATION))
+#define IS_FDCAN_ID_TYPE(ID_TYPE) (((ID_TYPE) == FDCAN_STANDARD_ID) || \
+                                   ((ID_TYPE) == FDCAN_EXTENDED_ID))
+#define IS_FDCAN_FILTER_CFG(CONFIG) (((CONFIG) == FDCAN_FILTER_DISABLE      ) || \
+                                     ((CONFIG) == FDCAN_FILTER_TO_RXFIFO0   ) || \
+                                     ((CONFIG) == FDCAN_FILTER_TO_RXFIFO1   ) || \
+                                     ((CONFIG) == FDCAN_FILTER_REJECT       ) || \
+                                     ((CONFIG) == FDCAN_FILTER_HP           ) || \
+                                     ((CONFIG) == FDCAN_FILTER_TO_RXFIFO0_HP) || \
+                                     ((CONFIG) == FDCAN_FILTER_TO_RXFIFO1_HP))
+#define IS_FDCAN_TX_LOCATION(LOCATION) (((LOCATION) == FDCAN_TX_BUFFER0 ) || ((LOCATION) == FDCAN_TX_BUFFER1 ) || \
+                                        ((LOCATION) == FDCAN_TX_BUFFER2 ))
+#define IS_FDCAN_TX_LOCATION_LIST(LOCATION) (((LOCATION) >= FDCAN_TX_BUFFER0) && \
+                                             ((LOCATION) <= (FDCAN_TX_BUFFER0 | FDCAN_TX_BUFFER1 | FDCAN_TX_BUFFER2)))
+#define IS_FDCAN_RX_FIFO(FIFO) (((FIFO) == FDCAN_RX_FIFO0) || \
+                                ((FIFO) == FDCAN_RX_FIFO1))
+#define IS_FDCAN_RX_FIFO_MODE(MODE) (((MODE) == FDCAN_RX_FIFO_BLOCKING ) || \
+                                     ((MODE) == FDCAN_RX_FIFO_OVERWRITE))
+#define IS_FDCAN_STD_FILTER_TYPE(TYPE) (((TYPE) == FDCAN_FILTER_RANGE) || \
+                                        ((TYPE) == FDCAN_FILTER_DUAL ) || \
+                                        ((TYPE) == FDCAN_FILTER_MASK ))
+#define IS_FDCAN_EXT_FILTER_TYPE(TYPE) (((TYPE) == FDCAN_FILTER_RANGE        ) || \
+                                        ((TYPE) == FDCAN_FILTER_DUAL         ) || \
+                                        ((TYPE) == FDCAN_FILTER_MASK         ) || \
+                                        ((TYPE) == FDCAN_FILTER_RANGE_NO_EIDM))
+#define IS_FDCAN_FRAME_TYPE(TYPE) (((TYPE) == FDCAN_DATA_FRAME  ) || \
+                                   ((TYPE) == FDCAN_REMOTE_FRAME))
+#define IS_FDCAN_DLC(DLC) (((DLC) == FDCAN_DLC_BYTES_0 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_1 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_2 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_3 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_4 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_5 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_6 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_7 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_8 ) || \
+                           ((DLC) == FDCAN_DLC_BYTES_12) || \
+                           ((DLC) == FDCAN_DLC_BYTES_16) || \
+                           ((DLC) == FDCAN_DLC_BYTES_20) || \
+                           ((DLC) == FDCAN_DLC_BYTES_24) || \
+                           ((DLC) == FDCAN_DLC_BYTES_32) || \
+                           ((DLC) == FDCAN_DLC_BYTES_48) || \
+                           ((DLC) == FDCAN_DLC_BYTES_64))
+#define IS_FDCAN_ESI(ESI) (((ESI) == FDCAN_ESI_ACTIVE ) || \
+                           ((ESI) == FDCAN_ESI_PASSIVE))
+#define IS_FDCAN_BRS(BRS) (((BRS) == FDCAN_BRS_OFF) || \
+                           ((BRS) == FDCAN_BRS_ON ))
+#define IS_FDCAN_FDF(FDF) (((FDF) == FDCAN_CLASSIC_CAN) || \
+                           ((FDF) == FDCAN_FD_CAN     ))
+#define IS_FDCAN_EFC(EFC) (((EFC) == FDCAN_NO_TX_EVENTS   ) || \
+                           ((EFC) == FDCAN_STORE_TX_EVENTS))
+#define IS_FDCAN_IT(IT) (((IT) & ~(FDCAN_IR_MASK)) == 0U)
+#define IS_FDCAN_IT_GROUP(IT_GROUP) (((IT_GROUP) & ~(FDCAN_ILS_MASK)) == 0U)
+#define IS_FDCAN_NON_MATCHING(DESTINATION) (((DESTINATION) == FDCAN_ACCEPT_IN_RX_FIFO0) || \
+                                            ((DESTINATION) == FDCAN_ACCEPT_IN_RX_FIFO1) || \
+                                            ((DESTINATION) == FDCAN_REJECT            ))
+#define IS_FDCAN_REJECT_REMOTE(DESTINATION) (((DESTINATION) == FDCAN_FILTER_REMOTE) || \
+                                             ((DESTINATION) == FDCAN_REJECT_REMOTE))
+#define IS_FDCAN_IT_LINE(IT_LINE) (((IT_LINE) == FDCAN_INTERRUPT_LINE0) || \
+                                   ((IT_LINE) == FDCAN_INTERRUPT_LINE1))
+#define IS_FDCAN_TIMESTAMP(OPERATION) (((OPERATION) == FDCAN_TIMESTAMP_INTERNAL) || \
+                                       ((OPERATION) == FDCAN_TIMESTAMP_EXTERNAL))
+#define IS_FDCAN_TIMESTAMP_PRESCALER(PRESCALER) (((PRESCALER) == FDCAN_TIMESTAMP_PRESC_1 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_2 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_3 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_4 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_5 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_6 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_7 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_8 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_9 ) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_10) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_11) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_12) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_13) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_14) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_15) || \
+                                                 ((PRESCALER) == FDCAN_TIMESTAMP_PRESC_16))
+#define IS_FDCAN_TIMEOUT(OPERATION) (((OPERATION) == FDCAN_TIMEOUT_CONTINUOUS   ) || \
+                                     ((OPERATION) == FDCAN_TIMEOUT_TX_EVENT_FIFO) || \
+                                     ((OPERATION) == FDCAN_TIMEOUT_RX_FIFO0     ) || \
+                                     ((OPERATION) == FDCAN_TIMEOUT_RX_FIFO1     ))
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup FDCAN_Private_Functions_Prototypes FDCAN Private Functions Prototypes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @defgroup FDCAN_Private_Functions FDCAN Private Functions
+  * @{
+  */
+
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* FDCAN1 */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32G0xx_HAL_FDCAN_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_flash.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_flash.h
@@ -48,6 +48,9 @@ typedef struct
 {
   uint32_t TypeErase;   /*!< Mass erase or page erase.
                              This parameter can be a value of @ref FLASH_Type_Erase */
+  uint32_t Banks;       /*!< Select bank to erase.
+                             This parameter must be a value of @ref FLASH_Banks
+                             (FLASH_BANK_BOTH should be used only for mass erase) */
   uint32_t Page;        /*!< Initial Flash page to erase when page erase is enabled
                              This parameter must be a value between 0 and (FLASH_PAGE_NB - 1) */
   uint32_t NbPages;     /*!< Number of pages to be erased.
@@ -85,6 +88,8 @@ typedef struct
                                    @ref FLASH_OB_USER_IWDG_STANDBY,
                                    @ref FLASH_OB_USER_WWDG_SW,
                                    @ref FLASH_OB_USER_SRAM_PARITY,
+                                   @ref FLASH_OB_USER_BANK_SWAP(*),
+                                   @ref FLASH_OB_USER_DUAL_BANK(*),
                                    @ref FLASH_OB_USER_nBOOT_SEL,
                                    @ref FLASH_OB_USER_nBOOT1,
                                    @ref FLASH_OB_USER_nBOOT0,
@@ -103,12 +108,27 @@ typedef struct
                                    to protect. Make sure this parameter is multiple of PCROP granularity: 512 Bytes.*/
   uint32_t PCROP1BEndAddr;    /*!< PCROP End address (used for OPTIONBYTE_PCROP). It represents first address of end block
                                    to protect. Make sure this parameter is multiple of PCROP granularity: 512 Bytes.*/
+#if defined(FLASH_DBANK_SUPPORT)
+  uint32_t PCROP2AStartAddr;  /*!< PCROP Start address (used for OPTIONBYTE_PCROP). It represents first address of start block
+                                   to protect. Make sure this parameter is multiple of PCROP granularity: 512 Bytes.*/
+  uint32_t PCROP2AEndAddr;    /*!< PCROP End address (used for OPTIONBYTE_PCROP). It represents first address of end block
+                                   to protect. Make sure this parameter is multiple of PCROP granularity: 512 Bytes.*/
+  uint32_t PCROP2BStartAddr;  /*!< PCROP Start address (used for OPTIONBYTE_PCROP). It represents first address of start block
+                                   to protect. Make sure this parameter is multiple of PCROP granularity: 512 Bytes.*/
+  uint32_t PCROP2BEndAddr;    /*!< PCROP End address (used for OPTIONBYTE_PCROP). It represents first address of end block
+                                   to protect. Make sure this parameter is multiple of PCROP granularity: 512 Bytes.*/
+#endif
 #endif
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
   uint32_t BootEntryPoint;    /*!< Allow to force a unique boot entry point to Flash or system Flash */
   uint32_t SecSize;           /*!< This parameter defines securable memory area width in number of pages starting from Flash base address.
                                    This parameter must be a value between [0] and [FLASH_PAGE_NB],
                                    [0] meaning no secure area defined, [1] meaning first page only protected, etc... */
+#if defined(FLASH_DBANK_SUPPORT)
+  uint32_t SecSize2;           /*!< This parameter defines securable memory area width in number of pages starting from 2nd Bank start address.
+                                   This parameter must be a value between [0] and [FLASH_PAGE_NB],
+                                   [0] meaning no secure area defined, [1] meaning first page only protected, etc... */
+#endif
 #endif
 } FLASH_OBProgramInitTypeDef;
 
@@ -121,6 +141,7 @@ typedef struct
   uint32_t          ErrorCode;         /* FLASH error code */
   uint32_t          ProcedureOnGoing;  /* Internal variable to indicate which procedure is ongoing or not in IT context */
   uint32_t          Address;           /* Internal variable to save address selected for program in IT context */
+  uint32_t          Banks;             /* Internal variable to save current bank selected during erase in IT context */
   uint32_t          Page;              /* Internal variable to define the current page which is erasing in IT context */
   uint32_t          NbPagesToErase;    /* Internal variable to save the remaining pages to erase in IT context */
 } FLASH_ProcessTypeDef;
@@ -149,9 +170,9 @@ typedef struct
 /** @defgroup FLASH_Latency FLASH Latency
   * @{
   */
-#define FLASH_LATENCY_0                 0x00000000UL                                /*!< FLASH Zero wait state */
-#define FLASH_LATENCY_1                 FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state */
-#define FLASH_LATENCY_2                 FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states */
+#define FLASH_LATENCY_0                 0x00000000UL        /*!< FLASH Zero wait state */
+#define FLASH_LATENCY_1                 FLASH_ACR_LATENCY_0 /*!< FLASH One wait state */
+#define FLASH_LATENCY_2                 FLASH_ACR_LATENCY_1 /*!< FLASH Two wait states */
 /**
   * @}
   */
@@ -159,36 +180,36 @@ typedef struct
 /** @defgroup FLASH_Flags FLASH Flags Definition
   * @{
   */
-#define FLASH_FLAG_EOP                  FLASH_SR_EOP      /*!< FLASH End of operation flag */
-#define FLASH_FLAG_OPERR                FLASH_SR_OPERR    /*!< FLASH Operation error flag */
-#define FLASH_FLAG_PROGERR              FLASH_SR_PROGERR  /*!< FLASH Programming error flag */
-#define FLASH_FLAG_WRPERR               FLASH_SR_WRPERR   /*!< FLASH Write protection error flag */
-#define FLASH_FLAG_PGAERR               FLASH_SR_PGAERR   /*!< FLASH Programming alignment error flag */
-#define FLASH_FLAG_SIZERR               FLASH_SR_SIZERR   /*!< FLASH Size error flag  */
-#define FLASH_FLAG_PGSERR               FLASH_SR_PGSERR   /*!< FLASH Programming sequence error flag */
-#define FLASH_FLAG_MISERR               FLASH_SR_MISERR   /*!< FLASH Fast programming data miss error flag */
-#define FLASH_FLAG_FASTERR              FLASH_SR_FASTERR  /*!< FLASH Fast programming error flag */
+#define FLASH_FLAG_EOP                  ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_EOP_Pos)         /*!< FLASH End of operation flag */
+#define FLASH_FLAG_OPERR                ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_OPERR_Pos)       /*!< FLASH Operation error flag */
+#define FLASH_FLAG_PROGERR              ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_PROGERR_Pos)     /*!< FLASH Programming error flag */
+#define FLASH_FLAG_WRPERR               ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_WRPERR_Pos)      /*!< FLASH Write protection error flag */
+#define FLASH_FLAG_PGAERR               ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_PGAERR_Pos)      /*!< FLASH Programming alignment error flag */
+#define FLASH_FLAG_SIZERR               ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_SIZERR_Pos)      /*!< FLASH Size error flag  */
+#define FLASH_FLAG_PGSERR               ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_PGSERR_Pos)      /*!< FLASH Programming sequence error flag */
+#define FLASH_FLAG_MISERR               ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_MISERR_Pos)      /*!< FLASH Fast programming data miss error flag */
+#define FLASH_FLAG_FASTERR              ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_FASTERR_Pos)     /*!< FLASH Fast programming error flag */
 #if defined(FLASH_PCROP_SUPPORT)
-#define FLASH_FLAG_RDERR                FLASH_SR_RDERR    /*!< FLASH PCROP read error flag */
+#define FLASH_FLAG_RDERR                ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_RDERR_Pos)       /*!< FLASH PCROP read error flag */
 #endif /* FLASH_PCROP_SUPPORT */
-#define FLASH_FLAG_OPTVERR              FLASH_SR_OPTVERR  /*!< FLASH Option validity error flag */
-#define FLASH_FLAG_BSY                  FLASH_SR_BSY1     /*!< FLASH Operation Busy flag */
-#define FLASH_FLAG_CFGBSY               FLASH_SR_CFGBSY   /*!< FLASH Configuration Busy flag */
-#define FLASH_FLAG_ECCC                 FLASH_ECCR_ECCC   /*!< FLASH ECC correction */
-#define FLASH_FLAG_ECCD                 FLASH_ECCR_ECCD   /*!< FLASH ECC detection */
-
-#if defined(FLASH_PCROP_SUPPORT)
-#define FLASH_FLAG_ALL_ERRORS           (FLASH_FLAG_OPERR   | FLASH_FLAG_PROGERR | FLASH_FLAG_WRPERR | \
-                                         FLASH_FLAG_PGAERR  | FLASH_FLAG_SIZERR  | FLASH_FLAG_PGSERR | \
-                                         FLASH_FLAG_MISERR  | FLASH_FLAG_FASTERR | FLASH_FLAG_RDERR  | \
-                                         FLASH_FLAG_OPTVERR | FLASH_FLAG_ECCC    | FLASH_FLAG_ECCD)
-#else
-#define FLASH_FLAG_ALL_ERRORS           (FLASH_FLAG_OPERR   | FLASH_FLAG_PROGERR | FLASH_FLAG_WRPERR | \
-                                         FLASH_FLAG_PGAERR  | FLASH_FLAG_SIZERR  | FLASH_FLAG_PGSERR | \
-                                         FLASH_FLAG_MISERR  | FLASH_FLAG_FASTERR | \
-                                         FLASH_FLAG_OPTVERR | FLASH_FLAG_ECCC    | FLASH_FLAG_ECCD)
-
-#endif /* FLASH_PCROP_SUPPORT */
+#define FLASH_FLAG_OPTVERR              ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_OPTVERR_Pos)     /*!< FLASH Option validity error flag */
+#define FLASH_FLAG_BSY1                 ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_BSY1_Pos)        /*!< FLASH Operation Busy flag for Bank 1 */
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_FLAG_BSY2                  ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_BSY2_Pos)       /*!< FLASH Operation Busy flag for Bank 2 */
+#endif
+#define FLASH_FLAG_BSY                  FLASH_FLAG_BSY1                                                       /*!< FLASH Operation Busy flag - legacy name for single bank */
+#define FLASH_FLAG_CFGBSY               ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_CFGBSY_Pos)      /*!< FLASH Configuration Busy flag */
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_FLAG_PESD                 ((FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS) | FLASH_SR_PESD_Pos)        /*!< FLASH Programming/erase operation suspended */
+#endif
+#define FLASH_FLAG_ECCC1                ((FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS) | FLASH_ECCR_ECCC_Pos)   /*!< FLASH ECC correction on bank 1 */
+#define FLASH_FLAG_ECCD1                ((FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS) | FLASH_ECCR_ECCD_Pos)   /*!< FLASH ECC detection on bank 1 */
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_FLAG_ECCC2                ((FLASH_FLAG_ECCR2_ID << FLASH_FLAG_REG_POS) | FLASH_ECC2R_ECCC_Pos)  /*!< FLASH ECC correction on bank 2 */
+#define FLASH_FLAG_ECCD2                ((FLASH_FLAG_ECCR2_ID << FLASH_FLAG_REG_POS) | FLASH_ECC2R_ECCD_Pos)  /*!< FLASH ECC detection on bank 2 */
+#endif
+#define FLASH_FLAG_ECCC                 FLASH_FLAG_ECCC1   /*!< FLASH ECC correction - legacy name for single bank */
+#define FLASH_FLAG_ECCD                 FLASH_FLAG_ECCD1   /*!< FLASH ECC detection - legacy name for single bank */
 /**
   * @}
   */
@@ -197,12 +218,16 @@ typedef struct
   * @brief FLASH Interrupt definition
   * @{
   */
-#define FLASH_IT_EOP                    FLASH_CR_EOPIE              /*!< End of FLASH Operation Interrupt source */
-#define FLASH_IT_OPERR                  FLASH_CR_ERRIE              /*!< Error Interrupt source */
+#define FLASH_IT_EOP                    ((FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS) | FLASH_CR_EOPIE_Pos)         /*!< End of FLASH Operation Interrupt source */
+#define FLASH_IT_OPERR                  ((FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS) | FLASH_CR_ERRIE_Pos)         /*!< Error Interrupt source */
 #if defined(FLASH_PCROP_SUPPORT)
-#define FLASH_IT_RDERR                  FLASH_CR_RDERRIE            /*!< PCROP Read Error Interrupt source*/
+#define FLASH_IT_RDERR                  ((FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS) | FLASH_CR_RDERRIE_Pos)       /*!< PCROP Read Error Interrupt source*/
 #endif
-#define FLASH_IT_ECCC                   (FLASH_ECCR_ECCCIE >> FLASH_ECCR_ECCCIE_Pos)   /*!< ECC Correction Interrupt source */
+#define FLASH_IT_ECCC1                  ((FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS) | FLASH_ECCR_ECCCIE_Pos)   /*!< ECC Correction on Bank 1 Interrupt source */
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_IT_ECCC2                  ((FLASH_FLAG_ECCR2_ID << FLASH_FLAG_REG_POS) | FLASH_ECC2R_ECCCIE_Pos)  /*!< ECC Correction on Bank 2 Interrupt source */
+#endif
+#define FLASH_IT_ECCC                   FLASH_IT_ECCC1                                                          /*!< ECC Correction - legacy name for single bank */
 /**
   * @}
   */
@@ -211,19 +236,19 @@ typedef struct
   * @{
   */
 #define HAL_FLASH_ERROR_NONE            0x00000000U
-#define HAL_FLASH_ERROR_OP              FLASH_FLAG_OPERR
-#define HAL_FLASH_ERROR_PROG            FLASH_FLAG_PROGERR
-#define HAL_FLASH_ERROR_WRP             FLASH_FLAG_WRPERR
-#define HAL_FLASH_ERROR_PGA             FLASH_FLAG_PGAERR
-#define HAL_FLASH_ERROR_SIZ             FLASH_FLAG_SIZERR
-#define HAL_FLASH_ERROR_PGS             FLASH_FLAG_PGSERR
-#define HAL_FLASH_ERROR_MIS             FLASH_FLAG_MISERR
-#define HAL_FLASH_ERROR_FAST            FLASH_FLAG_FASTERR
+#define HAL_FLASH_ERROR_OP              FLASH_SR_EOP
+#define HAL_FLASH_ERROR_PROG            FLASH_SR_PROGERR
+#define HAL_FLASH_ERROR_WRP             FLASH_SR_WRPERR
+#define HAL_FLASH_ERROR_PGA             FLASH_SR_PGAERR
+#define HAL_FLASH_ERROR_SIZ             FLASH_SR_SIZERR
+#define HAL_FLASH_ERROR_PGS             FLASH_SR_PGSERR
+#define HAL_FLASH_ERROR_MIS             FLASH_SR_MISERR
+#define HAL_FLASH_ERROR_FAST            FLASH_SR_FASTERR
 #if defined(FLASH_PCROP_SUPPORT)
-#define HAL_FLASH_ERROR_RD              FLASH_FLAG_RDERR
+#define HAL_FLASH_ERROR_RD              FLASH_SR_RDERR
 #endif
-#define HAL_FLASH_ERROR_OPTV            FLASH_FLAG_OPTVERR
-#define HAL_FLASH_ERROR_ECCD            FLASH_FLAG_ECCD
+#define HAL_FLASH_ERROR_OPTV            FLASH_SR_OPTVERR
+#define HAL_FLASH_ERROR_ECCD            FLASH_ECCR_ECCD
 /**
   * @}
   */
@@ -236,6 +261,18 @@ typedef struct
 /**
   * @}
   */
+
+/** @defgroup FLASH_Banks FLASH Banks
+  * @{
+  */
+#define FLASH_BANK_1                    FLASH_CR_MER1   /*!< Bank 1 */
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_BANK_2                    FLASH_CR_MER2   /*!< Bank 2 */
+#endif
+/**
+  * @}
+  */
+
 
 /** @defgroup FLASH_Type_Program FLASH Program Type
   * @{
@@ -259,11 +296,11 @@ typedef struct
 #define OPTIONBYTE_SEC                  0x00000010U  /*!< SEC option byte configuration */
 #endif
 
-#if defined(STM32G071xx) || defined(STM32G081xx) || defined(STM32G031xx) || defined(STM32G041xx)
-#define OPTIONBYTE_ALL                  (OPTIONBYTE_WRP  | OPTIONBYTE_RDP | OPTIONBYTE_USER | \
-                                        OPTIONBYTE_PCROP | OPTIONBYTE_SEC)                   /*!< All option byte configuration */
-#elif defined (STM32G070xx) || defined (STM32G030xx)
-#define OPTIONBYTE_ALL                  (OPTIONBYTE_WRP  | OPTIONBYTE_RDP | OPTIONBYTE_USER) /*!< All option byte configuration */
+#if defined(FLASH_PCROP_SUPPORT) && defined(FLASH_SECURABLE_MEMORY_SUPPORT)
+#define OPTIONBYTE_ALL                  (OPTIONBYTE_WRP   | OPTIONBYTE_RDP | OPTIONBYTE_USER | \
+                                         OPTIONBYTE_PCROP | OPTIONBYTE_SEC)                   /*!< All option byte configuration */
+#else
+#define OPTIONBYTE_ALL                  (OPTIONBYTE_WRP   | OPTIONBYTE_RDP | OPTIONBYTE_USER) /*!< All option byte configuration */
 #endif
 /**
   * @}
@@ -274,6 +311,10 @@ typedef struct
   */
 #define OB_WRPAREA_ZONE_A               0x00000001U  /*!< Flash Zone A */
 #define OB_WRPAREA_ZONE_B               0x00000002U  /*!< Flash Zone B */
+#if defined(FLASH_DBANK_SUPPORT)
+#define OB_WRPAREA_ZONE2_A              0x00000004U  /*!< Flash Bank 2 Zone A */
+#define OB_WRPAREA_ZONE2_B              0x00000008U  /*!< Flash Bank 2 Zone B */
+#endif
 /**
   * @}
   */
@@ -305,6 +346,10 @@ typedef struct
 #define OB_USER_IWDG_STOP               FLASH_OPTR_IWDG_STOP                        /*!< Independent watchdog counter freeze in stop mode */
 #define OB_USER_IWDG_STDBY              FLASH_OPTR_IWDG_STDBY                       /*!< Independent watchdog counter freeze in standby mode */
 #define OB_USER_WWDG_SW                 FLASH_OPTR_WWDG_SW                          /*!< Window watchdog selection */
+#if defined(FLASH_DBANK_SUPPORT)
+#define OB_USER_BANK_SWAP               FLASH_OPTR_nSWAP_BANK                       /*!< Swap bank memory addresses */
+#define OB_USER_DUAL_BANK               FLASH_OPTR_DUAL_BANK                        /*!< Select single or dual bank (depending of device memory size) */
+#endif
 #define OB_USER_RAM_PARITY_CHECK        FLASH_OPTR_RAM_PARITY_CHECK                 /*!< Sram parity check control */
 #define OB_USER_nBOOT_SEL               FLASH_OPTR_nBOOT_SEL                        /*!< Boot Selection */
 #define OB_USER_nBOOT1                  FLASH_OPTR_nBOOT1                           /*!< nBoot1 configuration */
@@ -315,18 +360,37 @@ typedef struct
 #if defined(FLASH_OPTR_IRHEN)
 #define OB_USER_INPUT_RESET_HOLDER      FLASH_OPTR_IRHEN                            /*!< Internal reset holder enable */
 #endif
-#if defined(STM32G071xx) || defined(STM32G081xx) || defined(STM32G031xx) || defined(STM32G041xx)
+
+#if defined(FLASH_DBANK_SUPPORT)
+#if defined(PWR_BOR_SUPPORT) && defined(PWR_SHDW_SUPPORT) && defined(GPIO_NRST_CONFIG_SUPPORT)
+#define OB_USER_ALL                     (OB_USER_BOR_EN           | OB_USER_BOR_LEV    | OB_USER_nRST_STOP | \
+                                         OB_USER_nRST_STDBY       | OB_USER_nRST_SHDW  | OB_USER_IWDG_SW   | \
+                                         OB_USER_IWDG_STOP        | OB_USER_IWDG_STDBY | OB_USER_WWDG_SW   | \
+                                         OB_USER_BANK_SWAP        | OB_USER_DUAL_BANK                      | \
+                                         OB_USER_RAM_PARITY_CHECK | OB_USER_nBOOT_SEL  | OB_USER_nBOOT1    | \
+                                         OB_USER_nBOOT0           | OB_USER_NRST_MODE  | OB_USER_INPUT_RESET_HOLDER)   /*!< all option bits */
+#else
+#define OB_USER_ALL                     (                                                OB_USER_nRST_STOP | \
+                                         OB_USER_nRST_STDBY                            | OB_USER_IWDG_SW   | \
+                                         OB_USER_IWDG_STOP        | OB_USER_IWDG_STDBY | OB_USER_WWDG_SW   | \
+                                         OB_USER_BANK_SWAP        | OB_USER_DUAL_BANK                      | \
+                                         OB_USER_RAM_PARITY_CHECK | OB_USER_nBOOT_SEL  | OB_USER_nBOOT1    | \
+                                         OB_USER_nBOOT0)                                                               /*!< all option bits */
+#endif
+#else
+#if defined(PWR_BOR_SUPPORT) && defined(PWR_SHDW_SUPPORT) && defined(GPIO_NRST_CONFIG_SUPPORT)
 #define OB_USER_ALL                     (OB_USER_BOR_EN           | OB_USER_BOR_LEV    | OB_USER_nRST_STOP | \
                                          OB_USER_nRST_STDBY       | OB_USER_nRST_SHDW  | OB_USER_IWDG_SW   | \
                                          OB_USER_IWDG_STOP        | OB_USER_IWDG_STDBY | OB_USER_WWDG_SW   | \
                                          OB_USER_RAM_PARITY_CHECK | OB_USER_nBOOT_SEL  | OB_USER_nBOOT1    | \
                                          OB_USER_nBOOT0           | OB_USER_NRST_MODE  | OB_USER_INPUT_RESET_HOLDER)   /*!< all option bits */
-#elif defined (STM32G070xx) || defined (STM32G030xx)
+#else
 #define OB_USER_ALL                     (                                                OB_USER_nRST_STOP | \
                                          OB_USER_nRST_STDBY                            | OB_USER_IWDG_SW   | \
                                          OB_USER_IWDG_STOP        | OB_USER_IWDG_STDBY | OB_USER_WWDG_SW   | \
                                          OB_USER_RAM_PARITY_CHECK | OB_USER_nBOOT_SEL  | OB_USER_nBOOT1    | \
                                          OB_USER_nBOOT0)                                                               /*!< all option bits */
+#endif
 #endif
 /**
   * @}
@@ -423,6 +487,26 @@ typedef struct
   * @}
   */
 
+#if defined(FLASH_DBANK_SUPPORT)
+/** @defgroup FLASH_OB_USER_BANK_SWAP FLASH Option Bytes User bank swap Type
+  * @{
+  */
+#define OB_USER_DUALBANK_SWAP_ENABLE    0x00000000U            /*!< Enable bank swap */
+#define OB_USER_DUALBANK_SWAP_DISABLE   FLASH_OPTR_nSWAP_BANK  /*!< Disable bank swap */
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_OB_USER_DUAL_BANK FLASH Option Bytes User dual bank enable Type
+  * @{
+  */
+#define OB_USER_DUALBANK_DISABLE        0x00000000U           /*!< Disable dual bank */
+#define OB_USER_DUALBANK_ENABLE         FLASH_OPTR_DUAL_BANK  /*!< Enable dual bank */
+/**
+  * @}
+  */
+#endif
+
 /** @defgroup FLASH_OB_USER_SRAM_PARITY FLASH Option Bytes User SRAM parity
   * @{
   */
@@ -488,6 +572,10 @@ typedef struct
   */
 #define OB_PCROP_ZONE_A                 0x00000001U /*!< PCROP Zone A */
 #define OB_PCROP_ZONE_B                 0x00000002U /*!< PCROP Zone B */
+#if defined(FLASH_DBANK_SUPPORT)
+#define OB_PCROP_ZONE2_A                0x00000004U /*!< PCROP Bank 2 Zone A */
+#define OB_PCROP_ZONE2_B                0x00000008U /*!< PCROP Bank 2 Zone B */
+#endif
 /**
   * @}
   */
@@ -591,37 +679,55 @@ typedef struct
 /**
   * @brief  Enable the specified FLASH interrupt.
   * @param  __INTERRUPT__ FLASH interrupt
-  *         This parameter can be any combination of the following values:
+  *         This parameter can be one of the following values :
   *     @arg @ref FLASH_IT_EOP End of FLASH Operation Interrupt
   *     @arg @ref FLASH_IT_OPERR Error Interrupt
   *     @arg @ref FLASH_IT_RDERR PCROP Read Error Interrupt(*)
-  *     @arg @ref FLASH_IT_ECCC ECC Correction Interrupt
+  *     @arg @ref FLASH_IT_ECCC1 ECC Correction Interrupt on bank 1
+  *     @arg @ref FLASH_IT_ECCC2 ECC Correction Interrupt on bank 2(*)
+  *     @arg @ref FLASH_IT_ECCC ECC Correction Interrupt - legacy name for single bank
   * @note (*) availability depends on devices
   * @retval none
   */
-#define __HAL_FLASH_ENABLE_IT(__INTERRUPT__)    do { if(((__INTERRUPT__) & FLASH_IT_ECCC) != 0U) { SET_BIT(FLASH->ECCR, FLASH_ECCR_ECCCIE); }\
-                                                     if(((__INTERRUPT__) & (~FLASH_IT_ECCC)) != 0U) { SET_BIT(FLASH->CR, ((__INTERRUPT__) & (~FLASH_IT_ECCC))); }\
+#if defined(FLASH_DBANK_SUPPORT)
+#define __HAL_FLASH_ENABLE_IT(__INTERRUPT__)    do { if(((__INTERRUPT__) & (FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS)) != 0U) { SET_BIT(FLASH->CR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }             \
+                                                     else if(((__INTERRUPT__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) { SET_BIT(FLASH->ECCR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }   \
+                                                     else if(((__INTERRUPT__) & (FLASH_FLAG_ECCR2_ID << FLASH_FLAG_REG_POS)) != 0U) { SET_BIT(FLASH->ECC2R, (1uL << ((__INTERRUPT__) & 0x1Fu))); }  \
                                                    } while(0U)
+#else
+#define __HAL_FLASH_ENABLE_IT(__INTERRUPT__)    do { if(((__INTERRUPT__) & (FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS)) != 0U) { SET_BIT(FLASH->CR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }             \
+                                                     else if(((__INTERRUPT__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) { SET_BIT(FLASH->ECCR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }   \
+                                                   } while(0U)
+#endif
 
 /**
   * @brief  Disable the specified FLASH interrupt.
   * @param  __INTERRUPT__ FLASH interrupt
-  *         This parameter can be any combination of the following values:
+  *         This parameter can be one of the following values :
   *     @arg @ref FLASH_IT_EOP End of FLASH Operation Interrupt
   *     @arg @ref FLASH_IT_OPERR Error Interrupt
   *     @arg @ref FLASH_IT_RDERR PCROP Read Error Interrupt(*)
-  *     @arg @ref FLASH_IT_ECCC ECC Correction Interrupt
+  *     @arg @ref FLASH_IT_ECCC1 ECC Correction Interrupt on bank 1
+  *     @arg @ref FLASH_IT_ECCC2 ECC Correction Interrupt on bank 2(*)
+  *     @arg @ref FLASH_IT_ECCC ECC Correction Interrupt - legacy name for single bank
   * @note (*) availability depends on devices
   * @retval none
   */
-#define __HAL_FLASH_DISABLE_IT(__INTERRUPT__)   do { if(((__INTERRUPT__) & FLASH_IT_ECCC) != 0U) { CLEAR_BIT(FLASH->ECCR, FLASH_ECCR_ECCCIE); }\
-                                                     if(((__INTERRUPT__) & (~FLASH_IT_ECCC)) != 0U) { CLEAR_BIT(FLASH->CR, ((__INTERRUPT__) & (~FLASH_IT_ECCC))); }\
+#if defined(FLASH_DBANK_SUPPORT)
+#define __HAL_FLASH_DISABLE_IT(__INTERRUPT__)   do { if(((__INTERRUPT__) & (FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS)) != 0U) { CLEAR_BIT(FLASH->CR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }             \
+                                                     else if(((__INTERRUPT__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) { CLEAR_BIT(FLASH->ECCR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }   \
+                                                     else if(((__INTERRUPT__) & (FLASH_FLAG_ECCR2_ID << FLASH_FLAG_REG_POS)) != 0U) { CLEAR_BIT(FLASH->ECC2R, (1uL << ((__INTERRUPT__) & 0x1Fu))); }  \
                                                    } while(0U)
+#else
+#define __HAL_FLASH_DISABLE_IT(__INTERRUPT__)   do { if(((__INTERRUPT__) & (FLASH_FLAG_CR_ID << FLASH_FLAG_REG_POS)) != 0U) { CLEAR_BIT(FLASH->CR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }             \
+                                                     else if(((__INTERRUPT__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) { CLEAR_BIT(FLASH->ECCR, (1uL << ((__INTERRUPT__) & 0x1Fu))); }   \
+                                                   } while(0U)
+#endif
 
 /**
   * @brief  Check whether the specified FLASH flag is set or not.
   * @param  __FLAG__ specifies the FLASH flag to check.
-  *   This parameter can be one of the following values:
+  *         This parameter can be one of the following values :
   *     @arg @ref FLASH_FLAG_EOP FLASH End of Operation flag
   *     @arg @ref FLASH_FLAG_OPERR FLASH Operation error flag
   *     @arg @ref FLASH_FLAG_PROGERR FLASH Programming error flag
@@ -633,21 +739,35 @@ typedef struct
   *     @arg @ref FLASH_FLAG_FASTERR FLASH Fast programming error flag
   *     @arg @ref FLASH_FLAG_RDERR FLASH PCROP read  error flag(*)
   *     @arg @ref FLASH_FLAG_OPTVERR FLASH Option validity error flag
-  *     @arg @ref FLASH_FLAG_BSY FLASH write/erase operations in progress flag
+  *     @arg @ref FLASH_FLAG_BSY1 FLASH bank 1 write/erase operations in progress flag
+  *     @arg @ref FLASH_FLAG_BSY2 FLASH bank 2 write/erase operations in progress flag(*)
+  *     @arg @ref FLASH_FLAG_BSY FLASH write/erase operations in progress flag  - legacy name for single bank
   *     @arg @ref FLASH_FLAG_CFGBSY FLASH configuration is busy : program or erase setting are used.
-  *     @arg @ref FLASH_FLAG_ECCC FLASH one ECC error has been detected and corrected
-  *     @arg @ref FLASH_FLAG_ECCD FLASH two ECC errors have been detected
+  *     @arg @ref FLASH_FLAG_ECCC1 FLASH one ECC error has been detected and corrected
+  *     @arg @ref FLASH_FLAG_ECCD1 FLASH two ECC errors have been detected on bank 1
+  *     @arg @ref FLASH_FLAG_ECCC2 FLASH one ECC error has been detected and corrected on bank 2(*)
+  *     @arg @ref FLASH_FLAG_ECCD2 FLASH two ECC errors have been detected on bank 2(*)
+  *     @arg @ref FLASH_FLAG_ECCC FLASH one ECC error has been detected and corrected - legacy name for single bank
+  *     @arg @ref FLASH_FLAG_ECCD FLASH two ECC errors have been detected - legacy name for single bank
   * @note (*) availability depends on devices
-  * @retval The new state of FLASH_FLAG (SET or RESET).
+  * @retval The state of FLASH_FLAG (SET or RESET).
   */
-#define __HAL_FLASH_GET_FLAG(__FLAG__)          ((((__FLAG__) & (FLASH_FLAG_ECCC | FLASH_FLAG_ECCD)) != 0U) ? \
-                                                 (READ_BIT(FLASH->ECCR, (__FLAG__)) == (__FLAG__))  : \
-                                                 (READ_BIT(FLASH->SR,   (__FLAG__)) == (__FLAG__)))
+#if defined(FLASH_DBANK_SUPPORT)
+#define __HAL_FLASH_GET_FLAG(__FLAG__)          ((((__FLAG__) & (FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS)) != 0U) ?             \
+                                                     (READ_BIT(FLASH->SR, (1uL << ((__FLAG__) & 0x1Fu))) != 0x00u) :        \
+                                                     ((((__FLAG__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) ? \
+                                                     (READ_BIT(FLASH->ECCR, (1uL << ((__FLAG__) & 0x1Fu))) != 0x00u) :      \
+                                                     (READ_BIT(FLASH->ECC2R, (1uL << ((__FLAG__) & 0x1Fu))) != 0x00u)))
+#else
+#define __HAL_FLASH_GET_FLAG(__FLAG__)          ((((__FLAG__) & (FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS)) != 0U) ?   \
+                                                  (READ_BIT(FLASH->SR, (1uL << ((__FLAG__) & 0x1Fu))) != 0x00u) : \
+                                                  (READ_BIT(FLASH->ECCR, (1uL << ((__FLAG__) & 0x1Fu))) != 0x00u))
+#endif
 
 /**
-  * @brief  Clear the FLASHs pending flags.
+  * @brief  Clear the FLASH pending flags.
   * @param  __FLAG__ specifies the FLASH flags to clear.
-  *   This parameter can be any combination of the following values:
+  *         This parameter can be one of the following values :
   *     @arg @ref FLASH_FLAG_EOP FLASH End of Operation flag
   *     @arg @ref FLASH_FLAG_OPERR FLASH Operation error flag
   *     @arg @ref FLASH_FLAG_PROGERR FLASH Programming error flag
@@ -659,14 +779,25 @@ typedef struct
   *     @arg @ref FLASH_FLAG_FASTERR FLASH Fast programming error flag
   *     @arg @ref FLASH_FLAG_RDERR FLASH PCROP read  error flag
   *     @arg @ref FLASH_FLAG_OPTVERR FLASH Option validity error flag
-  *     @arg @ref FLASH_FLAG_ECCC FLASH one ECC error has been detected and corrected
-  *     @arg @ref FLASH_FLAG_ECCD FLASH two ECC errors have been detected
-  *     @arg @ref FLASH_FLAG_ALL_ERRORS FLASH All errors flags
+  *     @arg @ref FLASH_FLAG_ECCC1 FLASH one ECC error has been detected and corrected
+  *     @arg @ref FLASH_FLAG_ECCD1 FLASH two ECC errors have been detected on bank 1
+  *     @arg @ref FLASH_FLAG_ECCC2 FLASH one ECC error has been detected and corrected on bank 2(*)
+  *     @arg @ref FLASH_FLAG_ECCD2 FLASH two ECC errors have been detected on bank 2(*)
+  *     @arg @ref FLASH_FLAG_ECCC FLASH one ECC error has been detected and corrected - legacy name for single bank
+  *     @arg @ref FLASH_FLAG_ECCD FLASH two ECC errors have been detected - legacy name for single bank
+  * @note (*) availability depends on devices
   * @retval None
   */
-#define __HAL_FLASH_CLEAR_FLAG(__FLAG__)        do { if(((__FLAG__) & (FLASH_FLAG_ECCC | FLASH_FLAG_ECCD)) != 0U) { SET_BIT(FLASH->ECCR, ((__FLAG__) & (FLASH_FLAG_ECCC | FLASH_FLAG_ECCD))); }\
-                                                     if(((__FLAG__) & ~(FLASH_FLAG_ECCC | FLASH_FLAG_ECCD)) != 0U) { WRITE_REG(FLASH->SR, ((__FLAG__) & ~(FLASH_FLAG_ECCC | FLASH_FLAG_ECCD))); }\
+#if defined(FLASH_DBANK_SUPPORT)
+#define __HAL_FLASH_CLEAR_FLAG(__FLAG__)        do { if(((__FLAG__) & (FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS)) != 0U)         { FLASH->SR = (1uL << ((__FLAG__) & 0x1Fu)); }    \
+                                                     else if(((__FLAG__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) { FLASH->ECCR = (1uL << ((__FLAG__) & 0x1Fu)); }  \
+                                                     else if(((__FLAG__) & (FLASH_FLAG_ECCR2_ID << FLASH_FLAG_REG_POS)) != 0U) { FLASH->ECC2R = (1uL << ((__FLAG__) & 0x1Fu)); }  \
                                                    } while(0U)
+#else
+#define __HAL_FLASH_CLEAR_FLAG(__FLAG__)        do { if(((__FLAG__) & (FLASH_FLAG_SR_ID << FLASH_FLAG_REG_POS)) != 0U)         { FLASH->SR = (1uL << ((__FLAG__) & 0x1Fu)); }    \
+                                                     else if(((__FLAG__) & (FLASH_FLAG_ECCR1_ID << FLASH_FLAG_REG_POS)) != 0U) { FLASH->ECCR = (1uL << ((__FLAG__) & 0x1Fu)); }  \
+                                                   } while(0U)
+#endif
 /**
   * @}
   */
@@ -744,35 +875,52 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
   */
 #define FLASH_SIZE_DATA_REGISTER        FLASHSIZE_BASE
 
-#define FLASH_SIZE                      (((*((uint32_t *)FLASH_SIZE_DATA_REGISTER)) & (0x00FFU)) << 10U)
-
-#define FLASH_BANK_SIZE                 (FLASH_SIZE)   /*!< FLASH Bank Size */
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_BANK_SIZE                 (FLASH_SIZE >> 1) /*!< FLASH Bank Size is Flash size divided by 2 */
+#else
+#define FLASH_BANK_SIZE                 (FLASH_SIZE)      /*!< FLASH Bank Size */
+#endif
 
 #define FLASH_PAGE_SIZE                 0x00000800U    /*!< FLASH Page Size, 2 KBytes */
 
 #if defined(STM32G081xx)||defined(STM32G071xx)||defined(STM32G070xx)
 #define FLASH_PAGE_NB                   64U
+#elif defined(STM32G0C1xx)||defined(STM32G0B1xx)||defined(STM32G0B0xx)
+/* warning : on those product, constant represents number of page per bank */
+#define FLASH_PAGE_NB                   128U
 #else
 #define FLASH_PAGE_NB                   32U
 #endif
 
 #define FLASH_TIMEOUT_VALUE             1000U          /*!< FLASH Execution Timeout, 1 s */
 
-#define FLASH_TYPENONE                  0x00000000U    /*!< No Programmation Procedure On Going */
+#define FLASH_TYPENONE                  0x00000000U    /*!< No programming Procedure On Going */
 
 #if defined(FLASH_PCROP_SUPPORT)
-#define FLASH_FLAG_SR_ERROR             (FLASH_FLAG_OPERR  | FLASH_FLAG_PROGERR | FLASH_FLAG_WRPERR |  \
-                                         FLASH_FLAG_PGAERR | FLASH_FLAG_SIZERR  | FLASH_FLAG_PGSERR |   \
-                                         FLASH_FLAG_MISERR | FLASH_FLAG_FASTERR | FLASH_FLAG_RDERR |   \
-                                         FLASH_FLAG_OPTVERR)     /*!< All SR error flags */
+#define FLASH_SR_ERRORS                 (FLASH_SR_OPERR  | FLASH_SR_PROGERR | FLASH_SR_WRPERR | \
+                                        FLASH_SR_PGAERR | FLASH_SR_SIZERR  | FLASH_SR_PGSERR |  \
+                                        FLASH_SR_MISERR | FLASH_SR_FASTERR | FLASH_SR_RDERR |   \
+                                        FLASH_SR_OPTVERR) /*!< All SR error flags */
 #else
-#define FLASH_FLAG_SR_ERROR             (FLASH_FLAG_OPERR  | FLASH_FLAG_PROGERR | FLASH_FLAG_WRPERR |  \
-                                         FLASH_FLAG_PGAERR | FLASH_FLAG_SIZERR  | FLASH_FLAG_PGSERR |   \
-                                         FLASH_FLAG_MISERR | FLASH_FLAG_FASTERR |   \
-                                         FLASH_FLAG_OPTVERR)     /*!< All SR error flags */
+#define FLASH_SR_ERRORS                 (FLASH_SR_OPERR  | FLASH_SR_PROGERR | FLASH_SR_WRPERR | \
+                                        FLASH_SR_PGAERR | FLASH_SR_SIZERR  | FLASH_SR_PGSERR |  \
+                                        FLASH_SR_MISERR | FLASH_SR_FASTERR |                    \
+                                        FLASH_SR_OPTVERR) /*!< All SR error flags */
 #endif
 
-#define FLASH_FLAG_SR_CLEAR             (FLASH_FLAG_SR_ERROR | FLASH_SR_EOP)
+#if defined(FLASH_DBANK_SUPPORT)
+#define FLASH_SR_CLEAR                  (FLASH_SR_ERRORS | FLASH_SR_EOP | FLASH_SR_PESD)
+#else
+#define FLASH_SR_CLEAR                  (FLASH_SR_ERRORS | FLASH_SR_EOP)
+#endif
+
+/* Internal defines for HAL macro usage */
+#define FLASH_FLAG_REG_POS              16u
+#define FLASH_FLAG_SR_ID                1u
+#define FLASH_FLAG_CR_ID                2u
+#define FLASH_FLAG_ECCR1_ID             4u
+#define FLASH_FLAG_ECCR2_ID             8u
+
 /**
   * @}
   */
@@ -782,6 +930,11 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
  *  @{
  */
 #define IS_FLASH_MAIN_MEM_ADDRESS(__ADDRESS__)         (((__ADDRESS__) >= (FLASH_BASE)) && ((__ADDRESS__) <= (FLASH_BASE + FLASH_SIZE - 1UL)))
+
+#define IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(__ADDRESS__)  (((__ADDRESS__) >= (FLASH_BASE)) && ((__ADDRESS__) <= (FLASH_BASE + FLASH_BANK_SIZE - 1UL)))
+#if defined(FLASH_DBANK_SUPPORT)
+#define IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(__ADDRESS__) (((__ADDRESS__) >= (FLASH_BASE + FLASH_BANK_SIZE)) && ((__ADDRESS__) <= (FLASH_BASE + FLASH_SIZE - 1UL)))
+#endif
 
 #define IS_FLASH_PROGRAM_MAIN_MEM_ADDRESS(__ADDRESS__) (((__ADDRESS__) >= (FLASH_BASE)) && ((__ADDRESS__) <= (FLASH_BASE + FLASH_SIZE - 8UL)))
 
@@ -793,7 +946,13 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 
 #define IS_FLASH_PAGE(__PAGE__)                        ((__PAGE__) < FLASH_PAGE_NB)
 
-#define IS_FLASH_BANK(__BANK__)                        ((__BANK__) == 0x00UL)
+#if defined(FLASH_DBANK_SUPPORT)
+#define IS_FLASH_BANK(__BANK__)                        (((__BANK__) == FLASH_BANK_1)  || \
+                                                        ((__BANK__) == FLASH_BANK_2)  || \
+                                                        ((__BANK__) == (FLASH_BANK_2 | FLASH_BANK_1)))
+#else
+#define IS_FLASH_BANK(__BANK__)                        ((__BANK__) == FLASH_BANK_1)
+#endif
 
 #define IS_FLASH_TYPEERASE(__VALUE__)                  (((__VALUE__) == FLASH_TYPEERASE_PAGES) || \
                                                         ((__VALUE__) == FLASH_TYPEERASE_MASS))
@@ -804,7 +963,12 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #define IS_OPTIONBYTE(__VALUE__)                       ((((__VALUE__) & OPTIONBYTE_ALL) != 0x00U) && \
                                                        (((__VALUE__) & ~OPTIONBYTE_ALL) == 0x00U))
 
+#if defined(FLASH_DBANK_SUPPORT)
+#define IS_OB_WRPAREA(__VALUE__)                       (((__VALUE__) == OB_WRPAREA_ZONE_A) || ((__VALUE__) == OB_WRPAREA_ZONE_B) || \
+                                                        ((__VALUE__) == OB_WRPAREA_ZONE2_A) || ((__VALUE__) == OB_WRPAREA_ZONE2_B))
+#else
 #define IS_OB_WRPAREA(__VALUE__)                       (((__VALUE__) == OB_WRPAREA_ZONE_A) || ((__VALUE__) == OB_WRPAREA_ZONE_B))
+#endif
 
 #define IS_OB_RDP_LEVEL(__LEVEL__)                     (((__LEVEL__) == OB_RDP_LEVEL_0)   ||\
                                                         ((__LEVEL__) == OB_RDP_LEVEL_1)   ||\
@@ -816,7 +980,12 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #define IS_OB_USER_CONFIG(__TYPE__,__CONFIG__)         ((~(__TYPE__) & (__CONFIG__)) == 0x00U)
 
 #if defined(FLASH_PCROP_SUPPORT)
+#if defined(FLASH_DBANK_SUPPORT)
+#define IS_OB_PCROP_CONFIG(__CONFIG__)                 (((__CONFIG__) & ~(OB_PCROP_ZONE_A | OB_PCROP_ZONE_B | \
+                                                                          OB_PCROP_ZONE2_A | OB_PCROP_ZONE2_B | OB_PCROP_RDP_ERASE)) == 0x00U)
+#else
 #define IS_OB_PCROP_CONFIG(__CONFIG__)                 (((__CONFIG__) & ~(OB_PCROP_ZONE_A | OB_PCROP_ZONE_B | OB_PCROP_RDP_ERASE)) == 0x00U)
+#endif
 #endif
 
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_flash_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_flash_ex.h
@@ -70,7 +70,7 @@ void              HAL_FLASHEx_DisableDebugger(void);
 uint32_t          HAL_FLASHEx_FlashEmptyCheck(void);
 void              HAL_FLASHEx_ForceFlashEmpty(uint32_t FlashEmpty);
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
-void              HAL_FLASHEx_EnableSecMemProtection(uint32_t Bank);
+void              HAL_FLASHEx_EnableSecMemProtection(uint32_t Banks);
 #endif
 HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
 void              HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
@@ -97,7 +97,7 @@ void              HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
   *  @{
   */
 #define IS_FLASH_EMPTY_CHECK(__VALUE__)     (((__VALUE__) == FLASH_PROG_EMPTY) || ((__VALUE__) == FLASH_PROG_NOT_EMPTY))
-void              FLASH_PageErase(uint32_t Page);
+void              FLASH_PageErase(uint32_t Banks, uint32_t Page);
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_gpio_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_gpio_ex.h
@@ -46,7 +46,258 @@ extern "C" {
 /** @defgroup GPIOEx_Alternate_function_selection GPIOEx Alternate function selection
   * @{
   */
+#if defined (STM32G0C1xx) || defined (STM32G0B1xx)
+/*------------------------- STM32G0C1xx / STM32G0B1xx ------------------------*/
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_CEC           ((uint8_t)0x00)  /*!< CEC Alternate Function mapping */
+#define GPIO_AF0_CRS           ((uint8_t)0x00)  /*!< CRS Alternate Function mapping */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
+#define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
+#define GPIO_AF0_LPTIM1        ((uint8_t)0x00)  /*!< LPTIM1 Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
+#define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF0_TIM14         ((uint8_t)0x00)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF0_TIM15         ((uint8_t)0x00)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF0_TIM16         ((uint8_t)0x00)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF0_TIM17         ((uint8_t)0x00)  /*!< TIM17 Alternate Function mapping */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /*!< USART2 Alternate Function mapping */
+#define GPIO_AF0_USART3        ((uint8_t)0x00)  /*!< USART3 Alternate Function mapping */
+#define GPIO_AF0_USART4        ((uint8_t)0x00)  /*!< USART4 Alternate Function mapping */
+#define GPIO_AF0_UCPD1         ((uint8_t)0x00)  /*!< UCPD1 Alternate Function mapping */
+#define GPIO_AF0_UCPD2         ((uint8_t)0x00)  /*!< UCPD2 Alternate Function mapping */
 
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_CEC           ((uint8_t)0x01)  /*!< CEC Alternate Function mapping */
+#define GPIO_AF1_EVENTOUT      ((uint8_t)0x01)  /*!< EVENTOUT Alternate Function mapping */
+#define GPIO_AF1_IR            ((uint8_t)0x01)  /*!< IR Alternate Function mapping */
+#define GPIO_AF1_LPTIM2        ((uint8_t)0x01)  /*!< LPTIM2 Alternate Function mapping */
+#define GPIO_AF1_LPUART1       ((uint8_t)0x01)  /*!< LPUART1 Alternate Function mapping */
+#define GPIO_AF1_LPUART2       ((uint8_t)0x01)  /*!< LPUART2 Alternate Function mapping */
+#define GPIO_AF1_OSC           ((uint8_t)0x01)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF1_SPI1          ((uint8_t)0x01)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM3          ((uint8_t)0x01)  /*!< TIM3 Alternate Function mapping */
+#define GPIO_AF1_USART1        ((uint8_t)0x01)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF1_USART2        ((uint8_t)0x01)  /*!< USART2 Alternate Function mapping */
+#define GPIO_AF1_USART4        ((uint8_t)0x01)  /*!< USART4 Alternate Function mapping */
+#define GPIO_AF1_UCPD1         ((uint8_t)0x01)  /*!< UCPD1 Alternate Function mapping */
+#define GPIO_AF1_UCPD2         ((uint8_t)0x01)  /*!< UCPD2 Alternate Function mapping */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_LPTIM1        ((uint8_t)0x02)  /*!< LPTIM1 Alternate Function mapping */
+#define GPIO_AF2_LPTIM2        ((uint8_t)0x02)  /*!< LPTIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM1          ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2          ((uint8_t)0x02)  /*!< TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM4          ((uint8_t)0x02)  /*!< TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM14         ((uint8_t)0x02)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF2_TIM15         ((uint8_t)0x02)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF2_TIM16         ((uint8_t)0x02)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF2_TIM17         ((uint8_t)0x02)  /*!< TIM17 Alternate Function mapping */
+#define GPIO_AF2_USB           ((uint8_t)0x02)  /*!< USB Alternate Function mapping */
+
+
+/**
+  * @brief   AF 3 selection
+  */
+#define GPIO_AF3_FDCAN1        ((uint8_t)0x03)  /*!< FDCAN1 Alternate Function mapping */
+#define GPIO_AF3_FDCAN2        ((uint8_t)0x03)  /*!< FDCAN2 Alternate Function mapping */
+#define GPIO_AF3_LPUART2       ((uint8_t)0x03)  /*!< LPUART2 Alternate Function mapping */
+#define GPIO_AF3_USART5        ((uint8_t)0x03)  /*!< USART5 Alternate Function mapping */
+#define GPIO_AF3_USART6        ((uint8_t)0x03)  /*!< USART6 Alternate Function mapping */
+#define GPIO_AF3_MCO2          ((uint8_t)0x03)  /*!< MCO2 Alternate Function mapping */
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_CRS           ((uint8_t)0x04)  /*!< CRS Alternate Function mapping */
+#define GPIO_AF4_SPI2          ((uint8_t)0x04)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF4_SPI3          ((uint8_t)0x04)  /*!< SPI3 Alternate Function mapping */
+#define GPIO_AF4_TIM14         ((uint8_t)0x04)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF4_TIM15         ((uint8_t)0x04)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF4_USART1        ((uint8_t)0x04)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF4_USART3        ((uint8_t)0x04)  /*!< USART3 Alternate Function mapping */
+#define GPIO_AF4_USART4        ((uint8_t)0x04)  /*!< USART4 Alternate Function mapping */
+#define GPIO_AF4_USART6        ((uint8_t)0x04)  /*!< USART6 Alternate Function mapping */
+#define GPIO_AF4_UCPD1         ((uint8_t)0x04)  /*!< UCPD1 Alternate Function mapping */
+#define GPIO_AF4_UCPD2         ((uint8_t)0x04)  /*!< UCPD2 Alternate Function mapping */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_LPTIM1        ((uint8_t)0x05)  /*!< LPTIM1 Alternate Function mapping */
+#define GPIO_AF5_LPTIM2        ((uint8_t)0x05)  /*!< LPTIM2 Alternate Function mapping */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF5_TIM15         ((uint8_t)0x05)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF5_TIM16         ((uint8_t)0x05)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF5_TIM17         ((uint8_t)0x05)  /*!< TIM17 Alternate Function mapping */
+#define GPIO_AF5_USART3        ((uint8_t)0x05)  /*!< USART3 Alternate Function mapping */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_I2C1          ((uint8_t)0x06)  /*!< I2C1 Alternate Function mapping */
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /*!< I2C2 Alternate Function mapping */
+#define GPIO_AF6_I2C3          ((uint8_t)0x06)  /*!< I2C3 Alternate Function mapping */
+#define GPIO_AF6_LPUART1       ((uint8_t)0x06)  /*!< LPUART1 Alternate Function mapping */
+#define GPIO_AF6_UCPD1         ((uint8_t)0x06)  /*!< UCPD1 Alternate Function mapping */
+#define GPIO_AF6_UCPD2         ((uint8_t)0x06)  /*!< UCPD2 Alternate Function mapping */
+#define GPIO_AF6_USB           ((uint8_t)0x06)  /*!< USB Alternate Function mapping */
+
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_COMP1         ((uint8_t)0x07)  /*!< COMP1 Alternate Function mapping */
+#define GPIO_AF7_COMP2         ((uint8_t)0x07)  /*!< COMP2 Alternate Function mapping */
+#define GPIO_AF7_COMP3         ((uint8_t)0x07)  /*!< COMP3 Alternate Function mapping */
+#define GPIO_AF7_EVENTOUT      ((uint8_t)0x07)  /*!< EVENTOUT Alternate Function mapping */
+
+/**
+  * @brief   AF 8 selection
+  */
+#define GPIO_AF8_I2C2          ((uint8_t)0x08)  /*!< I2C2 Alternate Function mapping */
+#define GPIO_AF8_USART5        ((uint8_t)0x08)  /*!< USART5 Alternate Function mapping */
+#define GPIO_AF8_USART6        ((uint8_t)0x08)  /*!< USART5 Alternate Function mapping */
+
+/**
+  * @brief   AF 9 selection
+  */
+#define GPIO_AF9_I2C3          ((uint8_t)0x09)  /*!< I2C3 Alternate Function mapping */
+#define GPIO_AF9_SPI3          ((uint8_t)0x09)  /*!< SPI3 Alternate Function mapping */
+#define GPIO_AF9_TIM4          ((uint8_t)0x09)  /*!< TIM4 Alternate Function mapping */
+
+/**
+  * @brief   AF 10 selection
+  */
+#define GPIO_AF10_LPUART2      ((uint8_t)0x0A)  /*!< LPUART2 Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)         ((AF) <= (uint8_t)0x0A)
+
+#endif
+
+#if defined (STM32G0B0xx)
+/*------------------------- STM32G0B0xx ------------------------*/
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_CRS           ((uint8_t)0x00)  /*!< CRS Alternate Function mapping */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
+#define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
+#define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF0_TIM14         ((uint8_t)0x00)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF0_TIM15         ((uint8_t)0x00)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF0_TIM16         ((uint8_t)0x00)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF0_TIM17         ((uint8_t)0x00)  /*!< TIM17 Alternate Function mapping */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /*!< USART2 Alternate Function mapping */
+#define GPIO_AF0_USART3        ((uint8_t)0x00)  /*!< USART3 Alternate Function mapping */
+#define GPIO_AF0_USART4        ((uint8_t)0x00)  /*!< USART4 Alternate Function mapping */
+
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_EVENTOUT      ((uint8_t)0x01)  /*!< EVENTOUT Alternate Function mapping */
+#define GPIO_AF1_IR            ((uint8_t)0x01)  /*!< IR Alternate Function mapping */
+#define GPIO_AF1_OSC           ((uint8_t)0x01)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF1_SPI1          ((uint8_t)0x01)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM3          ((uint8_t)0x01)  /*!< TIM3 Alternate Function mapping */
+#define GPIO_AF1_USART1        ((uint8_t)0x01)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF1_USART2        ((uint8_t)0x01)  /*!< USART2 Alternate Function mapping */
+#define GPIO_AF1_USART4        ((uint8_t)0x01)  /*!< USART4 Alternate Function mapping */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_TIM1          ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM4          ((uint8_t)0x02)  /*!< TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM14         ((uint8_t)0x02)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF2_TIM15         ((uint8_t)0x02)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF2_TIM16         ((uint8_t)0x02)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF2_TIM17         ((uint8_t)0x02)  /*!< TIM17 Alternate Function mapping */
+#define GPIO_AF2_USB           ((uint8_t)0x02)  /*!< USB Alternate Function mapping */
+
+
+/**
+  * @brief   AF 3 selection
+  */
+#define GPIO_AF3_USART5        ((uint8_t)0x03)  /*!< USART5 Alternate Function mapping */
+#define GPIO_AF3_USART6        ((uint8_t)0x03)  /*!< USART6 Alternate Function mapping */
+#define GPIO_AF3_MCO2          ((uint8_t)0x03)  /*!< MCO2 Alternate Function mapping */
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_CRS           ((uint8_t)0x04)  /*!< CRS Alternate Function mapping */
+#define GPIO_AF4_SPI2          ((uint8_t)0x04)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF4_SPI3          ((uint8_t)0x04)  /*!< SPI3 Alternate Function mapping */
+#define GPIO_AF4_TIM14         ((uint8_t)0x04)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF4_TIM15         ((uint8_t)0x04)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF4_USART1        ((uint8_t)0x04)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF4_USART3        ((uint8_t)0x04)  /*!< USART3 Alternate Function mapping */
+#define GPIO_AF4_USART4        ((uint8_t)0x04)  /*!< USART4 Alternate Function mapping */
+#define GPIO_AF4_USART6        ((uint8_t)0x04)  /*!< USART6 Alternate Function mapping */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF5_TIM15         ((uint8_t)0x05)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF5_TIM16         ((uint8_t)0x05)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF5_TIM17         ((uint8_t)0x05)  /*!< TIM17 Alternate Function mapping */
+#define GPIO_AF5_USART3        ((uint8_t)0x05)  /*!< USART3 Alternate Function mapping */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_I2C1          ((uint8_t)0x06)  /*!< I2C1 Alternate Function mapping */
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /*!< I2C2 Alternate Function mapping */
+#define GPIO_AF6_I2C3          ((uint8_t)0x06)  /*!< I2C3 Alternate Function mapping */
+#define GPIO_AF6_USB           ((uint8_t)0x06)  /*!< USB Alternate Function mapping */
+
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_EVENTOUT      ((uint8_t)0x07)  /*!< EVENTOUT Alternate Function mapping */
+
+/**
+  * @brief   AF 8 selection
+  */
+#define GPIO_AF8_I2C2          ((uint8_t)0x08)  /*!< I2C2 Alternate Function mapping */
+#define GPIO_AF8_USART5        ((uint8_t)0x08)  /*!< USART5 Alternate Function mapping */
+#define GPIO_AF8_USART6        ((uint8_t)0x08)  /*!< USART5 Alternate Function mapping */
+
+/**
+  * @brief   AF 9 selection
+  */
+#define GPIO_AF9_I2C3          ((uint8_t)0x09)  /*!< I2C3 Alternate Function mapping */
+#define GPIO_AF9_SPI3          ((uint8_t)0x09)  /*!< SPI3 Alternate Function mapping */
+#define GPIO_AF9_TIM4          ((uint8_t)0x09)  /*!< TIM4 Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)         ((AF) <= (uint8_t)0x09)
+
+#endif
 
 
 #if defined (STM32G081xx) || defined (STM32G071xx)
@@ -58,7 +309,7 @@ extern "C" {
 #define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
 #define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
 #define GPIO_AF0_LPTIM1        ((uint8_t)0x00)  /*!< LPTIM1 Alternate Function mapping */
-#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1 and MCO2) Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
 #define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
@@ -123,7 +374,7 @@ extern "C" {
   */
 #define GPIO_AF5_LPTIM1        ((uint8_t)0x05)  /*!< LPTIM1 Alternate Function mapping */
 #define GPIO_AF5_LPTIM2        ((uint8_t)0x05)  /*!< LPTIM2 Alternate Function mapping */
-#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
 #define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
 #define GPIO_AF5_TIM15         ((uint8_t)0x05)  /*!< TIM15 Alternate Function mapping */
@@ -157,7 +408,7 @@ extern "C" {
   */
 #define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
 #define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
-#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1 and MCO2) Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
 #define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
@@ -207,7 +458,7 @@ extern "C" {
 /**
   * @brief   AF 5 selection
   */
-#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
 #define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
 #define GPIO_AF5_TIM15         ((uint8_t)0x05)  /*!< TIM15 Alternate Function mapping */
@@ -230,6 +481,161 @@ extern "C" {
 
 #endif /* STM32G070xx */
 
+#if defined (STM32G051xx) || defined (STM32G061xx)
+/*------------------------- STM32G061xx / STM32G051xx ------------------------*/
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
+#define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
+#define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF0_TIM14         ((uint8_t)0x00)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /*!< USART2 Alternate Function mapping */
+
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_IR            ((uint8_t)0x01)  /*!< IR Alternate Function mapping */
+#define GPIO_AF1_LPUART1       ((uint8_t)0x01)  /*!< LPUART1 Alternate Function mapping */
+#define GPIO_AF1_OSC           ((uint8_t)0x01)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM3          ((uint8_t)0x01)  /*!< TIM3 Alternate Function mapping */
+#define GPIO_AF1_USART1        ((uint8_t)0x01)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF1_USART2        ((uint8_t)0x01)  /*!< USART2 Alternate Function mapping */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_TIM1          ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2          ((uint8_t)0x02)  /*!< TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM14         ((uint8_t)0x02)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF2_TIM15         ((uint8_t)0x02)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF2_TIM16         ((uint8_t)0x02)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF2_TIM17         ((uint8_t)0x02)  /*!< TIM17 Alternate Function mapping */
+
+/**
+  * @brief   AF 3 selection
+  */
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_SPI2          ((uint8_t)0x04)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF4_TIM14         ((uint8_t)0x04)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF4_TIM15         ((uint8_t)0x04)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF4_USART1        ((uint8_t)0x04)  /*!< USART1 Alternate Function mapping */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_LPTIM1        ((uint8_t)0x05)  /*!< LPTIM1 Alternate Function mapping */
+#define GPIO_AF5_LPTIM2        ((uint8_t)0x05)  /*!< LPTIM2 Alternate Function mapping */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF5_TIM15         ((uint8_t)0x05)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF5_TIM16         ((uint8_t)0x05)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF5_TIM17         ((uint8_t)0x05)  /*!< TIM17 Alternate Function mapping */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_I2C1          ((uint8_t)0x06)  /*!< I2C1 Alternate Function mapping */
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /*!< I2C2 Alternate Function mapping */
+#define GPIO_AF6_LPUART1       ((uint8_t)0x06)  /*!< LPUART1 Alternate Function mapping */
+
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_COMP1         ((uint8_t)0x07)  /*!< COMP1 Alternate Function mapping */
+#define GPIO_AF7_COMP2         ((uint8_t)0x07)  /*!< COMP2 Alternate Function mapping */
+#define GPIO_AF7_EVENTOUT      ((uint8_t)0x07)  /*!< EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)         ((AF) <= (uint8_t)0x07)
+
+#endif /* STM32G051xx || STM32G061xx */
+
+#if defined (STM32G050xx)
+/*------------------------- STM32G050xx --------------------------------------*/
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
+#define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
+#define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF0_TIM14         ((uint8_t)0x00)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /*!< USART2 Alternate Function mapping */
+
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_IR            ((uint8_t)0x01)  /*!< IR Alternate Function mapping */
+#define GPIO_AF1_OSC           ((uint8_t)0x01)  /*!< OSC (By pass and Enable) Alternate Function mapping */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM3          ((uint8_t)0x01)  /*!< TIM3 Alternate Function mapping */
+#define GPIO_AF1_USART1        ((uint8_t)0x01)  /*!< USART1 Alternate Function mapping */
+#define GPIO_AF1_USART2        ((uint8_t)0x01)  /*!< USART2 Alternate Function mapping */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_TIM1          ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM14         ((uint8_t)0x02)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF2_TIM15         ((uint8_t)0x02)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF2_TIM16         ((uint8_t)0x02)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF2_TIM17         ((uint8_t)0x02)  /*!< TIM17 Alternate Function mapping */
+
+/**
+  * @brief   AF 3 selection
+  */
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_SPI2          ((uint8_t)0x04)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF4_TIM14         ((uint8_t)0x04)  /*!< TIM14 Alternate Function mapping */
+#define GPIO_AF4_TIM15         ((uint8_t)0x04)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF4_USART1        ((uint8_t)0x04)  /*!< USART1 Alternate Function mapping */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
+#define GPIO_AF5_TIM15         ((uint8_t)0x05)  /*!< TIM15 Alternate Function mapping */
+#define GPIO_AF5_TIM16         ((uint8_t)0x05)  /*!< TIM16 Alternate Function mapping */
+#define GPIO_AF5_TIM17         ((uint8_t)0x05)  /*!< TIM17 Alternate Function mapping */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_I2C1          ((uint8_t)0x06)  /*!< I2C1 Alternate Function mapping */
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /*!< I2C2 Alternate Function mapping */
+
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_EVENTOUT      ((uint8_t)0x07)  /*!< EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)         ((AF) <= (uint8_t)0x07)
+
+#endif /* STM32G050xx */
+
 #if defined (STM32G031xx) || defined (STM32G041xx)
 /*------------------------- STM32G041xx / STM32G031xx ------------------------*/
 /**
@@ -237,7 +643,7 @@ extern "C" {
   */
 #define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
 #define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
-#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1 and MCO2) Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
 #define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
@@ -284,7 +690,7 @@ extern "C" {
   */
 #define GPIO_AF5_LPTIM1        ((uint8_t)0x05)  /*!< LPTIM1 Alternate Function mapping */
 #define GPIO_AF5_LPTIM2        ((uint8_t)0x05)  /*!< LPTIM2 Alternate Function mapping */
-#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
 #define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
 #define GPIO_AF5_TIM16         ((uint8_t)0x05)  /*!< TIM16 Alternate Function mapping */
@@ -313,7 +719,7 @@ extern "C" {
   */
 #define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /*!< EVENTOUT Alternate Function mapping */
 #define GPIO_AF0_IR            ((uint8_t)0x00)  /*!< IR Alternate Function mapping */
-#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1 and MCO2) Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO (MCO1) Alternate Function mapping */
 #define GPIO_AF0_OSC           ((uint8_t)0x00)  /*!< OSC (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_OSC32         ((uint8_t)0x00)  /*!< OSC32 (By pass and Enable) Alternate Function mapping */
 #define GPIO_AF0_SWJ           ((uint8_t)0x00)  /*!< SWJ (SWD) Alternate Function mapping */
@@ -356,7 +762,7 @@ extern "C" {
 /**
   * @brief   AF 5 selection
   */
-#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05)  /*!< SPI2 Alternate Function mapping */
 #define GPIO_AF5_TIM1          ((uint8_t)0x05)  /*!< TIM1 Alternate Function mapping */
 #define GPIO_AF5_TIM16         ((uint8_t)0x05)  /*!< TIM16 Alternate Function mapping */
@@ -393,10 +799,18 @@ extern "C" {
 /** @defgroup GPIOEx_Get_Port_Index GPIOEx Get Port Index
 * @{
   */
+#if defined(GPIOE)
+#define GPIO_GET_INDEX(__GPIOx__)    (((__GPIOx__) == (GPIOA))? 0uL :\
+                                      ((__GPIOx__) == (GPIOB))? 1uL :\
+                                      ((__GPIOx__) == (GPIOC))? 2uL :\
+                                      ((__GPIOx__) == (GPIOD))? 3uL :\
+                                      ((__GPIOx__) == (GPIOE))? 4uL : 5uL)
+#else
 #define GPIO_GET_INDEX(__GPIOx__)    (((__GPIOx__) == (GPIOA))? 0uL :\
                                       ((__GPIOx__) == (GPIOB))? 1uL :\
                                       ((__GPIOx__) == (GPIOC))? 2uL :\
                                       ((__GPIOx__) == (GPIOD))? 3uL : 5uL)
+#endif
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_hcd.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_hcd.h
@@ -1,0 +1,498 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_hcd.h
+  * @author  MCD Application Team
+  * @brief   Header file of HCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32G0xx_HAL_HCD_H
+#define STM32G0xx_HAL_HCD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_ll_usb.h"
+
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup HCD HCD
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup HCD_Exported_Types HCD Exported Types
+  * @{
+  */
+
+/** @defgroup HCD_Exported_Types_Group1 HCD State Structure definition
+  * @{
+  */
+typedef enum
+{
+  HAL_HCD_STATE_RESET    = 0x00,
+  HAL_HCD_STATE_READY    = 0x01,
+  HAL_HCD_STATE_ERROR    = 0x02,
+  HAL_HCD_STATE_BUSY     = 0x03,
+  HAL_HCD_STATE_TIMEOUT  = 0x04
+} HCD_StateTypeDef;
+
+typedef USB_DRD_TypeDef   HCD_TypeDef;
+typedef USB_DRD_CfgTypeDef      HCD_InitTypeDef;
+typedef USB_DRD_HCTypeDef       HCD_HCTypeDef;
+typedef USB_DRD_URBStateTypeDef HCD_URBStateTypeDef;
+typedef USB_DRD_HCStateTypeDef  HCD_HCStateTypeDef;
+
+typedef enum
+{
+  HCD_HCD_STATE_DISCONNECTED = 0x00U,
+  HCD_HCD_STATE_CONNECTED    = 0x01U,
+  HCD_HCD_STATE_RESETED      = 0x02U,
+  HCD_HCD_STATE_RUN          = 0x03U,
+  HCD_HCD_STATE_SUSPEND      = 0x04U,
+  HCD_HCD_STATE_RESUME       = 0x05U,
+} HCD_HostStateTypeDef;
+
+/* PMA lookup Table size depending on PMA Size
+ * 8Bytes each Block 32Bit in each word
+ */
+#define PMA_BLOCKS        ((USB_DRD_PMA_SIZE) / (8U * 32U))
+/**
+  * @}
+  */
+
+/** @defgroup HCD_Exported_Types_Group2 HCD Handle Structure definition
+  * @{
+  */
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+typedef struct __HCD_HandleTypeDef
+#else
+typedef struct
+#endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
+{
+  HCD_TypeDef               *Instance;  /*!< Register base address    */
+  HCD_InitTypeDef           Init;       /*!< HCD required parameters  */
+  HCD_HCTypeDef             hc[16];     /*!< Host channels parameters */
+  uint16_t                  phy_chin_state[8];  /*!< Physical Channel in State (Used/Free) */
+  uint16_t                  phy_chout_state[8]; /*!< Physical Channel out State (Used/Free)*/
+  uint32_t                  PMALookupTable[PMA_BLOCKS]; /*PMA LookUp Table */
+  HCD_HostStateTypeDef      HostState; /*!< USB current state DICONNECT/CONNECT/RUN/SUSPEND/RESUME */
+  HAL_LockTypeDef           Lock;       /*!< HCD peripheral status    */
+  __IO HCD_StateTypeDef     State;      /*!< HCD communication state  */
+  __IO  uint32_t            ErrorCode;  /*!< HCD Error code           */
+  void                      *pData;     /*!< Pointer Stack Handler    */
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+  void (* SOFCallback)(struct __HCD_HandleTypeDef *hhcd);                               /*!< USB OTG HCD SOF callback                */
+  void (* ConnectCallback)(struct __HCD_HandleTypeDef *hhcd);                           /*!< USB OTG HCD Connect callback            */
+  void (* DisconnectCallback)(struct __HCD_HandleTypeDef *hhcd);                        /*!< USB OTG HCD Disconnect callback         */
+  void (* PortEnabledCallback)(struct __HCD_HandleTypeDef *hhcd);                       /*!< USB OTG HCD Port Enable callback        */
+  void (* PortDisabledCallback)(struct __HCD_HandleTypeDef *hhcd);                      /*!< USB OTG HCD Port Disable callback       */
+  void (* HC_NotifyURBChangeCallback)(struct __HCD_HandleTypeDef *hhcd, uint8_t chnum,
+                                      HCD_URBStateTypeDef urb_state);                   /*!< USB OTG HCD Host Channel Notify URB Change callback  */
+
+  void (* MspInitCallback)(struct __HCD_HandleTypeDef *hhcd);                           /*!< USB OTG HCD Msp Init callback           */
+  void (* MspDeInitCallback)(struct __HCD_HandleTypeDef *hhcd);                         /*!< USB OTG HCD Msp DeInit callback         */
+#endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
+} HCD_HandleTypeDef;
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup HCD_Exported_Constants HCD Exported Constants
+  * @{
+  */
+
+/** @defgroup HCD_Speed HCD Speed
+  * @{
+  */
+#define HCD_SPEED_FULL               USBH_FSLS_SPEED
+#define HCD_SPEED_LOW                USBH_FSLS_SPEED
+
+/**
+  * @}
+  */
+
+/** @defgroup HCD_PHY_Module HCD PHY Module
+  * @{
+  */
+#define HCD_PHY_ULPI                 1U
+#define HCD_PHY_EMBEDDED             2U
+/**
+  * @}
+  */
+
+/** @defgroup HCD_Error_Code_definition HCD Error Code definition
+  * @brief  HCD Error Code definition
+  * @{
+  */
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+#define  HAL_HCD_ERROR_INVALID_CALLBACK                        (0x00000010U)    /*!< Invalid Callback error  */
+#endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup HCD_Exported_Macros HCD Exported Macros
+  *  @brief macros to handle interrupts and specific clock configurations
+  * @{
+  */
+#define __HAL_HCD_ENABLE(__HANDLE__)                   (void)USB_EnableGlobalInt ((__HANDLE__)->Instance)
+#define __HAL_HCD_DISABLE(__HANDLE__)                  (void)USB_DisableGlobalInt ((__HANDLE__)->Instance)
+
+#define __HAL_HCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_HCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->ISTR) &= ~(__INTERRUPT__))
+#define __HAL_HCD_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0U)
+
+#define __HAL_HCD_GET_CHNUM(__HANDLE__)                    (((__HANDLE__)->Instance->ISTR) & USB_ISTR_IDN)
+#define __HAL_HCD_GET_CHDIR(__HANDLE__)                    (((__HANDLE__)->Instance->ISTR) & USB_ISTR_DIR)
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup HCD_Exported_Functions HCD Exported Functions
+  * @{
+  */
+
+/** @defgroup HCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_DeInit(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                                  uint8_t epnum, uint8_t dev_address,
+                                  uint8_t speed, uint8_t ep_type, uint16_t mps);
+
+HAL_StatusTypeDef HAL_HCD_HC_Halt(HCD_HandleTypeDef *hhcd, uint8_t ch_num);
+HAL_StatusTypeDef HAL_HCD_HC_Close(HCD_HandleTypeDef *hhcd, uint8_t ch_num);
+void              HAL_HCD_MspInit(HCD_HandleTypeDef *hhcd);
+void              HAL_HCD_MspDeInit(HCD_HandleTypeDef *hhcd);
+
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+/** @defgroup HAL_HCD_Callback_ID_enumeration_definition HAL USB OTG HCD Callback ID enumeration definition
+  * @brief  HAL USB OTG HCD Callback ID enumeration definition
+  * @{
+  */
+typedef enum
+{
+  HAL_HCD_SOF_CB_ID            = 0x01,       /*!< USB HCD SOF callback ID           */
+  HAL_HCD_CONNECT_CB_ID        = 0x02,       /*!< USB HCD Connect callback ID       */
+  HAL_HCD_DISCONNECT_CB_ID     = 0x03,       /*!< USB HCD Disconnect callback ID    */
+  HAL_HCD_PORT_ENABLED_CB_ID   = 0x04,       /*!< USB HCD Port Enable callback ID   */
+  HAL_HCD_PORT_DISABLED_CB_ID  = 0x05,       /*!< USB HCD Port Disable callback ID  */
+
+  HAL_HCD_MSPINIT_CB_ID        = 0x06,       /*!< USB HCD MspInit callback ID       */
+  HAL_HCD_MSPDEINIT_CB_ID      = 0x07        /*!< USB HCD MspDeInit callback ID     */
+
+} HAL_HCD_CallbackIDTypeDef;
+/**
+  * @}
+  */
+
+/** @defgroup HAL_HCD_Callback_pointer_definition HAL USB OTG HCD Callback pointer definition
+  * @brief  HAL USB OTG HCD Callback pointer definition
+  * @{
+  */
+
+typedef void (*pHCD_CallbackTypeDef)(HCD_HandleTypeDef *hhcd);                   /*!< pointer to a common USB OTG HCD callback function  */
+typedef void (*pHCD_HC_NotifyURBChangeCallbackTypeDef)(HCD_HandleTypeDef *hhcd,
+                                                       uint8_t epnum,
+                                                       HCD_URBStateTypeDef urb_state);   /*!< pointer to USB OTG HCD host channel  callback */
+/**
+  * @}
+  */
+
+HAL_StatusTypeDef HAL_HCD_RegisterCallback(HCD_HandleTypeDef *hhcd,
+                                           HAL_HCD_CallbackIDTypeDef CallbackID,
+                                           pHCD_CallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_HCD_UnRegisterCallback(HCD_HandleTypeDef *hhcd,
+                                             HAL_HCD_CallbackIDTypeDef CallbackID);
+
+HAL_StatusTypeDef HAL_HCD_RegisterHC_NotifyURBChangeCallback(HCD_HandleTypeDef *hhcd,
+                                                             pHCD_HC_NotifyURBChangeCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_HCD_UnRegisterHC_NotifyURBChangeCallback(HCD_HandleTypeDef *hhcd);
+#endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/* I/O operation functions  ***************************************************/
+/** @addtogroup HCD_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_HCD_HC_SubmitRequest(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                                           uint8_t direction, uint8_t ep_type,
+                                           uint8_t token, uint8_t *pbuff,
+                                           uint16_t length, uint8_t do_ping);
+
+/* Non-Blocking mode: Interrupt */
+void HAL_HCD_IRQHandler(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_SOF_Callback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_Connect_Callback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_Disconnect_Callback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_PortEnabled_Callback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_PortDisabled_Callback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_SuspendCallback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_ResumeCallback(HCD_HandleTypeDef *hhcd);
+void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd, uint8_t chnum,
+                                         HCD_URBStateTypeDef urb_state);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  **********************************************/
+/** @addtogroup HCD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_HCD_ResetPort(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_Start(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_Stop(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_Suspend(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_Resume(HCD_HandleTypeDef *hhcd);
+HAL_StatusTypeDef HAL_HCD_ResumePort(HCD_HandleTypeDef *hhcd);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+/** @addtogroup HCD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+HCD_StateTypeDef        HAL_HCD_GetState(HCD_HandleTypeDef *hhcd);
+HCD_URBStateTypeDef     HAL_HCD_HC_GetURBState(HCD_HandleTypeDef *hhcd, uint8_t chnum);
+HCD_HCStateTypeDef      HAL_HCD_HC_GetState(HCD_HandleTypeDef *hhcd, uint8_t chnum);
+uint32_t                HAL_HCD_HC_GetXferCount(HCD_HandleTypeDef *hhcd, uint8_t chnum);
+uint32_t                HAL_HCD_GetCurrentFrame(HCD_HandleTypeDef *hhcd);
+uint32_t                HAL_HCD_GetCurrentSpeed(HCD_HandleTypeDef *hhcd);
+
+/* PMA Allocation functions  **********************************************/
+/** @addtogroup PMA Allocation
+  * @{
+  */
+HAL_StatusTypeDef  HAL_HCD_PMAlloc(HCD_HandleTypeDef *hhcd, uint8_t  pipe,
+                                   uint16_t pipe_kind,  uint16_t mps);
+
+HAL_StatusTypeDef  HAL_HCD_PMADeAlloc(HCD_HandleTypeDef *hhcd, uint8_t  pipe);
+HAL_StatusTypeDef  HAL_HCD_PMAReset(HCD_HandleTypeDef *hhcd);
+
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup HCD_Private_Macros HCD Private Macros
+  * @{
+  */
+/** @defgroup HCD_LOGICAL_CHANNEL HCD Logical Channel
+  * @{
+  */
+#define HCD_LOGICAL_CH_NOT_OPENED             0xFFU
+#define HCD_FREE_CH_NOT_FOUND                 0xFFU
+/**
+  * @}
+  */
+
+/** @defgroup HCD_ENDP_Kind HCD Endpoint Kind
+  * @{
+  */
+#define HCD_SNG_BUF                            0U
+#define HCD_DBL_BUF                            1U
+/**
+  * @}
+  */
+
+/* Set Channel */
+#define HCD_SET_CHANNEL                        USB_DRD_SET_CHEP
+
+/* Get Channel Register */
+#define HCD_GET_CHANNEL                        USB_DRD_GET_CHEP
+
+
+/**
+  * @brief free buffer used from the application realizing it to the line
+  *         toggles bit SW_BUF in the double buffered endpoint register
+  * @param USBx USB device.
+  * @param   bChNum, bDir
+  * @retval None
+  */
+#define HCD_FreeUserBuffer                     USB_DRD_FreeUserBuffer
+
+/**
+  * @brief Set the Setup bit in the corresponding channel, when a Setup
+     transaction is needed.
+  * @param USBx USB device.
+  * @param   bChNum
+  * @retval None
+  */
+#define HAC_SET_CH_TX_SETUP                    USB_DRD_CHEP_TX_SETUP
+
+/**
+  * @brief  sets the status for tx transfer (bits STAT_TX[1:0]).
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @param  wState new state
+  * @retval None
+  */
+#define HCD_SET_CH_TX_STATUS                   USB_DRD_SET_CHEP_TX_STATUS
+
+/**
+  * @brief  sets the status for rx transfer (bits STAT_TX[1:0])
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @param  wState new state
+  * @retval None
+  */
+#define HCD_SET_CH_RX_STATUS                   USB_DRD_SET_CHEP_RX_STATUS
+/**
+  * @brief  gets the status for tx/rx transfer (bits STAT_TX[1:0]
+  *         /STAT_RX[1:0])
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval status
+  */
+#define HCD_GET_CH_TX_STATUS                   USB_DRD_GET_CHEP_TX_STATUS
+#define HCD_GET_CH_RX_STATUS                   USB_DRD_GET_CHEP_RX_STATUS
+/**
+  * @brief  Sets/clears directly EP_KIND bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_SET_CH_DBUF                        USB_DRD_SET_CH_KIND
+
+/**
+  * @brief  Clears bit ERR_RX in the Channel register
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_CLEAR_RX_CH_ERR                    USB_DRD_CLEAR_CHEP_RX_ERR
+
+/**
+  * @brief  Clears bit ERR_TX in the Channel register
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_CLEAR_TX_CH_ERR                    USB_DRD_CLEAR_CHEP_TX_ERR
+/**
+  * @brief  Clears bit CTR_RX / CTR_TX in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_CLEAR_RX_CH_CTR                    USB_DRD_CLEAR_RX_CHEP_CTR
+#define HCD_CLEAR_TX_CH_CTR                    USB_DRD_CLEAR_TX_CHEP_CTR
+
+/**
+  * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_RX_DTOG                            USB_DRD_RX_DTOG
+#define HCD_TX_DTOG                            USB_DRD_TX_DTOG
+/**
+  * @brief  Clears DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_CLEAR_RX_DTOG                      USB_DRD_CLEAR_RX_DTOG
+#define HCD_CLEAR_TX_DTOG                      USB_DRD_CLEAR_TX_DTOG
+
+/**
+  * @brief  sets counter for the tx/rx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @param  wCount Counter value.
+  * @retval None
+  */
+#define HCD_SET_CH_TX_CNT                      USB_DRD_SET_CHEP_TX_CNT
+#define HCD_SET_CH_RX_CNT                      USB_DRD_SET_CHEP_RX_CNT
+/**
+  * @brief  gets counter of the tx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval Counter value
+  */
+#define HCD_GET_CH_TX_CNT                      USB_DRD_GET_CHEP_TX_CNT
+#define HCD_GET_CH_RX_CNT                      USB_DRD_GET_CHEP_RX_CNT
+/**
+  * @brief  Gets buffer 0/1 address of a double buffer endpoint.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @param  bDir endpoint dir  EP_DBUF_OUT = OUT
+  *         EP_DBUF_IN  = IN
+  * @param  wCount: Counter value
+  * @retval None
+  */
+#define HCD_SET_CH_DBUF0_CNT                   USB_DRD_SET_CHEP_DBUF0_CNT
+#define HCD_SET_CH_DBUF1_CNT                   USB_DRD_SET_CHEP_DBUF1_CNT
+#define HCD_SET_CH_DBUF_CNT                    USB_DRD_SET_CHEP_DBUF_CNT
+
+/**
+  * @brief  Gets buffer 0/1 rx/tx counter for double buffering.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define HCD_GET_CH_DBUF0_CNT                   USB_DRD_GET_CHEP_DBUF0_CNT
+#define HCD_GET_CH_DBUF1_CNT                   USB_DRD_GET_CHEP_DBUF1_CNT
+/**
+  * @}
+  */
+/* Private functions prototypes ----------------------------------------------*/
+
+ /**
+  * @}
+  */
+ /**
+  * @}
+  */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32G0xx_HAL_HCD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_hcd.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_hcd.h
@@ -28,7 +28,7 @@ extern "C" {
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g0xx_ll_usb.h"
 
-
+#if defined (USB_DRD_FS)
 /** @addtogroup STM32G0xx_HAL_Driver
   * @{
   */
@@ -487,7 +487,7 @@ HAL_StatusTypeDef  HAL_HCD_PMAReset(HCD_HandleTypeDef *hhcd);
  /**
   * @}
   */
-
+#endif /* defined (USB_DRD_FS) */
 
 #ifdef __cplusplus
 }

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_i2c_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_i2c_ex.h
@@ -55,6 +55,7 @@ extern "C" {
 /** @defgroup I2CEx_FastModePlus I2C Extended Fast Mode Plus
   * @{
   */
+#define I2C_FMP_NOT_SUPPORTED           0xAAAA0000U                                     /*!< Fast Mode Plus not supported       */
 #define I2C_FASTMODEPLUS_PA9            SYSCFG_CFGR1_I2C_PA9_FMP                        /*!< Enable Fast Mode Plus on PA9       */
 #define I2C_FASTMODEPLUS_PA10           SYSCFG_CFGR1_I2C_PA10_FMP                       /*!< Enable Fast Mode Plus on PA10      */
 #define I2C_FASTMODEPLUS_PB6            SYSCFG_CFGR1_I2C_PB6_FMP                        /*!< Enable Fast Mode Plus on PB6       */
@@ -63,6 +64,11 @@ extern "C" {
 #define I2C_FASTMODEPLUS_PB9            SYSCFG_CFGR1_I2C_PB9_FMP                        /*!< Enable Fast Mode Plus on PB9       */
 #define I2C_FASTMODEPLUS_I2C1           SYSCFG_CFGR1_I2C1_FMP                           /*!< Enable Fast Mode Plus on I2C1 pins */
 #define I2C_FASTMODEPLUS_I2C2           SYSCFG_CFGR1_I2C2_FMP                           /*!< Enable Fast Mode Plus on I2C2 pins */
+#if defined(SYSCFG_CFGR1_I2C3_FMP)
+#define I2C_FASTMODEPLUS_I2C3           SYSCFG_CFGR1_I2C3_FMP                           /*!< Enable Fast Mode Plus on I2C3 pins */
+#else
+#define I2C_FASTMODEPLUS_I2C3           (uint32_t)(0x00000400U | I2C_FMP_NOT_SUPPORTED) /*!< Fast Mode Plus I2C3 not supported  */
+#endif
 /**
   * @}
   */
@@ -109,14 +115,16 @@ void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus);
 
 #define IS_I2C_DIGITAL_FILTER(FILTER)   ((FILTER) <= 0x0000000FU)
 
-#define IS_I2C_FASTMODEPLUS(__CONFIG__) ((((__CONFIG__) & (I2C_FASTMODEPLUS_PA9))  == I2C_FASTMODEPLUS_PA9)     || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_PA10)) == I2C_FASTMODEPLUS_PA10)    || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_PB6))  == I2C_FASTMODEPLUS_PB6)     || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_PB7))  == I2C_FASTMODEPLUS_PB7)     || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_PB8))  == I2C_FASTMODEPLUS_PB8)     || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_PB9))  == I2C_FASTMODEPLUS_PB9)     || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C1)) == I2C_FASTMODEPLUS_I2C1)    || \
-                                         (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C2)) == I2C_FASTMODEPLUS_I2C2))
+#define IS_I2C_FASTMODEPLUS(__CONFIG__) ((((__CONFIG__) & I2C_FMP_NOT_SUPPORTED) != I2C_FMP_NOT_SUPPORTED) && \
+                                         ((((__CONFIG__) & (I2C_FASTMODEPLUS_PA9))  == I2C_FASTMODEPLUS_PA9)     || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PA10)) == I2C_FASTMODEPLUS_PA10)    || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB6))  == I2C_FASTMODEPLUS_PB6)     || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB7))  == I2C_FASTMODEPLUS_PB7)     || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB8))  == I2C_FASTMODEPLUS_PB8)     || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_PB9))  == I2C_FASTMODEPLUS_PB9)     || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C1)) == I2C_FASTMODEPLUS_I2C1)    || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C2)) == I2C_FASTMODEPLUS_I2C2)    || \
+                                          (((__CONFIG__) & (I2C_FASTMODEPLUS_I2C3)) == I2C_FASTMODEPLUS_I2C3)))
 
 
 

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_i2s.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_i2s.h
@@ -25,10 +25,10 @@
 extern "C" {
 #endif
 
-#if defined(SPI_I2S_SUPPORT)
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g0xx_hal_def.h"
 
+#if defined(SPI_I2S_SUPPORT)
 /** @addtogroup STM32G0xx_HAL_Driver
   * @{
   */
@@ -87,7 +87,7 @@ typedef enum
 typedef struct __I2S_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_I2S_REGISTER_CALLBACKS */
 {
   SPI_TypeDef                *Instance;    /*!< I2S registers base address */
 
@@ -174,6 +174,7 @@ typedef  void (*pI2S_CallbackTypeDef)(I2S_HandleTypeDef *hi2s); /*!< pointer to 
 #if (USE_HAL_I2S_REGISTER_CALLBACKS == 1U)
 #define HAL_I2S_ERROR_INVALID_CALLBACK   (0x00000020U)  /*!< Invalid Callback error      */
 #endif /* USE_HAL_I2S_REGISTER_CALLBACKS */
+#define HAL_I2S_ERROR_BUSY_LINE_RX       (0x00000040U)  /*!< Busy Rx Line error          */
 /**
   * @}
   */
@@ -270,7 +271,8 @@ typedef  void (*pI2S_CallbackTypeDef)(I2S_HandleTypeDef *hi2s); /*!< pointer to 
 #define I2S_FLAG_CHSIDE                  SPI_SR_CHSIDE
 #define I2S_FLAG_BSY                     SPI_SR_BSY
 
-#define I2S_FLAG_MASK                   (SPI_SR_RXNE | SPI_SR_TXE | SPI_SR_UDR | SPI_SR_OVR | SPI_SR_FRE | SPI_SR_CHSIDE | SPI_SR_BSY)
+#define I2S_FLAG_MASK                   (SPI_SR_RXNE\
+                                         | SPI_SR_TXE | SPI_SR_UDR | SPI_SR_OVR | SPI_SR_FRE | SPI_SR_CHSIDE | SPI_SR_BSY)
 /**
   * @}
   */
@@ -296,7 +298,7 @@ typedef  void (*pI2S_CallbackTypeDef)(I2S_HandleTypeDef *hi2s); /*!< pointer to 
                                                                   } while(0)
 #else
 #define __HAL_I2S_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_I2S_STATE_RESET)
-#endif
+#endif /* USE_HAL_I2S_REGISTER_CALLBACKS */
 
 /** @brief  Enable the specified SPI peripheral (in I2S mode).
   * @param  __HANDLE__ specifies the I2S Handle.
@@ -342,7 +344,8 @@ typedef  void (*pI2S_CallbackTypeDef)(I2S_HandleTypeDef *hi2s); /*!< pointer to 
   *            @arg I2S_IT_ERR: Error interrupt enable
   * @retval The new state of __IT__ (TRUE or FALSE).
   */
-#define __HAL_I2S_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_I2S_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2\
+                                                              & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Checks whether the specified I2S flag is set or not.
   * @param  __HANDLE__ specifies the I2S Handle.
@@ -364,19 +367,28 @@ typedef  void (*pI2S_CallbackTypeDef)(I2S_HandleTypeDef *hi2s); /*!< pointer to 
   * @retval None
   */
 #define __HAL_I2S_CLEAR_OVRFLAG(__HANDLE__) do{ \
-                                               __IO uint32_t tmpreg_ovr = 0x00U; \
-                                               tmpreg_ovr = (__HANDLE__)->Instance->DR; \
-                                               tmpreg_ovr = (__HANDLE__)->Instance->SR; \
-                                               UNUSED(tmpreg_ovr); \
+                                                __IO uint32_t tmpreg_ovr = 0x00U; \
+                                                tmpreg_ovr = (__HANDLE__)->Instance->DR; \
+                                                tmpreg_ovr = (__HANDLE__)->Instance->SR; \
+                                                UNUSED(tmpreg_ovr); \
                                               }while(0U)
 /** @brief Clears the I2S UDR pending flag.
   * @param  __HANDLE__ specifies the I2S Handle.
   * @retval None
   */
 #define __HAL_I2S_CLEAR_UDRFLAG(__HANDLE__) do{\
-                                               __IO uint32_t tmpreg_udr = 0x00U;\
-                                               tmpreg_udr = ((__HANDLE__)->Instance->SR);\
-                                               UNUSED(tmpreg_udr); \
+                                                __IO uint32_t tmpreg_udr = 0x00U;\
+                                                tmpreg_udr = ((__HANDLE__)->Instance->SR);\
+                                                UNUSED(tmpreg_udr); \
+                                              }while(0U)
+/** @brief Flush the I2S DR Register.
+  * @param  __HANDLE__ specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_FLUSH_RX_DR(__HANDLE__)  do{\
+                                                __IO uint32_t tmpreg_dr = 0x00U;\
+                                                tmpreg_dr = ((__HANDLE__)->Instance->DR);\
+                                                UNUSED(tmpreg_dr); \
                                               }while(0U)
 /**
   * @}
@@ -398,7 +410,8 @@ void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_I2S_REGISTER_CALLBACKS == 1U)
-HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID, pI2S_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID,
+                                           pI2S_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_I2S_UnRegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_I2S_REGISTER_CALLBACKS */
 /**
@@ -453,21 +466,13 @@ uint32_t HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
-/** @defgroup I2S_Private_Constants I2S Private Constants
-  * @{
-  */
-
-/**
-  * @}
-  */
-
 /* Private macros ------------------------------------------------------------*/
 /** @defgroup I2S_Private_Macros I2S Private Macros
   * @{
   */
 
 /** @brief  Check whether the specified SPI flag is set or not.
-  * @param  __SR__  copy of I2S SR regsiter.
+  * @param  __SR__  copy of I2S SR register.
   * @param  __FLAG__ specifies the flag to check.
   *         This parameter can be one of the following values:
   *            @arg I2S_FLAG_RXNE: Receive buffer not empty flag
@@ -478,10 +483,11 @@ uint32_t HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
   *            @arg I2S_FLAG_BSY: Busy flag
   * @retval SET or RESET.
   */
-#define I2S_CHECK_FLAG(__SR__, __FLAG__)         ((((__SR__) & ((__FLAG__) & I2S_FLAG_MASK)) == ((__FLAG__) & I2S_FLAG_MASK)) ? SET : RESET)
+#define I2S_CHECK_FLAG(__SR__, __FLAG__)         ((((__SR__)\
+                                                    & ((__FLAG__) & I2S_FLAG_MASK)) == ((__FLAG__) & I2S_FLAG_MASK)) ? SET : RESET)
 
 /** @brief  Check whether the specified SPI Interrupt is set or not.
-  * @param  __CR2__  copy of I2S CR2 regsiter.
+  * @param  __CR2__  copy of I2S CR2 register.
   * @param  __INTERRUPT__ specifies the SPI interrupt source to check.
   *         This parameter can be one of the following values:
   *            @arg I2S_IT_TXE: Tx buffer empty interrupt enable
@@ -489,7 +495,8 @@ uint32_t HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
   *            @arg I2S_IT_ERR: Error interrupt enable
   * @retval SET or RESET.
   */
-#define I2S_CHECK_IT_SOURCE(__CR2__, __INTERRUPT__)      ((((__CR2__) & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define I2S_CHECK_IT_SOURCE(__CR2__, __INTERRUPT__)      ((((__CR2__)\
+                                                            & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Checks if I2S Mode parameter is in allowed range.
   * @param  __MODE__ specifies the I2S Mode.
@@ -517,15 +524,15 @@ uint32_t HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
 
 #define IS_I2S_AUDIO_FREQ(__FREQ__) ((((__FREQ__) >= I2S_AUDIOFREQ_8K)    && \
                                       ((__FREQ__) <= I2S_AUDIOFREQ_192K)) || \
-                                      ((__FREQ__) == I2S_AUDIOFREQ_DEFAULT))
+                                     ((__FREQ__) == I2S_AUDIOFREQ_DEFAULT))
 
 /** @brief  Checks if I2S Serial clock steady state parameter is in allowed range.
   * @param  __CPOL__ specifies the I2S serial clock steady state.
   *         This parameter can be a value of @ref I2S_Clock_Polarity
   * @retval None
   */
-#define IS_I2S_CPOL(CPOL) (((CPOL) == I2S_CPOL_LOW) || \
-                           ((CPOL) == I2S_CPOL_HIGH))
+#define IS_I2S_CPOL(__CPOL__) (((__CPOL__) == I2S_CPOL_LOW) || \
+                               ((__CPOL__) == I2S_CPOL_HIGH))
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_irda_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_irda_ex.h
@@ -70,7 +70,78 @@ extern "C" {
   * @param  __CLOCKSOURCE__ output variable.
   * @retval IRDA clocking source, written in __CLOCKSOURCE__.
   */
-#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                   \
+      {                                                       \
+        case RCC_USART1CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                   \
+      {                                                       \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART3)                 \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                   \
+      {                                                       \
+        case RCC_USART3CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else                                                      \
+    {                                                         \
+      (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;         \
+    }                                                         \
+  } while(0U)
+#elif defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
 #define IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
   do {                                                        \
     if((__HANDLE__)->Instance == USART1)                      \
@@ -120,7 +191,7 @@ extern "C" {
       (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;         \
     }                                                         \
   } while(0U)
-#elif defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#else
 #define IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
   do {                                                        \
     if((__HANDLE__)->Instance == USART1)                      \
@@ -144,16 +215,12 @@ extern "C" {
           break;                                              \
       }                                                       \
     }                                                         \
-    else if((__HANDLE__)->Instance == USART2)                 \
-    {                                                         \
-      (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;             \
-    }                                                         \
     else                                                      \
     {                                                         \
       (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;         \
     }                                                         \
   } while(0U)
-#endif /* STM32G081xx || STM32G071xx || STM32G070xx */
+#endif
 
 /** @brief  Compute the mask to apply to retrieve the received data
   *         according to the word length and to the parity bits activation.

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_lptim.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_lptim.h
@@ -22,7 +22,7 @@
 #define STM32G0xx_HAL_LPTIM_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -42,6 +42,8 @@
 /** @defgroup LPTIM_Exported_Types LPTIM Exported Types
   * @{
   */
+#define LPTIM_EXTI_LINE_LPTIM1  EXTI_IMR1_IM29  /*!< External interrupt line 29 Connected to the LPTIM1 EXTI Line */
+#define LPTIM_EXTI_LINE_LPTIM2  EXTI_IMR1_IM30  /*!< External interrupt line 30 Connected to the LPTIM2 EXTI Line */
 
 /**
   * @brief  LPTIM Clock configuration definition
@@ -54,7 +56,7 @@ typedef struct
   uint32_t Prescaler;      /*!< Specifies the counter clock Prescaler.
                            This parameter can be a value of @ref LPTIM_Clock_Prescaler */
 
-}LPTIM_ClockConfigTypeDef;
+} LPTIM_ClockConfigTypeDef;
 
 /**
   * @brief  LPTIM Clock configuration definition
@@ -72,7 +74,7 @@ typedef struct
                            Note: This parameter is used only when Ultra low power clock source is used.
                            This parameter can be a value of @ref LPTIM_Clock_Sample_Time */
 
-}LPTIM_ULPClockConfigTypeDef;
+} LPTIM_ULPClockConfigTypeDef;
 
 /**
   * @brief  LPTIM Trigger configuration definition
@@ -89,7 +91,7 @@ typedef struct
   uint32_t SampleTime;    /*!< Selects the trigger sampling time to configure the clock glitch filter.
                           Note: This parameter is used only when an external trigger is used.
                           This parameter can be a value of @ref LPTIM_Trigger_Sample_Time  */
-}LPTIM_TriggerConfigTypeDef;
+} LPTIM_TriggerConfigTypeDef;
 
 /**
   * @brief  LPTIM Initialization Structure definition
@@ -120,7 +122,7 @@ typedef struct
                                                     Note: This parameter is used only for encoder feature so is used only
                                                     for LPTIM1 instance.
                                                     This parameter can be a value of @ref LPTIM_Input2_Source */
-}LPTIM_InitTypeDef;
+} LPTIM_InitTypeDef;
 
 /**
   * @brief  HAL LPTIM State structure definition
@@ -131,8 +133,8 @@ typedef enum
   HAL_LPTIM_STATE_READY            = 0x01U,    /*!< Peripheral Initialized and ready for use    */
   HAL_LPTIM_STATE_BUSY             = 0x02U,    /*!< An internal process is ongoing              */
   HAL_LPTIM_STATE_TIMEOUT          = 0x03U,    /*!< Timeout state                               */
-  HAL_LPTIM_STATE_ERROR            = 0x04U     /*!< Internal Process is ongoing                */
-}HAL_LPTIM_StateTypeDef;
+  HAL_LPTIM_STATE_ERROR            = 0x04U     /*!< Internal Process is ongoing                 */
+} HAL_LPTIM_StateTypeDef;
 
 /**
   * @brief  LPTIM handle Structure definition
@@ -141,30 +143,30 @@ typedef enum
 typedef struct __LPTIM_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
 {
-      LPTIM_TypeDef              *Instance;         /*!< Register base address     */
+  LPTIM_TypeDef                 *Instance;         /*!< Register base address     */
 
-      LPTIM_InitTypeDef           Init;             /*!< LPTIM required parameters */
+  LPTIM_InitTypeDef              Init;             /*!< LPTIM required parameters */
 
-      HAL_StatusTypeDef           Status;           /*!< LPTIM peripheral status   */
+  HAL_StatusTypeDef              Status;           /*!< LPTIM peripheral status   */
 
-      HAL_LockTypeDef             Lock;             /*!< LPTIM locking object      */
+  HAL_LockTypeDef                Lock;             /*!< LPTIM locking object      */
 
-   __IO  HAL_LPTIM_StateTypeDef   State;            /*!< LPTIM peripheral state    */
+  __IO  HAL_LPTIM_StateTypeDef   State;            /*!< LPTIM peripheral state    */
 
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
-  void  (* MspInitCallback)         (struct __LPTIM_HandleTypeDef *hlptim);  /*!< LPTIM Base Msp Init Callback                 */
-  void  (* MspDeInitCallback)       (struct __LPTIM_HandleTypeDef *hlptim);  /*!< LPTIM Base Msp DeInit Callback               */
-  void  (* CompareMatchCallback)    (struct __LPTIM_HandleTypeDef *hlptim);  /*!< Compare match Callback                       */
-  void  (* AutoReloadMatchCallback) (struct __LPTIM_HandleTypeDef *hlptim);  /*!< Auto-reload match Callback                   */
-  void  (* TriggerCallback)         (struct __LPTIM_HandleTypeDef *hlptim);  /*!< External trigger event detection Callback    */
-  void  (* CompareWriteCallback)    (struct __LPTIM_HandleTypeDef *hlptim);  /*!< Compare register write complete Callback     */
-  void  (* AutoReloadWriteCallback) (struct __LPTIM_HandleTypeDef *hlptim);  /*!< Auto-reload register write complete Callback */
-  void  (* DirectionUpCallback)     (struct __LPTIM_HandleTypeDef *hlptim);  /*!< Up-counting direction change Callback        */
-  void  (* DirectionDownCallback)   (struct __LPTIM_HandleTypeDef *hlptim);  /*!< Down-counting direction change Callback      */
+  void (* MspInitCallback)(struct __LPTIM_HandleTypeDef *hlptim);            /*!< LPTIM Base Msp Init Callback                 */
+  void (* MspDeInitCallback)(struct __LPTIM_HandleTypeDef *hlptim);          /*!< LPTIM Base Msp DeInit Callback               */
+  void (* CompareMatchCallback)(struct __LPTIM_HandleTypeDef *hlptim);       /*!< Compare match Callback                       */
+  void (* AutoReloadMatchCallback)(struct __LPTIM_HandleTypeDef *hlptim);    /*!< Auto-reload match Callback                   */
+  void (* TriggerCallback)(struct __LPTIM_HandleTypeDef *hlptim);            /*!< External trigger event detection Callback    */
+  void (* CompareWriteCallback)(struct __LPTIM_HandleTypeDef *hlptim);       /*!< Compare register write complete Callback     */
+  void (* AutoReloadWriteCallback)(struct __LPTIM_HandleTypeDef *hlptim);    /*!< Auto-reload register write complete Callback */
+  void (* DirectionUpCallback)(struct __LPTIM_HandleTypeDef *hlptim);        /*!< Up-counting direction change Callback        */
+  void (* DirectionDownCallback)(struct __LPTIM_HandleTypeDef *hlptim);      /*!< Down-counting direction change Callback      */
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
-}LPTIM_HandleTypeDef;
+} LPTIM_HandleTypeDef;
 
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
 /**
@@ -181,12 +183,12 @@ typedef enum
   HAL_LPTIM_AUTORELOAD_WRITE_CB_ID = 0x06U,    /*!< Auto-reload register write complete Callback ID  */
   HAL_LPTIM_DIRECTION_UP_CB_ID     = 0x07U,    /*!< Up-counting direction change Callback ID         */
   HAL_LPTIM_DIRECTION_DOWN_CB_ID   = 0x08U,    /*!< Down-counting direction change Callback ID       */
-}HAL_LPTIM_CallbackIDTypeDef;
+} HAL_LPTIM_CallbackIDTypeDef;
 
 /**
   * @brief  HAL TIM Callback pointer definition
   */
-typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< pointer to the LPTIM callback function */
+typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef *hlptim);  /*!< pointer to the LPTIM callback function */
 
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
 /**
@@ -315,7 +317,7 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   */
 
 #define LPTIM_INPUT1SOURCE_GPIO          0x00000000U                                   /*!< For LPTIM1 and LPTIM2 */
-#define LPTIM_INPUT1SOURCE_COMP1        LPTIM_CFGR2_IN1SEL_0                          /*!< For LPTIM1 and LPTIM2 */
+#define LPTIM_INPUT1SOURCE_COMP1         LPTIM_CFGR2_IN1SEL_0                          /*!< For LPTIM1 and LPTIM2 */
 #define LPTIM_INPUT1SOURCE_COMP2         LPTIM_CFGR2_IN1SEL_1                          /*!< For LPTIM2 */
 #define LPTIM_INPUT1SOURCE_COMP1_COMP2   (LPTIM_CFGR2_IN1SEL_1 | LPTIM_CFGR2_IN1SEL_0) /*!< For LPTIM2 */
 /**
@@ -350,7 +352,6 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
 /** @defgroup LPTIM_Interrupts_Definition LPTIM Interrupts Definition
   * @{
   */
-
 #define LPTIM_IT_DOWN                            LPTIM_IER_DOWNIE
 #define LPTIM_IT_UP                              LPTIM_IER_UPIE
 #define LPTIM_IT_ARROK                           LPTIM_IER_ARROKIE
@@ -390,14 +391,19 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   * @param  __HANDLE__ LPTIM handle
   * @retval None
   */
-#define __HAL_LPTIM_ENABLE(__HANDLE__)   ((__HANDLE__)->Instance->CR |=  (LPTIM_CR_ENABLE))
+#define __HAL_LPTIM_ENABLE(__HANDLE__)   ((__HANDLE__)->Instance->CR |= (LPTIM_CR_ENABLE))
 
 /**
   * @brief  Disable the LPTIM peripheral.
   * @param  __HANDLE__ LPTIM handle
+  * @note   The following sequence is required to solve LPTIM disable HW limitation.
+  *         Please check Errata Sheet ES0335 for more details under "MCU may remain
+  *         stuck in LPTIM interrupt when entering Stop mode" section.
+  * @note   Please call @ref HAL_LPTIM_GetState() after a call to __HAL_LPTIM_DISABLE to
+  *         check for TIMEOUT.
   * @retval None
   */
-#define __HAL_LPTIM_DISABLE(__HANDLE__)  ((__HANDLE__)->Instance->CR &=  ~(LPTIM_CR_ENABLE))
+#define __HAL_LPTIM_DISABLE(__HANDLE__)   LPTIM_Disable(__HANDLE__)
 
 /**
   * @brief  Start the LPTIM peripheral in Continuous mode.
@@ -431,6 +437,7 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   * @param  __HANDLE__ LPTIM handle
   * @param  __VALUE__ Autoreload value
   * @retval None
+  * @note   The ARR register can only be modified when the LPTIM instance is enabled.
   */
 #define __HAL_LPTIM_AUTORELOAD_SET(__HANDLE__ , __VALUE__)  ((__HANDLE__)->Instance->ARR =  (__VALUE__))
 
@@ -439,6 +446,7 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   * @param  __HANDLE__ LPTIM handle
   * @param  __VALUE__ Compare value
   * @retval None
+  * @note   The CMP register can only be modified when the LPTIM instance is enabled.
   */
 #define __HAL_LPTIM_COMPARE_SET(__HANDLE__ , __VALUE__)     ((__HANDLE__)->Instance->CMP =  (__VALUE__))
 
@@ -487,10 +495,11 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   *            @arg LPTIM_IT_ARRM    : Autoreload match Interrupt.
   *            @arg LPTIM_IT_CMPM    : Compare match Interrupt.
   * @retval None.
+  * @note   The LPTIM interrupts can only be enabled when the LPTIM instance is disabled.
   */
 #define __HAL_LPTIM_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->IER  |= (__INTERRUPT__))
 
- /**
+/**
   * @brief  Disable the specified LPTIM interrupt.
   * @param  __HANDLE__ LPTIM handle.
   * @param  __INTERRUPT__ LPTIM interrupt to set.
@@ -503,10 +512,11 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   *            @arg LPTIM_IT_ARRM    : Autoreload match Interrupt.
   *            @arg LPTIM_IT_CMPM    : Compare match Interrupt.
   * @retval None.
+  * @note   The LPTIM interrupts can only be disabled when the LPTIM instance is disabled.
   */
 #define __HAL_LPTIM_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->IER  &= (~(__INTERRUPT__)))
 
-    /**
+/**
   * @brief  Check whether the specified LPTIM interrupt source is enabled or not.
   * @param  __HANDLE__ LPTIM handle.
   * @param  __INTERRUPT__ LPTIM interrupt to check.
@@ -524,6 +534,56 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
 #define __HAL_LPTIM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /**
+  * @brief  Enable the LPTIM1 EXTI line in interrupt mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT()            (EXTI->IMR1 |= LPTIM_EXTI_LINE_LPTIM1)
+
+/**
+  * @brief  Disable the LPTIM1 EXTI line in interrupt mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~(LPTIM_EXTI_LINE_LPTIM1))
+
+
+/**
+  * @brief  Enable the LPTIM1 EXTI line in event mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM1_EXTI_ENABLE_EVENT()         (EXTI->EMR1 |= LPTIM_EXTI_LINE_LPTIM1)
+
+/**
+  * @brief  Disable the LPTIM1 EXTI line in event mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM1_EXTI_DISABLE_EVENT()        (EXTI->EMR1 &= ~(LPTIM_EXTI_LINE_LPTIM1))
+
+/**
+  * @brief  Enable the LPTIM2 EXTI line in interrupt mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM2_EXTI_ENABLE_IT()            (EXTI->IMR1 |= LPTIM_EXTI_LINE_LPTIM2)
+
+/**
+  * @brief  Disable the LPTIM2 EXTI line in interrupt mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM2_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~(LPTIM_EXTI_LINE_LPTIM2))
+
+
+/**
+  * @brief  Enable the LPTIM2 EXTI line in event mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM2_EXTI_ENABLE_EVENT()         (EXTI->EMR1 |= LPTIM_EXTI_LINE_LPTIM2)
+
+/**
+  * @brief  Disable the LPTIM2 EXTI line in event mode.
+  * @retval None
+  */
+#define __HAL_LPTIM_LPTIM2_EXTI_DISABLE_EVENT()        (EXTI->EMR1 &= ~(LPTIM_EXTI_LINE_LPTIM2))
+
+/**
   * @}
   */
 
@@ -532,6 +592,10 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef * hlptim); /*!< poin
   * @{
   */
 
+/** @addtogroup LPTIM_Exported_Functions_Group1
+ *  @brief    Initialization and Configuration functions.
+ * @{
+ */
 /* Initialization/de-initialization functions  ********************************/
 HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim);
 HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim);
@@ -539,7 +603,14 @@ HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim);
 /* MSP functions  *************************************************************/
 void HAL_LPTIM_MspInit(LPTIM_HandleTypeDef *hlptim);
 void HAL_LPTIM_MspDeInit(LPTIM_HandleTypeDef *hlptim);
+/**
+  * @}
+  */
 
+/** @addtogroup LPTIM_Exported_Functions_Group2
+ *  @brief   Start-Stop operation functions.
+ * @{
+ */
 /* Start/Stop operation functions  *********************************************/
 /* ################################# PWM Mode ################################*/
 /* Blocking mode: Polling */
@@ -588,12 +659,26 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop(LPTIM_HandleTypeDef *hlptim);
 /* Non-Blocking mode: Interrupt */
 HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period);
 HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+/**
+  * @}
+  */
 
+/** @addtogroup LPTIM_Exported_Functions_Group3
+ *  @brief  Read operation functions.
+ * @{
+ */
 /* Reading operation functions ************************************************/
 uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim);
 uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim);
 uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim);
+/**
+  * @}
+  */
 
+/** @addtogroup LPTIM_Exported_Functions_Group4
+ *  @brief  LPTIM IRQ handler and callback functions.
+ * @{
+ */
 /* LPTIM IRQ functions  *******************************************************/
 void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim);
 
@@ -611,9 +696,19 @@ void HAL_LPTIM_DirectionDownCallback(LPTIM_HandleTypeDef *hlptim);
 HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef *lphtim, HAL_LPTIM_CallbackIDTypeDef CallbackID, pLPTIM_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef *lphtim, HAL_LPTIM_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
 
+/** @addtogroup LPTIM_Group5
+ *  @brief   Peripheral State functions.
+ * @{
+ */
 /* Peripheral State functions  ************************************************/
 HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim);
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -735,7 +830,7 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim);
 /** @defgroup LPTIM_Private_Functions LPTIM Private Functions
   * @{
   */
-
+void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim);
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pcd.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pcd.h
@@ -1,0 +1,584 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_pcd.h
+  * @author  MCD Application Team
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32G0xx_HAL_PCD_H
+#define STM32G0xx_HAL_PCD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_ll_usb.h"
+
+#if defined (USB_DRD_FS)
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCD
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup PCD_Exported_Types PCD Exported Types
+  * @{
+  */
+
+/**
+  * @brief  PCD State structure definition
+  */
+typedef enum
+{
+  HAL_PCD_STATE_RESET   = 0x00,
+  HAL_PCD_STATE_READY   = 0x01,
+  HAL_PCD_STATE_ERROR   = 0x02,
+  HAL_PCD_STATE_BUSY    = 0x03,
+  HAL_PCD_STATE_TIMEOUT = 0x04
+} PCD_StateTypeDef;
+
+/* Device LPM suspend state */
+typedef enum
+{
+  LPM_L0 = 0x00, /* on */
+  LPM_L1 = 0x01, /* LPM L1 sleep */
+  LPM_L2 = 0x02, /* suspend */
+  LPM_L3 = 0x03, /* off */
+} PCD_LPM_StateTypeDef;
+
+typedef enum
+{
+  PCD_LPM_L0_ACTIVE = 0x00, /* on */
+  PCD_LPM_L1_ACTIVE = 0x01, /* LPM L1 sleep */
+} PCD_LPM_MsgTypeDef;
+
+typedef enum
+{
+  PCD_BCD_ERROR                     = 0xFF,
+  PCD_BCD_CONTACT_DETECTION         = 0xFE,
+  PCD_BCD_STD_DOWNSTREAM_PORT       = 0xFD,
+  PCD_BCD_CHARGING_DOWNSTREAM_PORT  = 0xFC,
+  PCD_BCD_DEDICATED_CHARGING_PORT   = 0xFB,
+  PCD_BCD_DISCOVERY_COMPLETED       = 0x00,
+
+} PCD_BCD_MsgTypeDef;
+
+typedef USB_DRD_TypeDef        PCD_TypeDef;
+typedef USB_DRD_CfgTypeDef     PCD_InitTypeDef;
+typedef USB_DRD_EPTypeDef      PCD_EPTypeDef;
+
+/**
+  * @brief  PCD Handle Structure definition
+  */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+typedef struct __PCD_HandleTypeDef
+#else
+typedef struct
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+{
+  PCD_TypeDef             *Instance;   /*!< Register base address             */
+  PCD_InitTypeDef         Init;        /*!< PCD required parameters           */
+  __IO uint8_t            USB_Address; /*!< USB Address                       */
+  PCD_EPTypeDef           IN_ep[8];   /*!< IN endpoint parameters             */
+  PCD_EPTypeDef           OUT_ep[8];  /*!< OUT endpoint parameters            */
+  HAL_LockTypeDef         Lock;        /*!< PCD peripheral status             */
+  __IO PCD_StateTypeDef   State;       /*!< PCD communication state           */
+  __IO  uint32_t          ErrorCode;   /*!< PCD Error code                    */
+  uint32_t                Setup[12];   /*!< Setup packet buffer               */
+  PCD_LPM_StateTypeDef    LPM_State;   /*!< LPM State                         */
+  uint32_t                BESL;
+
+
+  uint32_t lpm_active;                 /*!< Enable or disable the Link Power Management .
+                                       This parameter can be set to ENABLE or DISABLE        */
+
+  uint32_t battery_charging_active;    /*!< Enable or disable Battery charging.
+                                       This parameter can be set to ENABLE or DISABLE        */
+  void                    *pData;      /*!< Pointer to upper stack Handler */
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+  void (* SOFCallback)(struct __PCD_HandleTypeDef *hpcd);                              /*!< USB OTG PCD SOF callback                */
+  void (* SetupStageCallback)(struct __PCD_HandleTypeDef *hpcd);                       /*!< USB OTG PCD Setup Stage callback        */
+  void (* ResetCallback)(struct __PCD_HandleTypeDef *hpcd);                            /*!< USB OTG PCD Reset callback              */
+  void (* SuspendCallback)(struct __PCD_HandleTypeDef *hpcd);                          /*!< USB OTG PCD Suspend callback            */
+  void (* ResumeCallback)(struct __PCD_HandleTypeDef *hpcd);                           /*!< USB OTG PCD Resume callback             */
+  void (* ConnectCallback)(struct __PCD_HandleTypeDef *hpcd);                          /*!< USB OTG PCD Connect callback            */
+  void (* DisconnectCallback)(struct __PCD_HandleTypeDef *hpcd);                       /*!< USB OTG PCD Disconnect callback         */
+
+  void (* DataOutStageCallback)(struct __PCD_HandleTypeDef *hpcd, uint8_t epnum);      /*!< USB OTG PCD Data OUT Stage callback     */
+  void (* DataInStageCallback)(struct __PCD_HandleTypeDef *hpcd, uint8_t epnum);       /*!< USB OTG PCD Data IN Stage callback      */
+  void (* ISOOUTIncompleteCallback)(struct __PCD_HandleTypeDef *hpcd, uint8_t epnum);  /*!< USB OTG PCD ISO OUT Incomplete callback */
+  void (* ISOINIncompleteCallback)(struct __PCD_HandleTypeDef *hpcd, uint8_t epnum);   /*!< USB OTG PCD ISO IN Incomplete callback  */
+  void (* BCDCallback)(struct __PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg);      /*!< USB OTG PCD BCD callback                */
+  void (* LPMCallback)(struct __PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg);      /*!< USB OTG PCD LPM callback                */
+
+  void (* MspInitCallback)(struct __PCD_HandleTypeDef *hpcd);                          /*!< USB OTG PCD Msp Init callback           */
+  void (* MspDeInitCallback)(struct __PCD_HandleTypeDef *hpcd);                        /*!< USB OTG PCD Msp DeInit callback         */
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+} PCD_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Include PCD HAL Extended module */
+#include "stm32g0xx_hal_pcd_ex.h"
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
+  * @{
+  */
+
+/** @defgroup PCD_Speed PCD Speed
+  * @{
+  */
+#define PCD_SPEED_FULL               USBD_FS_SPEED
+/**
+  * @}
+  */
+
+/** @defgroup PCD_PHY_Module PCD PHY Module
+  * @{
+  */
+#define PCD_PHY_ULPI                 1U
+#define PCD_PHY_EMBEDDED             2U
+#define PCD_PHY_UTMI                 3U
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Error_Code_definition PCD Error Code definition
+  * @brief  PCD Error Code definition
+  * @{
+  */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+#define  HAL_PCD_ERROR_INVALID_CALLBACK                        (0x00000010U)    /*!< Invalid Callback error  */
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup PCD_Exported_Macros PCD Exported Macros
+  *  @brief macros to handle interrupts and specific clock configurations
+  * @{
+  */
+
+
+#define __HAL_PCD_ENABLE(__HANDLE__)                                  (void)USB_EnableGlobalInt ((__HANDLE__)->Instance)
+#define __HAL_PCD_DISABLE(__HANDLE__)                                 (void)USB_DisableGlobalInt ((__HANDLE__)->Instance)
+#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__)                 ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)               (((__HANDLE__)->Instance->ISTR) &= (uint16_t)(~(__INTERRUPT__)))
+
+#define __HAL_USB_WAKEUP_EXTI_ENABLE_IT()                             EXTI->IMR2 |= USB_WAKEUP_EXTI_LINE
+#define __HAL_USB_WAKEUP_EXTI_DISABLE_IT()                            EXTI->IMR2 &= ~(USB_WAKEUP_EXTI_LINE)
+
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCD_Exported_Functions PCD Exported Functions
+  * @{
+  */
+
+/* Initialization/de-initialization functions  ********************************/
+/** @addtogroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd);
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+/** @defgroup HAL_PCD_Callback_ID_enumeration_definition HAL USB OTG PCD Callback ID enumeration definition
+  * @brief  HAL USB OTG PCD Callback ID enumeration definition
+  * @{
+  */
+typedef enum
+{
+  HAL_PCD_SOF_CB_ID          = 0x01,      /*!< USB PCD SOF callback ID          */
+  HAL_PCD_SETUPSTAGE_CB_ID   = 0x02,      /*!< USB PCD Setup Stage callback ID  */
+  HAL_PCD_RESET_CB_ID        = 0x03,      /*!< USB PCD Reset callback ID        */
+  HAL_PCD_SUSPEND_CB_ID      = 0x04,      /*!< USB PCD Suspend callback ID      */
+  HAL_PCD_RESUME_CB_ID       = 0x05,      /*!< USB PCD Resume callback ID       */
+  HAL_PCD_CONNECT_CB_ID      = 0x06,      /*!< USB PCD Connect callback ID      */
+  HAL_PCD_DISCONNECT_CB_ID   = 0x07,      /*!< USB PCD Disconnect callback ID   */
+
+  HAL_PCD_MSPINIT_CB_ID      = 0x08,      /*!< USB PCD MspInit callback ID      */
+  HAL_PCD_MSPDEINIT_CB_ID    = 0x09       /*!< USB PCD MspDeInit callback ID    */
+
+} HAL_PCD_CallbackIDTypeDef;
+/**
+  * @}
+  */
+
+/** @defgroup HAL_PCD_Callback_pointer_definition HAL USB OTG PCD Callback pointer definition
+  * @brief  HAL USB OTG PCD Callback pointer definition
+  * @{
+  */
+
+typedef void (*pPCD_CallbackTypeDef)(PCD_HandleTypeDef *hpcd);                                   /*!< pointer to a common USB OTG PCD callback function  */
+typedef void (*pPCD_DataOutStageCallbackTypeDef)(PCD_HandleTypeDef *hpcd, uint8_t epnum);        /*!< pointer to USB OTG PCD Data OUT Stage callback     */
+typedef void (*pPCD_DataInStageCallbackTypeDef)(PCD_HandleTypeDef *hpcd, uint8_t epnum);         /*!< pointer to USB OTG PCD Data IN Stage callback      */
+typedef void (*pPCD_IsoOutIncpltCallbackTypeDef)(PCD_HandleTypeDef *hpcd, uint8_t epnum);        /*!< pointer to USB OTG PCD ISO OUT Incomplete callback */
+typedef void (*pPCD_IsoInIncpltCallbackTypeDef)(PCD_HandleTypeDef *hpcd, uint8_t epnum);         /*!< pointer to USB OTG PCD ISO IN Incomplete callback  */
+typedef void (*pPCD_LpmCallbackTypeDef)(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg);        /*!< pointer to USB OTG PCD LPM callback                */
+typedef void (*pPCD_BcdCallbackTypeDef)(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg);        /*!< pointer to USB OTG PCD BCD callback                */
+
+/**
+  * @}
+  */
+
+HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd,
+                                           HAL_PCD_CallbackIDTypeDef CallbackID,
+                                           pPCD_CallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterCallback(PCD_HandleTypeDef *hpcd,
+                                             HAL_PCD_CallbackIDTypeDef CallbackID);
+
+HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_DataOutStageCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd);
+
+HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_DataInStageCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterDataInStageCallback(PCD_HandleTypeDef *hpcd);
+
+HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_IsoOutIncpltCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd);
+
+HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_IsoInIncpltCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd);
+
+HAL_StatusTypeDef HAL_PCD_RegisterBcdCallback(PCD_HandleTypeDef *hpcd,
+                                              pPCD_BcdCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterBcdCallback(PCD_HandleTypeDef *hpcd);
+
+HAL_StatusTypeDef HAL_PCD_RegisterLpmCallback(PCD_HandleTypeDef *hpcd,
+                                              pPCD_LpmCallbackTypeDef pCallback);
+
+HAL_StatusTypeDef HAL_PCD_UnRegisterLpmCallback(PCD_HandleTypeDef *hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/* I/O operation functions  ***************************************************/
+/* Non-Blocking mode: Interrupt */
+/** @addtogroup PCD_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd);
+
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd);
+
+void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+/**
+  * @}
+  */
+
+/* Peripheral Control functions  **********************************************/
+/** @addtogroup PCD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address);
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr,
+                                  uint16_t ep_mps, uint8_t ep_type);
+
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr,
+                                     uint8_t *pBuf, uint32_t len);
+
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr,
+                                      uint8_t *pBuf, uint32_t len);
+
+
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+
+uint32_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+/**
+  * @}
+  */
+
+/* Peripheral State functions  ************************************************/
+/** @addtogroup PCD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup PCD_Private_Constants PCD Private Constants
+  * @{
+  */
+/** @defgroup USB_EXTI_Line_Interrupt USB EXTI line interrupt
+  * @{
+  */
+
+
+#define USB_WAKEUP_EXTI_LINE                                          (0x1U << 4)  /*!< USB FS EXTI Line WakeUp Interrupt */
+
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_EP0_MPS PCD EP0 MPS
+  * @{
+  */
+#define PCD_EP0MPS_64                                                 EP_MPS_64
+#define PCD_EP0MPS_32                                                 EP_MPS_32
+#define PCD_EP0MPS_16                                                 EP_MPS_16
+#define PCD_EP0MPS_08                                                 EP_MPS_8
+/**
+  * @}
+  */
+
+/** @defgroup PCD_ENDP PCD ENDP
+  * @{
+  */
+#define PCD_ENDP0                                                     0U
+#define PCD_ENDP1                                                     1U
+#define PCD_ENDP2                                                     2U
+#define PCD_ENDP3                                                     3U
+#define PCD_ENDP4                                                     4U
+#define PCD_ENDP5                                                     5U
+#define PCD_ENDP6                                                     6U
+#define PCD_ENDP7                                                     7U
+/**
+  * @}
+  */
+
+/** @defgroup PCD_ENDP_Kind PCD Endpoint Kind
+  * @{
+  */
+#define PCD_SNG_BUF                                                   0U
+#define PCD_DBL_BUF                                                   1U
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PCD_Private_Macros PCD Private Macros
+  * @{
+  */
+/* SetENDPOINT */
+#define PCD_SET_ENDPOINT                       USB_DRD_SET_CHEP
+
+/* GetENDPOINT Register value*/
+#define PCD_GET_ENDPOINT                       USB_DRD_GET_CHEP
+
+/* ENDPOINT transfer */
+#define USB_EP0StartXfer                       USB_EPStartXfer
+
+/**
+  * @brief free buffer used from the application realizing it to the line
+  *         toggles bit SW_BUF in the double buffered endpoint register
+  * @param USBx USB device.
+  * @param   bEpNum, bDir
+  * @retval None
+  */
+#define PCD_FreeUserBuffer                     USB_DRD_FreeUserBuffer
+
+/**
+  * @brief  sets the status for tx transfer (bits STAT_TX[1:0]).
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  wState new state
+  * @retval None
+  */
+#define PCD_SET_EP_TX_STATUS                   USB_DRD_SET_CHEP_TX_STATUS
+
+/**
+  * @brief  sets the status for rx transfer (bits STAT_TX[1:0])
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  wState new state
+  * @retval None
+  */
+#define PCD_SET_EP_RX_STATUS                   USB_DRD_SET_CHEP_RX_STATUS
+
+/**
+  * @brief  Sets/clears directly EP_KIND bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @retval None
+  */
+#define PCD_SET_EP_DBUF                        USB_DRD_SET_CHEP_KIND
+#define PCD_CLEAR_EP_DBUF                      USB_DRD_CLEAR_CHEP_KIND
+
+/**
+  * @brief  Clears bit CTR_RX / CTR_TX in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @retval None
+  */
+#define PCD_CLEAR_RX_EP_CTR                    USB_DRD_CLEAR_RX_CHEP_CTR
+#define PCD_CLEAR_TX_EP_CTR                    USB_DRD_CLEAR_TX_CHEP_CTR
+/**
+  * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @retval None
+  */
+#define PCD_RX_DTOG                            USB_DRD_RX_DTOG
+#define PCD_TX_DTOG                            USB_DRD_TX_DTOG
+/**
+  * @brief  Clears DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @retval None
+  */
+#define PCD_CLEAR_RX_DTOG                      USB_DRD_CLEAR_RX_DTOG
+#define PCD_CLEAR_TX_DTOG                      USB_DRD_CLEAR_TX_DTOG
+
+/**
+  * @brief  Sets address in an endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  bAddr Address.
+  * @retval None
+  */
+#define PCD_SET_EP_ADDRESS                     USB_DRD_SET_CHEP_ADDRESS
+
+/**
+  * @brief  sets address of the tx/rx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  wAddr address to be set (must be word aligned).
+  * @retval None
+  */
+#define PCD_SET_EP_TX_ADDRESS                  USB_DRD_SET_CHEP_TX_ADDRESS
+#define PCD_SET_EP_RX_ADDRESS                  USB_DRD_SET_CHEP_RX_ADDRESS
+
+/**
+  * @brief  sets counter for the tx/rx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  wCount Counter value.
+  * @retval None
+  */
+#define PCD_SET_EP_TX_CNT                      USB_DRD_SET_CHEP_TX_CNT
+#define PCD_SET_EP_RX_CNT                      USB_DRD_SET_CHEP_RX_CNT
+
+/**
+  * @brief  gets counter of the tx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @retval Counter value
+  */
+#define PCD_GET_EP_TX_CNT                      USB_DRD_GET_CHEP_TX_CNT
+#define PCD_GET_EP_RX_CNT                      USB_DRD_GET_CHEP_RX_CNT
+
+/**
+  * @brief  Sets addresses in a double buffer endpoint.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  wBuf0Addr: buffer 0 address.
+  * @param  wBuf1Addr = buffer 1 address.
+  * @retval None
+  */
+#define PCD_SET_EP_DBUF_ADDR                   USB_DRD_SET_CHEP_DBUF_ADDR
+
+/**
+  * @brief  Gets buffer 0/1 address of a double buffer endpoint.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @param  bDir endpoint dir  EP_DBUF_OUT = OUT
+  *         EP_DBUF_IN  = IN
+  * @param  wCount: Counter value
+  * @retval None
+  */
+#define PCD_SET_EP_DBUF0_CNT                   USB_DRD_SET_CHEP_DBUF0_CNT
+#define PCD_SET_EP_DBUF1_CNT                   USB_DRD_SET_CHEP_DBUF1_CNT
+#define PCD_SET_EP_DBUF_CNT                    USB_DRD_SET_CHEP_DBUF_CNT
+
+/**
+  * @brief  Gets buffer 0/1 rx/tx counter for double buffering.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpNum Endpoint Number.
+  * @retval None
+  */
+#define PCD_GET_EP_DBUF0_CNT                   USB_DRD_GET_CHEP_DBUF0_CNT
+#define PCD_GET_EP_DBUF1_CNT                   USB_DRD_GET_CHEP_DBUF1_CNT
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* defined (USB_DRD_FS) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32G0xx_HAL_PCD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pcd_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pcd_ex.h
@@ -1,0 +1,91 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_pcd_ex.h
+  * @author  MCD Application Team
+  * @brief   Header file of PCD HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32G0xx_HAL_PCD_EX_H
+#define STM32G0xx_HAL_PCD_EX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal_def.h"
+
+#if defined (USB_DRD_FS)
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCDEx
+  * @{
+  */
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCDEx_Exported_Functions PCDEx Exported Functions
+  * @{
+  */
+/** @addtogroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
+  * @{
+  */
+
+
+
+HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, uint16_t ep_addr,
+                                       uint16_t ep_kind, uint32_t pmaadress);
+
+
+HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd);
+
+
+HAL_StatusTypeDef HAL_PCDEx_ActivateBCD(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCDEx_DeActivateBCD(PCD_HandleTypeDef *hpcd);
+void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd);
+
+void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg);
+void HAL_PCDEx_BCD_Callback(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* defined (USB_DRD_FS) */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* STM32G0xx_HAL_PCD_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pwr.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pwr.h
@@ -42,20 +42,6 @@
   * @{
   */
 
-#if defined(PWR_PVD_SUPPORT)
-/**
-  * @brief  PWR PVD configuration structure definition
-  */
-typedef struct
-{
-  uint32_t PVDLevel;    /*!< PVDLevel: Specifies the PVD detection level.
-                              This parameter can be a value or a combination of
-                              @ref PWR_PVD_detection_level. */
-
-  uint32_t Mode;        /*!< Mode: Specifies the operating mode for the selected pins.
-                              This parameter can be a value of @ref PWR_PVD_Mode. */
-}PWR_PVDTypeDef;
-#endif
 /**
   * @}
   */
@@ -65,78 +51,24 @@ typedef struct
   * @{
   */
 
-#if defined(PWR_PVD_SUPPORT)
-/** @defgroup PWR_PVD_detection_level  Programmable Voltage Detection levels
-  * @note   see datasheet for selection voltage value
-  * @{
-  */
-#define PWR_PVDLEVEL_RISING_0               (0x00000000u)                                           /*!< PVD threshold level 0 for rising detection */
-#define PWR_PVDLEVEL_RISING_1               (PWR_CR2_PVDRT_0)                                       /*!< PVD threshold level 1 for rising detection */
-#define PWR_PVDLEVEL_RISING_2               (PWR_CR2_PVDRT_1)                                       /*!< PVD threshold level 2 for rising detection */
-#define PWR_PVDLEVEL_RISING_3               (PWR_CR2_PVDRT_0 | PWR_CR2_PVDRT_1)                     /*!< PVD threshold level 3 for rising detection */
-#define PWR_PVDLEVEL_RISING_4               (PWR_CR2_PVDRT_2)                                       /*!< PVD threshold level 4 for rising detection */
-#define PWR_PVDLEVEL_RISING_5               (PWR_CR2_PVDRT_2 | PWR_CR2_PVDRT_0)                     /*!< PVD threshold level 5 for rising detection */
-#define PWR_PVDLEVEL_RISING_6               (PWR_CR2_PVDRT_2 | PWR_CR2_PVDRT_1)                     /*!< PVD threshold level 6 for rising detection */
-#define PWR_PVDLEVEL_FALLING_0              (0x00000000u)                                           /*!< PVD threshold level 0 for falling detection */
-#define PWR_PVDLEVEL_FALLING_1              (PWR_CR2_PVDFT_0)                                       /*!< PVD threshold level 1 for falling detection */
-#define PWR_PVDLEVEL_FALLING_2              (PWR_CR2_PVDFT_1)                                       /*!< PVD threshold level 2 for falling detection */
-#define PWR_PVDLEVEL_FALLING_3              (PWR_CR2_PVDFT_0 | PWR_CR2_PVDFT_1)                     /*!< PVD threshold level 3 for falling detection */
-#define PWR_PVDLEVEL_FALLING_4              (PWR_CR2_PVDFT_2)                                       /*!< PVD threshold level 4 for falling detection */
-#define PWR_PVDLEVEL_FALLING_5              (PWR_CR2_PVDFT_2 | PWR_CR2_PVDFT_0)                     /*!< PVD threshold level 5 for falling detection */
-#define PWR_PVDLEVEL_FALLING_6              (PWR_CR2_PVDFT_2 | PWR_CR2_PVDFT_1)                     /*!< PVD threshold level 6 for falling detection */
-#define PWR_PVDLEVEL_0                      (PWR_PVDLEVEL_RISING_0 | PWR_PVDLEVEL_FALLING_0)        /*!< same PVD threshold level 0 on rising & falling */
-#define PWR_PVDLEVEL_1                      (PWR_PVDLEVEL_RISING_1 | PWR_PVDLEVEL_FALLING_1)        /*!< same PVD threshold level 1 on rising & falling */
-#define PWR_PVDLEVEL_2                      (PWR_PVDLEVEL_RISING_2 | PWR_PVDLEVEL_FALLING_2)        /*!< same PVD threshold level 2 on rising & falling */
-#define PWR_PVDLEVEL_3                      (PWR_PVDLEVEL_RISING_3 | PWR_PVDLEVEL_FALLING_3)        /*!< same PVD threshold level 3 on rising & falling */
-#define PWR_PVDLEVEL_4                      (PWR_PVDLEVEL_RISING_4 | PWR_PVDLEVEL_FALLING_4)        /*!< same PVD threshold level 4 on rising & falling */
-#define PWR_PVDLEVEL_5                      (PWR_PVDLEVEL_RISING_5 | PWR_PVDLEVEL_FALLING_5)        /*!< same PVD threshold level 5 on rising & falling */
-#define PWR_PVDLEVEL_6                      (PWR_PVDLEVEL_RISING_6 | PWR_PVDLEVEL_FALLING_6)        /*!< same PVD threshold level 6 on rising & falling */
-#define PWR_PVDLEVEL_7                      (PWR_CR2_PVDRT_2 | PWR_CR2_PVDRT_1 | PWR_CR2_PVDRT_0)   /*!< External input analog voltage (compared internally to VREFINT) */
-/**
-  * @}
-  */
-
-/** @defgroup PWR_PVD_Mode  PWR PVD interrupt and event mode
-  * @{
-  */
-#define PWR_PVD_MODE_NORMAL                 (0x00000000u)  /*!< basic mode is used */
-#define PWR_PVD_MODE_IT_RISING              (0x00010001u)  /*!< External Interrupt Mode with Rising edge trigger detection */
-#define PWR_PVD_MODE_IT_FALLING             (0x00010002u)  /*!< External Interrupt Mode with Falling edge trigger detection */
-#define PWR_PVD_MODE_IT_RISING_FALLING      (0x00010003u)  /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
-#define PWR_PVD_MODE_EVENT_RISING           (0x00020001u)  /*!< Event Mode with Rising edge trigger detection */
-#define PWR_PVD_MODE_EVENT_FALLING          (0x00020002u)  /*!< Event Mode with Falling edge trigger detection */
-#define PWR_PVD_MODE_EVENT_RISING_FALLING   (0x00020003u)  /*!< Event Mode with Rising/Falling edge trigger detection */
-/**
-  * @}
-  */
-
-/** @defgroup PWR_PVD_EXTI_LINE  PWR PVD external interrupt line
-  * @{
-  */
-#define PWR_EXTI_LINE_PVD                   (EXTI_IMR1_IM16)  /*!< External interrupt line 16 connected to PVD */
-/**
-  * @}
-  */
-
-/** @defgroup PWR_PVD_EVENT_LINE  PWR PVD event line
-  * @{
-  */
-#define PWR_EVENT_LINE_PVD                  (EXTI_EMR1_EM16)  /*!< Event line 16 connected to PVD */
-/**
-  * @}
-  */
-#endif
-
 /** @defgroup PWR_WakeUp_Pins  PWR WakeUp pins
   * @{
   */
 #define PWR_WAKEUP_PIN1                     PWR_CR3_EWUP1  /*!< Wakeup pin 1 (with high level detection) */
 #define PWR_WAKEUP_PIN2                     PWR_CR3_EWUP2  /*!< Wakeup pin 2 (with high level detection) */
+#if defined(PWR_CR3_EWUP3)
+#define PWR_WAKEUP_PIN3                     PWR_CR3_EWUP3  /*!< Wakeup pin 3 (with high level detection) */
+#endif
 #define PWR_WAKEUP_PIN4                     PWR_CR3_EWUP4  /*!< Wakeup pin 4 (with high level detection) */
+#if defined(PWR_CR3_EWUP5)
 #define PWR_WAKEUP_PIN5                     PWR_CR3_EWUP5  /*!< Wakeup pin 5 (with high level detection) */
+#endif
 #define PWR_WAKEUP_PIN6                     PWR_CR3_EWUP6  /*!< Wakeup pin 6 (with high level detection) */
 #define PWR_WAKEUP_PIN1_HIGH                PWR_CR3_EWUP1  /*!< Wakeup pin 1 (with high level detection) */
 #define PWR_WAKEUP_PIN2_HIGH                PWR_CR3_EWUP2  /*!< Wakeup pin 2 (with high level detection) */
+#if defined(PWR_CR3_EWUP3)
+#define PWR_WAKEUP_PIN3_HIGH                PWR_CR3_EWUP3  /*!< Wakeup pin 3 (with high level detection) */
+#endif
 #define PWR_WAKEUP_PIN4_HIGH                PWR_CR3_EWUP4  /*!< Wakeup pin 4 (with high level detection) */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_WAKEUP_PIN5_HIGH                PWR_CR3_EWUP5  /*!< Wakeup pin 5 (with high level detection) */
@@ -144,6 +76,9 @@ typedef struct
 #define PWR_WAKEUP_PIN6_HIGH                PWR_CR3_EWUP6  /*!< Wakeup pin 6 (with high level detection) */
 #define PWR_WAKEUP_PIN1_LOW                 ((PWR_CR4_WP1 << PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP1) /*!< Wakeup pin 1 (with low level detection) */
 #define PWR_WAKEUP_PIN2_LOW                 ((PWR_CR4_WP2 << PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP2) /*!< Wakeup pin 2 (with low level detection) */
+#if defined(PWR_CR3_EWUP3)
+#define PWR_WAKEUP_PIN3_LOW                 ((PWR_CR4_WP3 << PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP3) /*!< Wakeup pin 3 (with low level detection) */
+#endif
 #define PWR_WAKEUP_PIN4_LOW                 ((PWR_CR4_WP4 << PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP4) /*!< Wakeup pin 4 (with low level detection) */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_WAKEUP_PIN5_LOW                 ((PWR_CR4_WP5 << PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP5) /*!< Wakeup pin 5 (with low level detection) */
@@ -193,8 +128,7 @@ typedef struct
   * @}
   */
 
-
-/** @defgroup PWREx_Flag  PWR Status Flags
+/** @defgroup PWR_Flag  PWR Status Flags
   * @brief  Elements values convention: 0000 00XX 000Y YYYYb
   *           - Y YYYY  : Flag position in the XX register (5 bits)
   *           - XX  : Status register (2 bits)
@@ -206,6 +140,9 @@ typedef struct
   */
 #define PWR_FLAG_WUF1                       (0x00010000u | PWR_SR1_WUF1)      /*!< Wakeup event on wakeup pin 1 */
 #define PWR_FLAG_WUF2                       (0x00010000u | PWR_SR1_WUF2)      /*!< Wakeup event on wakeup pin 2 */
+#if defined(PWR_CR3_EWUP3)
+#define PWR_FLAG_WUF3                       (0x00010000u | PWR_SR1_WUF3)      /*!< Wakeup event on wakeup pin 3 */
+#endif
 #define PWR_FLAG_WUF4                       (0x00010000u | PWR_SR1_WUF4)      /*!< Wakeup event on wakeup pin 4 */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_FLAG_WUF5                       (0x00010000u | PWR_SR1_WUF5)      /*!< Wakeup event on wakeup pin 5 */
@@ -220,6 +157,10 @@ typedef struct
 #if defined(PWR_PVD_SUPPORT)
 #define PWR_FLAG_PVDO                       (0x00020000u | PWR_SR2_PVDO)      /*!< Power Voltage Detector output */
 #endif
+#if defined(PWR_PVM_SUPPORT)
+#define PWR_FLAG_PVMO_USB                   (0x00020000u | PWR_SR2_PVMO_USB)  /*!< Power Voltage Monitoring output */
+#endif
+
 /**
   * @}
   */
@@ -239,10 +180,12 @@ typedef struct
   *                  was received from the WKUP pin 1.
   *            @arg PWR_FLAG_WUF2: Wake Up Flag 2. Indicates that a wakeup event
   *                  was received from the WKUP pin 2.
+  *            @arg PWR_FLAG_WUF3: Wake Up Flag 3. Indicates that a wakeup event
+  *                  was received from the WKUP pin 3. (*)
   *            @arg PWR_FLAG_WUF4: Wake Up Flag 4. Indicates that a wakeup event
   *                  was received from the WKUP pin 4.
   *            @arg PWR_FLAG_WUF5: Wake Up Flag 5. Indicates that a wakeup event
-  *                  was received from the WKUP pin 5.
+  *                  was received from the WKUP pin 5. (*)
   *            @arg PWR_FLAG_WUF6: Wake Up Flag 6. Indicates that a wakeup event
   *                  was received from the WKUP pin 6.
   *            @arg PWR_FLAG_SB: StandBy Flag. Indicates that the system
@@ -273,10 +216,12 @@ typedef struct
   *                  was received from the WKUP pin 1.
   *            @arg PWR_FLAG_WUF2: Wake Up Flag 2. Indicates that a wakeup event
   *                  was received from the WKUP pin 2.
+  *            @arg PWR_FLAG_WUF3: Wake Up Flag 3. Indicates that a wakeup event
+  *                  was received from the WKUP pin 3. (*)
   *            @arg PWR_FLAG_WUF4: Wake Up Flag 4. Indicates that a wakeup event
   *                  was received from the WKUP pin 4.
   *            @arg PWR_FLAG_WUF5: Wake Up Flag 5. Indicates that a wakeup event
-  *                  was received from the WKUP pin 5.
+  *                  was received from the WKUP pin 5. (*)
   *            @arg PWR_FLAG_WUF6: Wake Up Flag 6. Indicates that a wakeup event
   *                  was received from the WKUP pin 6.
   *            @arg PWR_FLAG_WUF: Encompasses all Wake Up Flags.
@@ -286,112 +231,12 @@ typedef struct
   */
 #define __HAL_PWR_CLEAR_FLAG(__FLAG__)      (PWR->SCR = (__FLAG__))
 
-#if defined(PWR_PVD_SUPPORT)
-/**
-  * @brief Enable the PVD Extended Interrupt Line.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_ENABLE_IT()            SET_BIT(EXTI->IMR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Disable the PVD Extended Interrupt Line.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_DISABLE_IT()           CLEAR_BIT(EXTI->IMR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Enable the PVD Event Line.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_ENABLE_EVENT()         SET_BIT(EXTI->EMR1, PWR_EVENT_LINE_PVD)
-
-/**
-  * @brief Disable the PVD Event Line.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_DISABLE_EVENT()        CLEAR_BIT(EXTI->EMR1, PWR_EVENT_LINE_PVD)
-
-/**
-  * @brief Enable the PVD Extended Interrupt Rising Trigger.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Disable the PVD Extended Interrupt Rising Trigger.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Enable the PVD Extended Interrupt Falling Trigger.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE()  SET_BIT(EXTI->FTSR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Disable the PVD Extended Interrupt Falling Trigger.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE() CLEAR_BIT(EXTI->FTSR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief  Enable the PVD Extended Interrupt Rising & Falling Trigger.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_FALLING_EDGE()  \
-  do {                                                   \
-    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();             \
-    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();            \
-  } while(0U)
-
-/**
-  * @brief Disable the PVD Extended Interrupt Rising & Falling Trigger.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_FALLING_EDGE()  \
-  do {                                                    \
-    __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();             \
-    __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();            \
-  } while(0U)
-
-/**
-  * @brief  Generate a Software interrupt on selected EXTI line.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_GENERATE_SWIT()        SET_BIT(EXTI->SWIER1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Check whether or not the PVD EXTI interrupt Rising flag is set.
-  * @retval EXTI PVD Line Status.
-  */
-#define __HAL_PWR_PVD_EXTI_GET_RISING_FLAG()      (EXTI->RPR1 & PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Check whether or not the PVD EXTI interrupt Falling flag is set.
-  * @retval EXTI PVD Line Status.
-  */
-#define __HAL_PWR_PVD_EXTI_GET_FALLING_FLAG()     (EXTI->FPR1 & PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Clear the PVD EXTI interrupt Rising flag.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_CLEAR_RISING_FLAG()    WRITE_REG(EXTI->RPR1, PWR_EXTI_LINE_PVD)
-
-/**
-  * @brief Clear the PVD EXTI interrupt Falling flag.
-  * @retval None
-  */
-#define __HAL_PWR_PVD_EXTI_CLEAR_FALLING_FLAG()   WRITE_REG(EXTI->FPR1, PWR_EXTI_LINE_PVD)
-#endif
-
 /**
   * @}
   */
 
 /* Private constants-------------------------------------------------------*/
-/** @defgroup PWREx_WUP_Polarity Shift to apply to retrieve polarity information from PWR_WAKEUP_PINy_xxx constants
+/** @defgroup PWR_WUP_Polarity Shift to apply to retrieve polarity information from PWR_WAKEUP_PINy_xxx constants
   * @{
   */
 #define PWR_WUP_POLARITY_SHIFT              0x08u   /*!< Internal constant used to retrieve wakeup pin polariry */
@@ -403,17 +248,7 @@ typedef struct
 /** @defgroup PWR_Private_Macros  PWR Private Macros
   * @{
   */
-#if defined(PWR_PVD_SUPPORT)
-#define IS_PWR_PVD_LEVEL(LEVEL)                   (((LEVEL) & ~(PWR_CR2_PVDRT | PWR_CR2_PVDFT)) == 0x00000000u)
 
-#define IS_PWR_PVD_MODE(MODE)                     (((MODE) == PWR_PVD_MODE_NORMAL)              || \
-                                                   ((MODE) == PWR_PVD_MODE_IT_RISING)           || \
-                                                   ((MODE) == PWR_PVD_MODE_IT_FALLING)          || \
-                                                   ((MODE) == PWR_PVD_MODE_IT_RISING_FALLING)   || \
-                                                   ((MODE) == PWR_PVD_MODE_EVENT_RISING)        || \
-                                                   ((MODE) == PWR_PVD_MODE_EVENT_FALLING)       || \
-                                                   ((MODE) == PWR_PVD_MODE_EVENT_RISING_FALLING))
-#endif
 #define IS_PWR_WAKEUP_PIN(PIN)                    ((((PIN) & ((PWR_CR4_WP << 8U) | (PWR_CR3_EWUP))) != 0x00000000u) && \
                                                    (((PIN) & ~((PWR_CR4_WP << 8U) | (PWR_CR3_EWUP))) == 0x00000000u))
 
@@ -453,11 +288,7 @@ void              HAL_PWR_DeInit(void);
 /* Peripheral Control functions  ************************************************/
 void              HAL_PWR_EnableBkUpAccess(void);
 void              HAL_PWR_DisableBkUpAccess(void);
-#if defined(PWR_PVD_SUPPORT)
-HAL_StatusTypeDef HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD);
-void              HAL_PWR_EnablePVD(void);
-void              HAL_PWR_DisablePVD(void);
-#endif
+
 /* WakeUp pins configuration functions ****************************************/
 void              HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity);
 void              HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
@@ -470,11 +301,7 @@ void              HAL_PWR_EnableSleepOnExit(void);
 void              HAL_PWR_DisableSleepOnExit(void);
 void              HAL_PWR_EnableSEVOnPend(void);
 void              HAL_PWR_DisableSEVOnPend(void);
-#if defined(PWR_PVD_SUPPORT)
-void              HAL_PWR_PVD_IRQHandler(void);
-void              HAL_PWR_PVD_Rising_Callback(void);
-void              HAL_PWR_PVD_Falling_Callback(void);
-#endif
+
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pwr_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_pwr_ex.h
@@ -38,10 +38,146 @@
   */
 
 /* Exported types ------------------------------------------------------------*/
+/** @defgroup PWREx_Exported_Types PWR Extended Exported Types
+  * @{
+  */
+
+#if defined(PWR_PVM_SUPPORT)
+/**
+  * @brief  PWR PVM configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PVMType;   /*!< PVMType: Specifies which voltage is monitored and against which threshold.
+                           This parameter can be a value of @ref PWREx_PVM_Type.
+                           @arg @ref PWR_PVM_USB Peripheral Voltage Monitoring USB enable */
+
+  uint32_t Mode;      /*!< Mode: Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref PWREx_PVM_Mode. */
+}PWR_PVMTypeDef;
+#endif
+
+#if defined(PWR_PVD_SUPPORT)
+/**
+  * @brief  PWR PVD configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PVDLevel;    /*!< PVDLevel: Specifies the PVD detection level.
+                              This parameter can be a value or a combination of
+                              @ref PWR_PVD_detection_level. */
+
+  uint32_t Mode;        /*!< Mode: Specifies the operating mode for the selected pins.
+                              This parameter can be a value of @ref PWR_PVD_Mode. */
+}PWR_PVDTypeDef;
+#endif
+
+/**
+  * @}
+  */
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup PWREx_Exported_Constants  PWR Extended Exported Constants
   * @{
   */
+#if defined(PWR_PVD_SUPPORT)
+/** @defgroup PWR_PVD_detection_level  Programmable Voltage Detection levels
+  * @note   see datasheet for selection voltage value
+  * @{
+  */
+#define PWR_PVDLEVEL_RISING_0               (0x00000000u)                                           /*!< PVD threshold level 0 for rising detection */
+#define PWR_PVDLEVEL_RISING_1               (PWR_CR2_PVDRT_0)                                       /*!< PVD threshold level 1 for rising detection */
+#define PWR_PVDLEVEL_RISING_2               (PWR_CR2_PVDRT_1)                                       /*!< PVD threshold level 2 for rising detection */
+#define PWR_PVDLEVEL_RISING_3               (PWR_CR2_PVDRT_0 | PWR_CR2_PVDRT_1)                     /*!< PVD threshold level 3 for rising detection */
+#define PWR_PVDLEVEL_RISING_4               (PWR_CR2_PVDRT_2)                                       /*!< PVD threshold level 4 for rising detection */
+#define PWR_PVDLEVEL_RISING_5               (PWR_CR2_PVDRT_2 | PWR_CR2_PVDRT_0)                     /*!< PVD threshold level 5 for rising detection */
+#define PWR_PVDLEVEL_RISING_6               (PWR_CR2_PVDRT_2 | PWR_CR2_PVDRT_1)                     /*!< PVD threshold level 6 for rising detection */
+#define PWR_PVDLEVEL_FALLING_0              (0x00000000u)                                           /*!< PVD threshold level 0 for falling detection */
+#define PWR_PVDLEVEL_FALLING_1              (PWR_CR2_PVDFT_0)                                       /*!< PVD threshold level 1 for falling detection */
+#define PWR_PVDLEVEL_FALLING_2              (PWR_CR2_PVDFT_1)                                       /*!< PVD threshold level 2 for falling detection */
+#define PWR_PVDLEVEL_FALLING_3              (PWR_CR2_PVDFT_0 | PWR_CR2_PVDFT_1)                     /*!< PVD threshold level 3 for falling detection */
+#define PWR_PVDLEVEL_FALLING_4              (PWR_CR2_PVDFT_2)                                       /*!< PVD threshold level 4 for falling detection */
+#define PWR_PVDLEVEL_FALLING_5              (PWR_CR2_PVDFT_2 | PWR_CR2_PVDFT_0)                     /*!< PVD threshold level 5 for falling detection */
+#define PWR_PVDLEVEL_FALLING_6              (PWR_CR2_PVDFT_2 | PWR_CR2_PVDFT_1)                     /*!< PVD threshold level 6 for falling detection */
+#define PWR_PVDLEVEL_0                      (PWR_PVDLEVEL_RISING_0 | PWR_PVDLEVEL_FALLING_0)        /*!< same PVD threshold level 0 on rising & falling */
+#define PWR_PVDLEVEL_1                      (PWR_PVDLEVEL_RISING_1 | PWR_PVDLEVEL_FALLING_1)        /*!< same PVD threshold level 1 on rising & falling */
+#define PWR_PVDLEVEL_2                      (PWR_PVDLEVEL_RISING_2 | PWR_PVDLEVEL_FALLING_2)        /*!< same PVD threshold level 2 on rising & falling */
+#define PWR_PVDLEVEL_3                      (PWR_PVDLEVEL_RISING_3 | PWR_PVDLEVEL_FALLING_3)        /*!< same PVD threshold level 3 on rising & falling */
+#define PWR_PVDLEVEL_4                      (PWR_PVDLEVEL_RISING_4 | PWR_PVDLEVEL_FALLING_4)        /*!< same PVD threshold level 4 on rising & falling */
+#define PWR_PVDLEVEL_5                      (PWR_PVDLEVEL_RISING_5 | PWR_PVDLEVEL_FALLING_5)        /*!< same PVD threshold level 5 on rising & falling */
+#define PWR_PVDLEVEL_6                      (PWR_PVDLEVEL_RISING_6 | PWR_PVDLEVEL_FALLING_6)        /*!< same PVD threshold level 6 on rising & falling */
+#define PWR_PVDLEVEL_7                      (PWR_CR2_PVDRT_2 | PWR_CR2_PVDRT_1 | PWR_CR2_PVDRT_0)   /*!< External input analog voltage (compared internally to VREFINT) */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_Mode  PWR PVD interrupt and event mode
+  * @{
+  */
+#define PWR_PVD_MODE_NORMAL                 (0x00000000u)  /*!< basic mode is used */
+#define PWR_PVD_MODE_IT_RISING              (0x00010001u)  /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_IT_FALLING             (0x00010002u)  /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_IT_RISING_FALLING      (0x00010003u)  /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING           (0x00020001u)  /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_EVENT_FALLING          (0x00020002u)  /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING_FALLING   (0x00020003u)  /*!< Event Mode with Rising/Falling edge trigger detection */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_EXTI_LINE  PWR PVD external interrupt line
+  * @{
+  */
+#define PWR_EXTI_LINE_PVD                   (EXTI_IMR1_IM16)  /*!< External interrupt line 16 connected to PVD */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_EVENT_LINE  PWR PVD event line
+  * @{
+  */
+#define PWR_EVENT_LINE_PVD                  (EXTI_EMR1_EM16)  /*!< Event line 16 connected to PVD */
+/**
+  * @}
+  */
+#endif
+
+#if defined(PWR_PVM_SUPPORT)
+/** @defgroup PWREx_PVM_Type Peripheral Voltage Monitoring type
+  * @{
+  */
+#define PWR_PVM_USB                  PWR_CR2_PVMEN_USB  /*!< Peripheral Voltage Monitoring enable for USB peripheral: Enable to keep the USB peripheral voltage monitoring under control (power domain Vddio2) */
+/**
+  * @}
+  */
+/** @defgroup PWREx_PVM_Mode  PWR PVM interrupt and event mode
+  * @{
+  */
+#define PWR_PVM_MODE_NORMAL                 ((uint32_t)0x00000000)   /*!< basic mode is used */
+#define PWR_PVM_MODE_IT_RISING              ((uint32_t)0x00010001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVM_MODE_IT_FALLING             ((uint32_t)0x00010002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVM_MODE_IT_RISING_FALLING      ((uint32_t)0x00010003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVM_MODE_EVENT_RISING           ((uint32_t)0x00020001)   /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVM_MODE_EVENT_FALLING          ((uint32_t)0x00020002)   /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVM_MODE_EVENT_RISING_FALLING   ((uint32_t)0x00020003)   /*!< Event Mode with Rising/Falling edge trigger detection */
+/**
+  * @}
+  */
+/** @defgroup PWR_PVM_EXTI_LINE  PWR PVM external interrupt line
+  * @{
+  */
+#define PWR_EXTI_LINE_PVM                   (EXTI_IMR2_IM34)  /*!< External interrupt line 34 connected to PVM */
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVM_EVENT_LINE  PWR PVM event line
+  * @{
+  */
+#define PWR_EVENT_LINE_PVM                  (EXTI_EMR2_EM34)  /*!< Event line 34 connected to PVM */
+/**
+  * @}
+  */
+#endif
 
 /** @defgroup PWREx_VBAT_Battery_Charging_Selection  PWR battery charging resistor selection
   * @{
@@ -83,6 +219,9 @@
 #define PWR_GPIO_B                          (0x00000001u)  /*!< GPIO port B */
 #define PWR_GPIO_C                          (0x00000002u)  /*!< GPIO port C */
 #define PWR_GPIO_D                          (0x00000003u)  /*!< GPIO port D */
+#if defined (GPIOE)
+#define PWR_GPIO_E                          (0x00000004u)  /*!< GPIO port E */
+#endif
 #define PWR_GPIO_F                          (0x00000005u)  /*!< GPIO port F */
 /**
   * @}
@@ -107,26 +246,277 @@
   * @}
   */
 
+/** @addtogroup PWR_Flag  PWR Status Flags
+  * @brief  Elements values convention: 0000 00XX 000Y YYYYb
+  *           - Y YYYY  : Flag position in the XX register (5 bits)
+  *           - XX  : Status register (2 bits)
+  *                 - 01: SR1 register
+  *                 - 10: SR2 register
+  *         The only exception is PWR_FLAG_WU, encompassing all
+  *         wake-up flags and set to PWR_SR1_WUF.
+  * @{
+  */
+#if defined(PWR_PVM_SUPPORT)
+#define PWR_FLAG_PVMOUSB                    (0x00020000u | PWR_SR2_PVMO_USB)   /*!< USB Peripheral Voltage Monitoring output */
+#endif
+/**
+  * @}
+  */
+
 /**
   * @}
   */
 
 /* Exported macros -----------------------------------------------------------*/
+/** @addtogroup PWREx_Exported_Macros  PWR Extended Exported Macros
+  * @{
+  */
+#if defined(PWR_PVD_SUPPORT)
+/**
+  * @brief Enable the PVD Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_IT()            SET_BIT(EXTI->IMR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_IT()           CLEAR_BIT(EXTI->IMR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_EVENT()         SET_BIT(EXTI->EMR1, PWR_EVENT_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_EVENT()        CLEAR_BIT(EXTI->EMR1, PWR_EVENT_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Enable the PVD Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE()  SET_BIT(EXTI->FTSR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE() CLEAR_BIT(EXTI->FTSR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief  Enable the PVD Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                   \
+    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0U)
+
+/**
+  * @brief Disable the PVD Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0U)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_GENERATE_SWIT()        SET_BIT(EXTI->SWIER1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Check whether or not the PVD EXTI interrupt Rising flag is set.
+  * @retval EXTI PVD Line Status.
+  */
+#define __HAL_PWR_PVD_EXTI_GET_RISING_FLAG()      (EXTI->RPR1 & PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Check whether or not the PVD EXTI interrupt Falling flag is set.
+  * @retval EXTI PVD Line Status.
+  */
+#define __HAL_PWR_PVD_EXTI_GET_FALLING_FLAG()     (EXTI->FPR1 & PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Clear the PVD EXTI interrupt Rising flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_CLEAR_RISING_FLAG()    WRITE_REG(EXTI->RPR1, PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief Clear the PVD EXTI interrupt Falling flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVD_EXTI_CLEAR_FALLING_FLAG()   WRITE_REG(EXTI->FPR1, PWR_EXTI_LINE_PVD)
+#endif
+
+#if defined(PWR_PVM_SUPPORT)
+/**
+  * @brief Enable the PVM Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_ENABLE_IT()            SET_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Disable the PVM Extended Interrupt Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_DISABLE_IT()           CLEAR_BIT(EXTI->IMR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Enable the PVM Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_ENABLE_EVENT()         SET_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM)
+
+/**
+  * @brief Disable the PVM Event Line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_DISABLE_EVENT()        CLEAR_BIT(EXTI->EMR2, PWR_EVENT_LINE_PVM)
+
+/**
+  * @brief Enable the PVM Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_ENABLE_RISING_EDGE()   SET_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Disable the PVM Extended Interrupt Rising Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_DISABLE_RISING_EDGE()  CLEAR_BIT(EXTI->RTSR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Enable the PVM Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_ENABLE_FALLING_EDGE()  SET_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Disable the PVM Extended Interrupt Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_DISABLE_FALLING_EDGE() CLEAR_BIT(EXTI->FTSR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief  Enable the PVM Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_ENABLE_RISING_FALLING_EDGE()  \
+  do {                                                   \
+    __HAL_PWR_PVM_EXTI_ENABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM_EXTI_ENABLE_FALLING_EDGE();            \
+  } while(0U)
+
+/**
+  * @brief Disable the PVM Extended Interrupt Rising & Falling Trigger.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_DISABLE_RISING_FALLING_EDGE()  \
+  do {                                                    \
+    __HAL_PWR_PVM_EXTI_DISABLE_RISING_EDGE();             \
+    __HAL_PWR_PVM_EXTI_DISABLE_FALLING_EDGE();            \
+  } while(0U)
+
+/**
+  * @brief  Generate a Software interrupt on selected EXTI line.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_GENERATE_SWIT()        SET_BIT(EXTI->SWIER2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Check whether or not the PVM EXTI interrupt Rising flag is set.
+  * @retval EXTI PVM Line Status.
+  */
+#define __HAL_PWR_PVM_EXTI_GET_RISING_FLAG()      (EXTI->RPR2 & PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Check whether or not the PVM EXTI interrupt Falling flag is set.
+  * @retval EXTI PVM Line Status.
+  */
+#define __HAL_PWR_PVM_EXTI_GET_FALLING_FLAG()     (EXTI->FPR2 & PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Clear the PVM EXTI interrupt Rising flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_CLEAR_RISING_FLAG()    WRITE_REG(EXTI->RPR2, PWR_EXTI_LINE_PVM)
+
+/**
+  * @brief Clear the PVM EXTI interrupt Falling flag.
+  * @retval None
+  */
+#define __HAL_PWR_PVM_EXTI_CLEAR_FALLING_FLAG()   WRITE_REG(EXTI->FPR2, PWR_EXTI_LINE_PVM)
+#endif
+/**
+  * @}
+  */
+
+/* Private define ------------------------------------------------------------*/
+/** @defgroup PWR_Extended_Private_Defines PWR Extended Private Defines
+  * @{
+  */
+
+/** @defgroup PWREx_PVM_Mode_Mask PWR PVM Mode Mask
+  * @{
+  */
+#define PVM_MODE_IT               ((uint32_t)0x00010000)  /*!< Mask for interruption yielded by PVM threshold crossing */
+#define PVM_MODE_EVT              ((uint32_t)0x00020000)  /*!< Mask for event yielded by PVM threshold crossing        */
+#define PVM_RISING_EDGE           ((uint32_t)0x00000001)  /*!< Mask for rising edge set as PVM trigger                 */
+#define PVM_FALLING_EDGE          ((uint32_t)0x00000002)  /*!< Mask for falling edge set as PVM trigger                */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 /* Private macros ------------------------------------------------------------*/
 /** @addtogroup  PWREx_Private_Macros   PWR Extended Private Macros
   * @{
   */
+
 #define IS_PWR_BATTERY_RESISTOR_SELECT(__RESISTOR__) (((__RESISTOR__) == PWR_BATTERY_CHARGING_RESISTOR_5) || \
                                                       ((__RESISTOR__) == PWR_BATTERY_CHARGING_RESISTOR_1_5))
 
 #define IS_PWR_GPIO_BIT_NUMBER(__BIT_NUMBER__)  ((((__BIT_NUMBER__) & 0x0000FFFFu) != 0x00u) && \
                                                  (((__BIT_NUMBER__) & 0xFFFF0000u) == 0x00u))
-
+#if defined (GPIOE)
+#define IS_PWR_GPIO(__GPIO__)               (((__GPIO__) == PWR_GPIO_A) || \
+                                             ((__GPIO__) == PWR_GPIO_B) || \
+                                             ((__GPIO__) == PWR_GPIO_C) || \
+                                             ((__GPIO__) == PWR_GPIO_D) || \
+                                             ((__GPIO__) == PWR_GPIO_E) || \
+                                             ((__GPIO__) == PWR_GPIO_F))
+#else
 #define IS_PWR_GPIO(__GPIO__)               (((__GPIO__) == PWR_GPIO_A) || \
                                              ((__GPIO__) == PWR_GPIO_B) || \
                                              ((__GPIO__) == PWR_GPIO_C) || \
                                              ((__GPIO__) == PWR_GPIO_D) || \
                                              ((__GPIO__) == PWR_GPIO_F))
+#endif
 
 #define IS_PWR_FLASH_POWERDOWN(__MODE__)    ((((__MODE__) & (PWR_FLASHPD_LPRUN | PWR_FLASHPD_LPSLEEP | PWR_FLASHPD_STOP)) != 0x00u) && \
                                              (((__MODE__) & ~(PWR_FLASHPD_LPRUN | PWR_FLASHPD_LPSLEEP | PWR_FLASHPD_STOP)) == 0x00u))
@@ -134,6 +524,29 @@
 #define IS_PWR_VOLTAGE_SCALING_RANGE(RANGE) (((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE1) || \
                                              ((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE2))
 
+#if defined(PWR_PVD_SUPPORT)
+#define IS_PWR_PVD_LEVEL(LEVEL)                   (((LEVEL) & ~(PWR_CR2_PVDRT | PWR_CR2_PVDFT)) == 0x00000000u)
+
+#define IS_PWR_PVD_MODE(MODE)                     (((MODE) == PWR_PVD_MODE_NORMAL)              || \
+                                                   ((MODE) == PWR_PVD_MODE_IT_RISING)           || \
+                                                   ((MODE) == PWR_PVD_MODE_IT_FALLING)          || \
+                                                   ((MODE) == PWR_PVD_MODE_IT_RISING_FALLING)   || \
+                                                   ((MODE) == PWR_PVD_MODE_EVENT_RISING)        || \
+                                                   ((MODE) == PWR_PVD_MODE_EVENT_FALLING)       || \
+                                                   ((MODE) == PWR_PVD_MODE_EVENT_RISING_FALLING))
+#endif
+
+#if defined(PWR_PVM_SUPPORT)
+#define IS_PWR_PVM_TYPE(TYPE) ((TYPE) == PWR_PVM_USB)
+
+#define IS_PWR_PVM_MODE(MODE)  (((MODE) == PWR_PVM_MODE_NORMAL)              ||\
+                                ((MODE) == PWR_PVM_MODE_IT_RISING)           ||\
+                                ((MODE) == PWR_PVM_MODE_IT_FALLING)          ||\
+                                ((MODE) == PWR_PVM_MODE_IT_RISING_FALLING)   ||\
+                                ((MODE) == PWR_PVM_MODE_EVENT_RISING)        ||\
+                                ((MODE) == PWR_PVM_MODE_EVENT_FALLING)       ||\
+                                ((MODE) == PWR_PVM_MODE_EVENT_RISING_FALLING))
+#endif
 /**
   * @}
   */
@@ -170,12 +583,38 @@ void              HAL_PWREx_EnableFlashPowerDown(uint32_t PowerMode);
 void              HAL_PWREx_DisableFlashPowerDown(uint32_t PowerMode);
 uint32_t          HAL_PWREx_GetVoltageRange(void);
 HAL_StatusTypeDef HAL_PWREx_ControlVoltageScaling(uint32_t VoltageScaling);
+#if defined(PWR_PVD_SUPPORT)
+/* Power voltage detection configuration functions ****************************/
+HAL_StatusTypeDef HAL_PWREx_ConfigPVD(PWR_PVDTypeDef *sConfigPVD);
+void              HAL_PWREx_EnablePVD(void);
+void              HAL_PWREx_DisablePVD(void);
+#endif
+#if defined(PWR_PVM_SUPPORT)
+/* Power voltage monitoring configuration functions ***************************/
+void HAL_PWREx_EnableVddIO2(void);
+void HAL_PWREx_DisableVddIO2(void);
+void HAL_PWREx_EnableVddUSB(void);
+void HAL_PWREx_DisableVddUSB(void);
+void HAL_PWREx_EnablePVMUSB(void);
+void HAL_PWREx_DisablePVMUSB(void);
+HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM);
+#endif
 
 /* Low Power modes configuration functions ************************************/
 void              HAL_PWREx_EnableLowPowerRunMode(void);
 HAL_StatusTypeDef HAL_PWREx_DisableLowPowerRunMode(void);
 #if defined(PWR_SHDW_SUPPORT)
 void              HAL_PWREx_EnterSHUTDOWNMode(void);
+#endif
+
+#if defined(PWR_PVD_SUPPORT) && defined(PWR_PVM_SUPPORT)
+void              HAL_PWREx_PVD_PVM_IRQHandler(void);
+void              HAL_PWREx_PVD_PVM_Rising_Callback(void);
+void              HAL_PWREx_PVD_PVM_Falling_Callback(void);
+#elif defined(PWR_PVD_SUPPORT)
+void              HAL_PWREx_PVD_IRQHandler(void);
+void              HAL_PWREx_PVD_Rising_Callback(void);
+void              HAL_PWREx_PVD_Falling_Callback(void);
 #endif
 
 /**

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rcc.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rcc.h
@@ -45,6 +45,9 @@ extern "C" {
 #define CR_REG_INDEX              1U
 #define BDCR_REG_INDEX            2U
 #define CSR_REG_INDEX             3U
+#if defined(RCC_HSI48_SUPPORT)
+#define CRRCR_REG_INDEX           4U
+#endif /* RCC_HSI48_SUPPORT */
 
 #define RCC_FLAG_MASK             0x1FU
 
@@ -59,11 +62,22 @@ extern "C" {
   * @{
   */
 
-#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__) (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE)                           || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE) || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI) || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI) || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE))
+#if defined(RCC_HSI48_SUPPORT)
+#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__)                                     \
+  (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE)                               || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE)     || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI)     || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI48) == RCC_OSCILLATORTYPE_HSI48) || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI)     || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE))
+#else
+#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__)                                 \
+  (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE)                           || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE) || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI) || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI) || \
+   (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE))
+#endif /* RCC_HSI48_SUPPORT */
 
 #define IS_RCC_HSE(__HSE__)  (((__HSE__) == RCC_HSE_OFF) || ((__HSE__) == RCC_HSE_ON) || \
                               ((__HSE__) == RCC_HSE_BYPASS))
@@ -72,6 +86,10 @@ extern "C" {
                               ((__LSE__) == RCC_LSE_BYPASS))
 
 #define IS_RCC_HSI(__HSI__)  (((__HSI__) == RCC_HSI_OFF) || ((__HSI__) == RCC_HSI_ON))
+
+#if defined(RCC_HSI48_SUPPORT)
+#define IS_RCC_HSI48(__HSI48__)  (((__HSI48__) == RCC_HSI48_OFF) || ((__HSI48__) == RCC_HSI48_ON))
+#endif /* RCC_HSI48_SUPPORT */
 
 #define IS_RCC_HSI_CALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= (uint32_t)127U)
 
@@ -97,7 +115,7 @@ extern "C" {
 
 #if defined(RCC_PLLQ_SUPPORT)
 #define IS_RCC_PLLQ_VALUE(__VALUE__) ((RCC_PLLQ_DIV2 <= (__VALUE__)) && ((__VALUE__) <= RCC_PLLQ_DIV8))
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
 
 #define IS_RCC_PLLR_VALUE(__VALUE__) ((RCC_PLLR_DIV2 <= (__VALUE__)) && ((__VALUE__) <= RCC_PLLR_DIV8))
 
@@ -124,20 +142,96 @@ extern "C" {
                                          ((__SOURCE__) == RCC_RTCCLKSOURCE_LSI) || \
                                          ((__SOURCE__) == RCC_RTCCLKSOURCE_HSE_DIV32))
 
+#if defined(RCC_MCO2_SUPPORT)
+#define IS_RCC_MCO(__MCOX__) ( ((__MCOX__) == RCC_MCO1) || ((__MCOX__) == RCC_MCO2) )
+#else
 #define IS_RCC_MCO(__MCOX__) ((__MCOX__) == RCC_MCO1)
+#endif /* RCC_MCO2_SUPPORT */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
 #define IS_RCC_MCO1SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO1SOURCE_NOCLOCK) || \
-                                       ((__SOURCE__) == RCC_MCO1SOURCE_SYSCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_SYSCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSI)   || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSI48) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSE)   || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_LSI)    || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_LSE)     || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLPCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLQCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_RTCCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_RTC_WKUP))
+#elif defined(STM32G0B0xx)
+#define IS_RCC_MCO1SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO1SOURCE_NOCLOCK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_SYSCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSI) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_HSE) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_LSI) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_LSE)     || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLPCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_PLLQCLK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_RTCCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_RTC_WKUP))
+#else
+#define IS_RCC_MCO1SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO1SOURCE_NOCLOCK) || \
+                                       ((__SOURCE__) == RCC_MCO1SOURCE_SYSCLK)  || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_HSI) || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_HSE) || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_PLLCLK) || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_LSI) || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_LSE))
+#endif /* STM32G0C1xx || STM32G0B1xx */
 
-#define IS_RCC_MCODIV(__DIV__) (((__DIV__) == RCC_MCODIV_1) || ((__DIV__) == RCC_MCODIV_2) || \
-                                ((__DIV__) == RCC_MCODIV_4) || ((__DIV__) == RCC_MCODIV_8) || \
-                                ((__DIV__) == RCC_MCODIV_16)|| ((__DIV__) == RCC_MCODIV_32) || \
-                                ((__DIV__) == RCC_MCODIV_64)|| ((__DIV__) == RCC_MCODIV_128))
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define IS_RCC_MCODIV(__DIV__) (((__DIV__) == RCC_MCODIV_1)  || ((__DIV__) == RCC_MCODIV_2)   || \
+                                ((__DIV__) == RCC_MCODIV_4)  || ((__DIV__) == RCC_MCODIV_8)   || \
+                                ((__DIV__) == RCC_MCODIV_16) || ((__DIV__) == RCC_MCODIV_32)  || \
+                                ((__DIV__) == RCC_MCODIV_64) || ((__DIV__) == RCC_MCODIV_128) || \
+                                ((__DIV__) == RCC_MCODIV_256)|| ((__DIV__) == RCC_MCODIV_512) || \
+                                ((__DIV__) == RCC_MCODIV_1024))
+#else
+#define IS_RCC_MCODIV(__DIV__) (((__DIV__) == RCC_MCODIV_1)  || ((__DIV__) == RCC_MCODIV_2)   || \
+                                ((__DIV__) == RCC_MCODIV_4)  || ((__DIV__) == RCC_MCODIV_8)   || \
+                                ((__DIV__) == RCC_MCODIV_16) || ((__DIV__) == RCC_MCODIV_32)  || \
+                                ((__DIV__) == RCC_MCODIV_64) || ((__DIV__) == RCC_MCODIV_128))
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
+#if defined(RCC_MCO2_SUPPORT)
+#if defined(RCC_HSI48_SUPPORT)
+#define IS_RCC_MCO2SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO2SOURCE_NOCLOCK) || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_SYSCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_HSI48)   || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_HSI)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_HSE)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_PLLCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_LSI)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_LSE)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_PLLPCLK) || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_PLLQCLK) || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_RTCCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_RTC_WKUP))
+#else
+#define IS_RCC_MCO2SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO2SOURCE_NOCLOCK) || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_SYSCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_HSI)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_HSE)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_PLLCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_LSI)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_LSE)     || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_PLLPCLK) || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_PLLQCLK) || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_RTCCLK)  || \
+                                       ((__SOURCE__) == RCC_MCO2SOURCE_RTC_WKUP))
+#endif /* RCC_HSI48_SUPPORT */
+#define IS_RCC_MCO2DIV(__DIV__) (((__DIV__) == RCC_MCO2DIV_1)  || ((__DIV__) == RCC_MCO2DIV_2)  || \
+                                 ((__DIV__) == RCC_MCO2DIV_4)  || ((__DIV__) == RCC_MCO2DIV_8)  || \
+                                 ((__DIV__) == RCC_MCO2DIV_16) || ((__DIV__) == RCC_MCO2DIV_32) || \
+                                 ((__DIV__) == RCC_MCO2DIV_64) || ((__DIV__) == RCC_MCO2DIV_128)|| \
+                                 ((__DIV__) == RCC_MCO2DIV_256)|| ((__DIV__) == RCC_MCO2DIV_512)|| \
+                                 ((__DIV__) == RCC_MCO2DIV_1024))
+
+#endif /* RCC_MCO2_SUPPORT */
 
 #define IS_RCC_LSE_DRIVE(__DRIVE__) (((__DRIVE__) == RCC_LSEDRIVE_LOW)        || \
                                      ((__DRIVE__) == RCC_LSEDRIVE_MEDIUMLOW)  || \
@@ -178,7 +272,7 @@ typedef struct
   uint32_t PLLQ;       /*!< PLLQ: PLL Division factor.
                             User have to set the PLLQ parameter correctly to not exceed max frequency 64MHZ.
                             This parameter must be a value of @ref RCC_PLLQ_Clock_Divider             */
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
 
   uint32_t PLLR;       /*!< PLLR: PLL Division for the main system clock.
                             User have to set the PLLR parameter correctly to not exceed max frequency 64MHZ.
@@ -212,12 +306,18 @@ typedef struct
   uint32_t LSIState;             /*!< The new state of the LSI.
                                       This parameter can be a value of @ref RCC_LSI_Config                        */
 
+#if defined(RCC_HSI48_SUPPORT)
+  uint32_t HSI48State;             /*!< The new state of the HSI48 (only applicable to STM32G0C1xx/STM32G0B1xx/STM32G0B0xx devices).
+                                        This parameter can be a value of @ref RCC_HSI48_Config */
+
+#endif /* RCC_HSI48_SUPPORT */
+
   RCC_PLLInitTypeDef PLL;        /*!< Main PLL structure parameters                                               */
 
 } RCC_OscInitTypeDef;
 
 /**
-  * @brief  RCC System, AHB and APB busses clock configuration structure definition
+  * @brief  RCC System, AHB and APB buses clock configuration structure definition
   */
 typedef struct
 {
@@ -262,6 +362,10 @@ typedef struct
 #define RCC_OSCILLATORTYPE_HSI         0x00000002U   /*!< HSI to configure */
 #define RCC_OSCILLATORTYPE_LSE         0x00000004U   /*!< LSE to configure */
 #define RCC_OSCILLATORTYPE_LSI         0x00000008U   /*!< LSI to configure */
+#if defined(RCC_HSI48_SUPPORT)
+#define RCC_OSCILLATORTYPE_HSI48       0x00000020U   /*!< HSI48 to configure */
+#endif /* RCC_HSI48_SUPPORT */
+
 /**
   * @}
   */
@@ -271,7 +375,7 @@ typedef struct
   */
 #define RCC_HSE_OFF                    0x00000000U                                /*!< HSE clock deactivation */
 #define RCC_HSE_ON                     RCC_CR_HSEON                               /*!< HSE clock activation */
-#define RCC_HSE_BYPASS                 ((uint32_t)(RCC_CR_HSEBYP | RCC_CR_HSEON)) /*!< External clock source for HSE clock */
+#define RCC_HSE_BYPASS                 (RCC_CR_HSEBYP | RCC_CR_HSEON)             /*!< External clock source for HSE clock */
 /**
   * @}
   */
@@ -281,7 +385,7 @@ typedef struct
   */
 #define RCC_LSE_OFF                    0x00000000U                                    /*!< LSE clock deactivation */
 #define RCC_LSE_ON                     RCC_BDCR_LSEON                                 /*!< LSE clock activation */
-#define RCC_LSE_BYPASS                 ((uint32_t)(RCC_BDCR_LSEBYP | RCC_BDCR_LSEON)) /*!< External clock source for LSE clock */
+#define RCC_LSE_BYPASS                 (RCC_BDCR_LSEBYP | RCC_BDCR_LSEON)             /*!< External clock source for LSE clock */
 /**
   * @}
   */
@@ -320,6 +424,17 @@ typedef struct
 /**
   * @}
   */
+
+#if defined(RCC_HSI48_SUPPORT)
+/** @defgroup RCC_HSI48_Config HSI48 Config
+  * @{
+  */
+#define RCC_HSI48_OFF                  0x00000000U       /*!< HSI48 clock deactivation */
+#define RCC_HSI48_ON                   RCC_CR_HSI48ON    /*!< HSI48 clock activation */
+/**
+  * @}
+  */
+#endif /* RCC_HSI48_SUPPORT */
 
 /** @defgroup RCC_PLL_Config PLL Config
   * @{
@@ -397,7 +512,7 @@ typedef struct
 #define RCC_PLLQ_DIV8                  (RCC_PLLCFGR_PLLQ_2 |RCC_PLLCFGR_PLLQ_1 | RCC_PLLCFGR_PLLQ_0)  /*!< PLLQ division factor = 8 */
 /**  * @}
   */
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
 
 /** @defgroup RCC_PLLR_Clock_Divider PLLR Clock Divider
   * @{
@@ -428,7 +543,7 @@ typedef struct
 #define RCC_PLLPCLK                 RCC_PLLCFGR_PLLPEN      /*!< PLLPCLK selection from main PLL */
 #if defined(RCC_PLLQ_SUPPORT)
 #define RCC_PLLQCLK                 RCC_PLLCFGR_PLLQEN      /*!< PLLQCLK selection from main PLL */
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
 #define RCC_PLLRCLK                 RCC_PLLCFGR_PLLREN      /*!< PLLRCLK selection from main PLL */
 
 /**
@@ -512,6 +627,10 @@ typedef struct
   * @{
   */
 #define RCC_MCO1                       0x00000000U
+#if defined(RCC_MCO2_SUPPORT)
+#define RCC_MCO2                       0x00000001U            /*!< MCO2 index */
+#endif /* RCC_MCO2_SUPPORT */
+
 #define RCC_MCO                        RCC_MCO1               /*!< MCO1 to be compliant with other families with 2 MCOs*/
 /**
   * @}
@@ -522,16 +641,25 @@ typedef struct
   */
 #define RCC_MCO1SOURCE_NOCLOCK         0x00000000U                            /*!< MCO1 output disabled, no clock on MCO1 */
 #define RCC_MCO1SOURCE_SYSCLK          RCC_CFGR_MCOSEL_0                      /*!< SYSCLK selection as MCO1 source */
+#if defined(RCC_HSI48_SUPPORT)
+#define RCC_MCO1SOURCE_HSI48           RCC_CFGR_MCOSEL_1                      /*!< HSI48 selection as MCO1 source */
+#endif /* RCC_HSI48_SUPPORT */
 #define RCC_MCO1SOURCE_HSI             (RCC_CFGR_MCOSEL_0| RCC_CFGR_MCOSEL_1) /*!< HSI selection as MCO1 source */
 #define RCC_MCO1SOURCE_HSE             RCC_CFGR_MCOSEL_2                      /*!< HSE selection as MCO1 source */
 #define RCC_MCO1SOURCE_PLLCLK          (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_2)  /*!< PLLCLK selection as MCO1 source */
 #define RCC_MCO1SOURCE_LSI             (RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_2)  /*!< LSI selection as MCO1 source */
 #define RCC_MCO1SOURCE_LSE             (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_2) /*!< LSE selection as MCO1 source */
+#if defined(RCC_CFGR_MCOSEL_3)
+#define RCC_MCO1SOURCE_PLLPCLK         RCC_CFGR_MCOSEL_3                       /*!< PLLPCLK selection as MCO1 source */
+#define RCC_MCO1SOURCE_PLLQCLK         (RCC_CFGR_MCOSEL_3|RCC_CFGR_MCOSEL_0)   /*!< PLLQCLK selection as MCO1 source */
+#define RCC_MCO1SOURCE_RTCCLK          (RCC_CFGR_MCOSEL_3|RCC_CFGR_MCOSEL_1)   /*!< RTCCLK selection as MCO1 source */
+#define RCC_MCO1SOURCE_RTC_WKUP        (RCC_CFGR_MCOSEL_3|RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_0) /*!< RTC_Wakeup selection as MCO1 source */
+#endif /* RCC_CFGR_MCOSEL_3 */
 /**
   * @}
   */
 
-/** @defgroup RCC_MCOx_Clock_Prescaler MCO1 Clock Prescaler
+/** @defgroup RCC_MCO1_Clock_Prescaler MCO1 Clock Prescaler
   * @{
   */
 #define RCC_MCODIV_1                   0x00000000U                                                 /*!< MCO not divided */
@@ -542,9 +670,55 @@ typedef struct
 #define RCC_MCODIV_32                  (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_0)                     /*!< MCO divided by 32 */
 #define RCC_MCODIV_64                  (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_1)                     /*!< MCO divided by 64 */
 #define RCC_MCODIV_128                 (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_1 | RCC_CFGR_MCOPRE_0) /*!< MCO divided by 128 */
+#if defined(RCC_CFGR_MCOPRE_3)
+#define RCC_MCODIV_256                 RCC_CFGR_MCOPRE_3                                           /*!< MCO divided by 256 */
+#define RCC_MCODIV_512                (RCC_CFGR_MCOPRE_3 | RCC_CFGR_MCOPRE_0)                      /*!< MCO divided by 512 */
+#define RCC_MCODIV_1024               (RCC_CFGR_MCOPRE_3 | RCC_CFGR_MCOPRE_1)                      /*!< MCO divided by 1024 */
+#endif /* RCC_CFGR_MCOSEL_3 */
 /**
   * @}
   */
+
+#if defined(RCC_MCO2_SUPPORT)
+/** @defgroup RCC_MCO2_Clock_Source MCO2 Clock Source
+  * @{
+  */
+#define RCC_MCO2SOURCE_NOCLOCK         0x00000000U                              /*!< MCO2 output disabled, no clock on MCO2 */
+#define RCC_MCO2SOURCE_SYSCLK          RCC_CFGR_MCO2SEL_0                       /*!< SYSCLK selection as MCO2 source */
+#if defined(RCC_HSI48_SUPPORT)
+#define RCC_MCO2SOURCE_HSI48           RCC_CFGR_MCO2SEL_1                       /*!< HSI48 selection as MCO2 source */
+#endif /* RCC_HSI48_SUPPORT */
+#define RCC_MCO2SOURCE_HSI             (RCC_CFGR_MCO2SEL_1| RCC_CFGR_MCO2SEL_0) /*!< HSI selection as MCO2 source */
+#define RCC_MCO2SOURCE_HSE             RCC_CFGR_MCO2SEL_2                       /*!< HSE selection as MCO2 source */
+#define RCC_MCO2SOURCE_PLLCLK          (RCC_CFGR_MCO2SEL_2|RCC_CFGR_MCO2SEL_0)  /*!< PLLCLK selection as MCO2 source */
+#define RCC_MCO2SOURCE_LSI             (RCC_CFGR_MCO2SEL_2|RCC_CFGR_MCO2SEL_1)  /*!< LSI selection as MCO2 source */
+#define RCC_MCO2SOURCE_LSE             (RCC_CFGR_MCO2SEL_2|RCC_CFGR_MCO2SEL_1|RCC_CFGR_MCO2SEL_0) /*!< LSE selection as MCO2 source */
+#define RCC_MCO2SOURCE_PLLPCLK         RCC_CFGR_MCO2SEL_3                       /*!< PLLPCLK selection as MCO2 source */
+#define RCC_MCO2SOURCE_PLLQCLK         (RCC_CFGR_MCO2SEL_3|RCC_CFGR_MCO2SEL_0)  /*!< PLLQCLK selection as MCO2 source */
+#define RCC_MCO2SOURCE_RTCCLK          (RCC_CFGR_MCO2SEL_3|RCC_CFGR_MCO2SEL_1)  /*!< RTCCLK selection as MCO2 source */
+#define RCC_MCO2SOURCE_RTC_WKUP        (RCC_CFGR_MCO2SEL_3|RCC_CFGR_MCO2SEL_1|RCC_CFGR_MCO2SEL_0) /*!< RTC_Wakeup selection as MCO2 source */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCO2_Clock_Prescaler MCO2 Clock Prescaler
+  * @{
+  */
+#define RCC_MCO2DIV_1                  0x00000000U                                                    /*!< MCO2 not divided */
+#define RCC_MCO2DIV_2                  RCC_CFGR_MCO2PRE_0                                             /*!< MCO2 divided by 2 */
+#define RCC_MCO2DIV_4                  RCC_CFGR_MCO2PRE_1                                             /*!< MCO2 divided by 4 */
+#define RCC_MCO2DIV_8                  (RCC_CFGR_MCO2PRE_1 | RCC_CFGR_MCO2PRE_0)                      /*!< MCO2 divided by 8 */
+#define RCC_MCO2DIV_16                 RCC_CFGR_MCO2PRE_2                                             /*!< MCO2 divided by 16 */
+#define RCC_MCO2DIV_32                 (RCC_CFGR_MCO2PRE_2 | RCC_CFGR_MCO2PRE_0)                      /*!< MCO2 divided by 32 */
+#define RCC_MCO2DIV_64                 (RCC_CFGR_MCO2PRE_2 | RCC_CFGR_MCO2PRE_1)                      /*!< MCO2 divided by 64 */
+#define RCC_MCO2DIV_128                (RCC_CFGR_MCO2PRE_2 | RCC_CFGR_MCO2PRE_1 | RCC_CFGR_MCO2PRE_0) /*!< MCO2 divided by 128 */
+#define RCC_MCO2DIV_256                RCC_CFGR_MCO2PRE_3                                             /*!< MCO2 divided by 256 */
+#define RCC_MCO2DIV_512                (RCC_CFGR_MCO2PRE_3 | RCC_CFGR_MCO2PRE_0)                      /*!< MCO2 divided by 512 */
+#define RCC_MCO2DIV_1024               (RCC_CFGR_MCO2PRE_3 | RCC_CFGR_MCO2PRE_1)                      /*!< MCO2 divided by 1024 */
+/**
+  * @}
+  */
+#endif /* RCC_MCO2_SUPPORT */
 
 /** @defgroup RCC_Interrupt Interrupts
   * @{
@@ -556,6 +730,9 @@ typedef struct
 #define RCC_IT_PLLRDY                  RCC_CIFR_PLLRDYF            /*!< PLL Ready Interrupt flag */
 #define RCC_IT_CSS                     RCC_CIFR_CSSF               /*!< HSE Clock Security System Interrupt flag */
 #define RCC_IT_LSECSS                  RCC_CIFR_LSECSSF            /*!< LSE Clock Security System Interrupt flag */
+#if defined(RCC_HSI48_SUPPORT)
+#define RCC_IT_HSI48RDY                RCC_CIFR_HSI48RDYF          /*!< HSI48 Ready Interrupt flag */
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -570,9 +747,9 @@ typedef struct
   * @{
   */
 /* Flags in the CR register */
-#define RCC_FLAG_HSIRDY                ((CR_REG_INDEX << 5U) | RCC_CR_HSIRDY_Pos) /*!< HSI Ready flag */
-#define RCC_FLAG_HSERDY                ((CR_REG_INDEX << 5U) | RCC_CR_HSERDY_Pos) /*!< HSE Ready flag */
-#define RCC_FLAG_PLLRDY                ((CR_REG_INDEX << 5U) | RCC_CR_PLLRDY_Pos) /*!< PLL Ready flag */
+#define RCC_FLAG_HSIRDY                ((CR_REG_INDEX << 5U) | RCC_CR_HSIRDY_Pos)  /*!< HSI Ready flag */
+#define RCC_FLAG_HSERDY                ((CR_REG_INDEX << 5U) | RCC_CR_HSERDY_Pos)  /*!< HSE Ready flag */
+#define RCC_FLAG_PLLRDY                ((CR_REG_INDEX << 5U) | RCC_CR_PLLRDY_Pos)  /*!< PLL Ready flag */
 
 /* Flags in the BDCR register */
 #define RCC_FLAG_LSERDY                ((BDCR_REG_INDEX << 5U) | RCC_BDCR_LSERDY_Pos)  /*!< LSE Ready flag */
@@ -587,6 +764,11 @@ typedef struct
 #define RCC_FLAG_IWDGRST               ((CSR_REG_INDEX << 5U) | RCC_CSR_IWDGRSTF_Pos)  /*!< Independent Watchdog reset flag */
 #define RCC_FLAG_WWDGRST               ((CSR_REG_INDEX << 5U) | RCC_CSR_WWDGRSTF_Pos)  /*!< Window watchdog reset flag */
 #define RCC_FLAG_LPWRRST               ((CSR_REG_INDEX << 5U) | RCC_CSR_LPWRRSTF_Pos)  /*!< Low-Power reset flag */
+
+#if defined(RCC_HSI48_SUPPORT)
+/* Flags in the CRRCR register */
+#define RCC_FLAG_HSI48RDY              ((CRRCR_REG_INDEX << 5U) | RCC_CRRCR_RC48RDY_Pos) /*!< HSI48 Ready flag */
+#endif /* RCC_HSI48_SUPPORT */
 
 /**
   * @}
@@ -629,6 +811,18 @@ typedef struct
                                                  UNUSED(tmpreg); \
                                                } while(0U)
 
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->AHBENR, RCC_AHBENR_DMA2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+
+#endif /* DMA2 */
+
+
 #define __HAL_RCC_FLASH_CLK_ENABLE()           do { \
                                                  __IO uint32_t tmpreg; \
                                                  SET_BIT(RCC->AHBENR, RCC_AHBENR_FLASHEN); \
@@ -666,6 +860,9 @@ typedef struct
 #endif /* AES */
 
 #define __HAL_RCC_DMA1_CLK_DISABLE()           CLEAR_BIT(RCC->AHBENR, RCC_AHBENR_DMA1EN)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_CLK_DISABLE()           CLEAR_BIT(RCC->AHBENR, RCC_AHBENR_DMA2EN)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_CLK_DISABLE()          CLEAR_BIT(RCC->AHBENR, RCC_AHBENR_FLASHEN)
 #define __HAL_RCC_CRC_CLK_DISABLE()            CLEAR_BIT(RCC->AHBENR, RCC_AHBENR_CRCEN)
 #if defined(RNG)
@@ -717,6 +914,17 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIODEN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
+
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->IOPENR, RCC_IOPENR_GPIOEEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOEEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* GPIOE */
+
 #define __HAL_RCC_GPIOF_CLK_ENABLE()           do { \
                                                  __IO uint32_t tmpreg; \
                                                  SET_BIT(RCC->IOPENR, RCC_IOPENR_GPIOFEN); \
@@ -729,6 +937,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_CLK_DISABLE()          CLEAR_BIT(RCC->IOPENR, RCC_IOPENR_GPIOBEN)
 #define __HAL_RCC_GPIOC_CLK_DISABLE()          CLEAR_BIT(RCC->IOPENR, RCC_IOPENR_GPIOCEN)
 #define __HAL_RCC_GPIOD_CLK_DISABLE()          CLEAR_BIT(RCC->IOPENR, RCC_IOPENR_GPIODEN)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_CLK_DISABLE()          CLEAR_BIT(RCC->IOPENR, RCC_IOPENR_GPIOEEN)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_CLK_DISABLE()          CLEAR_BIT(RCC->IOPENR, RCC_IOPENR_GPIOFEN)
 
 /**
@@ -750,7 +961,7 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM2EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* TIM2 */
 
 #define __HAL_RCC_TIM3_CLK_ENABLE()            do { \
                                                  __IO uint32_t tmpreg; \
@@ -759,6 +970,16 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM3EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
+
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_TIM4EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM4EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* TIM4 */
 
 #define __HAL_RCC_TIM6_CLK_ENABLE()            do { \
                                                  __IO uint32_t tmpreg; \
@@ -775,6 +996,16 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM7EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
+
+#if defined(CRS)
+#define __HAL_RCC_CRS_CLK_ENABLE()             do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_CRSEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_CRSEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+#endif /* CRS */
 
 #define __HAL_RCC_RTCAPB_CLK_ENABLE()          do { \
                                                  __IO uint32_t tmpreg; \
@@ -799,6 +1030,15 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_SPI2EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_SPI3EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_SPI3EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* SPI3 */
 
 #define __HAL_RCC_USART2_CLK_ENABLE()          do { \
                                                  __IO uint32_t tmpreg; \
@@ -824,6 +1064,26 @@ typedef struct
                                                  UNUSED(tmpreg); \
                                                } while(0U)
 
+#if defined(USART5)
+#define __HAL_RCC_USART5_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_USART5EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_USART5EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* USART5 */
+
+#if defined(USART6)
+#define __HAL_RCC_USART6_CLK_ENABLE()           do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_USART6EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_USART6EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* USART6 */
+
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_ENABLE()         do { \
                                                  __IO uint32_t tmpreg; \
@@ -832,7 +1092,17 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_LPUART1EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* LPUART1 */
+
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_CLK_ENABLE()         do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_LPUART2EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_LPUART2EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* LPUART2 */
 
 #define __HAL_RCC_I2C1_CLK_ENABLE()            do { \
                                                  __IO uint32_t tmpreg; \
@@ -850,6 +1120,16 @@ typedef struct
                                                  UNUSED(tmpreg); \
                                                } while(0U)
 
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_I2C3EN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C3EN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* I2C3 */
+
 #if defined(CEC)
 #define __HAL_RCC_CEC_CLK_ENABLE()             do { \
                                                  __IO uint32_t tmpreg; \
@@ -858,7 +1138,7 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_CECEN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* CEC */
 
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_CLK_ENABLE()             do { \
@@ -868,7 +1148,7 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_UCPD1EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* UCPD1 */
 
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_CLK_ENABLE()             do { \
@@ -878,7 +1158,27 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_UCPD2EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* UCPD2 */
+
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_CLK_ENABLE()               do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_USBEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_USBEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0U)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_CLK_ENABLE()            do { \
+                                                 __IO uint32_t tmpreg; \
+                                                 SET_BIT(RCC->APBENR1, RCC_APBENR1_FDCANEN); \
+                                                 /* Delay after an RCC peripheral clock enabling */ \
+                                                 tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_FDCANEN); \
+                                                 UNUSED(tmpreg); \
+                                               } while(0)
+#endif /* FDCAN1 || FDCAN2 */
 
 #define __HAL_RCC_DBGMCU_CLK_ENABLE()             do { \
                                                  __IO uint32_t tmpreg; \
@@ -904,7 +1204,7 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_DAC1EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* DAC1 */
 
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_CLK_ENABLE()          do { \
@@ -914,7 +1214,7 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_LPTIM2EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* LPTIM2 */
 
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_CLK_ENABLE()          do { \
@@ -924,7 +1224,7 @@ typedef struct
                                                  tmpreg = READ_BIT(RCC->APBENR1, RCC_APBENR1_LPTIM1EN); \
                                                  UNUSED(tmpreg); \
                                                } while(0U)
-#endif
+#endif /* LPTIM1 */
 
 /**
   * @}
@@ -1014,16 +1314,25 @@ typedef struct
 
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_TIM2EN)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_TIM3EN)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_TIM4EN)
+#endif /* TIM4 */
 #if defined(TIM6)
 #define __HAL_RCC_TIM6_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_TIM6EN)
 #endif /* TIM6 */
 #if defined(TIM7)
 #define __HAL_RCC_TIM7_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_TIM7EN)
 #endif /* TIM7 */
+#if defined(CRS)
+#define __HAL_RCC_CRS_CLK_DISABLE()            CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_CRSEN);
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_RTCAPBEN)
 #define __HAL_RCC_SPI2_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_SPI2EN)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_SPI3EN)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_USART2EN)
 #if defined(USART3)
 #define __HAL_RCC_USART3_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_USART3EN)
@@ -1031,11 +1340,23 @@ typedef struct
 #if defined(USART4)
 #define __HAL_RCC_USART4_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_USART4EN)
 #endif /* USART4 */
+#if defined(USART5)
+#define __HAL_RCC_USART5_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_USART5EN)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_USART6EN)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_DISABLE()        CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_LPUART1EN)
 #endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_CLK_DISABLE()        CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_LPUART2EN)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_I2C1EN)
 #define __HAL_RCC_I2C2_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_I2C2EN)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_CLK_DISABLE()           CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_I2C3EN)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_CLK_DISABLE()            CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_CECEN)
 #endif /* CEC */
@@ -1045,6 +1366,12 @@ typedef struct
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_CLK_DISABLE()          CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_UCPD2EN)
 #endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_CLK_DISABLE()             CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_USBEN)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_CLK_DISABLE()          CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_FDCANEN)
+#endif /* FDCAN1 || FDCAN2 */
 #define __HAL_RCC_DBGMCU_CLK_DISABLE()         CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_DBGEN)
 #define __HAL_RCC_PWR_CLK_DISABLE()            CLEAR_BIT(RCC->APBENR1, RCC_APBENR1_PWREN)
 #if defined(DAC1)
@@ -1081,6 +1408,9 @@ typedef struct
   */
 
 #define __HAL_RCC_DMA1_IS_CLK_ENABLED()        (READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA1EN)  != RESET)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_IS_CLK_ENABLED()        (READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA2EN)  != RESET)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_IS_CLK_ENABLED()       (READ_BIT(RCC->AHBENR, RCC_AHBENR_FLASHEN) != RESET)
 #define __HAL_RCC_CRC_IS_CLK_ENABLED()         (READ_BIT(RCC->AHBENR, RCC_AHBENR_CRCEN)   != RESET)
 #if defined(RNG)
@@ -1091,6 +1421,9 @@ typedef struct
 #endif /* AES */
 
 #define __HAL_RCC_DMA1_IS_CLK_DISABLED()       (READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA1EN)  == RESET)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_IS_CLK_DISABLED()       (READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA2EN)  == RESET)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_IS_CLK_DISABLED()      (READ_BIT(RCC->AHBENR, RCC_AHBENR_FLASHEN) == RESET)
 #define __HAL_RCC_CRC_IS_CLK_DISABLED()        (READ_BIT(RCC->AHBENR, RCC_AHBENR_CRCEN)   == RESET)
 #if defined(RNG)
@@ -1114,6 +1447,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_IS_CLK_ENABLED()       (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOBEN) != RESET)
 #define __HAL_RCC_GPIOC_IS_CLK_ENABLED()       (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOCEN) != RESET)
 #define __HAL_RCC_GPIOD_IS_CLK_ENABLED()       (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIODEN) != RESET)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_IS_CLK_ENABLED()       (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOEEN) != RESET)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_IS_CLK_ENABLED()       (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOFEN) != RESET)
 
 
@@ -1121,6 +1457,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_IS_CLK_DISABLED()      (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOBEN) == RESET)
 #define __HAL_RCC_GPIOC_IS_CLK_DISABLED()      (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOCEN) == RESET)
 #define __HAL_RCC_GPIOD_IS_CLK_DISABLED()      (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIODEN) == RESET)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_IS_CLK_DISABLED()      (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOEEN) == RESET)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_IS_CLK_DISABLED()      (READ_BIT(RCC->IOPENR, RCC_IOPENR_GPIOFEN) == RESET)
 
 /**
@@ -1137,78 +1476,132 @@ typedef struct
 
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM2EN)   != 0U)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM3EN)   != 0U)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM4EN)   != 0U)
+#endif /* TIM4 */
 #define __HAL_RCC_TIM6_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM6EN)   != 0U)
 #define __HAL_RCC_TIM7_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM7EN)   != 0U)
+#if defined(CRS)
+#define __HAL_RCC_CRS_IS_CLK_ENABLED()         (READ_BIT(RCC->APBENR1, RCC_APBENR1_CRSEN)    != 0U)
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_RTCAPBEN) != 0U)
 #define __HAL_RCC_WWDG_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_WWDGEN)   != 0U)
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_IS_CLK_ENABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_FDCANEN)  != 0U)
+#endif /* FDCAN1 || FDCAN2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_IS_CLK_ENABLED()         (READ_BIT(RCC->APBENR1, RCC_APBENR1_USBEN)  != 0U)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
 #define __HAL_RCC_SPI2_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_SPI2EN)   != 0U)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_SPI3EN)   != 0U)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART2EN) != 0U)
 #define __HAL_RCC_USART3_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART3EN) != 0U)
 #define __HAL_RCC_USART4_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART4EN) != 0U)
+#if defined(USART5)
+#define __HAL_RCC_USART5_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART5EN) != 0U)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART6EN) != 0U)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_IS_CLK_ENABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPUART1EN)!= 0U)
-#endif
+#endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_IS_CLK_ENABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPUART2EN)!= 0U)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C1EN)   != 0U)
 #define __HAL_RCC_I2C2_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C2EN)   != 0U)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C3EN)   != 0U)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_IS_CLK_ENABLED()         (READ_BIT(RCC->APBENR1, RCC_APBENR1_CECEN)    != 0U)
-#endif
+#endif /* CEC */
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_IS_CLK_ENABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_UCPD1EN)  != 0U)
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_IS_CLK_ENABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_UCPD2EN)  != 0U)
-#endif
+#endif /* UCPD2 */
 #define __HAL_RCC_DBGMCU_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_DBGEN)    != 0U)
 #define __HAL_RCC_PWR_IS_CLK_ENABLED()         (READ_BIT(RCC->APBENR1, RCC_APBENR1_PWREN)    != 0U)
 #if defined(DAC1)
 #define __HAL_RCC_DAC1_IS_CLK_ENABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_DAC1EN)   != 0U)
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPTIM2EN) != 0U)
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_IS_CLK_ENABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPTIM1EN) != 0U)
-#endif
+#endif /* LPTIM1 */
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM2EN)   == 0U)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM3EN)   == 0U)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM4EN)   == 0U)
+#endif /* TIM4 */
 #define __HAL_RCC_TIM6_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM6EN)   == 0U)
 #define __HAL_RCC_TIM7_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_TIM7EN)   == 0U)
+#if defined(CRS)
+#define __HAL_RCC_CRS_IS_CLK_DISABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_CRSEN)    == 0U)
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_RTCAPBEN) == 0U)
 #define __HAL_RCC_WWDG_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_WWDGEN)   == 0U)
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_IS_CLK_DISABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_FDCANEN)  == 0U)
+#endif /* FDCAN1 || FDCAN2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_IS_CLK_DISABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_USBEN)  == 0U)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
 #define __HAL_RCC_SPI2_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_SPI2EN)   == 0U)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_SPI3EN)   == 0U)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART2EN) == 0U)
 #define __HAL_RCC_USART3_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART3EN) == 0U)
 #define __HAL_RCC_USART4_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART4EN) == 0U)
+#if defined(USART5)
+#define __HAL_RCC_USART5_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART5EN) == 0U)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_USART6EN) == 0U)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_IS_CLK_DISABLED()    (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPUART1EN)== 0U)
-#endif
+#endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_IS_CLK_DISABLED()    (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPUART2EN)== 0U)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C1EN)   == 0U)
 #define __HAL_RCC_I2C2_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C2EN)   == 0U)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_I2C3EN)   == 0U)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_IS_CLK_DISABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_CECEN)    == 0U)
-#endif
+#endif /* CEC */
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_IS_CLK_DISABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_UCPD1EN)  == 0U)
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_IS_CLK_DISABLED()      (READ_BIT(RCC->APBENR1, RCC_APBENR1_UCPD2EN)  == 0U)
-#endif
+#endif /* UCPD2 */
 #define __HAL_RCC_DBGMCU_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_DBGEN)    == 0U)
 #define __HAL_RCC_PWR_IS_CLK_DISABLED()        (READ_BIT(RCC->APBENR1, RCC_APBENR1_PWREN)    == 0U)
 #if defined(DAC1)
 #define __HAL_RCC_DAC1_IS_CLK_DISABLED()       (READ_BIT(RCC->APBENR1, RCC_APBENR1_DAC1EN)   == 0U)
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPTIM2EN) == 0U)
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_IS_CLK_DISABLED()     (READ_BIT(RCC->APBENR1, RCC_APBENR1_LPTIM1EN) == 0U)
-#endif
+#endif /* LPTIM1 */
 
 /**
   * @}
@@ -1256,6 +1649,9 @@ typedef struct
   */
 #define __HAL_RCC_AHB_FORCE_RESET()            WRITE_REG(RCC->AHBRSTR, 0xFFFFFFFFU)
 #define __HAL_RCC_DMA1_FORCE_RESET()           SET_BIT(RCC->AHBRSTR, RCC_AHBRSTR_DMA1RST)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_FORCE_RESET()           SET_BIT(RCC->AHBRSTR, RCC_AHBRSTR_DMA2RST)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_FORCE_RESET()          SET_BIT(RCC->AHBRSTR, RCC_AHBRSTR_FLASHRST)
 #define __HAL_RCC_CRC_FORCE_RESET()            SET_BIT(RCC->AHBRSTR, RCC_AHBRSTR_CRCRST)
 #if defined(RNG)
@@ -1267,6 +1663,9 @@ typedef struct
 
 #define __HAL_RCC_AHB_RELEASE_RESET()          WRITE_REG(RCC->AHBRSTR, 0x00000000U)
 #define __HAL_RCC_DMA1_RELEASE_RESET()         CLEAR_BIT(RCC->AHBRSTR, RCC_AHBRSTR_DMA1RST)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_RELEASE_RESET()         CLEAR_BIT(RCC->AHBRSTR, RCC_AHBRSTR_DMA2RST)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_RELEASE_RESET()        CLEAR_BIT(RCC->AHBRSTR, RCC_AHBRSTR_FLASHRST)
 #define __HAL_RCC_CRC_RELEASE_RESET()          CLEAR_BIT(RCC->AHBRSTR, RCC_AHBRSTR_CRCRST)
 #if defined(RNG)
@@ -1288,6 +1687,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_FORCE_RESET()          SET_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOBRST)
 #define __HAL_RCC_GPIOC_FORCE_RESET()          SET_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOCRST)
 #define __HAL_RCC_GPIOD_FORCE_RESET()          SET_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIODRST)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_FORCE_RESET()          SET_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOERST)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_FORCE_RESET()          SET_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOFRST)
 
 #define __HAL_RCC_IOP_RELEASE_RESET()          WRITE_REG(RCC->IOPRSTR, 0x00000000U)
@@ -1295,6 +1697,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_RELEASE_RESET()        CLEAR_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOBRST)
 #define __HAL_RCC_GPIOC_RELEASE_RESET()        CLEAR_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOCRST)
 #define __HAL_RCC_GPIOD_RELEASE_RESET()        CLEAR_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIODRST)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_RELEASE_RESET()        CLEAR_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOERST)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_RELEASE_RESET()        CLEAR_BIT(RCC->IOPRSTR, RCC_IOPRSTR_GPIOFRST)
 
 /**
@@ -1309,75 +1714,129 @@ typedef struct
 
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM2RST)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM3RST)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM4RST)
+#endif /* TIM4 */
 #define __HAL_RCC_TIM6_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM6RST)
 #define __HAL_RCC_TIM7_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM7RST)
+#if defined(CRS)
+#define __HAL_RCC_CRS_FORCE_RESET()            SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_CRSRST)
+#endif /* CRS */
 #define __HAL_RCC_SPI2_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_SPI2RST)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_SPI3RST)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART2RST)
 #define __HAL_RCC_USART3_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART3RST)
 #define __HAL_RCC_USART4_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART4RST)
+#if defined(USART5)
+#define __HAL_RCC_USART5_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART5RST)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART6RST)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_FORCE_RESET()        SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPUART1RST)
-#endif
+#endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_FORCE_RESET()        SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPUART2RST)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_I2C1RST)
 #define __HAL_RCC_I2C2_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_I2C2RST)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_I2C3RST)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_FORCE_RESET()            SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_CECRST)
-#endif
+#endif /* CEC */
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_FORCE_RESET()          SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_UCPD1RST)
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_FORCE_RESET()          SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_UCPD2RST)
-#endif
+#endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_FORCE_RESET()            SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USBRST)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_FORCE_RESET()          SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_FDCANRST)
+#endif /* FDCAN1 || FDCAN2 */
 #define __HAL_RCC_DBGMCU_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_DBGRST)
 #define __HAL_RCC_PWR_FORCE_RESET()            SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_PWRRST)
 #if defined(DAC1)
 #define __HAL_RCC_DAC1_FORCE_RESET()           SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_DAC1RST)
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPTIM2RST)
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_FORCE_RESET()         SET_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPTIM1RST)
-#endif
+#endif /* LPTIM1 */
 #define __HAL_RCC_APB1_RELEASE_RESET()         WRITE_REG(RCC->APBRSTR1, 0x00000000U)
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM2RST)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM3RST)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM4RST)
+#endif /* TIM4 */
 #define __HAL_RCC_TIM6_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM6RST)
 #define __HAL_RCC_TIM7_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_TIM7RST)
+#if defined(CRS)
+#define __HAL_RCC_CRS_RELEASE_RESET()          CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_CRSRST)
+#endif /* CRS */
 #define __HAL_RCC_SPI2_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_SPI2RST)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_SPI3RST)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART2RST)
 #define __HAL_RCC_USART3_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART3RST)
 #define __HAL_RCC_USART4_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART4RST)
+#if defined(USART5)
+#define __HAL_RCC_USART5_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART5RST)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USART6RST)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_RELEASE_RESET()      CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPUART1RST)
-#endif
+#endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_RELEASE_RESET()      CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPUART2RST)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_I2C1RST)
 #define __HAL_RCC_I2C2_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_I2C2RST)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_I2C3RST)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_RELEASE_RESET()          CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_CECRST)
-#endif
+#endif /* CEC */
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_RELEASE_RESET()        CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_UCPD1RST)
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_RELEASE_RESET()        CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_UCPD2RST)
-#endif
+#endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_RELEASE_RESET()          CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_USBRST)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_RELEASE_RESET()        CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_FDCANRST)
+#endif /* FDCAN1 || FDCAN2 */
 #define __HAL_RCC_DBGMCU_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_DBGRST)
 #define __HAL_RCC_PWR_RELEASE_RESET()          CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_PWRRST)
 #if defined(DAC1)
 #define __HAL_RCC_DAC1_RELEASE_RESET()         CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_DAC1RST)
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPTIM2RST)
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_RELEASE_RESET()       CLEAR_BIT(RCC->APBRSTR1, RCC_APBRSTR1_LPTIM1RST)
-#endif
+#endif /* LPTIM1 */
 /**
   * @}
   */
@@ -1426,6 +1885,9 @@ typedef struct
   */
 
 #define __HAL_RCC_DMA1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA1SMEN)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA2SMEN)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_CLK_SLEEP_ENABLE()     SET_BIT(RCC->AHBSMENR, RCC_AHBSMENR_FLASHSMEN)
 #define __HAL_RCC_SRAM_CLK_SLEEP_ENABLE()      SET_BIT(RCC->AHBSMENR, RCC_AHBSMENR_SRAMSMEN)
 #define __HAL_RCC_CRC_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHBSMENR, RCC_AHBSMENR_CRCSMEN)
@@ -1436,6 +1898,9 @@ typedef struct
 #define __HAL_RCC_AES_CLK_SLEEP_ENABLE()       SET_BIT(RCC->AHBSMENR, RCC_AHBSMENR_AESSMEN)
 #endif /* AES */
 #define __HAL_RCC_DMA1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA1SMEN)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA2SMEN)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->AHBSMENR, RCC_AHBSMENR_FLASHSMEN)
 #define __HAL_RCC_SRAM_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->AHBSMENR, RCC_AHBSMENR_SRAMSMEN)
 #define __HAL_RCC_CRC_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->AHBSMENR, RCC_AHBSMENR_CRCSMEN)
@@ -1463,12 +1928,18 @@ typedef struct
 #define __HAL_RCC_GPIOB_CLK_SLEEP_ENABLE()     SET_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOBSMEN)
 #define __HAL_RCC_GPIOC_CLK_SLEEP_ENABLE()     SET_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOCSMEN)
 #define __HAL_RCC_GPIOD_CLK_SLEEP_ENABLE()     SET_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIODSMEN)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_CLK_SLEEP_ENABLE()     SET_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOESMEN)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_CLK_SLEEP_ENABLE()     SET_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOFSMEN)
 
 #define __HAL_RCC_GPIOA_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOASMEN)
 #define __HAL_RCC_GPIOB_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOBSMEN)
 #define __HAL_RCC_GPIOC_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOCSMEN)
 #define __HAL_RCC_GPIOD_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIODSMEN)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOESMEN)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOFSMEN)
 /**
   *   @}
@@ -1484,78 +1955,132 @@ typedef struct
   */
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM2SMEN)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM3SMEN)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM4SMEN)
+#endif /* TIM4 */
 #define __HAL_RCC_TIM6_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM6SMEN)
 #define __HAL_RCC_TIM7_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM7SMEN)
+#if defined(CRS)
+#define __HAL_RCC_CRS_CLK_SLEEP_ENABLE()       SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CRSSMEN)
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_RTCAPBSMEN)
 #define __HAL_RCC_WWDG_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_WWDGSMEN)
 #define __HAL_RCC_SPI2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI2SMEN)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI3SMEN)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART2SMEN)
 #define __HAL_RCC_USART3_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART3SMEN)
 #define __HAL_RCC_USART4_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART4SMEN)
+#if defined(USART5)
+#define __HAL_RCC_USART5_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART5SMEN)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART6SMEN)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_SLEEP_ENABLE()   SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART1SMEN)
-#endif
+#endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_CLK_SLEEP_ENABLE()   SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART2SMEN)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C1SMEN)
 #define __HAL_RCC_I2C2_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C2SMEN)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C3SMEN)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_CLK_SLEEP_ENABLE()       SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CECSMEN)
-#endif
+#endif /* CEC */
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_UCPD1SMEN)
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_UCPD2SMEN)
-#endif
+#endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_CLK_SLEEP_ENABLE()       SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USBSMEN)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_CLK_SLEEP_ENABLE()     SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_FDCANSMEN)
+#endif /* FDCAN1 || FDCAN2 */
 #define __HAL_RCC_DBGMCU_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_DBGSMEN)
 #define __HAL_RCC_PWR_CLK_SLEEP_ENABLE()       SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_PWRSMEN)
 #if defined(DAC1)
 #define __HAL_RCC_DAC1_CLK_SLEEP_ENABLE()      SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_DAC1SMEN)
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPTIM2SMEN)
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_CLK_SLEEP_ENABLE()    SET_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPTIM1SMEN)
-#endif
+#endif /* LPTIM1 */
 #if defined(TIM2)
 #define __HAL_RCC_TIM2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM2SMEN)
-#endif
+#endif /* TIM2 */
 #define __HAL_RCC_TIM3_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM3SMEN)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM4SMEN)
+#endif /* TIM4 */
 #define __HAL_RCC_TIM6_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM6SMEN)
 #define __HAL_RCC_TIM7_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM7SMEN)
+#if defined(CRS)
+#define __HAL_RCC_CRS_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CRSSMEN)
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_RTCAPBSMEN)
 #define __HAL_RCC_WWDG_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_WWDGSMEN)
 #define __HAL_RCC_SPI2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI2SMEN)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI3SMEN)
+#endif /* TIM2 */
 #define __HAL_RCC_USART2_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART2SMEN)
 #define __HAL_RCC_USART3_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART3SMEN)
 #define __HAL_RCC_USART4_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART4SMEN)
+#if defined(USART5)
+#define __HAL_RCC_USART5_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART5SMEN)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART6SMEN)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_SLEEP_DISABLE()  CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART1SMEN)
-#endif
+#endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_CLK_SLEEP_DISABLE()  CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART2SMEN)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C1SMEN)
 #define __HAL_RCC_I2C2_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C2SMEN)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C3SMEN)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CECSMEN)
-#endif
+#endif /* CEC */
 #if defined(UCPD1)
 #define __HAL_RCC_UCPD1_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_UCPD1SMEN)
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_UCPD2SMEN)
-#endif
+#endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USBSMEN)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_CLK_SLEEP_DISABLE()    CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_FDCANSMEN)
+#endif /* FDCAN1) || FDCAN2 */
 #define __HAL_RCC_DBGMCU_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_DBGSMEN)
 #define __HAL_RCC_PWR_CLK_SLEEP_DISABLE()      CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_PWRSMEN)
 #if defined(DAC1)
 #define __HAL_RCC_DAC1_CLK_SLEEP_DISABLE()     CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_DAC1SMEN)
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define __HAL_RCC_LPTIM2_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPTIM2SMEN)
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define __HAL_RCC_LPTIM1_CLK_SLEEP_DISABLE()   CLEAR_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPTIM1SMEN)
-#endif
+#endif /* LPTIM1 */
 /**
   * @}
   */
@@ -1607,6 +2132,9 @@ typedef struct
   */
 
 #define __HAL_RCC_DMA1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA1SMEN) != RESET)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA2SMEN) != RESET)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_FLASHSMEN)!= RESET)
 #define __HAL_RCC_SRAM_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_SRAMSMEN) != RESET)
 #define __HAL_RCC_CRC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_CRCSMEN)  != RESET)
@@ -1617,6 +2145,9 @@ typedef struct
 #define __HAL_RCC_AES_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_AESSMEN)  != RESET)
 #endif /* AES */
 #define __HAL_RCC_DMA1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA1SMEN)  == RESET)
+#if defined(DMA2)
+#define __HAL_RCC_DMA2_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_DMA2SMEN)  == RESET)
+#endif /* DMA2 */
 #define __HAL_RCC_FLASH_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_FLASHSMEN) == RESET)
 #define __HAL_RCC_SRAM_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_SRAMSMEN)  == RESET)
 #define __HAL_RCC_CRC_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->AHBSMENR, RCC_AHBSMENR_CRCSMEN)   == RESET)
@@ -1645,6 +2176,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOBSMEN)!= RESET)
 #define __HAL_RCC_GPIOC_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOCSMEN)!= RESET)
 #define __HAL_RCC_GPIOD_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIODSMEN)!= RESET)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOESMEN)!= RESET)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOFSMEN)!= RESET)
 
 
@@ -1653,6 +2187,9 @@ typedef struct
 #define __HAL_RCC_GPIOB_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOBSMEN) == RESET)
 #define __HAL_RCC_GPIOC_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOCSMEN) == RESET)
 #define __HAL_RCC_GPIOD_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIODSMEN) == RESET)
+#if defined(GPIOE)
+#define __HAL_RCC_GPIOE_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOESMEN) == RESET)
+#endif /* GPIOE */
 #define __HAL_RCC_GPIOF_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->IOPSMENR, RCC_IOPSMENR_GPIOFSMEN) == RESET)
 
 /**
@@ -1671,15 +2208,24 @@ typedef struct
 #define __HAL_RCC_TIM2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM2SMEN)   != RESET)
 #endif /* TIM2 */
 #define __HAL_RCC_TIM3_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM3SMEN)   != RESET)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM4SMEN)   != RESET)
+#endif /* TIM4 */
 #if defined(TIM6)
 #define __HAL_RCC_TIM6_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM6SMEN)   != RESET)
 #endif /* TIM6 */
 #if defined(TIM7)
 #define __HAL_RCC_TIM7_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM7SMEN)   != RESET)
 #endif /* TIM7 */
+#if defined(CRS)
+#define __HAL_RCC_CRS_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CRSSMEN)    != RESET)
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_RTCAPBSMEN) != RESET)
 #define __HAL_RCC_WWDG_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_WWDGSMEN)   != RESET)
 #define __HAL_RCC_SPI2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI2SMEN)   != RESET)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI3SMEN)   != RESET)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART2SMEN) != RESET)
 #if defined(USART3)
 #define __HAL_RCC_USART3_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART3SMEN) != RESET)
@@ -1687,11 +2233,23 @@ typedef struct
 #if defined(USART4)
 #define __HAL_RCC_USART4_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART4SMEN) != RESET)
 #endif /* USART4 */
+#if defined(USART5)
+#define __HAL_RCC_USART5_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART5SMEN) != RESET)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART6SMEN) != RESET)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART1SMEN)!= RESET)
 #endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART2SMEN)!= RESET)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C1SMEN)   != RESET)
 #define __HAL_RCC_I2C2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C2SMEN)   != RESET)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C3SMEN)   != RESET)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CECSMEN)    != RESET)
 #endif /* CEC */
@@ -1701,6 +2259,12 @@ typedef struct
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_UCPD2SMEN)  != RESET)
 #endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USBSMEN)  != RESET)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_FDCANSMEN)  != RESET)
+#endif /* FDCAN1 || FDCAN2 */
 #define __HAL_RCC_DBGMCU_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_DBGSMEN)    != RESET)
 #define __HAL_RCC_PWR_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_PWRSMEN)    != RESET)
 #if defined(DAC1)
@@ -1716,15 +2280,24 @@ typedef struct
 #define __HAL_RCC_TIM2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM2SMEN)   == RESET)
 #endif /* TIM2 */
 #define __HAL_RCC_TIM3_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM3SMEN)   == RESET)
+#if defined(TIM4)
+#define __HAL_RCC_TIM4_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM4SMEN)   == RESET)
+#endif /* TIM4 */
 #if defined(TIM6)
 #define __HAL_RCC_TIM6_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM6SMEN)   == RESET)
 #endif /* TIM6 */
 #if defined(TIM7)
 #define __HAL_RCC_TIM7_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_TIM7SMEN)   == RESET)
-#endif /* TIM6 */
+#endif /* TIM7 */
+#if defined(CRS)
+#define __HAL_RCC_CRS_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CRSSMEN)    == RESET)
+#endif /* CRS */
 #define __HAL_RCC_RTCAPB_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_RTCAPBSMEN) == RESET)
 #define __HAL_RCC_WWDG_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_WWDGSMEN)   == RESET)
 #define __HAL_RCC_SPI2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI2SMEN)   == RESET)
+#if defined(SPI3)
+#define __HAL_RCC_SPI3_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_SPI3SMEN)   == RESET)
+#endif /* SPI3 */
 #define __HAL_RCC_USART2_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART2SMEN) == RESET)
 #if defined(USART3)
 #define __HAL_RCC_USART3_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART3SMEN) == RESET)
@@ -1732,11 +2305,23 @@ typedef struct
 #if defined(USART4)
 #define __HAL_RCC_USART4_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART4SMEN) == RESET)
 #endif /* USART4 */
+#if defined(USART5)
+#define __HAL_RCC_USART5_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART5SMEN) == RESET)
+#endif /* USART5 */
+#if defined(USART6)
+#define __HAL_RCC_USART6_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USART6SMEN) == RESET)
+#endif /* USART6 */
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART1SMEN)== RESET)
 #endif /* LPUART1 */
+#if defined(LPUART2)
+#define __HAL_RCC_LPUART2_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_LPUART2SMEN)== RESET)
+#endif /* LPUART2 */
 #define __HAL_RCC_I2C1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C1SMEN)   == RESET)
 #define __HAL_RCC_I2C2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C2SMEN)   == RESET)
+#if defined(I2C3)
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_I2C3SMEN)   == RESET)
+#endif /* I2C3 */
 #if defined(CEC)
 #define __HAL_RCC_CEC_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_CECSMEN)    == RESET)
 #endif /* CEC */
@@ -1746,6 +2331,12 @@ typedef struct
 #if defined(UCPD2)
 #define __HAL_RCC_UCPD2_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_UCPD2SMEN)  == RESET)
 #endif /* UCPD2 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define __HAL_RCC_USB_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_USBSMEN)  == RESET)
+#endif /* STM32G0B0xx || STM32G0B1xx || STM32G0C1xx */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define __HAL_RCC_FDCAN_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_FDCANSMEN)  == RESET)
+#endif /* FDCAN1 || FDCAN2 */
 #define __HAL_RCC_DBGMCU_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_DBGSMEN)    == RESET)
 #define __HAL_RCC_PWR_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APBSMENR1, RCC_APBSMENR1_PWRSMEN)    == RESET)
 #if defined(DAC1)
@@ -1778,7 +2369,7 @@ typedef struct
 #define __HAL_RCC_TIM14_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM14SMEN)  != RESET)
 #if defined(TIM15)
 #define __HAL_RCC_TIM15_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM15SMEN)  != RESET)
-#endif
+#endif /* TIM15 */
 #define __HAL_RCC_TIM16_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM16SMEN)  != RESET)
 #define __HAL_RCC_TIM17_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM17SMEN)  != RESET)
 #define __HAL_RCC_ADC_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_ADCSMEN)    != RESET)
@@ -1791,7 +2382,7 @@ typedef struct
 #define __HAL_RCC_TIM14_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM14SMEN)  == RESET)
 #if defined(TIM15)
 #define __HAL_RCC_TIM15_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM15SMEN)  == RESET)
-#endif
+#endif /* TIM15 */
 #define __HAL_RCC_TIM16_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM16SMEN)  == RESET)
 #define __HAL_RCC_TIM17_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_TIM17SMEN)  == RESET)
 #define __HAL_RCC_ADC_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APBSMENR2 , RCC_APBSMENR2_ADCSMEN)    == RESET)
@@ -1875,7 +2466,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICALIBRATIONVALUE__) \
-                  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, (uint32_t)(__HSICALIBRATIONVALUE__) << RCC_ICSCR_HSITRIM_Pos)
+  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, (uint32_t)(__HSICALIBRATIONVALUE__) << RCC_ICSCR_HSITRIM_Pos)
 
 /**
   * @brief    Macros to enable or disable the force of the Internal High Speed oscillator (HSI)
@@ -1903,7 +2494,7 @@ typedef struct
   *            @arg @ref RCC_HSI_DIV128 HSI clock source is divided by 128
   */
 #define __HAL_RCC_HSI_CONFIG(__HSIDIV__) \
-                 MODIFY_REG(RCC->CR, RCC_CR_HSIDIV, (__HSIDIV__))
+  MODIFY_REG(RCC->CR, RCC_CR_HSIDIV, (__HSIDIV__))
 
 /** @brief  Macros to enable or disable the Internal Low Speed oscillator (LSI).
   * @note   After enabling the LSI, the application software should wait on
@@ -1941,23 +2532,22 @@ typedef struct
   *            @arg @ref RCC_HSE_BYPASS  HSE oscillator bypassed with external clock.
   * @retval None
   */
-#define __HAL_RCC_HSE_CONFIG(__STATE__)                      \
-                    do {                                     \
-                      if((__STATE__) == RCC_HSE_ON)          \
-                      {                                      \
-                        SET_BIT(RCC->CR, RCC_CR_HSEON);      \
-                      }                                      \
-                      else if((__STATE__) == RCC_HSE_BYPASS) \
-                      {                                      \
-                        SET_BIT(RCC->CR, RCC_CR_HSEBYP);     \
-                        SET_BIT(RCC->CR, RCC_CR_HSEON);      \
-                      }                                      \
-                      else                                   \
-                      {                                      \
-                        CLEAR_BIT(RCC->CR, RCC_CR_HSEON);    \
-                        CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);   \
-                      }                                      \
-                    } while(0U)
+#define __HAL_RCC_HSE_CONFIG(__STATE__)  do {                                        \
+                                              if((__STATE__) == RCC_HSE_ON)          \
+                                              {                                      \
+                                                SET_BIT(RCC->CR, RCC_CR_HSEON);      \
+                                              }                                      \
+                                              else if((__STATE__) == RCC_HSE_BYPASS) \
+                                              {                                      \
+                                                SET_BIT(RCC->CR, RCC_CR_HSEBYP);     \
+                                                SET_BIT(RCC->CR, RCC_CR_HSEON);      \
+                                              }                                      \
+                                              else                                   \
+                                              {                                      \
+                                                CLEAR_BIT(RCC->CR, RCC_CR_HSEON);    \
+                                                CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);   \
+                                              }                                      \
+                                            } while(0U)
 
 /**
   * @brief  Macro to configure the External Low Speed oscillator (LSE).
@@ -1979,23 +2569,37 @@ typedef struct
   *            @arg @ref RCC_LSE_BYPASS  LSE oscillator bypassed with external clock.
   * @retval None
   */
-#define __HAL_RCC_LSE_CONFIG(__STATE__)                        \
-                    do {                                       \
-                      if((__STATE__) == RCC_LSE_ON)            \
-                      {                                        \
-                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
-                      }                                        \
-                      else if((__STATE__) == RCC_LSE_BYPASS)   \
-                      {                                        \
-                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEBYP);   \
-                        SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
-                      }                                        \
-                      else                                     \
-                      {                                        \
-                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);  \
-                        CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEBYP); \
-                      }                                        \
-                    } while(0U)
+#define __HAL_RCC_LSE_CONFIG(__STATE__)  do {                                          \
+                                              if((__STATE__) == RCC_LSE_ON)            \
+                                              {                                        \
+                                                SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                                              }                                        \
+                                              else if((__STATE__) == RCC_LSE_BYPASS)   \
+                                              {                                        \
+                                                SET_BIT(RCC->BDCR, RCC_BDCR_LSEBYP);   \
+                                                SET_BIT(RCC->BDCR, RCC_BDCR_LSEON);    \
+                                              }                                        \
+                                              else                                     \
+                                              {                                        \
+                                                CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEON);  \
+                                                CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEBYP); \
+                                              }                                        \
+                                            } while(0U)
+
+#if defined(RCC_HSI48_SUPPORT)
+/** @brief  Macros to enable or disable the Internal High Speed 48MHz oscillator (HSI48).
+  * @note   The HSI48 is stopped by hardware when entering STOP and STANDBY modes.
+  * @note   After enabling the HSI48, the application software should wait on HSI48RDY
+  *         flag to be set indicating that HSI48 clock is stable.
+  *         This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+#define __HAL_RCC_HSI48_ENABLE()  SET_BIT(RCC->CR, RCC_CR_HSI48ON)
+
+#define __HAL_RCC_HSI48_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_HSI48ON)
+
+#endif /* RCC_HSI48_SUPPORT */
+
 /**
   * @}
   */
@@ -2029,7 +2633,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_RTC_CONFIG(__RTC_CLKSOURCE__)  \
-                  MODIFY_REG( RCC->BDCR, RCC_BDCR_RTCSEL, (__RTC_CLKSOURCE__))
+  MODIFY_REG( RCC->BDCR, RCC_BDCR_RTCSEL, (__RTC_CLKSOURCE__))
 
 
 /** @brief Macro to get the RTC clock source.
@@ -2073,7 +2677,7 @@ typedef struct
   *
   */
 #define __HAL_RCC_PLL_PLLSOURCE_CONFIG(__PLLSOURCE__) \
-                  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (__PLLSOURCE__))
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (__PLLSOURCE__))
 
 /** @brief  Macro to configure the PLL multiplication factor.
   * @note   This function must be used only when the main PLL is disabled.
@@ -2086,7 +2690,7 @@ typedef struct
   *
   */
 #define __HAL_RCC_PLL_PLLM_CONFIG(__PLLM__) \
-                  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLM, (__PLLM__))
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLM, (__PLLM__))
 
 /**
   * @brief  Macro to configure the main PLL clock source, multiplication and division factors.
@@ -2127,33 +2731,26 @@ typedef struct
   */
 #if defined(RCC_PLLQ_SUPPORT)
 #define __HAL_RCC_PLL_CONFIG(__PLLSOURCE__, __PLLM__, __PLLN__, __PLLP__, __PLLQ__,__PLLR__ ) \
-                  MODIFY_REG( RCC->PLLCFGR,                                                   \
-                             (RCC_PLLCFGR_PLLSRC                              |               \
-                              RCC_PLLCFGR_PLLM                                |               \
-                              RCC_PLLCFGR_PLLN                                |               \
-                              RCC_PLLCFGR_PLLP                                |               \
-                              RCC_PLLCFGR_PLLQ                                |               \
-                              RCC_PLLCFGR_PLLR),                                              \
-                             ((uint32_t) (__PLLSOURCE__)                      |               \
-                              (uint32_t) (__PLLM__)                           |               \
-                              (uint32_t) ((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) |               \
-                              (uint32_t) (__PLLP__)                           |               \
-                              (uint32_t) (__PLLQ__)                           |               \
-                              (uint32_t) (__PLLR__)))
+  MODIFY_REG(RCC->PLLCFGR,                                                   \
+             (RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN |     \
+              RCC_PLLCFGR_PLLP   | RCC_PLLCFGR_PLLQ | RCC_PLLCFGR_PLLR),     \
+              ((uint32_t) (__PLLSOURCE__)                      |             \
+               (uint32_t) (__PLLM__)                           |             \
+               (uint32_t) ((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) |             \
+               (uint32_t) (__PLLP__)                           |             \
+               (uint32_t) (__PLLQ__)                           |             \
+               (uint32_t) (__PLLR__)))
 #else
 #define __HAL_RCC_PLL_CONFIG(__PLLSOURCE__, __PLLM__, __PLLN__, __PLLP__, __PLLR__ ) \
-                  MODIFY_REG( RCC->PLLCFGR,                                                   \
-                             (RCC_PLLCFGR_PLLSRC                              |               \
-                              RCC_PLLCFGR_PLLM                                |               \
-                              RCC_PLLCFGR_PLLN                                |               \
-                              RCC_PLLCFGR_PLLP                                |               \
-                              RCC_PLLCFGR_PLLR),                                              \
-                             ((uint32_t) (__PLLSOURCE__)                      |               \
-                              (uint32_t) (__PLLM__)                           |               \
-                              (uint32_t) ((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) |               \
-                              (uint32_t) (__PLLP__)                           |               \
-                              (uint32_t) (__PLLR__)))
-#endif
+  MODIFY_REG(RCC->PLLCFGR,                                                   \
+             (RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN |     \
+              RCC_PLLCFGR_PLLP | RCC_PLLCFGR_PLLR),                          \
+              ((uint32_t) (__PLLSOURCE__)                     |              \
+              (uint32_t) (__PLLM__)                           |              \
+              (uint32_t) ((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) |              \
+              (uint32_t) (__PLLP__)                           |              \
+              (uint32_t) (__PLLR__)))
+#endif /* RCC_PLLQ_SUPPORT */
 /** @brief  Macro to get the oscillator used as PLL clock source.
   * @retval The oscillator used as PLL clock source. The returned value can be one
   *         of the following:
@@ -2226,7 +2823,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_SYSCLK_CONFIG(__SYSCLKSOURCE__) \
-                  MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, (__SYSCLKSOURCE__))
+  MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, (__SYSCLKSOURCE__))
 
 /** @brief  Macro to get the clock source used as system clock.
   * @retval The clock source used as system clock. The returned value can be one
@@ -2254,9 +2851,9 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_LSEDRIVE_CONFIG(__LSEDRIVE__) \
-                  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSEDRV, (uint32_t)(__LSEDRIVE__))
+  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSEDRV, (uint32_t)(__LSEDRIVE__))
 
-/** @brief  Macro to configure the MCO clock.
+/** @brief  Macro to configure the Microcontroller output clock.
   * @param  __MCOCLKSOURCE__ specifies the MCO clock source.
   *          This parameter can be one of the following values:
   *            @arg @ref RCC_MCO1SOURCE_NOCLOCK  MCO output disabled
@@ -2266,16 +2863,62 @@ typedef struct
   *            @arg @ref RCC_MCO1SOURCE_PLLCLK  Main PLL clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_LSI LSI clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_LSE LSE clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_PLLPCLK PLLP output clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_PLLQCLK PLLQ output clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_RTCCLK RTC clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_RTC_WKUP RTC_WKUP clock selected as MCO source
+  @if STM32G0C1xx
+  *            @arg @ref RCC_MCO1SOURCE_HSI48  HSI48 clock selected as MCO source for devices with HSI48
+  @endif
   * @param  __MCODIV__ specifies the MCO clock prescaler.
   *          This parameter can be one of the following values:
-  *            @arg @ref RCC_MCODIV_1   MCO clock source is divided by 1
-  *            @arg @ref RCC_MCODIV_2   MCO clock source is divided by 2
-  *            @arg @ref RCC_MCODIV_4   MCO clock source is divided by 4
-  *            @arg @ref RCC_MCODIV_8   MCO clock source is divided by 8
-  *            @arg @ref RCC_MCODIV_16  MCO clock source is divided by 16
+  *            @arg @ref RCC_MCODIV_1    MCO clock source is divided by 1
+  *            @arg @ref RCC_MCODIV_2    MCO clock source is divided by 2
+  *            @arg @ref RCC_MCODIV_4    MCO clock source is divided by 4
+  *            @arg @ref RCC_MCODIV_8    MCO clock source is divided by 8
+  *            @arg @ref RCC_MCODIV_16   MCO clock source is divided by 16
+  *            @arg @ref RCC_MCODIV_32   MCO clock source is divided by 32
+  *            @arg @ref RCC_MCODIV_64   MCO clock source is divided by 128
+  *            @arg @ref RCC_MCODIV_128  MCO clock source is divided by 256
   */
 #define __HAL_RCC_MCO1_CONFIG(__MCOCLKSOURCE__, __MCODIV__) \
-                 MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE), ((__MCOCLKSOURCE__) | (__MCODIV__)))
+  MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE), ((__MCOCLKSOURCE__) | (__MCODIV__)))
+
+#if defined(RCC_MCO2_SUPPORT)
+/** @brief  Macro to configure the Microcontroller output clock 2.
+  * @param  __MCOCLKSOURCE__ specifies the MCO2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_MCO2SOURCE_NOCLOCK  MCO2 output disabled
+  *            @arg @ref RCC_MCO2SOURCE_SYSCLK System  clock selected as MCO source
+  *            @arg @ref RCC_MCO2SOURCE_HSI HSI clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_HSE HSE clock selected as MCO2 sourcee
+  *            @arg @ref RCC_MCO2SOURCE_PLLCLK  Main PLL clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_LSI LSI clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_LSE LSE clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_PLLPCLK PLLP output clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_PLLQCLK PLLQ output clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_RTCCLK RTC clock selected as MCO2 source
+  *            @arg @ref RCC_MCO2SOURCE_RTC_WKUP RTC_WKUP clock selected as MCO2 source
+  @if STM32G0C1xx
+  *            @arg @ref RCC_MCO2SOURCE_HSI48  HSI48 clock selected as MCO2 source for devices with HSI48
+  @endif
+  * @param  __MCODIV__ specifies the MCO clock prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_MCO2DIV_1     MCO2 clock source is divided by 1
+  *            @arg @ref RCC_MCO2DIV_2     MCO2 clock source is divided by 2
+  *            @arg @ref RCC_MCO2DIV_4     MCO2 clock source is divided by 4
+  *            @arg @ref RCC_MCO2DIV_8     MCO2 clock source is divided by 8
+  *            @arg @ref RCC_MCO2DIV_16    MCO2 clock source is divided by 16
+  *            @arg @ref RCC_MCO2DIV_32    MCO2 clock source is divided by 32
+  *            @arg @ref RCC_MCO2DIV_64    MCO2 clock source is divided by 64
+  *            @arg @ref RCC_MCO2DIV_128   MCO2 clock source is divided by 128
+  *            @arg @ref RCC_MCO2DIV_256   MCO2 clock source is divided by 256
+  *            @arg @ref RCC_MCO2DIV_512   MCO2 clock source is divided by 512
+  *            @arg @ref RCC_MCO2DIV_1024  MCO2 clock source is divided by 1024
+  */
+#define __HAL_RCC_MCO2_CONFIG(__MCOCLKSOURCE__, __MCODIV__) \
+  MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCO2SEL | RCC_CFGR_MCO2PRE), ((__MCOCLKSOURCE__) | (__MCODIV__)))
+#endif /* RCC_MCO2_SUPPORT */
 
 /**
   * @}
@@ -2293,7 +2936,10 @@ typedef struct
   *            @arg @ref RCC_IT_LSERDY LSE ready interrupt
   *            @arg @ref RCC_IT_HSIRDY HSI ready interrupt
   *            @arg @ref RCC_IT_HSERDY HSE ready interrupt
-  *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
+  *            @arg @ref RCC_IT_PLLRDY Main PLL ready interrupt
+  @if STM32G0C1xx
+  *            @arg @ref RCC_IT_HSI48RDY HSI48 ready interrupt for devices with HSI48
+  @endif
   * @retval None
   */
 #define __HAL_RCC_ENABLE_IT(__INTERRUPT__) SET_BIT(RCC->CIER, (__INTERRUPT__))
@@ -2306,6 +2952,9 @@ typedef struct
   *            @arg @ref RCC_IT_HSIRDY HSI ready interrupt
   *            @arg @ref RCC_IT_HSERDY HSE ready interrupt
   *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
+  @if STM32G0C1xx
+  *            @arg @ref RCC_IT_HSI48RDY HSI48 ready interrupt for devices with HSI48
+  @endif
   * @retval None
   */
 #define __HAL_RCC_DISABLE_IT(__INTERRUPT__) CLEAR_BIT(RCC->CIER, (__INTERRUPT__))
@@ -2320,6 +2969,9 @@ typedef struct
   *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
   *            @arg @ref RCC_IT_CSS     HSE Clock security system interrupt
   *            @arg @ref RCC_IT_LSECSS  LSE Clock security system interrupt
+  @if STM32G0C1xx
+  *            @arg @ref RCC_IT_HSI48RDY HSI48 ready interrupt for devices with HSI48
+  @endif
   * @retval None
   */
 #define __HAL_RCC_CLEAR_IT(__INTERRUPT__) (RCC->CICR = (__INTERRUPT__))
@@ -2334,6 +2986,9 @@ typedef struct
   *            @arg @ref RCC_IT_PLLRDY  Main PLL ready interrupt
   *            @arg @ref RCC_IT_CSS     HSE Clock security system interrupt
   *            @arg @ref RCC_IT_LSECSS  LSE Clock security system interrupt
+  @if STM32G0C1xx
+  *            @arg @ref RCC_IT_HSI48RDY HSI48 ready interrupt for devices with HSI48
+  @endif
   * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
   */
 #define __HAL_RCC_GET_IT(__INTERRUPT__) ((RCC->CIFR & (__INTERRUPT__)) == (__INTERRUPT__))
@@ -2354,6 +3009,9 @@ typedef struct
   *            @arg @ref RCC_FLAG_LSERDY LSE oscillator clock ready
   *            @arg @ref RCC_FLAG_LSECSSD Clock security system failure on LSE oscillator detection
   *            @arg @ref RCC_FLAG_LSIRDY LSI oscillator clock ready
+  @if STM32G0C1xx
+  *            @arg @ref RCC_IT_HSI48RDY HSI48 ready interrupt for devices with HSI48
+  @endif
   *            @arg @ref RCC_FLAG_PWRRST BOR or POR/PDR reset
   *            @arg @ref RCC_FLAG_OBLRST OBLRST reset
   *            @arg @ref RCC_FLAG_PINRST Pin reset
@@ -2363,11 +3021,20 @@ typedef struct
   *            @arg @ref RCC_FLAG_LPWRRST Low Power reset
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
-#define __HAL_RCC_GET_FLAG(__FLAG__) (((((((__FLAG__) >> 5U) == CR_REG_INDEX) ? RCC->CR :                  \
-                                        ((((__FLAG__) >> 5U) == BDCR_REG_INDEX) ? RCC->BDCR :              \
-                                        ((((__FLAG__) >> 5U) == CSR_REG_INDEX) ? RCC->CSR : RCC->CIFR))) & \
-                                          (1U << ((__FLAG__) & RCC_FLAG_MASK))) != RESET) \
-                                            ? 1U : 0U)
+#if defined(RCC_HSI48_SUPPORT)
+#define __HAL_RCC_GET_FLAG(__FLAG__)                                      \
+  (((((((__FLAG__) >> 5U) == CR_REG_INDEX) ? RCC->CR :                    \
+     ((((__FLAG__) >> 5U) == CRRCR_REG_INDEX) ? RCC->CRRCR :              \
+     ((((__FLAG__) >> 5U) == BDCR_REG_INDEX) ? RCC->BDCR :                \
+     ((((__FLAG__) >> 5U) == CSR_REG_INDEX) ? RCC->CSR : RCC->CIFR)))) &  \
+     (1U << ((__FLAG__) & RCC_FLAG_MASK))) != RESET) ? 1U : 0U)
+#else
+#define __HAL_RCC_GET_FLAG(__FLAG__)                                    \
+  (((((((__FLAG__) >> 5U) == CR_REG_INDEX) ? RCC->CR :                  \
+     ((((__FLAG__) >> 5U) == BDCR_REG_INDEX) ? RCC->BDCR :              \
+     ((((__FLAG__) >> 5U) == CSR_REG_INDEX) ? RCC->CSR : RCC->CIFR))) & \
+     (1U << ((__FLAG__) & RCC_FLAG_MASK))) != RESET) ? 1U : 0U)
+#endif /* RCC_HSI48_SUPPORT */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rcc_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rcc_ex.h
@@ -52,50 +52,129 @@ typedef struct
 
   uint32_t Usart1ClockSelection;   /*!< Specifies USART1 clock source.
                                         This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
-#if (RCC_CCIPR_USART2SEL)
+#if defined(RCC_CCIPR_USART2SEL)
   uint32_t Usart2ClockSelection;   /*!< Specifies USART2 clock source.
                                         This parameter can be a value of @ref RCCEx_USART2_Clock_Source */
-#endif
-#if (RCC_CCIPR_LPUART1SEL)
+#endif /* RCC_CCIPR_USART2SEL */
+
+#if defined(RCC_CCIPR_USART3SEL)
+  uint32_t Usart3ClockSelection;   /*!< Specifies USART3 clock source.
+                                        This parameter can be a value of @ref RCCEx_USART3_Clock_Source */
+#endif /* RCC_CCIPR_USART3SEL */
+
+#if defined(LPUART1)
   uint32_t Lpuart1ClockSelection;  /*!< Specifies LPUART1 clock source
                                         This parameter can be a value of @ref RCCEx_LPUART1_Clock_Source */
-#endif
+#endif /* LPUART1 */
+
+#if defined(LPUART2)
+  uint32_t Lpuart2ClockSelection;  /*!< Specifies LPUART2 clock source
+                                        This parameter can be a value of @ref RCCEx_LPUART2_Clock_Source */
+#endif /* LPUART2 */
+
   uint32_t I2c1ClockSelection;     /*!< Specifies I2C1 clock source
                                         This parameter can be a value of @ref RCCEx_I2C1_Clock_Source */
 
+#if defined(RCC_CCIPR_I2C2SEL)
+  uint32_t I2c2ClockSelection;     /*!< Specifies I2C2 clock source
+                                        This parameter can be a value of @ref RCCEx_I2C2_Clock_Source */
+#endif /* RCC_CCIPR_I2C2SEL */
+
   uint32_t I2s1ClockSelection;     /*!< Specifies I2S1 clock source
                                         This parameter can be a value of @ref RCCEx_I2S1_Clock_Source */
-
-#if (RCC_CCIPR_LPTIM1SEL)
+#if defined(RCC_CCIPR2_I2S2SEL)
+  uint32_t I2s2ClockSelection;     /*!< Specifies I2S2 clock source
+                                        This parameter can be a value of @ref RCCEx_I2S2_Clock_Source */
+#endif /* RCC_CCIPR2_I2S2SEL */
+#if defined(RCC_CCIPR_LPTIM1SEL)
   uint32_t Lptim1ClockSelection;   /*!< Specifies LPTIM1 clock source
                                         This parameter can be a value of @ref RCCEx_LPTIM1_Clock_Source */
-#endif
-#if (RCC_CCIPR_LPTIM2SEL)
+#endif /* RCC_CCIPR_LPTIM1SEL */
+#if defined(RCC_CCIPR_LPTIM2SEL)
   uint32_t Lptim2ClockSelection;   /*!< Specifies LPTIM2 clock source
                                         This parameter can be a value of @ref RCCEx_LPTIM2_Clock_Source */
-#endif
+#endif /* RCC_CCIPR_LPTIM2SEL */
 #if defined(RNG)
   uint32_t RngClockSelection;      /*!< Specifies RNG clock source
                                         This parameter can be a value of @ref RCCEx_RNG_Clock_Source */
-#endif
+#endif /* RNG */
   uint32_t AdcClockSelection;      /*!< Specifies ADC interface clock source
                                         This parameter can be a value of @ref RCCEx_ADC_Clock_Source */
 #if defined(CEC)
   uint32_t CecClockSelection;      /*!< Specifies CEC Clock clock source
                                         This parameter can be a value of @ref RCCEx_CEC_Clock_Source */
-#endif
-#if (RCC_CCIPR_TIM1SEL)
-  uint32_t Tim1ClockSelection;      /*!< Specifies TIM1 Clock clock source
+#endif /* CEC */
+#if defined(RCC_CCIPR_TIM1SEL)
+  uint32_t Tim1ClockSelection;     /*!< Specifies TIM1 Clock clock source
                                          This parameter can be a value of @ref RCCEx_TIM1_Clock_Source */
-#endif
-#if (RCC_CCIPR_TIM15SEL)
-  uint32_t Tim15ClockSelection;     /*!< Specifies TIM15 Clock clock source
+#endif /* RCC_CCIPR_TIM1SEL */
+#if defined(RCC_CCIPR_TIM15SEL)
+  uint32_t Tim15ClockSelection;    /*!< Specifies TIM15 Clock clock source
                                          This parameter can be a value of @ref RCCEx_TIM15_Clock_Source */
-#endif
+#endif /* RCC_CCIPR_TIM15SEL */
   uint32_t RTCClockSelection;      /*!< Specifies RTC clock source.
                                         This parameter can be a value of @ref RCC_RTC_Clock_Source */
+#if defined(RCC_CCIPR2_USBSEL)
+  uint32_t UsbClockSelection;      /*!< Specifies USB Clock clock source
+                                        This parameter can be a value of @ref RCCEx_USB_Clock_Source */
+#endif /* RCC_CCIPR2_USBSEL */
+#if defined(FDCAN1) || defined(FDCAN2)
+  uint32_t FdcanClockSelection;    /*!< Specifies FDCAN Clock clock source
+                                        This parameter can be a value of @ref RCCEx_FDCAN_Clock_Source */
+#endif /* FDCAN1 || FDCAN2 */
 } RCC_PeriphCLKInitTypeDef;
 
+#if defined(CRS)
+
+/**
+  * @brief RCC_CRS Init structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;             /*!< Specifies the division factor of the SYNC signal.
+                                       This parameter can be a value of @ref RCCEx_CRS_SynchroDivider */
+
+  uint32_t Source;                /*!< Specifies the SYNC signal source.
+                                       This parameter can be a value of @ref RCCEx_CRS_SynchroSource */
+
+  uint32_t Polarity;              /*!< Specifies the input polarity for the SYNC signal source.
+                                       This parameter can be a value of @ref RCCEx_CRS_SynchroPolarity */
+
+  uint32_t ReloadValue;           /*!< Specifies the value to be loaded in the frequency error counter with each SYNC event.
+                                       It can be calculated in using macro __HAL_RCC_CRS_RELOADVALUE_CALCULATE(__FTARGET__, __FSYNC__)
+                                       This parameter must be a number between 0 and 0xFFFF or a value of @ref RCCEx_CRS_ReloadValueDefault .*/
+
+  uint32_t ErrorLimitValue;       /*!< Specifies the value to be used to evaluate the captured frequency error value.
+                                       This parameter must be a number between 0 and 0xFF or a value of @ref RCCEx_CRS_ErrorLimitDefault */
+
+  uint32_t HSI48CalibrationValue; /*!< Specifies a user-programmable trimming value to the HSI48 oscillator.
+                                       This parameter must be a number between 0 and 0x7F or a value of @ref RCCEx_CRS_HSI48CalibrationDefault */
+
+} RCC_CRSInitTypeDef;
+
+/**
+  * @brief RCC_CRS Synchronization structure definition
+  */
+typedef struct
+{
+  uint32_t ReloadValue;           /*!< Specifies the value loaded in the Counter reload value.
+                                       This parameter must be a number between 0 and 0xFFFF */
+
+  uint32_t HSI48CalibrationValue; /*!< Specifies value loaded in HSI48 oscillator smooth trimming.
+                                       This parameter must be a number between 0 and 0x7F */
+
+  uint32_t FreqErrorCapture;      /*!< Specifies the value loaded in the .FECAP, the frequency error counter
+                                       value latched in the time of the last SYNC event.
+                                       This parameter must be a number between 0 and 0xFFFF */
+
+  uint32_t FreqErrorDirection;    /*!< Specifies the value loaded in the .FEDIR, the counting direction of the
+                                       frequency error counter latched in the time of the last SYNC event.
+                                       It shows whether the actual frequency is below or above the target.
+                                       This parameter must be a value of @ref RCCEx_CRS_FreqErrorDirection*/
+
+} RCC_CRSSynchroInfoTypeDef;
+
+#endif /* CRS */
 /**
   * @}
   */
@@ -121,10 +200,16 @@ typedef struct
 #if defined(RCC_CCIPR_USART2SEL)
 #define RCC_PERIPHCLK_USART2           0x00000002U
 #endif /* RCC_CCIPR_USART2SEL */
-#if defined(RCC_CCIPR_LPUART1SEL)
-#define RCC_PERIPHCLK_LPUART1          0x00000020U
-#endif /* RCC_CCIPR_LPUART1SEL */
-#define RCC_PERIPHCLK_I2C1             0x00000040U
+#if defined(RCC_CCIPR_USART3SEL)
+#define RCC_PERIPHCLK_USART3           0x00000004U
+#endif /* RCC_CCIPR_USART3SEL */
+#if defined(LPUART1)
+#define RCC_PERIPHCLK_LPUART1          0x00000010U
+#endif /* LPUART1 */
+#define RCC_PERIPHCLK_I2C1             0x00000020U
+#if defined(RCC_CCIPR_I2C2SEL)
+#define RCC_PERIPHCLK_I2C2             0x00000040U
+#endif /* RCC_CCIPR_I2C2SEL */
 #if defined(RCC_CCIPR_LPTIM1SEL)
 #define RCC_PERIPHCLK_LPTIM1           0x00000200U
 #endif /* RCC_CCIPR_LPTIM1SEL */
@@ -132,6 +217,12 @@ typedef struct
 #define RCC_PERIPHCLK_LPTIM2           0x00000400U
 #endif /* RCC_CCIPR_LPTIM2SEL */
 #define RCC_PERIPHCLK_I2S1             0x00000800U
+#if defined(LPUART2)
+#define RCC_PERIPHCLK_LPUART2          0x00001000U
+#endif /* LPUART2 */
+#if defined(RCC_CCIPR2_I2S2SEL)
+#define RCC_PERIPHCLK_I2S2             0x00002000U
+#endif /* RCC_CCIPR2_I2S2SEL */
 #define RCC_PERIPHCLK_ADC              0x00004000U
 #define RCC_PERIPHCLK_RTC              0x00020000U
 #if defined(RCC_CCIPR_RNGSEL)
@@ -146,7 +237,12 @@ typedef struct
 #if defined(RCC_CCIPR_TIM15SEL)
 #define RCC_PERIPHCLK_TIM15            0x00400000U
 #endif /* RCC_CCIPR_TIM15SEL */
-
+#if defined(RCC_CCIPR2_USBSEL)
+#define RCC_PERIPHCLK_USB              0x01000000U
+#endif /* RCC_CCIPR2_USBSEL */
+#if defined(FDCAN1) || defined(FDCAN2)
+#define RCC_PERIPHCLK_FDCAN            0x02000000U
+#endif /* FDCAN1 || FDCAN2 */
 /**
   * @}
   */
@@ -155,10 +251,10 @@ typedef struct
 /** @defgroup RCCEx_USART1_Clock_Source RCC USART1 Clock Source
   * @{
   */
-#define RCC_USART1CLKSOURCE_PCLK1      0x00000000U                                      /*!< APB clock selected as USART 1 clock */
-#define RCC_USART1CLKSOURCE_SYSCLK     RCC_CCIPR_USART1SEL_0                            /*!< SYSCLK clock selected as USART 1 clock */
-#define RCC_USART1CLKSOURCE_HSI        RCC_CCIPR_USART1SEL_1                            /*!< HSI clock selected as USART 1 clock */
-#define RCC_USART1CLKSOURCE_LSE        (RCC_CCIPR_USART1SEL_0 | RCC_CCIPR_USART1SEL_1)  /*!< LSE clock selected as USART 1 clock */
+#define RCC_USART1CLKSOURCE_PCLK1      0x00000000U                                      /*!< APB clock selected as USART1 clock */
+#define RCC_USART1CLKSOURCE_SYSCLK     RCC_CCIPR_USART1SEL_0                            /*!< SYSCLK clock selected as USART1 clock */
+#define RCC_USART1CLKSOURCE_HSI        RCC_CCIPR_USART1SEL_1                            /*!< HSI clock selected as USART1 clock */
+#define RCC_USART1CLKSOURCE_LSE        (RCC_CCIPR_USART1SEL_0 | RCC_CCIPR_USART1SEL_1)  /*!< LSE clock selected as USART1 clock */
 /**
   * @}
   */
@@ -167,26 +263,52 @@ typedef struct
 /** @defgroup RCCEx_USART2_Clock_Source RCC USART2 Clock Source
   * @{
   */
-#define RCC_USART2CLKSOURCE_PCLK1      0x00000000U                                      /*!< APB clock selected as USART 2 clock */
-#define RCC_USART2CLKSOURCE_SYSCLK     RCC_CCIPR_USART2SEL_0                            /*!< SYSCLK clock selected as USART 2 clock */
-#define RCC_USART2CLKSOURCE_HSI        RCC_CCIPR_USART2SEL_1                            /*!< HSI clock selected as USART 2 clock */
-#define RCC_USART2CLKSOURCE_LSE        (RCC_CCIPR_USART2SEL_0 | RCC_CCIPR_USART2SEL_1)  /*!< LSE clock selected as USART 2 clock */
+#define RCC_USART2CLKSOURCE_PCLK1      0x00000000U                                      /*!< APB clock selected as USART2 clock */
+#define RCC_USART2CLKSOURCE_SYSCLK     RCC_CCIPR_USART2SEL_0                            /*!< SYSCLK clock selected as USART2 clock */
+#define RCC_USART2CLKSOURCE_HSI        RCC_CCIPR_USART2SEL_1                            /*!< HSI clock selected as USART2 clock */
+#define RCC_USART2CLKSOURCE_LSE        (RCC_CCIPR_USART2SEL_0 | RCC_CCIPR_USART2SEL_1)  /*!< LSE clock selected as USART2 clock */
 /**
   * @}
   */
 #endif /* RCC_CCIPR_USART2SEL */
-#if defined(RCC_CCIPR_LPUART1SEL)
-/** @defgroup RCCEx_LPUART1_Clock_Source RCC LPUART1 Clock Source
+#if defined(RCC_CCIPR_USART3SEL)
+/** @defgroup RCCEx_USART3_Clock_Source RCC USART3 Clock Source
   * @{
   */
-#define RCC_LPUART1CLKSOURCE_PCLK1     0x00000000U                                        /*!< APB clock selected as LPUART 1 clock */
-#define RCC_LPUART1CLKSOURCE_SYSCLK    RCC_CCIPR_LPUART1SEL_0                             /*!< SYSCLK clock selected as LPUART 1 clock */
-#define RCC_LPUART1CLKSOURCE_HSI       RCC_CCIPR_LPUART1SEL_1                             /*!< HSI clock selected as LPUART 1 clock */
-#define RCC_LPUART1CLKSOURCE_LSE       (RCC_CCIPR_LPUART1SEL_0 | RCC_CCIPR_LPUART1SEL_1)  /*!< LSE clock selected as LPUART 1 clock */
+#define RCC_USART3CLKSOURCE_PCLK1      0x00000000U                                      /*!< APB clock selected as USART3 clock */
+#define RCC_USART3CLKSOURCE_SYSCLK     RCC_CCIPR_USART3SEL_0                            /*!< SYSCLK clock selected as USART3 clock */
+#define RCC_USART3CLKSOURCE_HSI        RCC_CCIPR_USART3SEL_1                            /*!< HSI clock selected as USART3 clock */
+#define RCC_USART3CLKSOURCE_LSE        (RCC_CCIPR_USART3SEL_0 | RCC_CCIPR_USART3SEL_1)  /*!< LSE clock selected as USART3 clock */
 /**
   * @}
   */
-#endif /* RCC_CCIPR_LPUART1SEL */
+#endif /* RCC_CCIPR_USART3SEL */
+
+#if defined(LPUART1)
+/** @defgroup RCCEx_LPUART1_Clock_Source RCC LPUART1 Clock Source
+  * @{
+  */
+#define RCC_LPUART1CLKSOURCE_PCLK1     0x00000000U                                        /*!< APB clock selected as LPUART1 clock */
+#define RCC_LPUART1CLKSOURCE_SYSCLK    RCC_CCIPR_LPUART1SEL_0                             /*!< SYSCLK clock selected as LPUART1 clock */
+#define RCC_LPUART1CLKSOURCE_HSI       RCC_CCIPR_LPUART1SEL_1                             /*!< HSI clock selected as LPUART1 clock */
+#define RCC_LPUART1CLKSOURCE_LSE       (RCC_CCIPR_LPUART1SEL_0 | RCC_CCIPR_LPUART1SEL_1)  /*!< LSE clock selected as LPUART1 clock */
+/**
+  * @}
+  */
+#endif /* LPUART1 */
+
+#if defined(LPUART2)
+/** @defgroup RCCEx_LPUART2_Clock_Source RCC LPUART2 Clock Source
+  * @{
+  */
+#define RCC_LPUART2CLKSOURCE_PCLK1     0x00000000U                                        /*!< APB clock selected as LPUART2 clock */
+#define RCC_LPUART2CLKSOURCE_SYSCLK    RCC_CCIPR_LPUART2SEL_0                             /*!< SYSCLK clock selected as LPUART2 clock */
+#define RCC_LPUART2CLKSOURCE_HSI       RCC_CCIPR_LPUART2SEL_1                             /*!< HSI clock selected as LPUART2 clock */
+#define RCC_LPUART2CLKSOURCE_LSE       (RCC_CCIPR_LPUART2SEL_0 | RCC_CCIPR_LPUART2SEL_1)  /*!< LSE clock selected as LPUART2 clock */
+/**
+  * @}
+  */
+#endif /* LPUART2 */
 
 /** @defgroup RCCEx_I2C1_Clock_Source RCC I2C1 Clock Source
   * @{
@@ -198,19 +320,50 @@ typedef struct
   * @}
   */
 
+#if defined(RCC_CCIPR_I2C2SEL)
+/** @defgroup RCCEx_I2C2_Clock_Source RCC I2C2 Clock Source
+  * @{
+  */
+#define RCC_I2C2CLKSOURCE_PCLK1        0x00000000U                                      /*!< APB clock selected as I2C2 clock */
+#define RCC_I2C2CLKSOURCE_SYSCLK       RCC_CCIPR_I2C2SEL_0                              /*!< SYSCLK clock selected as I2C2 clock */
+#define RCC_I2C2CLKSOURCE_HSI          RCC_CCIPR_I2C2SEL_1                              /*!< HSI clock selected as I2C2 clock */
+/**
+  * @}
+  */
+#endif /* RCC_CCIPR_I2C2SEL */
+
 /** @defgroup RCCEx_I2S1_Clock_Source RCC I2S1 Clock Source
   * @{
   */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define RCC_I2S1CLKSOURCE_SYSCLK       0x00000000U                                      /*!< SYSCLK clock selected as I2S1 clock */
+#define RCC_I2S1CLKSOURCE_PLL          RCC_CCIPR2_I2S1SEL_0                             /*!< PLL "P" selected as I2S1 clock */
+#define RCC_I2S1CLKSOURCE_HSI          RCC_CCIPR2_I2S1SEL_1                             /*!< HSI clock selected as I2S1 clock */
+#define RCC_I2S1CLKSOURCE_EXT          RCC_CCIPR2_I2S1SEL                               /*!< External I2S clock source selected as I2S1 clock */
+#else
 #define RCC_I2S1CLKSOURCE_SYSCLK       0x00000000U                                     /*!< SYSCLK clock selected as I2S1 clock */
 #define RCC_I2S1CLKSOURCE_PLL          RCC_CCIPR_I2S1SEL_0                             /*!< PLL "P" selected as I2S1 clock */
 #define RCC_I2S1CLKSOURCE_HSI          RCC_CCIPR_I2S1SEL_1                             /*!< HSI clock selected as I2S1 clock */
 #define RCC_I2S1CLKSOURCE_EXT          RCC_CCIPR_I2S1SEL                               /*!< External I2S clock source selected as I2S1 clock */
-
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 /**
   * @}
   */
 
-#if (RCC_CCIPR_LPTIM1SEL)
+#if defined(RCC_CCIPR2_I2S2SEL)
+/** @defgroup RCCEx_I2S2_Clock_Source RCC I2S2 Clock Source
+  * @{
+  */
+#define RCC_I2S2CLKSOURCE_SYSCLK       0x00000000U                                      /*!< SYSCLK clock selected as I2S2 clock */
+#define RCC_I2S2CLKSOURCE_PLL          RCC_CCIPR2_I2S2SEL_0                             /*!< PLL "P" selected as I2S2 clock */
+#define RCC_I2S2CLKSOURCE_HSI          RCC_CCIPR2_I2S2SEL_1                             /*!< HSI clock selected as I2S2 clock */
+#define RCC_I2S2CLKSOURCE_EXT          RCC_CCIPR2_I2S2SEL                               /*!< External I2S clock source selected as I2S2 clock */
+/**
+  * @}
+  */
+#endif  /* RCC_CCIPR2_I2S2SEL */
+
+#if defined(RCC_CCIPR_LPTIM1SEL)
 /** @defgroup RCCEx_LPTIM1_Clock_Source RCC LPTIM1 Clock Source
   * @{
   */
@@ -223,7 +376,7 @@ typedef struct
   */
 #endif /* RCC_CCIPR_LPTIM1SEL */
 
-#if (RCC_CCIPR_LPTIM2SEL)
+#if defined(RCC_CCIPR_LPTIM2SEL)
 /** @defgroup RCCEx_LPTIM2_Clock_Source RCC LPTIM2 Clock Source
   * @{
   */
@@ -262,6 +415,33 @@ typedef struct
   */
 #endif /* RNG */
 
+#if defined(FDCAN1) || defined(FDCAN2)
+/** @defgroup RCCEx_FDCAN_Clock_Source RCC FDCAN Clock Source
+  * @{
+  */
+#define RCC_FDCANCLKSOURCE_PCLK1        0x00000000U                        /*!< PCLK1 selected as FDCAN clock */
+#define RCC_FDCANCLKSOURCE_PLL          RCC_CCIPR2_FDCANSEL_0              /*!< PLL "Q" selected as FDCAN clock */
+#define RCC_FDCANCLKSOURCE_HSE          RCC_CCIPR2_FDCANSEL_1              /*!< HSE oscillator clock selected as FDCAN clock */
+
+/**
+  * @}
+  */
+#endif /* FDCAN1 || FDCAN2 */
+
+#if defined(RCC_CCIPR2_USBSEL)
+/** @defgroup RCCEx_USB_Clock_Source USB Clock Source
+  * @{
+  */
+#if defined(RCC_HSI48_SUPPORT)
+#define RCC_USBCLKSOURCE_HSI48         0x00000000U            /*!< HSI48 oscillator clock selected as USB clock */
+#endif /* RCC_HSI48_SUPPORT */
+#define RCC_USBCLKSOURCE_HSE           RCC_CCIPR2_USBSEL_0  /*!< HSE oscillator clock selected as USB clock */
+#define RCC_USBCLKSOURCE_PLL           RCC_CCIPR2_USBSEL_1  /*!< PLL "Q" selected as USB clock */
+/**
+  * @}
+  */
+#endif /* RCC_CCIPR2_USBSEL */
+
 /** @defgroup RCCEx_ADC_Clock_Source RCC ADC Clock Source
   * @{
   */
@@ -284,7 +464,7 @@ typedef struct
   */
 #endif /* CEC */
 
-#if (RCC_CCIPR_TIM1SEL)
+#if defined(RCC_CCIPR_TIM1SEL)
 /** @defgroup RCCEx_TIM1_Clock_Source RCC TIM1 Clock Source
   * @{
   */
@@ -295,7 +475,7 @@ typedef struct
   */
 #endif /* RCC_CCIPR_TIM1SEL */
 
-#if (RCC_CCIPR_TIM15SEL)
+#if defined(RCC_CCIPR_TIM15SEL)
 /** @defgroup RCCEx_TIM15_Clock_Source RCC TIM15 Clock Source
   * @{
   */
@@ -307,6 +487,123 @@ typedef struct
   */
 #endif /* RCC_CCIPR_TIM15SEL */
 
+#if defined(CRS)
+
+/** @defgroup RCCEx_CRS_Status RCCEx CRS Status
+  * @{
+  */
+#define RCC_CRS_NONE                   0x00000000U
+#define RCC_CRS_TIMEOUT                0x00000001U
+#define RCC_CRS_SYNCOK                 0x00000002U
+#define RCC_CRS_SYNCWARN               0x00000004U
+#define RCC_CRS_SYNCERR                0x00000008U
+#define RCC_CRS_SYNCMISS               0x00000010U
+#define RCC_CRS_TRIMOVF                0x00000020U
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_SynchroSource RCCEx CRS SynchroSource
+  * @{
+  */
+#define RCC_CRS_SYNC_SOURCE_GPIO       0x00000000U             /*!< Synchro Signal source GPIO */
+#define RCC_CRS_SYNC_SOURCE_LSE        CRS_CFGR_SYNCSRC_0      /*!< Synchro Signal source LSE */
+#define RCC_CRS_SYNC_SOURCE_USB        CRS_CFGR_SYNCSRC_1      /*!< Synchro Signal source USB SOF (default)*/
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_SynchroDivider RCCEx CRS SynchroDivider
+  * @{
+  */
+#define RCC_CRS_SYNC_DIV1        0x00000000U                               /*!< Synchro Signal not divided (default) */
+#define RCC_CRS_SYNC_DIV2        CRS_CFGR_SYNCDIV_0                        /*!< Synchro Signal divided by 2 */
+#define RCC_CRS_SYNC_DIV4        CRS_CFGR_SYNCDIV_1                        /*!< Synchro Signal divided by 4 */
+#define RCC_CRS_SYNC_DIV8        (CRS_CFGR_SYNCDIV_1 | CRS_CFGR_SYNCDIV_0) /*!< Synchro Signal divided by 8 */
+#define RCC_CRS_SYNC_DIV16       CRS_CFGR_SYNCDIV_2                        /*!< Synchro Signal divided by 16 */
+#define RCC_CRS_SYNC_DIV32       (CRS_CFGR_SYNCDIV_2 | CRS_CFGR_SYNCDIV_0) /*!< Synchro Signal divided by 32 */
+#define RCC_CRS_SYNC_DIV64       (CRS_CFGR_SYNCDIV_2 | CRS_CFGR_SYNCDIV_1) /*!< Synchro Signal divided by 64 */
+#define RCC_CRS_SYNC_DIV128      CRS_CFGR_SYNCDIV                          /*!< Synchro Signal divided by 128 */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_SynchroPolarity RCCEx CRS SynchroPolarity
+  * @{
+  */
+#define RCC_CRS_SYNC_POLARITY_RISING   0x00000000U         /*!< Synchro Active on rising edge (default) */
+#define RCC_CRS_SYNC_POLARITY_FALLING  CRS_CFGR_SYNCPOL    /*!< Synchro Active on falling edge */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_ReloadValueDefault RCCEx CRS ReloadValueDefault
+  * @{
+  */
+#define RCC_CRS_RELOADVALUE_DEFAULT    0x0000BB7FU   /*!< The reset value of the RELOAD field corresponds
+                                                          to a target frequency of 48 MHz and a synchronization signal frequency of 1 kHz (SOF signal from USB). */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_ErrorLimitDefault RCCEx CRS ErrorLimitDefault
+  * @{
+  */
+#define RCC_CRS_ERRORLIMIT_DEFAULT     0x00000022U   /*!< Default Frequency error limit */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_HSI48CalibrationDefault RCCEx CRS HSI48CalibrationDefault
+  * @{
+  */
+#define RCC_CRS_HSI48CALIBRATION_DEFAULT 0x00000040U /*!< The default value is 64, which corresponds to the middle of the trimming interval.
+                                                          The trimming step is specified in the product datasheet. A higher TRIM value
+                                                          corresponds to a higher output frequency */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_FreqErrorDirection RCCEx CRS FreqErrorDirection
+  * @{
+  */
+#define RCC_CRS_FREQERRORDIR_UP        0x00000000U   /*!< Upcounting direction, the actual frequency is above the target */
+#define RCC_CRS_FREQERRORDIR_DOWN      CRS_ISR_FEDIR /*!< Downcounting direction, the actual frequency is below the target */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_Interrupt_Sources RCCEx CRS Interrupt Sources
+  * @{
+  */
+#define RCC_CRS_IT_SYNCOK              CRS_CR_SYNCOKIE       /*!< SYNC event OK */
+#define RCC_CRS_IT_SYNCWARN            CRS_CR_SYNCWARNIE     /*!< SYNC warning */
+#define RCC_CRS_IT_ERR                 CRS_CR_ERRIE          /*!< Error */
+#define RCC_CRS_IT_ESYNC               CRS_CR_ESYNCIE        /*!< Expected SYNC */
+#define RCC_CRS_IT_SYNCERR             CRS_CR_ERRIE          /*!< SYNC error */
+#define RCC_CRS_IT_SYNCMISS            CRS_CR_ERRIE          /*!< SYNC missed */
+#define RCC_CRS_IT_TRIMOVF             CRS_CR_ERRIE           /*!< Trimming overflow or underflow */
+
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_Flags RCCEx CRS Flags
+  * @{
+  */
+#define RCC_CRS_FLAG_SYNCOK            CRS_ISR_SYNCOKF       /*!< SYNC event OK flag     */
+#define RCC_CRS_FLAG_SYNCWARN          CRS_ISR_SYNCWARNF     /*!< SYNC warning flag      */
+#define RCC_CRS_FLAG_ERR               CRS_ISR_ERRF          /*!< Error flag        */
+#define RCC_CRS_FLAG_ESYNC             CRS_ISR_ESYNCF        /*!< Expected SYNC flag     */
+#define RCC_CRS_FLAG_SYNCERR           CRS_ISR_SYNCERR       /*!< SYNC error */
+#define RCC_CRS_FLAG_SYNCMISS          CRS_ISR_SYNCMISS      /*!< SYNC missed*/
+#define RCC_CRS_FLAG_TRIMOVF           CRS_ISR_TRIMOVF       /*!< Trimming overflow or underflow */
+
+/**
+  * @}
+  */
+
+#endif /* CRS */
 
 /**
   * @}
@@ -335,6 +632,25 @@ typedef struct
   */
 #define __HAL_RCC_GET_I2C1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2C1SEL)))
 
+#if defined(RCC_CCIPR_I2C2SEL)
+/** @brief  Macro to configure the I2C2 clock (I2C2CLK).
+  *
+  * @param  __I2C2_CLKSOURCE__  specifies the I2C2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_I2C2CLKSOURCE_HSI  HSI selected as I2C2 clock
+  *            @arg @ref RCC_I2C2CLKSOURCE_SYSCLK  System Clock selected as I2C2 clock
+  */
+#define __HAL_RCC_I2C2_CONFIG(__I2C2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2C2SEL, (uint32_t)(__I2C2_CLKSOURCE__))
+
+/** @brief  Macro to get the I2C2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_I2C2CLKSOURCE_HSI  HSI selected as I2C2 clock
+  *            @arg @ref RCC_I2C2CLKSOURCE_SYSCLK  System Clock selected as I2C2 clock
+  */
+#define __HAL_RCC_GET_I2C2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2C2SEL)))
+#endif /* RCC_CCIPR_I2C2SEL */
+
 /** @brief  Macro to configure the I2S1 clock (I2S1CLK).
   *
   * @param  __I2S1_CLKSOURCE__  specifies the I2S1 clock source.
@@ -344,9 +660,13 @@ typedef struct
   *            @arg @ref RCC_I2S1CLKSOURCE_HSI     HSI Clock selected as I2S1 clock
   *            @arg @ref RCC_I2S1CLKSOURCE_EXT     External clock selected as I2S1 clock
   */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define __HAL_RCC_I2S1_CONFIG(__I2S1_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR2, RCC_CCIPR2_I2S1SEL, (uint32_t)(__I2S1_CLKSOURCE__))
+#else
 #define __HAL_RCC_I2S1_CONFIG(__I2S1_CLKSOURCE__) \
                   MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2S1SEL, (uint32_t)(__I2S1_CLKSOURCE__))
-
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 /** @brief  Macro to get the I2S1 clock source.
   * @retval The clock source can be one of the following values:
   *            @arg @ref RCC_I2S1CLKSOURCE_SYSCLK  System Clock selected as I2S1 clock
@@ -354,8 +674,34 @@ typedef struct
   *            @arg @ref RCC_I2S1CLKSOURCE_HSI     HSI Clock selected as I2S1 clock
   *            @arg @ref RCC_I2S1CLKSOURCE_EXT     External clock selected as I2S1 clock
   */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define __HAL_RCC_GET_I2S1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR2, RCC_CCIPR2_I2S1SEL)))
+#else
 #define __HAL_RCC_GET_I2S1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2S1SEL)))
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
+#if defined(RCC_CCIPR2_I2S2SEL)
+/** @brief  Macro to configure the I2S2 clock (I2S2CLK).
+  *
+  * @param  __I2S2_CLKSOURCE__  specifies the I2S2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_I2S2CLKSOURCE_SYSCLK  System Clock selected as I2S2 clock
+  *            @arg @ref RCC_I2S2CLKSOURCE_PLL     PLLP Clock selected as I2S2 clock
+  *            @arg @ref RCC_I2S2CLKSOURCE_HSI     HSI Clock selected as I2S2 clock
+  *            @arg @ref RCC_I2S2CLKSOURCE_EXT     External clock selected as I2S2 clock
+  */
+#define __HAL_RCC_I2S2_CONFIG(__I2S2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR2, RCC_CCIPR2_I2S2SEL, (uint32_t)(__I2S2_CLKSOURCE__))
+
+/** @brief  Macro to get the I2S2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_I2S2CLKSOURCE_SYSCLK  System Clock selected as I2S2 clock
+  *            @arg @ref RCC_I2S2CLKSOURCE_PLL     PLLP Clock selected as I2S2 clock
+  *            @arg @ref RCC_I2S2CLKSOURCE_HSI     HSI Clock selected as I2S2 clock
+  *            @arg @ref RCC_I2S2CLKSOURCE_EXT     External clock selected as I2S2 clock
+  */
+#define __HAL_RCC_GET_I2S2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR2, RCC_CCIPR2_I2S2SEL)))
+#endif /* RCC_CCIPR2_I2S2SEL */
 
 /** @brief  Macro to configure the USART1 clock (USART1CLK).
   *
@@ -401,6 +747,29 @@ typedef struct
 #define __HAL_RCC_GET_USART2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART2SEL)))
 #endif /* RCC_CCIPR_USART2SEL */
 
+#if defined(RCC_CCIPR_USART3SEL)
+/** @brief  Macro to configure the USART3 clock (USART3CLK).
+  *
+  * @param  __USART3_CLKSOURCE__ specifies the USART3 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_USART3CLKSOURCE_PCLK1   PCLK1 selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_HSI  HSI selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_SYSCLK  System Clock selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_LSE  LSE selected as USART3 clock
+  */
+#define __HAL_RCC_USART3_CONFIG(__USART3_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_USART3SEL, (uint32_t)(__USART3_CLKSOURCE__))
+
+/** @brief  Macro to get the USART3 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_USART3CLKSOURCE_PCLK1   PCLK1 selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_HSI  HSI selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_SYSCLK  System Clock selected as USART3 clock
+  *            @arg @ref RCC_USART3CLKSOURCE_LSE  LSE selected as USART3 clock
+  */
+#define __HAL_RCC_GET_USART3_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART3SEL)))
+#endif /* RCC_CCIPR_USART3SEL */
+
 #if defined(RCC_CCIPR_LPUART1SEL)
 /** @brief  Macro to configure the LPUART1 clock (LPUART1CLK).
   *
@@ -424,7 +793,30 @@ typedef struct
 #define __HAL_RCC_GET_LPUART1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPUART1SEL)))
 #endif /* RCC_CCIPR_LPUART1SEL */
 
-#if (RCC_CCIPR_LPTIM1SEL)
+#if defined(RCC_CCIPR_LPUART2SEL)
+/** @brief  Macro to configure the LPUART2 clock (LPUART2CLK).
+  *
+  * @param  __LPUART2_CLKSOURCE__ specifies the LPUART2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg @ref RCC_LPUART2CLKSOURCE_PCLK1   PCLK1 selected as LPUART2 clock
+  *            @arg @ref RCC_LPUART2CLKSOURCE_HSI  HSI selected as LPUART2 clock
+  *            @arg @ref RCC_LPUART2CLKSOURCE_SYSCLK  System Clock selected as LPUART2 clock
+  *            @arg @ref RCC_LPUART2CLKSOURCE_LSE  LSE selected as LPUART2 clock
+  */
+#define __HAL_RCC_LPUART2_CONFIG(__LPUART2_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPUART2SEL, (uint32_t)(__LPUART2_CLKSOURCE__))
+
+/** @brief  Macro to get the LPUART2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_LPUART2CLKSOURCE_PCLK1  PCLK1 selected as LPUART2 clock
+  *            @arg @ref RCC_LPUART2CLKSOURCE_HSI HSI selected as LPUART2 clock
+  *            @arg @ref RCC_LPUART2CLKSOURCE_SYSCLK System Clock selected as LPUART2 clock
+  *            @arg @ref RCC_LPUART2CLKSOURCE_LSE LSE selected as LPUART2 clock
+  */
+#define __HAL_RCC_GET_LPUART2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPUART2SEL)))
+#endif /* RCC_CCIPR_LPUART2SEL */
+
+#if defined(RCC_CCIPR_LPTIM1SEL)
 /** @brief  Macro to configure the LPTIM1 clock (LPTIM1CLK).
   *
   * @param  __LPTIM1_CLKSOURCE__ specifies the LPTIM1 clock source.
@@ -447,7 +839,7 @@ typedef struct
 #define __HAL_RCC_GET_LPTIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPTIM1SEL)))
 #endif /* RCC_CCIPR_LPTIM1SEL */
 
-#if (RCC_CCIPR_LPTIM2SEL)
+#if defined(RCC_CCIPR_LPTIM2SEL)
 /** @brief  Macro to configure the LPTIM2 clock (LPTIM2CLK).
   *
   * @param  __LPTIM2_CLKSOURCE__ specifies the LPTIM2 clock source.
@@ -553,7 +945,7 @@ typedef struct
   */
 #define __HAL_RCC_GET_ADC_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_ADCSEL)))
 
-#if (RCC_CCIPR_TIM1SEL)
+#if defined(RCC_CCIPR_TIM1SEL)
 /** @brief  Macro to configure the TIM1 interface clock
   * @param  __TIM1_CLKSOURCE__ specifies the TIM1 digital interface clock source.
   *         This parameter can be one of the following values:
@@ -571,7 +963,7 @@ typedef struct
 #define __HAL_RCC_GET_TIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_TIM1SEL)))
 #endif /* RCC_CCIPR_TIM1SEL */
 
-#if (RCC_CCIPR_TIM15SEL)
+#if defined(RCC_CCIPR_TIM15SEL)
 /** @brief  Macro to configure the TIM15 interface clock
   * @param  __TIM15_CLKSOURCE__ specifies the TIM15 digital interface clock source.
   *         This parameter can be one of the following values:
@@ -589,21 +981,207 @@ typedef struct
 #define __HAL_RCC_GET_TIM15_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_TIM15SEL)))
 #endif /* RCC_CCIPR_TIM15SEL */
 
-/** @defgroup RCCEx_Flags_Interrupts_Management Flags Interrupts Management
-  * @brief macros to manage the specified RCC Flags and interrupts.
+#if defined(RCC_CCIPR2_USBSEL)
+/** @brief  Macro to configure the USB interface clock
+  * @param  __USB_CLKSOURCE__ specifies the USB digital interface clock source.
+  *         This parameter can be one of the following values:
+  *            @arg @ref RCC_USBCLKSOURCE_PLL    PLLQ Output Clock selected as USB clock (*)
+  *            @arg @ref RCC_USBCLKSOURCE_HSE    HSE Output Clock selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_HSI48  HSI48 Clock selected as USB clock (*)
+  *  (*) Feature not available on all devices
+  */
+#define __HAL_RCC_USB_CONFIG(__USB_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR2, RCC_CCIPR2_USBSEL, (uint32_t)(__USB_CLKSOURCE__))
+
+/** @brief  Macro to get the USB clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_USBCLKSOURCE_HSI48  HSI48 Clock selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_HSE    HSE Output Clock selected as USB clock
+  *            @arg @ref RCC_USBCLKSOURCE_PLL    PLLQ Output Clock selected as USB clock
+  */
+#define __HAL_RCC_GET_USB_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR2, RCC_CCIPR2_USBSEL)))
+#endif /* RCC_CCIPR2_USBSEL */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+/** @brief  Macro to configure the FDCAN interface clock
+  * @param  __FDCAN_CLKSOURCE__ specifies the FDCAN digital interface clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_FDCANCLKSOURCE_PLL    PLLQ Output Clock selected as FDCAN clock
+  *            @arg RCC_FDCANCLKSOURCE_PCLK1  System Clock selected as FDCAN clock
+  *            @arg RCC_FDCANCLKSOURCE_HSE    HSE Clock selected as FDCAN clock
+  */
+#define __HAL_RCC_FDCAN_CONFIG(__FDCAN_CLKSOURCE__) \
+                  MODIFY_REG(RCC->CCIPR2, RCC_CCIPR2_FDCANSEL, (uint32_t)(__FDCAN_CLKSOURCE__))
+
+/** @brief  Macro to get the FDCAN clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg @ref RCC_FDCANCLKSOURCE_PLL    PLLQ Output Clock selected as FDCAN clock
+  *            @arg @ref RCC_FDCANCLKSOURCE_PCLK1  System Clock selected as FDCAN clock
+  *            @arg @ref RCC_FDCANCLKSOURCE_HSE    HSE Clock selected as FDCAN clock
+  */
+#define __HAL_RCC_GET_FDCAN_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR2, RCC_CCIPR2_FDCANSEL)))
+#endif /* FDCAN1 || FDCAN2 */
+
+#if defined(CRS)
+
+/**
+  * @brief  Enable the specified CRS interrupts.
+  * @param  __INTERRUPT__ specifies the CRS interrupt sources to be enabled.
+  *          This parameter can be any combination of the following values:
+  *              @arg @ref RCC_CRS_IT_SYNCOK  SYNC event OK interrupt
+  *              @arg @ref RCC_CRS_IT_SYNCWARN  SYNC warning interrupt
+  *              @arg @ref RCC_CRS_IT_ERR  Synchronization or trimming error interrupt
+  *              @arg @ref RCC_CRS_IT_ESYNC  Expected SYNC interrupt
+  * @retval None
+  */
+#define __HAL_RCC_CRS_ENABLE_IT(__INTERRUPT__)   SET_BIT(CRS->CR, (__INTERRUPT__))
+
+/**
+  * @brief  Disable the specified CRS interrupts.
+  * @param  __INTERRUPT__ specifies the CRS interrupt sources to be disabled.
+  *          This parameter can be any combination of the following values:
+  *              @arg @ref RCC_CRS_IT_SYNCOK  SYNC event OK interrupt
+  *              @arg @ref RCC_CRS_IT_SYNCWARN  SYNC warning interrupt
+  *              @arg @ref RCC_CRS_IT_ERR  Synchronization or trimming error interrupt
+  *              @arg @ref RCC_CRS_IT_ESYNC  Expected SYNC interrupt
+  * @retval None
+  */
+#define __HAL_RCC_CRS_DISABLE_IT(__INTERRUPT__)  CLEAR_BIT(CRS->CR, (__INTERRUPT__))
+
+/** @brief  Check whether the CRS interrupt has occurred or not.
+  * @param  __INTERRUPT__ specifies the CRS interrupt source to check.
+  *         This parameter can be one of the following values:
+  *              @arg @ref RCC_CRS_IT_SYNCOK  SYNC event OK interrupt
+  *              @arg @ref RCC_CRS_IT_SYNCWARN  SYNC warning interrupt
+  *              @arg @ref RCC_CRS_IT_ERR  Synchronization or trimming error interrupt
+  *              @arg @ref RCC_CRS_IT_ESYNC  Expected SYNC interrupt
+  * @retval The new state of __INTERRUPT__ (SET or RESET).
+  */
+#define __HAL_RCC_CRS_GET_IT_SOURCE(__INTERRUPT__)  ((READ_BIT(CRS->CR, (__INTERRUPT__)) != 0U) ? SET : RESET)
+
+/** @brief  Clear the CRS interrupt pending bits
+  * @param  __INTERRUPT__ specifies the interrupt pending bit to clear.
+  *         This parameter can be any combination of the following values:
+  *              @arg @ref RCC_CRS_IT_SYNCOK  SYNC event OK interrupt
+  *              @arg @ref RCC_CRS_IT_SYNCWARN  SYNC warning interrupt
+  *              @arg @ref RCC_CRS_IT_ERR  Synchronization or trimming error interrupt
+  *              @arg @ref RCC_CRS_IT_ESYNC  Expected SYNC interrupt
+  *              @arg @ref RCC_CRS_IT_TRIMOVF  Trimming overflow or underflow interrupt
+  *              @arg @ref RCC_CRS_IT_SYNCERR  SYNC error interrupt
+  *              @arg @ref RCC_CRS_IT_SYNCMISS  SYNC missed interrupt
+  */
+/* CRS IT Error Mask */
+#define  RCC_CRS_IT_ERROR_MASK                 (RCC_CRS_IT_TRIMOVF | RCC_CRS_IT_SYNCERR | RCC_CRS_IT_SYNCMISS)
+
+#define __HAL_RCC_CRS_CLEAR_IT(__INTERRUPT__)  do { \
+                                                 if(((__INTERRUPT__) & RCC_CRS_IT_ERROR_MASK) != 0U) \
+                                                 { \
+                                                   WRITE_REG(CRS->ICR, CRS_ICR_ERRC | ((__INTERRUPT__) & ~RCC_CRS_IT_ERROR_MASK)); \
+                                                 } \
+                                                 else \
+                                                 { \
+                                                   WRITE_REG(CRS->ICR, (__INTERRUPT__)); \
+                                                 } \
+                                               } while(0)
+
+/**
+  * @brief  Check whether the specified CRS flag is set or not.
+  * @param  __FLAG__ specifies the flag to check.
+  *          This parameter can be one of the following values:
+  *              @arg @ref RCC_CRS_FLAG_SYNCOK  SYNC event OK
+  *              @arg @ref RCC_CRS_FLAG_SYNCWARN  SYNC warning
+  *              @arg @ref RCC_CRS_FLAG_ERR  Error
+  *              @arg @ref RCC_CRS_FLAG_ESYNC  Expected SYNC
+  *              @arg @ref RCC_CRS_FLAG_TRIMOVF  Trimming overflow or underflow
+  *              @arg @ref RCC_CRS_FLAG_SYNCERR  SYNC error
+  *              @arg @ref RCC_CRS_FLAG_SYNCMISS  SYNC missed
+  * @retval The new state of _FLAG_ (TRUE or FALSE).
+  */
+#define __HAL_RCC_CRS_GET_FLAG(__FLAG__)  (READ_BIT(CRS->ISR, (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clear the CRS specified FLAG.
+  * @param __FLAG__ specifies the flag to clear.
+  *          This parameter can be one of the following values:
+  *              @arg @ref RCC_CRS_FLAG_SYNCOK  SYNC event OK
+  *              @arg @ref RCC_CRS_FLAG_SYNCWARN  SYNC warning
+  *              @arg @ref RCC_CRS_FLAG_ERR  Error
+  *              @arg @ref RCC_CRS_FLAG_ESYNC  Expected SYNC
+  *              @arg @ref RCC_CRS_FLAG_TRIMOVF  Trimming overflow or underflow
+  *              @arg @ref RCC_CRS_FLAG_SYNCERR  SYNC error
+  *              @arg @ref RCC_CRS_FLAG_SYNCMISS  SYNC missed
+  * @note RCC_CRS_FLAG_ERR clears RCC_CRS_FLAG_TRIMOVF, RCC_CRS_FLAG_SYNCERR, RCC_CRS_FLAG_SYNCMISS and consequently RCC_CRS_FLAG_ERR
+  * @retval None
+  */
+
+/* CRS Flag Error Mask */
+#define RCC_CRS_FLAG_ERROR_MASK                (RCC_CRS_FLAG_TRIMOVF | RCC_CRS_FLAG_SYNCERR | RCC_CRS_FLAG_SYNCMISS)
+
+#define __HAL_RCC_CRS_CLEAR_FLAG(__FLAG__)     do { \
+                                                 if(((__FLAG__) & RCC_CRS_FLAG_ERROR_MASK) != 0U) \
+                                                 { \
+                                                   WRITE_REG(CRS->ICR, CRS_ICR_ERRC | ((__FLAG__) & ~RCC_CRS_FLAG_ERROR_MASK)); \
+                                                 } \
+                                                 else \
+                                                 { \
+                                                   WRITE_REG(CRS->ICR, (__FLAG__)); \
+                                                 } \
+                                               } while(0)
+
+#endif /* CRS */
+
+/**
+  * @}
+  */
+
+#if defined(CRS)
+
+/** @defgroup RCCEx_CRS_Extended_Features RCCEx CRS Extended Features
   * @{
   */
+/**
+  * @brief  Enable the oscillator clock for frequency error counter.
+  * @note   when the CEN bit is set the CRS_CFGR register becomes write-protected.
+  * @retval None
+  */
+#define __HAL_RCC_CRS_FREQ_ERROR_COUNTER_ENABLE()  SET_BIT(CRS->CR, CRS_CR_CEN)
 
+/**
+  * @brief  Disable the oscillator clock for frequency error counter.
+  * @retval None
+  */
+#define __HAL_RCC_CRS_FREQ_ERROR_COUNTER_DISABLE() CLEAR_BIT(CRS->CR, CRS_CR_CEN)
 
+/**
+  * @brief  Enable the automatic hardware adjustment of TRIM bits.
+  * @note   When the AUTOTRIMEN bit is set the CRS_CFGR register becomes write-protected.
+  * @retval None
+  */
+#define __HAL_RCC_CRS_AUTOMATIC_CALIB_ENABLE()     SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN)
+
+/**
+  * @brief  Enable or disable the automatic hardware adjustment of TRIM bits.
+  * @retval None
+  */
+#define __HAL_RCC_CRS_AUTOMATIC_CALIB_DISABLE()    CLEAR_BIT(CRS->CR, CRS_CR_AUTOTRIMEN)
+
+/**
+  * @brief  Macro to calculate reload value to be set in CRS register according to target and sync frequencies
+  * @note   The RELOAD value should be selected according to the ratio between the target frequency and the frequency
+  *             of the synchronization source after prescaling. It is then decreased by one in order to
+  *             reach the expected synchronization on the zero value. The formula is the following:
+  *             RELOAD = (fTARGET / fSYNC) -1
+  * @param  __FTARGET__ Target frequency (value in Hz)
+  * @param  __FSYNC__ Synchronization signal frequency (value in Hz)
+  * @retval None
+  */
+#define __HAL_RCC_CRS_RELOADVALUE_CALCULATE(__FTARGET__, __FSYNC__)  (((__FTARGET__) / (__FSYNC__)) - 1U)
 
 /**
   * @}
   */
 
-
-/**
-  * @}
-  */
+#endif /* CRS */
 
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup RCCEx_Exported_Functions
@@ -633,6 +1211,27 @@ void              HAL_RCCEx_DisableLSCO(void);
   * @}
   */
 
+#if defined(CRS)
+
+/** @addtogroup RCCEx_Exported_Functions_Group3
+  * @{
+  */
+
+void              HAL_RCCEx_CRSConfig(RCC_CRSInitTypeDef *pInit);
+void              HAL_RCCEx_CRSSoftwareSynchronizationGenerate(void);
+void              HAL_RCCEx_CRSGetSynchronizationInfo(RCC_CRSSynchroInfoTypeDef *pSynchroInfo);
+uint32_t          HAL_RCCEx_CRSWaitSynchronization(uint32_t Timeout);
+void              HAL_RCCEx_CRS_IRQHandler(void);
+void              HAL_RCCEx_CRS_SyncOkCallback(void);
+void              HAL_RCCEx_CRS_SyncWarnCallback(void);
+void              HAL_RCCEx_CRS_ExpectedSyncCallback(void);
+void              HAL_RCCEx_CRS_ErrorCallback(uint32_t Error);
+
+/**
+  * @}
+  */
+
+#endif /* CRS */
 
 /**
   * @}
@@ -646,7 +1245,66 @@ void              HAL_RCCEx_DisableLSCO(void);
 #define IS_RCC_LSCOSOURCE(__SOURCE__) (((__SOURCE__) == RCC_LSCOSOURCE_LSI) || \
                                        ((__SOURCE__) == RCC_LSCOSOURCE_LSE))
 
-#if defined(STM32G081xx)
+#if defined(STM32G0C1xx)
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART3)  == RCC_PERIPHCLK_USART3)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART2) == RCC_PERIPHCLK_LPUART2) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C2)    == RCC_PERIPHCLK_I2C2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S2)    == RCC_PERIPHCLK_I2S2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)  == RCC_PERIPHCLK_LPTIM1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)  == RCC_PERIPHCLK_LPTIM2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RNG)     == RCC_PERIPHCLK_RNG)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_CEC)     == RCC_PERIPHCLK_CEC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_FDCAN)   == RCC_PERIPHCLK_FDCAN)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USB)     == RCC_PERIPHCLK_USB)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM15)   == RCC_PERIPHCLK_TIM15))
+
+#elif defined(STM32G0B1xx)
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART3)  == RCC_PERIPHCLK_USART3)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART2) == RCC_PERIPHCLK_LPUART2) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C2)    == RCC_PERIPHCLK_I2C2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S2)    == RCC_PERIPHCLK_I2S2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)  == RCC_PERIPHCLK_LPTIM1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)  == RCC_PERIPHCLK_LPTIM2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_CEC)     == RCC_PERIPHCLK_CEC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_FDCAN)   == RCC_PERIPHCLK_FDCAN)   || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USB)     == RCC_PERIPHCLK_USB)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM15)   == RCC_PERIPHCLK_TIM15))
+
+#elif defined(STM32G0B0xx)
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USART3)  == RCC_PERIPHCLK_USART3)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C2)    == RCC_PERIPHCLK_I2C2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S2)    == RCC_PERIPHCLK_I2S2)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_USB)     == RCC_PERIPHCLK_USB))
+
+#elif defined(STM32G081xx)
 #define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
                ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
                 (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
@@ -662,6 +1320,7 @@ void              HAL_RCCEx_DisableLSCO(void);
                 (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1)    || \
                 (((__SELECTION__) & RCC_PERIPHCLK_TIM15)   == RCC_PERIPHCLK_TIM15))
 #elif defined(STM32G071xx)
+
 #define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
                ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
                 (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
@@ -675,7 +1334,9 @@ void              HAL_RCCEx_DisableLSCO(void);
                 (((__SELECTION__) & RCC_PERIPHCLK_CEC)     == RCC_PERIPHCLK_CEC)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1)    || \
                 (((__SELECTION__) & RCC_PERIPHCLK_TIM15)   == RCC_PERIPHCLK_TIM15))
+
 #elif defined(STM32G070xx)
+
 #define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
                ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
                 (((__SELECTION__) & RCC_PERIPHCLK_USART2)  == RCC_PERIPHCLK_USART2)  || \
@@ -683,7 +1344,38 @@ void              HAL_RCCEx_DisableLSCO(void);
                 (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
                 (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC))
+
+#elif defined(STM32G061xx)
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)  == RCC_PERIPHCLK_LPTIM1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)  == RCC_PERIPHCLK_LPTIM2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RNG)     == RCC_PERIPHCLK_RNG)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM15)   == RCC_PERIPHCLK_TIM15))
+
+#elif defined(STM32G051xx)
+
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
+               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)  == RCC_PERIPHCLK_LPTIM1)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)  == RCC_PERIPHCLK_LPTIM2)  || \
+                (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1)    || \
+                (((__SELECTION__) & RCC_PERIPHCLK_TIM15)   == RCC_PERIPHCLK_TIM15))
+
 #elif defined(STM32G041xx)
+
 #define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
                ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
                 (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
@@ -695,7 +1387,9 @@ void              HAL_RCCEx_DisableLSCO(void);
                 (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_RNG)     == RCC_PERIPHCLK_RNG)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1))
+
 #elif defined(STM32G031xx)
+
 #define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
                ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
                 (((__SELECTION__) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1) || \
@@ -706,14 +1400,16 @@ void              HAL_RCCEx_DisableLSCO(void);
                 (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_TIM1)    == RCC_PERIPHCLK_TIM1))
-#elif defined(STM32G030xx)
+
+#elif defined(STM32G030xx) || defined(STM32G050xx)
+
 #define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
                ((((__SELECTION__) & RCC_PERIPHCLK_USART1)  == RCC_PERIPHCLK_USART1)  || \
                 (((__SELECTION__) & RCC_PERIPHCLK_I2C1)    == RCC_PERIPHCLK_I2C1)    || \
                 (((__SELECTION__) & RCC_PERIPHCLK_I2S1)    == RCC_PERIPHCLK_I2S1)    || \
                 (((__SELECTION__) & RCC_PERIPHCLK_ADC)     == RCC_PERIPHCLK_ADC)     || \
                 (((__SELECTION__) & RCC_PERIPHCLK_RTC)     == RCC_PERIPHCLK_RTC))
-#endif /* STM32G081xx */
+#endif /* STM32G0C1xx */
 
 #define IS_RCC_USART1CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_USART1CLKSOURCE_PCLK1)  || \
@@ -721,7 +1417,7 @@ void              HAL_RCCEx_DisableLSCO(void);
                 ((__SOURCE__) == RCC_USART1CLKSOURCE_LSE)    || \
                 ((__SOURCE__) == RCC_USART1CLKSOURCE_HSI))
 
-#if (RCC_CCIPR_USART2SEL)
+#if defined(RCC_CCIPR_USART2SEL)
 #define IS_RCC_USART2CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_USART2CLKSOURCE_PCLK1)  || \
                 ((__SOURCE__) == RCC_USART2CLKSOURCE_SYSCLK) || \
@@ -729,18 +1425,42 @@ void              HAL_RCCEx_DisableLSCO(void);
                 ((__SOURCE__) == RCC_USART2CLKSOURCE_HSI))
 #endif /* RCC_CCIPR_USART2SEL */
 
-#if (RCC_CCIPR_LPUART1SEL)
+#if defined(RCC_CCIPR_USART3SEL)
+#define IS_RCC_USART3CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USART3CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_USART3CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_USART3CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_USART3CLKSOURCE_HSI))
+#endif /* RCC_CCIPR_USART3SEL */
+
+#if defined(LPUART1)
 #define IS_RCC_LPUART1CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_LPUART1CLKSOURCE_PCLK1)  || \
                 ((__SOURCE__) == RCC_LPUART1CLKSOURCE_SYSCLK) || \
                 ((__SOURCE__) == RCC_LPUART1CLKSOURCE_LSE)    || \
                 ((__SOURCE__) == RCC_LPUART1CLKSOURCE_HSI))
-#endif /* RCC_CCIPR_LPUART1SEL */
+#endif /* LPUART1 */
+
+#if defined(LPUART2)
+#define IS_RCC_LPUART2CLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_LPUART2CLKSOURCE_PCLK1)  || \
+                ((__SOURCE__) == RCC_LPUART2CLKSOURCE_SYSCLK) || \
+                ((__SOURCE__) == RCC_LPUART2CLKSOURCE_LSE)    || \
+                ((__SOURCE__) == RCC_LPUART2CLKSOURCE_HSI))
+#endif /* LPUART2 */
 
 #define IS_RCC_I2C1CLKSOURCE(__SOURCE__)   \
                (((__SOURCE__) == RCC_I2C1CLKSOURCE_PCLK1)   || \
                 ((__SOURCE__) == RCC_I2C1CLKSOURCE_SYSCLK)  || \
                 ((__SOURCE__) == RCC_I2C1CLKSOURCE_HSI))
+
+#if defined(RCC_CCIPR_I2C2SEL)
+#define IS_RCC_I2C2CLKSOURCE(__SOURCE__)   \
+               (((__SOURCE__) == RCC_I2C2CLKSOURCE_PCLK1)   || \
+                ((__SOURCE__) == RCC_I2C2CLKSOURCE_SYSCLK)  || \
+                ((__SOURCE__) == RCC_I2C2CLKSOURCE_HSI))
+
+#endif /* RCC_CCIPR_I2C2SEL */
 
 #define IS_RCC_I2S1CLKSOURCE(__SOURCE__)   \
                (((__SOURCE__) == RCC_I2S1CLKSOURCE_SYSCLK)|| \
@@ -748,7 +1468,15 @@ void              HAL_RCCEx_DisableLSCO(void);
                 ((__SOURCE__) == RCC_I2S1CLKSOURCE_HSI)   || \
                 ((__SOURCE__) == RCC_I2S1CLKSOURCE_EXT))
 
-#if (RCC_CCIPR_LPTIM1SEL)
+#if defined(RCC_CCIPR2_I2S2SEL)
+#define IS_RCC_I2S2CLKSOURCE(__SOURCE__)   \
+               (((__SOURCE__) == RCC_I2S2CLKSOURCE_SYSCLK)|| \
+                ((__SOURCE__) == RCC_I2S2CLKSOURCE_PLL)   || \
+                ((__SOURCE__) == RCC_I2S2CLKSOURCE_HSI)   || \
+                ((__SOURCE__) == RCC_I2S2CLKSOURCE_EXT))
+#endif /* RCC_CCIPR2_I2S2SEL */
+
+#if defined(RCC_CCIPR_LPTIM1SEL)
 #define IS_RCC_LPTIM1CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_LPTIM1CLKSOURCE_PCLK1)|| \
                 ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSI)  || \
@@ -756,7 +1484,7 @@ void              HAL_RCCEx_DisableLSCO(void);
                 ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSE))
 #endif /* RCC_CCIPR_LPTIM1SEL */
 
-#if (RCC_CCIPR_LPTIM2SEL)
+#if defined(RCC_CCIPR_LPTIM2SEL)
 #define IS_RCC_LPTIM2CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_LPTIM2CLKSOURCE_PCLK1)|| \
                 ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSI)  || \
@@ -788,17 +1516,62 @@ void              HAL_RCCEx_DisableLSCO(void);
                 ((__SOURCE__) == RCC_CECCLKSOURCE_LSE))
 #endif /* CEC */
 
-#if (RCC_CCIPR_TIM1SEL)
+#if defined(FDCAN1) || defined(FDCAN2)
+#define IS_RCC_FDCANCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_FDCANCLKSOURCE_HSE)|| \
+                ((__SOURCE__) == RCC_FDCANCLKSOURCE_PLL)|| \
+                ((__SOURCE__) == RCC_FDCANCLKSOURCE_PCLK1))
+
+#endif /* FDCAN1 */
+
+#if defined(RCC_HSI48_SUPPORT)
+#define IS_RCC_USBCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USBCLKSOURCE_HSI48)|| \
+                ((__SOURCE__) == RCC_USBCLKSOURCE_HSE)  || \
+                ((__SOURCE__) == RCC_USBCLKSOURCE_PLL))
+#else
+#define IS_RCC_USBCLKSOURCE(__SOURCE__)  \
+               (((__SOURCE__) == RCC_USBCLKSOURCE_HSE)|| \
+                ((__SOURCE__) == RCC_USBCLKSOURCE_PLL))
+#endif /* RCC_HSI48_SUPPORT */
+
+#if defined(RCC_CCIPR_TIM1SEL)
 #define IS_RCC_TIM1CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_TIM1CLKSOURCE_PLL)     || \
                 ((__SOURCE__) == RCC_TIM1CLKSOURCE_PCLK1))
 #endif /* RCC_CCIPR_TIM1SEL */
 
-#if (RCC_CCIPR_TIM15SEL)
+#if defined(RCC_CCIPR_TIM15SEL)
 #define IS_RCC_TIM15CLKSOURCE(__SOURCE__)  \
                (((__SOURCE__) == RCC_TIM15CLKSOURCE_PLL)     || \
                 ((__SOURCE__) == RCC_TIM15CLKSOURCE_PCLK1))
 #endif /* RCC_CCIPR_TIM15SEL */
+
+#if defined(CRS)
+
+#define IS_RCC_CRS_SYNC_SOURCE(__SOURCE__) (((__SOURCE__) == RCC_CRS_SYNC_SOURCE_GPIO) || \
+                                            ((__SOURCE__) == RCC_CRS_SYNC_SOURCE_LSE)  || \
+                                            ((__SOURCE__) == RCC_CRS_SYNC_SOURCE_USB))
+
+#define IS_RCC_CRS_SYNC_DIV(__DIV__)       (((__DIV__) == RCC_CRS_SYNC_DIV1)  || ((__DIV__) == RCC_CRS_SYNC_DIV2)  || \
+                                            ((__DIV__) == RCC_CRS_SYNC_DIV4)  || ((__DIV__) == RCC_CRS_SYNC_DIV8)  || \
+                                            ((__DIV__) == RCC_CRS_SYNC_DIV16) || ((__DIV__) == RCC_CRS_SYNC_DIV32) || \
+                                            ((__DIV__) == RCC_CRS_SYNC_DIV64) || ((__DIV__) == RCC_CRS_SYNC_DIV128))
+
+#define IS_RCC_CRS_SYNC_POLARITY(__POLARITY__) (((__POLARITY__) == RCC_CRS_SYNC_POLARITY_RISING) || \
+                                                ((__POLARITY__) == RCC_CRS_SYNC_POLARITY_FALLING))
+
+#define IS_RCC_CRS_RELOADVALUE(__VALUE__)  (((__VALUE__) <= 0xFFFFU))
+
+#define IS_RCC_CRS_ERRORLIMIT(__VALUE__)   (((__VALUE__) <= 0xFFU))
+
+#define IS_RCC_CRS_HSI48CALIBRATION(__VALUE__) (((__VALUE__) <= 0x7FU))
+
+#define IS_RCC_CRS_FREQERRORDIR(__DIR__)   (((__DIR__) == RCC_CRS_FREQERRORDIR_UP) || \
+                                            ((__DIR__) == RCC_CRS_FREQERRORDIR_DOWN))
+
+#endif /* CRS */
+
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rtc.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rtc.h
@@ -195,6 +195,9 @@ typedef struct
 
   void  (* Tamper2EventCallback)     ( struct __RTC_HandleTypeDef * hrtc);           /*!< RTC Tamper 2 Event callback           */
 
+#if defined(TAMP_CR1_TAMP3E)
+  void  (* Tamper3EventCallback)     ( struct __RTC_HandleTypeDef * hrtc);           /*!< RTC Tamper 3 Event callback           */
+#endif
 
   void  (* InternalTamper3EventCallback)     ( struct __RTC_HandleTypeDef * hrtc);   /*!< RTC Internal Tamper 3 Event callback  */
 
@@ -215,7 +218,7 @@ typedef struct
 
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
 /**
-  * @brief  HAL LPTIM Callback ID enumeration definition
+  * @brief  HAL RTC Callback ID enumeration definition
   */
 typedef enum
 {
@@ -225,6 +228,9 @@ typedef enum
   HAL_RTC_WAKEUPTIMER_EVENT_CB_ID       = 0x03U,    /*!< RTC WakeUp Timer Event Callback ID */
   HAL_RTC_TAMPER1_EVENT_CB_ID           = 0x04U,    /*!< RTC Tamper 1 Callback ID           */
   HAL_RTC_TAMPER2_EVENT_CB_ID           = 0x05U,    /*!< RTC Tamper 2 Callback ID           */
+#if defined(TAMP_CR1_TAMP3E)
+  HAL_RTC_TAMPER3_EVENT_CB_ID           = 0x06U,    /*!< RTC Tamper 3 Callback ID           */
+#endif
   HAL_RTC_INTERNAL_TAMPER3_EVENT_CB_ID  = 0x09U,    /*!< RTC Internal Tamper 3 Callback ID  */
   HAL_RTC_INTERNAL_TAMPER4_EVENT_CB_ID  = 0x0AU,    /*!< RTC Internal Tamper 4 Callback ID  */
   HAL_RTC_INTERNAL_TAMPER5_EVENT_CB_ID  = 0x0BU,    /*!< RTC Internal Tamper 5 Callback ID  */
@@ -308,8 +314,8 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
   * @{
   */
-#define RTC_HOURFORMAT12_AM                 ((uint8_t)0x00U)
-#define RTC_HOURFORMAT12_PM                 ((uint8_t)0x40U)
+#define RTC_HOURFORMAT12_AM                 0x0u
+#define RTC_HOURFORMAT12_PM                 0x1u
 /**
   * @}
   */
@@ -739,7 +745,7 @@ void HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
 HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID, pRTC_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID);
-#endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rtc_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_rtc_ex.h
@@ -182,7 +182,12 @@ typedef struct
   */
 #define RTC_TAMPER_1                        TAMP_CR1_TAMP1E
 #define RTC_TAMPER_2                        TAMP_CR1_TAMP2E
+#if defined(TAMP_CR1_TAMP3E)
+#define RTC_TAMPER_3                        TAMP_CR1_TAMP3E
+#define RTC_TAMPER_ALL                      (TAMP_CR1_TAMP1E | TAMP_CR1_TAMP2E | TAMP_CR1_TAMP3E)
+#else
 #define RTC_TAMPER_ALL                      (TAMP_CR1_TAMP1E | TAMP_CR1_TAMP2E)
+#endif
 /**
   * @}
   */
@@ -306,7 +311,12 @@ typedef struct
   */
 #define RTC_IT_TAMP1                       TAMP_IER_TAMP1IE     /*!< Tamper 1 Interrupt */
 #define RTC_IT_TAMP2                       TAMP_IER_TAMP2IE     /*!< Tamper 2 Interrupt */
+#if defined(TAMP_CR1_TAMP3E)
+#define RTC_IT_TAMP3                       TAMP_IER_TAMP3IE     /*!< Tamper 3 Interrupt */
+#define RTC_IT_TAMPALL                     (TAMP_IER_TAMP1IE | TAMP_IER_TAMP2IE | TAMP_IER_TAMP3IE)
+#else
 #define RTC_IT_TAMPALL                     (TAMP_IER_TAMP1IE | TAMP_IER_TAMP2IE)
+#endif
 
 #define RTC_IT_INT_TAMP3                   TAMP_IER_ITAMP3IE
 #define RTC_IT_INT_TAMP4                   TAMP_IER_ITAMP4IE
@@ -323,7 +333,12 @@ typedef struct
   */
 #define RTC_FLAG_TAMP1                     TAMP_SR_TAMP1F
 #define RTC_FLAG_TAMP2                     TAMP_SR_TAMP2F
+#if defined(TAMP_CR1_TAMP3E)
+#define RTC_FLAG_TAMP3                     TAMP_SR_TAMP3F
+#define RTC_FLAG_TAMPALL                  (RTC_FLAG_TAMP1 | RTC_FLAG_TAMP2 | RTC_FLAG_TAMP3)
+#else
 #define RTC_FLAG_TAMPALL                  (RTC_FLAG_TAMP1 | RTC_FLAG_TAMP2)
+#endif
 #define RTC_FLAG_INT_TAMP3                 TAMP_SR_ITAMP3F
 #define RTC_FLAG_INT_TAMP4                 TAMP_SR_ITAMP4F
 #define RTC_FLAG_INT_TAMP5                 TAMP_SR_ITAMP5F
@@ -736,6 +751,7 @@ typedef struct
   *            @arg  RTC_ALL_TAMPER: All tampers
   *            @arg  RTC_TAMPER_1: Tamper1
   *            @arg  RTC_TAMPER_2: Tamper2
+  *            @arg  RTC_TAMPER_3: Tamper3 (*)
   * @retval None
   */
 #define __HAL_RTC_TAMPER_ENABLE(__HANDLE__, __TAMPER__)           (((TAMP_TypeDef *)((uint32_t)((__HANDLE__)->Instance) + (__HANDLE__)->TampOffset))->CR1 |= (__TAMPER__))
@@ -748,6 +764,7 @@ typedef struct
   *            @arg  RTC_ALL_TAMPER: All tampers
   *            @arg  RTC_TAMPER_1: Tamper1
   *            @arg  RTC_TAMPER_2: Tamper2
+  *            @arg  RTC_TAMPER_3: Tamper3 (*)
   */
 #define __HAL_RTC_TAMPER_DISABLE(__HANDLE__, __TAMPER__)           (((TAMP_TypeDef *)((uint32_t)((__HANDLE__)->Instance) + (__HANDLE__)->TampOffset))->CR1 &= ~(__TAMPER__))
 
@@ -761,6 +778,7 @@ typedef struct
   *             @arg  RTC_IT_TAMPALL: All tampers interrupts
   *             @arg  RTC_IT_TAMP1: Tamper1 interrupt
   *             @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *             @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
   * @retval None
   */
 #define __HAL_RTC_TAMPER_ENABLE_IT(__HANDLE__, __INTERRUPT__)        (((TAMP_TypeDef *)((uint32_t)((__HANDLE__)->Instance) + (__HANDLE__)->TampOffset))->IER |= (__INTERRUPT__))
@@ -773,6 +791,7 @@ typedef struct
   *            @arg  RTC_IT_TAMPALL: All tampers interrupts
   *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
   *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
   * @retval None
   */
 #define __HAL_RTC_TAMPER_DISABLE_IT(__HANDLE__, __INTERRUPT__)       (((TAMP_TypeDef *)((uint32_t)((__HANDLE__)->Instance) + (__HANDLE__)->TampOffset))->IER &= ~(__INTERRUPT__))
@@ -787,6 +806,7 @@ typedef struct
   *            @arg  RTC_IT_TAMPALL: All tampers interrupts
   *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
   *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
   *            @arg  RTC_IT_INT_TAMP3: Internal Tamper3 interrupt
   *            @arg  RTC_IT_INT_TAMP4: Internal Tamper4 interrupt
   *            @arg  RTC_IT_INT_TAMP5: Internal Tamper5 interrupt
@@ -804,6 +824,7 @@ typedef struct
   *            @arg  RTC_IT_TAMPALL: All tampers interrupts
   *            @arg  RTC_IT_TAMP1: Tamper1 interrupt
   *            @arg  RTC_IT_TAMP2: Tamper2 interrupt
+  *            @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
   *            @arg  RTC_IT_INT_TAMPALL: All internal tampers interrupts
   *            @arg  RTC_IT_INT_TAMP3: Internal Tamper3 interrupt
   *            @arg  RTC_IT_INT_TAMP4: Internal Tamper4 interrupt
@@ -821,6 +842,7 @@ typedef struct
   *          This parameter can be:
   *             @arg RTC_FLAG_TAMP1: Tamper1 flag
   *             @arg RTC_FLAG_TAMP2: Tamper2 flag
+  *             @arg RTC_FLAG_TAMP3: Tamper3 flag (*)
   *             @arg RTC_FLAG_INT_TAMP3: Internal Tamper3 flag
   *             @arg RTC_FLAG_INT_TAMP4: Internal Tamper4 flag
   *             @arg RTC_FLAG_INT_TAMP5: Internal Tamper5 flag
@@ -837,6 +859,7 @@ typedef struct
   *             @arg RTC_FLAG_TAMPALL: All Tamper flags
   *             @arg RTC_FLAG_TAMP1: Tamper1 flag
   *             @arg RTC_FLAG_TAMP2: Tamper2 flag
+  *             @arg RTC_FLAG_TAMP3: Tamper3 flag (*)
   *             @arg RTC_FLAG_INT_TAMP3: Internal Tamper3 flag
   *             @arg RTC_FLAG_INT_TAMP4: Internal Tamper4 flag
   *             @arg RTC_FLAG_INT_TAMP5: Internal Tamper5 flag
@@ -960,6 +983,9 @@ HAL_StatusTypeDef HAL_RTCEx_PollForInternalTamperEvent(RTC_HandleTypeDef *hrtc, 
 void              HAL_RTCEx_TamperIRQHandler(RTC_HandleTypeDef *hrtc);
 void              HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc);
 void              HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc);
+#if defined(TAMP_CR1_TAMP3E)
+void              HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc);
+#endif
 void              HAL_RTCEx_InternalTamper3EventCallback(RTC_HandleTypeDef *hrtc);
 void              HAL_RTCEx_InternalTamper4EventCallback(RTC_HandleTypeDef *hrtc);
 void              HAL_RTCEx_InternalTamper5EventCallback(RTC_HandleTypeDef *hrtc);
@@ -1094,7 +1120,7 @@ uint32_t          HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupReg
 
 
 
-/** @defgroup RTCEx_Substract_Fraction_Of_Second_Value RTCEx Substract Fraction Of Second Value
+/** @defgroup RTCEx_Subtract_Fraction_Of_Second_Value RTCEx Subtract Fraction Of Second Value
   * @{
   */
 #define IS_RTC_SHIFT_SUBFS(FS) ((FS) <= RTC_SHIFTR_SUBFS)

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_smartcard.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_smartcard.h
@@ -111,7 +111,7 @@ typedef struct
 } SMARTCARD_InitTypeDef;
 
 /**
-  * @brief  SMARTCARD advanced features initalization structure definition
+  * @brief  SMARTCARD advanced features initialization structure definition
   */
 typedef struct
 {
@@ -439,7 +439,7 @@ typedef enum
   * @}
   */
 
-/** @defgroup SMARTCARD_ClockPrescaler  Clock Prescaler
+/** @defgroup SMARTCARD_ClockPrescaler  SMARTCARD Clock Prescaler
   * @{
   */
 #define SMARTCARD_PRESCALER_DIV1    0x00000000U  /*!< fclk_pres = fclk     */
@@ -822,7 +822,78 @@ typedef enum
   * @param  __CLOCKSOURCE__ output variable.
   * @retval the SMARTCARD clocking source, written in __CLOCKSOURCE__.
   */
-#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define SMARTCARD_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)   \
+  do {                                                         \
+    if((__HANDLE__)->Instance == USART1)                       \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                    \
+      {                                                        \
+        case RCC_USART1CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;     \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_SYSCLK;    \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART2)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                    \
+      {                                                        \
+        case RCC_USART2CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;     \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_SYSCLK;    \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART3)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                    \
+      {                                                        \
+        case RCC_USART3CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;     \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;       \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_SYSCLK;    \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;       \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED; \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else                                                       \
+    {                                                          \
+      (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED;     \
+    }                                                          \
+  } while(0U)
+#elif defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
 #define SMARTCARD_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)   \
   do {                                                         \
     if((__HANDLE__)->Instance == USART1)                       \
@@ -872,7 +943,7 @@ typedef enum
       (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED;     \
     }                                                          \
   } while(0U)
-#elif defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#else
 #define SMARTCARD_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)   \
   do {                                                         \
     if((__HANDLE__)->Instance == USART1)                       \
@@ -896,16 +967,12 @@ typedef enum
           break;                                               \
       }                                                        \
     }                                                          \
-    else if((__HANDLE__)->Instance == USART2)                  \
-    {                                                          \
-      (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;         \
-    }                                                          \
     else                                                       \
     {                                                          \
       (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_UNDEFINED;     \
     }                                                          \
   } while(0U)
-#endif /* STM32G081xx || STM32G071xx || STM32G070xx */
+#endif
 
 /** @brief  Check the Baud rate range.
   * @note   The maximum Baud Rate is derived from the maximum clock on G0 (64 MHz)

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_smartcard_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_smartcard_ex.h
@@ -68,7 +68,7 @@ extern "C" {
   * @}
   */
 
-/** @defgroup SMARTCARDEx_FIFO_mode SMARTCARDEx FIFO mode
+/** @defgroup SMARTCARDEx_FIFO_mode SMARTCARD FIFO mode
   * @brief    SMARTCARD FIFO mode
   * @{
   */
@@ -78,7 +78,7 @@ extern "C" {
   * @}
   */
 
-/** @defgroup SMARTCARDEx_TXFIFO_threshold_level SMARTCARDEx TXFIFO threshold level
+/** @defgroup SMARTCARDEx_TXFIFO_threshold_level SMARTCARD TXFIFO threshold level
   * @brief    SMARTCARD TXFIFO level
   * @{
   */
@@ -92,7 +92,7 @@ extern "C" {
   * @}
   */
 
-/** @defgroup SMARTCARDEx_RXFIFO_threshold_level SMARTCARDEx RXFIFO threshold level
+/** @defgroup SMARTCARDEx_RXFIFO_threshold_level SMARTCARD RXFIFO threshold level
   * @brief    SMARTCARD RXFIFO level
   * @{
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_smbus.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_smbus.h
@@ -65,7 +65,7 @@ typedef struct
   uint32_t OwnAddress2;            /*!< Specifies the second device own address if dual addressing mode is selected
                                      This parameter can be a 7-bit address. */
 
-  uint32_t OwnAddress2Masks;       /*!< Specifies the acknoledge mask address second device own address if dual addressing mode is selected
+  uint32_t OwnAddress2Masks;       /*!< Specifies the acknowledge mask address second device own address if dual addressing mode is selected
                                      This parameter can be a value of @ref SMBUS_own_address2_masks. */
 
   uint32_t GeneralCallMode;        /*!< Specifies if general call mode is selected.
@@ -132,7 +132,11 @@ typedef struct
   * @brief  SMBUS handle Structure definition
   * @{
   */
+#if (USE_HAL_SMBUS_REGISTER_CALLBACKS == 1)
 typedef struct __SMBUS_HandleTypeDef
+#else
+typedef struct
+#endif  /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
 {
   I2C_TypeDef                  *Instance;       /*!< SMBUS registers base address       */
 
@@ -326,6 +330,7 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
 #define  SMBUS_NEXT_FRAME                       ((uint32_t)(SMBUS_RELOAD_MODE | SMBUS_SOFTEND_MODE))
 #define  SMBUS_FIRST_AND_LAST_FRAME_NO_PEC      SMBUS_AUTOEND_MODE
 #define  SMBUS_LAST_FRAME_NO_PEC                SMBUS_AUTOEND_MODE
+#define  SMBUS_FIRST_FRAME_WITH_PEC             ((uint32_t)(SMBUS_SOFTEND_MODE | SMBUS_SENDPEC_MODE))
 #define  SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC    ((uint32_t)(SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))
 #define  SMBUS_LAST_FRAME_WITH_PEC              ((uint32_t)(SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))
 
@@ -582,11 +587,12 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
                                                           ((REQUEST) == SMBUS_NO_STARTSTOP))
 
 
-#define IS_SMBUS_TRANSFER_OPTIONS_REQUEST(REQUEST)      (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST)       || \
+#define IS_SMBUS_TRANSFER_OPTIONS_REQUEST(REQUEST)      (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST)        || \
                                                           ((REQUEST) == SMBUS_FIRST_FRAME)                       || \
                                                           ((REQUEST) == SMBUS_NEXT_FRAME)                        || \
                                                           ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_NO_PEC)       || \
                                                           ((REQUEST) == SMBUS_LAST_FRAME_NO_PEC)                 || \
+                                                          ((REQUEST) == SMBUS_FIRST_FRAME_WITH_PEC)              || \
                                                           ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC)     || \
                                                           ((REQUEST) == SMBUS_LAST_FRAME_WITH_PEC))
 

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_spi.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_spi.h
@@ -383,7 +383,8 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
 #define SPI_FLAG_FRE                    SPI_SR_FRE    /* SPI Error flag: TI mode frame format error flag */
 #define SPI_FLAG_FTLVL                  SPI_SR_FTLVL  /* SPI fifo transmission level                     */
 #define SPI_FLAG_FRLVL                  SPI_SR_FRLVL  /* SPI fifo reception level                        */
-#define SPI_FLAG_MASK                   (SPI_SR_RXNE | SPI_SR_TXE | SPI_SR_BSY | SPI_SR_CRCERR | SPI_SR_MODF | SPI_SR_OVR | SPI_SR_FRE | SPI_SR_FTLVL | SPI_SR_FRLVL)
+#define SPI_FLAG_MASK                   (SPI_SR_RXNE | SPI_SR_TXE | SPI_SR_BSY | SPI_SR_CRCERR\
+                                         | SPI_SR_MODF | SPI_SR_OVR | SPI_SR_FRE | SPI_SR_FTLVL | SPI_SR_FRLVL)
 /**
   * @}
   */
@@ -433,7 +434,7 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
                                                                   } while(0)
 #else
 #define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SPI_STATE_RESET)
-#endif
+#endif /* USE_HAL_SPI_REGISTER_CALLBACKS */
 
 /** @brief  Enable the specified SPI interrupts.
   * @param  __HANDLE__ specifies the SPI Handle.
@@ -469,7 +470,8 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *            @arg SPI_IT_ERR: Error interrupt enable
   * @retval The new state of __IT__ (TRUE or FALSE).
   */
-#define __HAL_SPI_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_SPI_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2\
+                                                              & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Check whether the specified SPI flag is set or not.
   * @param  __HANDLE__ specifies the SPI Handle.
@@ -529,9 +531,9 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   */
 #define __HAL_SPI_CLEAR_FREFLAG(__HANDLE__)        \
   do{                                              \
-  __IO uint32_t tmpreg_fre = 0x00U;                \
-  tmpreg_fre = (__HANDLE__)->Instance->SR;         \
-  UNUSED(tmpreg_fre);                              \
+    __IO uint32_t tmpreg_fre = 0x00U;              \
+    tmpreg_fre = (__HANDLE__)->Instance->SR;       \
+    UNUSED(tmpreg_fre);                            \
   }while(0U)
 
 /** @brief  Enable the SPI peripheral.
@@ -580,7 +582,7 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
                                        SET_BIT((__HANDLE__)->Instance->CR1, SPI_CR1_CRCEN);}while(0U)
 
 /** @brief  Check whether the specified SPI flag is set or not.
-  * @param  __SR__  copy of SPI SR regsiter.
+  * @param  __SR__  copy of SPI SR register.
   * @param  __FLAG__ specifies the flag to check.
   *         This parameter can be one of the following values:
   *            @arg SPI_FLAG_RXNE: Receive buffer not empty flag
@@ -594,10 +596,11 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *            @arg SPI_FLAG_FRLVL: SPI fifo reception level
   * @retval SET or RESET.
   */
-#define SPI_CHECK_FLAG(__SR__, __FLAG__)         ((((__SR__) & ((__FLAG__) & SPI_FLAG_MASK)) == ((__FLAG__) & SPI_FLAG_MASK)) ? SET : RESET)
+#define SPI_CHECK_FLAG(__SR__, __FLAG__) ((((__SR__) & ((__FLAG__) & SPI_FLAG_MASK)) == \
+                                          ((__FLAG__) & SPI_FLAG_MASK)) ? SET : RESET)
 
 /** @brief  Check whether the specified SPI Interrupt is set or not.
-  * @param  __CR2__  copy of SPI CR2 regsiter.
+  * @param  __CR2__  copy of SPI CR2 register.
   * @param  __INTERRUPT__ specifies the SPI interrupt source to check.
   *         This parameter can be one of the following values:
   *            @arg SPI_IT_TXE: Tx buffer empty interrupt enable
@@ -605,15 +608,16 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *            @arg SPI_IT_ERR: Error interrupt enable
   * @retval SET or RESET.
   */
-#define SPI_CHECK_IT_SOURCE(__CR2__, __INTERRUPT__)      ((((__CR2__) & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define SPI_CHECK_IT_SOURCE(__CR2__, __INTERRUPT__) ((((__CR2__) & (__INTERRUPT__)) == \
+                                                     (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Checks if SPI Mode parameter is in allowed range.
   * @param  __MODE__ specifies the SPI Mode.
   *         This parameter can be a value of @ref SPI_Mode
   * @retval None
   */
-#define IS_SPI_MODE(__MODE__) (((__MODE__) == SPI_MODE_SLAVE) || \
-                               ((__MODE__) == SPI_MODE_MASTER))
+#define IS_SPI_MODE(__MODE__)      (((__MODE__) == SPI_MODE_SLAVE)   || \
+                                    ((__MODE__) == SPI_MODE_MASTER))
 
 /** @brief  Checks if SPI Direction Mode parameter is in allowed range.
   * @param  __MODE__ specifies the SPI Direction Mode.
@@ -661,33 +665,33 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *         This parameter can be a value of @ref SPI_Clock_Polarity
   * @retval None
   */
-#define IS_SPI_CPOL(__CPOL__) (((__CPOL__) == SPI_POLARITY_LOW) || \
-                               ((__CPOL__) == SPI_POLARITY_HIGH))
+#define IS_SPI_CPOL(__CPOL__)      (((__CPOL__) == SPI_POLARITY_LOW) || \
+                                    ((__CPOL__) == SPI_POLARITY_HIGH))
 
 /** @brief  Checks if SPI Clock Phase parameter is in allowed range.
   * @param  __CPHA__ specifies the SPI Clock Phase.
   *         This parameter can be a value of @ref SPI_Clock_Phase
   * @retval None
   */
-#define IS_SPI_CPHA(__CPHA__) (((__CPHA__) == SPI_PHASE_1EDGE) || \
-                               ((__CPHA__) == SPI_PHASE_2EDGE))
+#define IS_SPI_CPHA(__CPHA__)      (((__CPHA__) == SPI_PHASE_1EDGE) || \
+                                    ((__CPHA__) == SPI_PHASE_2EDGE))
 
 /** @brief  Checks if SPI Slave Select parameter is in allowed range.
   * @param  __NSS__ specifies the SPI Slave Select management parameter.
   *         This parameter can be a value of @ref SPI_Slave_Select_management
   * @retval None
   */
-#define IS_SPI_NSS(__NSS__) (((__NSS__) == SPI_NSS_SOFT)       || \
-                             ((__NSS__) == SPI_NSS_HARD_INPUT) || \
-                             ((__NSS__) == SPI_NSS_HARD_OUTPUT))
+#define IS_SPI_NSS(__NSS__)        (((__NSS__) == SPI_NSS_SOFT)       || \
+                                    ((__NSS__) == SPI_NSS_HARD_INPUT) || \
+                                    ((__NSS__) == SPI_NSS_HARD_OUTPUT))
 
 /** @brief  Checks if SPI NSS Pulse parameter is in allowed range.
   * @param  __NSSP__ specifies the SPI NSS Pulse Mode parameter.
   *         This parameter can be a value of @ref SPI_NSSP_Mode
   * @retval None
   */
-#define IS_SPI_NSSP(__NSSP__) (((__NSSP__) == SPI_NSS_PULSE_ENABLE) || \
-                               ((__NSSP__) == SPI_NSS_PULSE_DISABLE))
+#define IS_SPI_NSSP(__NSSP__)      (((__NSSP__) == SPI_NSS_PULSE_ENABLE) || \
+                                    ((__NSSP__) == SPI_NSS_PULSE_DISABLE))
 
 /** @brief  Checks if SPI Baudrate prescaler parameter is in allowed range.
   * @param  __PRESCALER__ specifies the SPI Baudrate prescaler.
@@ -708,16 +712,16 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *         This parameter can be a value of @ref SPI_MSB_LSB_transmission
   * @retval None
   */
-#define IS_SPI_FIRST_BIT(__BIT__) (((__BIT__) == SPI_FIRSTBIT_MSB) || \
-                                   ((__BIT__) == SPI_FIRSTBIT_LSB))
+#define IS_SPI_FIRST_BIT(__BIT__)  (((__BIT__) == SPI_FIRSTBIT_MSB) || \
+                                    ((__BIT__) == SPI_FIRSTBIT_LSB))
 
 /** @brief  Checks if SPI TI mode parameter is in allowed range.
   * @param  __MODE__ specifies the SPI TI mode.
   *         This parameter can be a value of @ref SPI_TI_mode
   * @retval None
   */
-#define IS_SPI_TIMODE(__MODE__) (((__MODE__) == SPI_TIMODE_DISABLE) || \
-                                 ((__MODE__) == SPI_TIMODE_ENABLE))
+#define IS_SPI_TIMODE(__MODE__)    (((__MODE__) == SPI_TIMODE_DISABLE) || \
+                                    ((__MODE__) == SPI_TIMODE_ENABLE))
 
 /** @brief  Checks if SPI CRC calculation enabled state is in allowed range.
   * @param  __CALCULATION__ specifies the SPI CRC calculation enable state.
@@ -732,8 +736,8 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *         This parameter can be a value of @ref SPI_CRC_length
   * @retval None
   */
-#define IS_SPI_CRC_LENGTH(__LENGTH__) (((__LENGTH__) == SPI_CRC_LENGTH_DATASIZE) ||\
-                                       ((__LENGTH__) == SPI_CRC_LENGTH_8BIT)  ||   \
+#define IS_SPI_CRC_LENGTH(__LENGTH__) (((__LENGTH__) == SPI_CRC_LENGTH_DATASIZE) || \
+                                       ((__LENGTH__) == SPI_CRC_LENGTH_8BIT)     || \
                                        ((__LENGTH__) == SPI_CRC_LENGTH_16BIT))
 
 /** @brief  Checks if SPI polynomial value to be used for the CRC calculation, is in allowed range.
@@ -741,7 +745,9 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *         This parameter must be a number between Min_Data = 0 and Max_Data = 65535
   * @retval None
   */
-#define IS_SPI_CRC_POLYNOMIAL(__POLYNOMIAL__) (((__POLYNOMIAL__) >= 0x1U) && ((__POLYNOMIAL__) <= 0xFFFFU) && (((__POLYNOMIAL__)&0x1U) != 0U))
+#define IS_SPI_CRC_POLYNOMIAL(__POLYNOMIAL__) (((__POLYNOMIAL__) >= 0x1U)    && \
+                                               ((__POLYNOMIAL__) <= 0xFFFFU) && \
+                                              (((__POLYNOMIAL__)&0x1U) != 0U))
 
 /** @brief  Checks if DMA handle is valid.
   * @param  __HANDLE__ specifies a DMA Handle.

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_tim.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_tim.h
@@ -167,7 +167,7 @@ typedef struct
                                This parameter can be a value of @ref TIM_Encoder_Mode */
 
   uint32_t IC1Polarity;   /*!< Specifies the active edge of the input signal.
-                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+                               This parameter can be a value of @ref TIM_Encoder_Input_Polarity */
 
   uint32_t IC1Selection;  /*!< Specifies the input.
                                This parameter can be a value of @ref TIM_Input_Capture_Selection */
@@ -179,7 +179,7 @@ typedef struct
                                This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
 
   uint32_t IC2Polarity;   /*!< Specifies the active edge of the input signal.
-                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+                               This parameter can be a value of @ref TIM_Encoder_Input_Polarity */
 
   uint32_t IC2Selection;  /*!< Specifies the input.
                               This parameter can be a value of @ref TIM_Input_Capture_Selection */
@@ -309,6 +309,26 @@ typedef enum
 } HAL_TIM_StateTypeDef;
 
 /**
+  * @brief  TIM Channel States definition
+  */
+typedef enum
+{
+  HAL_TIM_CHANNEL_STATE_RESET             = 0x00U,    /*!< TIM Channel initial state                         */
+  HAL_TIM_CHANNEL_STATE_READY             = 0x01U,    /*!< TIM Channel ready for use                         */
+  HAL_TIM_CHANNEL_STATE_BUSY              = 0x02U,    /*!< An internal process is ongoing on the TIM channel */
+} HAL_TIM_ChannelStateTypeDef;
+
+/**
+  * @brief  DMA Burst States definition
+  */
+typedef enum
+{
+  HAL_DMA_BURST_STATE_RESET             = 0x00U,    /*!< DMA Burst initial state */
+  HAL_DMA_BURST_STATE_READY             = 0x01U,    /*!< DMA Burst ready for use */
+  HAL_DMA_BURST_STATE_BUSY              = 0x02U,    /*!< Ongoing DMA Burst       */
+} HAL_TIM_DMABurstStateTypeDef;
+
+/**
   * @brief  HAL Active channel structures definition
   */
 typedef enum
@@ -331,13 +351,16 @@ typedef struct __TIM_HandleTypeDef
 typedef struct
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
 {
-  TIM_TypeDef                 *Instance;     /*!< Register base address             */
-  TIM_Base_InitTypeDef        Init;          /*!< TIM Time Base required parameters */
-  HAL_TIM_ActiveChannel       Channel;       /*!< Active channel                    */
-  DMA_HandleTypeDef           *hdma[7];      /*!< DMA Handlers array
-                                                  This array is accessed by a @ref DMA_Handle_index */
-  HAL_LockTypeDef             Lock;          /*!< Locking object                    */
-  __IO HAL_TIM_StateTypeDef   State;         /*!< TIM operation state               */
+  TIM_TypeDef                        *Instance;         /*!< Register base address                             */
+  TIM_Base_InitTypeDef               Init;              /*!< TIM Time Base required parameters                 */
+  HAL_TIM_ActiveChannel              Channel;           /*!< Active channel                                    */
+  DMA_HandleTypeDef                  *hdma[7];          /*!< DMA Handlers array
+                                                             This array is accessed by a @ref DMA_Handle_index */
+  HAL_LockTypeDef                    Lock;              /*!< Locking object                                    */
+  __IO HAL_TIM_StateTypeDef          State;             /*!< TIM operation state                               */
+  __IO HAL_TIM_ChannelStateTypeDef   ChannelState[6];   /*!< TIM channel operation state                       */
+  __IO HAL_TIM_ChannelStateTypeDef   ChannelNState[4];  /*!< TIM complementary channel operation state         */
+  __IO HAL_TIM_DMABurstStateTypeDef  DMABurstState;     /*!< DMA burst operation state                         */
 
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   void (* Base_MspInitCallback)(struct __TIM_HandleTypeDef *htim);              /*!< TIM Base Msp Init Callback                              */
@@ -377,35 +400,35 @@ typedef struct
   */
 typedef enum
 {
-   HAL_TIM_BASE_MSPINIT_CB_ID            = 0x00U    /*!< TIM Base MspInit Callback ID                              */
-  ,HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U    /*!< TIM Base MspDeInit Callback ID                            */
-  ,HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U    /*!< TIM IC MspInit Callback ID                                */
-  ,HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U    /*!< TIM IC MspDeInit Callback ID                              */
-  ,HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U    /*!< TIM OC MspInit Callback ID                                */
-  ,HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U    /*!< TIM OC MspDeInit Callback ID                              */
-  ,HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U    /*!< TIM PWM MspInit Callback ID                               */
-  ,HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U    /*!< TIM PWM MspDeInit Callback ID                             */
-  ,HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U    /*!< TIM One Pulse MspInit Callback ID                         */
-  ,HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U    /*!< TIM One Pulse MspDeInit Callback ID                       */
-  ,HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU    /*!< TIM Encoder MspInit Callback ID                           */
-  ,HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU    /*!< TIM Encoder MspDeInit Callback ID                         */
-  ,HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU    /*!< TIM Hall Sensor MspDeInit Callback ID                     */
-  ,HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU    /*!< TIM Hall Sensor MspDeInit Callback ID                     */
-  ,HAL_TIM_PERIOD_ELAPSED_CB_ID          = 0x0EU    /*!< TIM Period Elapsed Callback ID                             */
-  ,HAL_TIM_PERIOD_ELAPSED_HALF_CB_ID     = 0x0FU    /*!< TIM Period Elapsed half complete Callback ID               */
-  ,HAL_TIM_TRIGGER_CB_ID                 = 0x10U    /*!< TIM Trigger Callback ID                                    */
-  ,HAL_TIM_TRIGGER_HALF_CB_ID            = 0x11U    /*!< TIM Trigger half complete Callback ID                      */
+  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                              */
+  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                            */
+  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                */
+  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                              */
+  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                */
+  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                              */
+  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                               */
+  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                             */
+  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                         */
+  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                       */
+  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                           */
+  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                         */
+  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
+  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
+  , HAL_TIM_PERIOD_ELAPSED_CB_ID          = 0x0EU   /*!< TIM Period Elapsed Callback ID                             */
+  , HAL_TIM_PERIOD_ELAPSED_HALF_CB_ID     = 0x0FU   /*!< TIM Period Elapsed half complete Callback ID               */
+  , HAL_TIM_TRIGGER_CB_ID                 = 0x10U   /*!< TIM Trigger Callback ID                                    */
+  , HAL_TIM_TRIGGER_HALF_CB_ID            = 0x11U   /*!< TIM Trigger half complete Callback ID                      */
 
-  ,HAL_TIM_IC_CAPTURE_CB_ID              = 0x12U    /*!< TIM Input Capture Callback ID                              */
-  ,HAL_TIM_IC_CAPTURE_HALF_CB_ID         = 0x13U    /*!< TIM Input Capture half complete Callback ID                */
-  ,HAL_TIM_OC_DELAY_ELAPSED_CB_ID        = 0x14U    /*!< TIM Output Compare Delay Elapsed Callback ID               */
-  ,HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U    /*!< TIM PWM Pulse Finished Callback ID           */
-  ,HAL_TIM_PWM_PULSE_FINISHED_HALF_CB_ID = 0x16U    /*!< TIM PWM Pulse Finished half complete Callback ID           */
-  ,HAL_TIM_ERROR_CB_ID                   = 0x17U    /*!< TIM Error Callback ID                                      */
-  ,HAL_TIM_COMMUTATION_CB_ID             = 0x18U    /*!< TIM Commutation Callback ID                                */
-  ,HAL_TIM_COMMUTATION_HALF_CB_ID        = 0x19U    /*!< TIM Commutation half complete Callback ID                  */
-  ,HAL_TIM_BREAK_CB_ID                   = 0x1AU    /*!< TIM Break Callback ID                                      */
-  ,HAL_TIM_BREAK2_CB_ID                  = 0x1BU    /*!< TIM Break2 Callback ID                                     */
+  , HAL_TIM_IC_CAPTURE_CB_ID              = 0x12U   /*!< TIM Input Capture Callback ID                              */
+  , HAL_TIM_IC_CAPTURE_HALF_CB_ID         = 0x13U   /*!< TIM Input Capture half complete Callback ID                */
+  , HAL_TIM_OC_DELAY_ELAPSED_CB_ID        = 0x14U   /*!< TIM Output Compare Delay Elapsed Callback ID               */
+  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID           */
+  , HAL_TIM_PWM_PULSE_FINISHED_HALF_CB_ID = 0x16U   /*!< TIM PWM Pulse Finished half complete Callback ID           */
+  , HAL_TIM_ERROR_CB_ID                   = 0x17U   /*!< TIM Error Callback ID                                      */
+  , HAL_TIM_COMMUTATION_CB_ID             = 0x18U   /*!< TIM Commutation Callback ID                                */
+  , HAL_TIM_COMMUTATION_HALF_CB_ID        = 0x19U   /*!< TIM Commutation half complete Callback ID                  */
+  , HAL_TIM_BREAK_CB_ID                   = 0x1AU   /*!< TIM Break Callback ID                                      */
+  , HAL_TIM_BREAK2_CB_ID                  = 0x1BU   /*!< TIM Break2 Callback ID                                     */
 } HAL_TIM_CallbackIDTypeDef;
 
 /**
@@ -428,12 +451,16 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 /** @defgroup TIM_ClearInput_Source TIM Clear Input Source
   * @{
   */
-#define TIM_CLEARINPUTSOURCE_NONE           0x00000000U   /*!< OCREF_CLR is disabled */
-#define TIM_CLEARINPUTSOURCE_ETR            0x00000001U   /*!< OCREF_CLR is connected to ETRF input */
-#if defined(COMP1) && defined(COMP2)
-#define TIM_CLEARINPUTSOURCE_COMP1          0x00000002U   /*!< OCREF_CLR_INT is connected to COMP1 output */
-#define TIM_CLEARINPUTSOURCE_COMP2          0x00000004U   /*!< OCREF_CLR_INT is connected to COMP2 output */
-#endif /* COMP1 && COMP2 */
+#define TIM_CLEARINPUTSOURCE_NONE           0x10000000U           /*!< OCREF_CLR is disabled */
+#define TIM_CLEARINPUTSOURCE_ETR            0x20000000U           /*!< OCREF_CLR is connected to ETRF input */
+#if defined(COMP1) && defined(COMP2) && defined(COMP3)
+#define TIM_CLEARINPUTSOURCE_COMP1          0x00000000U           /*!< OCREF_CLR_INT is connected to COMP1 output */
+#define TIM_CLEARINPUTSOURCE_COMP2          TIM1_OR1_OCREF_CLR_0  /*!< OCREF_CLR_INT is connected to COMP2 output */
+#define TIM_CLEARINPUTSOURCE_COMP3          TIM1_OR1_OCREF_CLR_1  /*!< OCREF_CLR_INT is connected to COMP3 output */
+#elif defined(COMP1) && defined(COMP2)
+#define TIM_CLEARINPUTSOURCE_COMP1          0x00000000U           /*!< OCREF_CLR_INT is connected to COMP1 output */
+#define TIM_CLEARINPUTSOURCE_COMP2          TIM1_OR1_OCREF_CLR    /*!< OCREF_CLR_INT is connected to COMP2 output */
+#endif /* COMP1 && COMP2 && COMP3 */
 /**
   * @}
   */
@@ -530,6 +557,15 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
   * @}
   */
 
+/** @defgroup TIM_Update_Interrupt_Flag_Remap TIM Update Interrupt Flag Remap
+  * @{
+  */
+#define TIM_UIFREMAP_DISABLE               0x00000000U                          /*!< Update interrupt flag remap disabled */
+#define TIM_UIFREMAP_ENABLE                TIM_CR1_UIFREMAP                     /*!< Update interrupt flag remap enabled */
+/**
+  * @}
+  */
+
 /** @defgroup TIM_ClockDivision TIM Clock Division
   * @{
   */
@@ -619,6 +655,15 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define  TIM_ICPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING      /*!< Capture triggered by rising edge on timer input                  */
 #define  TIM_ICPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING     /*!< Capture triggered by falling edge on timer input                 */
 #define  TIM_ICPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE    /*!< Capture triggered by both rising and falling edges on timer input*/
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Encoder_Input_Polarity TIM Encoder Input Polarity
+  * @{
+  */
+#define  TIM_ENCODERINPUTPOLARITY_RISING   TIM_INPUTCHANNELPOLARITY_RISING      /*!< Encoder input with rising edge polarity  */
+#define  TIM_ENCODERINPUTPOLARITY_FALLING  TIM_INPUTCHANNELPOLARITY_FALLING     /*!< Encoder input with falling edge polarity */
 /**
   * @}
   */
@@ -753,6 +798,9 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define TIM_CLOCKSOURCE_TI1         TIM_TS_TI1FP1        /*!< External clock source mode 1 (TTI1FP1)                */
 #define TIM_CLOCKSOURCE_TI2         TIM_TS_TI2FP2        /*!< External clock source mode 1 (TTI2FP2)                */
 #define TIM_CLOCKSOURCE_ETRMODE1    TIM_TS_ETRF          /*!< External clock source mode 1 (ETRF)                   */
+#if defined(USB_BASE)
+#define TIM_CLOCKSOURCE_ITR7        TIM_TS_ITR7          /*!< External clock source mode 1 (ITR7)                   */
+#endif /* USB_BASE */
 /**
   * @}
   */
@@ -995,6 +1043,9 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define TIM_TS_TI1FP1        (TIM_SMCR_TS_0 | TIM_SMCR_TS_2)                                   /*!< Filtered Timer Input 1 (TI1FP1)        */
 #define TIM_TS_TI2FP2        (TIM_SMCR_TS_1 | TIM_SMCR_TS_2)                                   /*!< Filtered Timer Input 2 (TI2FP2)        */
 #define TIM_TS_ETRF          (TIM_SMCR_TS_0 | TIM_SMCR_TS_1 | TIM_SMCR_TS_2)                   /*!< Filtered External Trigger input (ETRF) */
+#if defined(USB_BASE)
+#define TIM_TS_ITR7          (TIM_SMCR_TS_0 | TIM_SMCR_TS_1 | TIM_SMCR_TS_3)                   /*!< Internal Trigger 7 (ITR7)              */
+#endif /* USB_BASE */
 #define TIM_TS_NONE          0x0000FFFFU                                                       /*!< No trigger selected                    */
 /**
   * @}
@@ -1108,25 +1159,49 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
   * @retval None
   */
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
-#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) do {                                                        \
-                                                      (__HANDLE__)->State             = HAL_TIM_STATE_RESET; \
-                                                      (__HANDLE__)->Base_MspInitCallback         = NULL;     \
-                                                      (__HANDLE__)->Base_MspDeInitCallback       = NULL;     \
-                                                      (__HANDLE__)->IC_MspInitCallback           = NULL;     \
-                                                      (__HANDLE__)->IC_MspDeInitCallback         = NULL;     \
-                                                      (__HANDLE__)->OC_MspInitCallback           = NULL;     \
-                                                      (__HANDLE__)->OC_MspDeInitCallback         = NULL;     \
-                                                      (__HANDLE__)->PWM_MspInitCallback          = NULL;     \
-                                                      (__HANDLE__)->PWM_MspDeInitCallback        = NULL;     \
-                                                      (__HANDLE__)->OnePulse_MspInitCallback     = NULL;     \
-                                                      (__HANDLE__)->OnePulse_MspDeInitCallback   = NULL;     \
-                                                      (__HANDLE__)->Encoder_MspInitCallback      = NULL;     \
-                                                      (__HANDLE__)->Encoder_MspDeInitCallback    = NULL;     \
-                                                      (__HANDLE__)->HallSensor_MspInitCallback   = NULL;     \
-                                                      (__HANDLE__)->HallSensor_MspDeInitCallback = NULL;     \
+#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) do {                                                               \
+                                                      (__HANDLE__)->State            = HAL_TIM_STATE_RESET;         \
+                                                      (__HANDLE__)->ChannelState[0]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[1]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[2]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[3]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[4]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[5]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[0] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[1] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[2] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[3] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->DMABurstState    = HAL_DMA_BURST_STATE_RESET;   \
+                                                      (__HANDLE__)->Base_MspInitCallback         = NULL;            \
+                                                      (__HANDLE__)->Base_MspDeInitCallback       = NULL;            \
+                                                      (__HANDLE__)->IC_MspInitCallback           = NULL;            \
+                                                      (__HANDLE__)->IC_MspDeInitCallback         = NULL;            \
+                                                      (__HANDLE__)->OC_MspInitCallback           = NULL;            \
+                                                      (__HANDLE__)->OC_MspDeInitCallback         = NULL;            \
+                                                      (__HANDLE__)->PWM_MspInitCallback          = NULL;            \
+                                                      (__HANDLE__)->PWM_MspDeInitCallback        = NULL;            \
+                                                      (__HANDLE__)->OnePulse_MspInitCallback     = NULL;            \
+                                                      (__HANDLE__)->OnePulse_MspDeInitCallback   = NULL;            \
+                                                      (__HANDLE__)->Encoder_MspInitCallback      = NULL;            \
+                                                      (__HANDLE__)->Encoder_MspDeInitCallback    = NULL;            \
+                                                      (__HANDLE__)->HallSensor_MspInitCallback   = NULL;            \
+                                                      (__HANDLE__)->HallSensor_MspDeInitCallback = NULL;            \
                                                      } while(0)
 #else
-#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_TIM_STATE_RESET)
+#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) do {                                                               \
+                                                      (__HANDLE__)->State            = HAL_TIM_STATE_RESET;         \
+                                                      (__HANDLE__)->ChannelState[0]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[1]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[2]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[3]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[4]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelState[5]  = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[0] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[1] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[2] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->ChannelNState[3] = HAL_TIM_CHANNEL_STATE_RESET; \
+                                                      (__HANDLE__)->DMABurstState    = HAL_DMA_BURST_STATE_RESET;   \
+                                                     } while(0)
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
 
 /**
@@ -1329,6 +1404,31 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define __HAL_TIM_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->SR = ~(__INTERRUPT__))
 
 /**
+  * @brief  Force a continuous copy of the update interrupt flag (UIF) into the timer counter register (bit 31).
+  * @note This allows both the counter value and a potential roll-over condition signalled by the UIFCPY flag to be read in an atomic way.
+  * @param  __HANDLE__ TIM handle.
+  * @retval None
+mode.
+  */
+#define __HAL_TIM_UIFREMAP_ENABLE(__HANDLE__)    (((__HANDLE__)->Instance->CR1 |= TIM_CR1_UIFREMAP))
+
+/**
+  * @brief  Disable update interrupt flag (UIF) remapping.
+  * @param  __HANDLE__ TIM handle.
+  * @retval None
+mode.
+  */
+#define __HAL_TIM_UIFREMAP_DISABLE(__HANDLE__)    (((__HANDLE__)->Instance->CR1 &= ~TIM_CR1_UIFREMAP))
+
+/**
+  * @brief  Get update interrupt flag (UIF) copy status.
+  * @param  __COUNTER__ Counter value.
+  * @retval The state of UIFCPY (TRUE or FALSE).
+mode.
+  */
+#define __HAL_TIM_GET_UIFCPY(__COUNTER__)    (((__COUNTER__) & (TIM_CNT_UIFCPY)) == (TIM_CNT_UIFCPY))
+
+/**
   * @brief  Indicates whether or not the TIM Counter is used as downcounter.
   * @param  __HANDLE__ TIM handle.
   * @retval False (Counter used as upcounter) or True (Counter used as downcounter)
@@ -1347,6 +1447,8 @@ mode.
 
 /**
   * @brief  Set the TIM Counter Register value on runtime.
+  * Note Please check if the bit 31 of CNT register is used as UIF copy or not, this may affect the counter range in case of 32 bits counter TIM instance.
+  *      Bit 31 of CNT can be enabled/disabled using __HAL_TIM_UIFREMAP_ENABLE()/__HAL_TIM_UIFREMAP_DISABLE() macros.
   * @param  __HANDLE__ TIM handle.
   * @param  __COUNTER__ specifies the Counter register new value.
   * @retval None
@@ -1651,7 +1753,13 @@ mode.
 /** @defgroup TIM_Private_Macros TIM Private Macros
   * @{
   */
-#if defined(COMP1) && defined(COMP2)
+#if defined(COMP1) && defined(COMP2) && defined(COMP3)
+#define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)      || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP1)    || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP2)    || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP3)    || \
+                                             ((__MODE__) == TIM_CLEARINPUTSOURCE_NONE))
+#elif defined(COMP1) && defined(COMP2)
 #define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)      || \
                                              ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP1)    || \
                                              ((__MODE__) == TIM_CLEARINPUTSOURCE_COMP2)    || \
@@ -1659,7 +1767,7 @@ mode.
 #else
 #define IS_TIM_CLEARINPUT_SOURCE(__MODE__)  (((__MODE__) == TIM_CLEARINPUTSOURCE_ETR)      || \
                                              ((__MODE__) == TIM_CLEARINPUTSOURCE_NONE))
-#endif /* COMP1 && COMP2 */
+#endif /* COMP1 && COMP2 && COMP3 */
 
 #define IS_TIM_DMA_BASE(__BASE__) (((__BASE__) == TIM_DMABASE_CR1)   || \
                                    ((__BASE__) == TIM_DMABASE_CR2)   || \
@@ -1695,6 +1803,9 @@ mode.
                                             ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED2)  || \
                                             ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED3))
 
+#define IS_TIM_UIFREMAP_MODE(__MODE__)     (((__MODE__) == TIM_UIFREMAP_DISABLE) || \
+                                            ((__MODE__) == TIM_UIFREMAP_ENALE))
+
 #define IS_TIM_CLOCKDIVISION_DIV(__DIV__)  (((__DIV__) == TIM_CLOCKDIVISION_DIV1) || \
                                             ((__DIV__) == TIM_CLOCKDIVISION_DIV2) || \
                                             ((__DIV__) == TIM_CLOCKDIVISION_DIV4))
@@ -1716,6 +1827,9 @@ mode.
 
 #define IS_TIM_OCNIDLE_STATE(__STATE__)    (((__STATE__) == TIM_OCNIDLESTATE_SET) || \
                                             ((__STATE__) == TIM_OCNIDLESTATE_RESET))
+
+#define IS_TIM_ENCODERINPUT_POLARITY(__POLARITY__)   (((__POLARITY__) == TIM_ENCODERINPUTPOLARITY_RISING)   || \
+                                                      ((__POLARITY__) == TIM_ENCODERINPUTPOLARITY_FALLING))
 
 #define IS_TIM_IC_POLARITY(__POLARITY__)   (((__POLARITY__) == TIM_ICPOLARITY_RISING)   || \
                                             ((__POLARITY__) == TIM_ICPOLARITY_FALLING)  || \
@@ -1880,14 +1994,26 @@ mode.
                                    ((__MODE__) == TIM_OCMODE_RETRIGERRABLE_OPM1) || \
                                    ((__MODE__) == TIM_OCMODE_RETRIGERRABLE_OPM2))
 
-#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
-                                                 ((__SELECTION__) == TIM_TS_ITR1) || \
-                                                 ((__SELECTION__) == TIM_TS_ITR2) || \
-                                                 ((__SELECTION__) == TIM_TS_ITR3) || \
+#if defined(USB_BASE)
+#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR1)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR2)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR3)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR7)    || \
                                                  ((__SELECTION__) == TIM_TS_TI1F_ED) || \
-                                                 ((__SELECTION__) == TIM_TS_TI1FP1) || \
-                                                 ((__SELECTION__) == TIM_TS_TI2FP2) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1FP1)  || \
+                                                 ((__SELECTION__) == TIM_TS_TI2FP2)  || \
                                                  ((__SELECTION__) == TIM_TS_ETRF))
+#else
+#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR1)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR2)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR3)    || \
+                                                 ((__SELECTION__) == TIM_TS_TI1F_ED) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1FP1)  || \
+                                                 ((__SELECTION__) == TIM_TS_TI2FP2)  || \
+                                                 ((__SELECTION__) == TIM_TS_ETRF))
+#endif /* USB_BASE */
 
 #define IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
                                                                ((__SELECTION__) == TIM_TS_ITR1) || \
@@ -1911,15 +2037,15 @@ mode.
 #define IS_TIM_TI1SELECTION(__TI1SELECTION__)  (((__TI1SELECTION__) == TIM_TI1SELECTION_CH1) || \
                                                 ((__TI1SELECTION__) == TIM_TI1SELECTION_XORCOMBINATION))
 
-#define IS_TIM_DMA_LENGTH(__LENGTH__)      (((__LENGTH__) == TIM_DMABURSTLENGTH_1TRANSFER) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_2TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_3TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_4TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_5TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_6TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_7TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_8TRANSFERS) || \
-                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_9TRANSFERS) || \
+#define IS_TIM_DMA_LENGTH(__LENGTH__)      (((__LENGTH__) == TIM_DMABURSTLENGTH_1TRANSFER)   || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_2TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_3TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_4TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_5TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_6TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_7TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_8TRANSFERS)  || \
+                                            ((__LENGTH__) == TIM_DMABURSTLENGTH_9TRANSFERS)  || \
                                             ((__LENGTH__) == TIM_DMABURSTLENGTH_10TRANSFERS) || \
                                             ((__LENGTH__) == TIM_DMABURSTLENGTH_11TRANSFERS) || \
                                             ((__LENGTH__) == TIM_DMABURSTLENGTH_12TRANSFERS) || \
@@ -1929,6 +2055,8 @@ mode.
                                             ((__LENGTH__) == TIM_DMABURSTLENGTH_16TRANSFERS) || \
                                             ((__LENGTH__) == TIM_DMABURSTLENGTH_17TRANSFERS) || \
                                             ((__LENGTH__) == TIM_DMABURSTLENGTH_18TRANSFERS))
+
+#define IS_TIM_DMA_DATA_LENGTH(LENGTH) (((LENGTH) >= 0x1U) && ((LENGTH) < 0x10000U))
 
 #define IS_TIM_IC_FILTER(__ICFILTER__)   ((__ICFILTER__) <= 0xFU)
 
@@ -1971,6 +2099,50 @@ mode.
    ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCER &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP)) :\
    ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCER &= ~(TIM_CCER_CC3P | TIM_CCER_CC3NP)) :\
    ((__HANDLE__)->Instance->CCER &= ~(TIM_CCER_CC4P | TIM_CCER_CC4NP)))
+
+#define TIM_CHANNEL_STATE_GET(__HANDLE__, __CHANNEL__)\
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? (__HANDLE__)->ChannelState[0] :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? (__HANDLE__)->ChannelState[1] :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? (__HANDLE__)->ChannelState[2] :\
+   ((__CHANNEL__) == TIM_CHANNEL_4) ? (__HANDLE__)->ChannelState[3] :\
+   ((__CHANNEL__) == TIM_CHANNEL_5) ? (__HANDLE__)->ChannelState[4] :\
+   (__HANDLE__)->ChannelState[5])
+
+#define TIM_CHANNEL_STATE_SET(__HANDLE__, __CHANNEL__, __CHANNEL_STATE__) \
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->ChannelState[0] = (__CHANNEL_STATE__)) :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->ChannelState[1] = (__CHANNEL_STATE__)) :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->ChannelState[2] = (__CHANNEL_STATE__)) :\
+   ((__CHANNEL__) == TIM_CHANNEL_4) ? ((__HANDLE__)->ChannelState[3] = (__CHANNEL_STATE__)) :\
+   ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->ChannelState[4] = (__CHANNEL_STATE__)) :\
+   ((__HANDLE__)->ChannelState[5] = (__CHANNEL_STATE__)))
+
+#define TIM_CHANNEL_STATE_SET_ALL(__HANDLE__,  __CHANNEL_STATE__) do { \
+  (__HANDLE__)->ChannelState[0]  = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelState[1]  = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelState[2]  = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelState[3]  = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelState[4]  = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelState[5]  = (__CHANNEL_STATE__);  \
+ } while(0)
+
+#define TIM_CHANNEL_N_STATE_GET(__HANDLE__, __CHANNEL__)\
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? (__HANDLE__)->ChannelNState[0] :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? (__HANDLE__)->ChannelNState[1] :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? (__HANDLE__)->ChannelNState[2] :\
+   (__HANDLE__)->ChannelNState[3])
+
+#define TIM_CHANNEL_N_STATE_SET(__HANDLE__, __CHANNEL__, __CHANNEL_STATE__) \
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->ChannelNState[0] = (__CHANNEL_STATE__)) :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->ChannelNState[1] = (__CHANNEL_STATE__)) :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->ChannelNState[2] = (__CHANNEL_STATE__)) :\
+   ((__HANDLE__)->ChannelNState[3] = (__CHANNEL_STATE__)))
+
+#define TIM_CHANNEL_N_STATE_SET_ALL(__HANDLE__,  __CHANNEL_STATE__) do { \
+  (__HANDLE__)->ChannelNState[0] = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelNState[1] = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelNState[2] = (__CHANNEL_STATE__);  \
+  (__HANDLE__)->ChannelNState[3] = (__CHANNEL_STATE__);  \
+ } while(0)
 
 /**
   * @}
@@ -2143,9 +2315,15 @@ HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, TIM_SlaveC
 HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef *sSlaveConfig);
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                               uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
+                                                   uint32_t BurstRequestSrc, uint32_t *BurstBuffer, uint32_t BurstLength,
+                                                   uint32_t DataLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                              uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
+                                                  uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength,
+                                                  uint32_t  DataLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
 HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource);
 uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel);
@@ -2191,6 +2369,11 @@ HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim);
+
+/* Peripheral Channel state functions  ************************************************/
+HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(TIM_HandleTypeDef *htim);
+HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(TIM_HandleTypeDef *htim,  uint32_t Channel);
+HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(TIM_HandleTypeDef *htim);
 /**
   * @}
   */
@@ -2210,7 +2393,6 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
 void TIM_ETR_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ExtTRGPrescaler,
                        uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter);
 
-void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma);
 void TIM_DMADelayPulseHalfCplt(DMA_HandleTypeDef *hdma);
 void TIM_DMAError(DMA_HandleTypeDef *hdma);
 void TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma);

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_tim_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_tim_ex.h
@@ -95,11 +95,19 @@ TIMEx_BreakInputConfigTypeDef;
 #define TIM_TIM1_ETR_ADC1_AWD1      (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0)     /* !< TIM1_ETR is connected to ADC1 AWD1 */
 #define TIM_TIM1_ETR_ADC1_AWD2      TIM1_AF1_ETRSEL_2                           /* !< TIM1_ETR is connected to ADC1 AWD2 */
 #define TIM_TIM1_ETR_ADC1_AWD3      (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)     /* !< TIM1_ETR is connected to ADC1 AWD3 */
+#if defined(COMP3)
+#define TIM_TIM1_ETR_COMP3          (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1)     /* !< TIM1_ETR is connected to COMP3 output */
+#endif
 #if defined(TIM2)
 #define TIM_TIM2_ETR_GPIO           0x00000000U                                 /* !< TIM2_ETR is connected to GPIO      */
 #define TIM_TIM2_ETR_COMP1          TIM2_AF1_ETRSEL_0                           /* !< TIM2_ETR is connected to COMP1 output */
 #define TIM_TIM2_ETR_COMP2          TIM2_AF1_ETRSEL_1                           /* !< TIM2_ETR is connected to COMP2 output */
 #define TIM_TIM2_ETR_LSE            (TIM2_AF1_ETRSEL_1 | TIM2_AF1_ETRSEL_0)     /* !< TIM2_ETR is connected to LSE */
+#if defined(COMP3)
+#define TIM_TIM2_ETR_MCO            TIM2_AF1_ETRSEL_2                           /* !< TIM2_ETR is connected to MCO */
+#define TIM_TIM2_ETR_MCO2           (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0)     /* !< TIM2_ETR is connected to MCO2 */
+#define TIM_TIM2_ETR_COMP3          (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1)     /* !< TIM2_ETR is connected to COMP3 output */
+#endif
 #endif /*  TIM2 */
 #if defined(TIM3)
 #define TIM_TIM3_ETR_GPIO           0x00000000U                                 /* !< TIM3_ETR is connected to GPIO */
@@ -107,7 +115,20 @@ TIMEx_BreakInputConfigTypeDef;
 #define TIM_TIM3_ETR_COMP1          TIM3_AF1_ETRSEL_0                           /* !< TIM3_ETR is connected to COMP1 output */
 #define TIM_TIM3_ETR_COMP2          TIM3_AF1_ETRSEL_1                           /* !< TIM3_ETR is connected to COMP2 output */
 #endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+#define TIM_TIM3_ETR_COMP3          (TIM3_AF1_ETRSEL_1 | TIM3_AF1_ETRSEL_0)     /* !< TIM3_ETR is connected to COMP3 output */
+#endif /* COMP3 */
 #endif /* TIM3 */
+#if defined(TIM4)
+#define TIM_TIM4_ETR_GPIO           0x00000000U                                 /* !< TIM4_ETR is connected to GPIO */
+#if defined(COMP1) && defined(COMP2)
+#define TIM_TIM4_ETR_COMP1          TIM4_AF1_ETRSEL_0                           /* !< TIM4_ETR is connected to COMP1 output */
+#define TIM_TIM4_ETR_COMP2          TIM4_AF1_ETRSEL_1                           /* !< TIM4_ETR is connected to COMP2 output */
+#endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+#define TIM_TIM4_ETR_COMP3          (TIM4_AF1_ETRSEL_1 | TIM4_AF1_ETRSEL_0)     /* !< TIM4_ETR is connected to COMP3 output */
+#endif /* COMP3 */
+#endif /* TIM4 */
 /**
   * @}
   */
@@ -129,6 +150,9 @@ TIMEx_BreakInputConfigTypeDef;
 #define TIM_BREAKINPUTSOURCE_COMP1    0x00000002U                               /* !< The COMP1 output is connected to the break input */
 #define TIM_BREAKINPUTSOURCE_COMP2    0x00000004U                               /* !< The COMP2 output is connected to the break input */
 #endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+#define TIM_BREAKINPUTSOURCE_COMP3    0x00000008U                               /* !< The COMP3 output is connected to the break input */
+#endif /* COMP3 */
 /**
   * @}
   */
@@ -159,10 +183,15 @@ TIMEx_BreakInputConfigTypeDef;
 #define TIM_TIM1_TI1_COMP1                    0x00000001U                       /* !< TIM1_TI1 is connected to COMP1 OUT */
 #endif /* COMP1 */
 
- #define TIM_TIM1_TI2_GPIO                     0x00000000U                       /* !< TIM1_TI2 is connected to GPIO */
+#define TIM_TIM1_TI2_GPIO                     0x00000000U                       /* !< TIM1_TI2 is connected to GPIO */
 #if defined(COMP2)
 #define TIM_TIM1_TI2_COMP2                    0x00000100U                       /* !< TIM1_TI2 is connected to COMP2 OUT */
 #endif /* COMP2 */
+
+#define TIM_TIM1_TI3_GPIO                     0x00000000U                       /* !< TIM1_TI3 is connected to GPIO */
+#if defined(COMP3)
+#define TIM_TIM1_TI3_COMP3                    0x00010000U                       /* !< TIM1_TI3 is connected to COMP3 OUT */
+#endif /* COMP3 */
 
 #if defined(TIM2)
 #define TIM_TIM2_TI1_GPIO                     0x00000000U                       /* !< TIM2_TI1 is connected to GPIO */
@@ -170,6 +199,11 @@ TIMEx_BreakInputConfigTypeDef;
 
 #define TIM_TIM2_TI2_GPIO                     0x00000000U                       /* !< TIM2_TI2 is connected to GPIO */
 #define TIM_TIM2_TI2_COMP2                    0x00000100U                       /* !< TIM2_TI2 is connected to COMP2 OUT */
+
+#define TIM_TIM2_TI3_GPIO                     0x00000000U                       /* !< TIM2_TI3 is connected to GPIO */
+#if defined(COMP3)
+#define TIM_TIM2_TI3_COMP3                    0x00010000U                       /* !< TIM2_TI3 is connected to COMP3 OUT */
+#endif /* COMP3 */
 #endif /* TIM2 */
 
 #define TIM_TIM3_TI1_GPIO                     0x00000000U                       /* !< TIM3_TI1 is connected to GPIO */
@@ -182,10 +216,35 @@ TIMEx_BreakInputConfigTypeDef;
 #define TIM_TIM3_TI2_COMP2                    0x00000100U                       /* !< TIM3_TI2 is connected to COMP2 OUT */
 #endif /* COMP2 */
 
+#define TIM_TIM3_TI3_GPIO                     0x00000000U                       /* !< TIM3_TI3 is connected to GPIO */
+#if defined(COMP3)
+#define TIM_TIM3_TI3_COMP3                    0x00010000U                       /* !< TIM3_TI3 is connected to COMP3 OUT */
+#endif /* COMP3 */
+
+#if defined(TIM4)
+#define TIM_TIM4_TI1_GPIO                     0x00000000U                       /* !< TIM4_TI1 is connected to GPIO */
+#if defined(COMP1)
+#define TIM_TIM4_TI1_COMP1                    0x00000001U                       /* !< TIM4_TI1 is connected to COMP1 OUT */
+#endif /* COMP1 */
+
+#define TIM_TIM4_TI2_GPIO                     0x00000000U                       /* !< TIM4_TI2 is connected to GPIO */
+#if defined(COMP2)
+#define TIM_TIM4_TI2_COMP2                    0x00000100U                       /* !< TIM4_TI2 is connected to COMP2 OUT */
+#endif /* COMP2 */
+
+#define TIM_TIM4_TI3_GPIO                     0x00000000U                       /* !< TIM4_TI3 is connected to GPIO */
+#if defined(COMP3)
+#define TIM_TIM4_TI3_COMP3                    0x00010000U                       /* !< TIM4_TI3 is connected to COMP3 OUT */
+#endif /* COMP3 */
+#endif /* TIM4 */
+
 #define TIM_TIM14_TI1_GPIO                    0x00000000U                       /* !< TIM14_TI1 is connected to GPIO */
 #define TIM_TIM14_TI1_RTC                     0x00000001U                       /* !< TIM14_TI1 is connected to RTC clock */
 #define TIM_TIM14_TI1_HSE_32                  0x00000002U                       /* !< TIM14_TI1 is connected to HSE div 32 */
 #define TIM_TIM14_TI1_MCO                     0x00000003U                       /* !< TIM14_TI1 is connected to MCO */
+#if defined(RCC_MCO2_SUPPORT)
+#define TIM_TIM14_TI1_MCO2                    0x00000004U                       /* !< TIM14_TI1 is connected to MCO2 */
+#endif
 
 #if defined(TIM15)
 #define TIM_TIM15_TI1_GPIO                    0x00000000U                       /* !< TIM15_TI1 is connected to GPIO */
@@ -201,10 +260,19 @@ TIMEx_BreakInputConfigTypeDef;
 #define TIM_TIM16_TI1_LSI                     0x00000001U                       /* !< TIM16_TI1 is connected to LSI */
 #define TIM_TIM16_TI1_LSE                     0x00000002U                       /* !< TIM16_TI1 is connected to LSE */
 #define TIM_TIM16_TI1_RTC_WAKEUP              0x00000003U                       /* !< TIM16_TI1 is connected to TRC wakeup interrupt */
+#if defined(RCC_MCO2_SUPPORT)
+#define TIM_TIM16_TI1_MCO2                    0x00000004U                       /* !< TIM16_TI1 is connected to MCO2 */
+#endif
 
 #define TIM_TIM17_TI1_GPIO                    0x00000000U                       /* !< TIM17_TI1 is connected to GPIO */
+#if defined(RCC_HSI48_SUPPORT)
+#define TIM_TIM17_TI1_HSI48                   0x00000001U                       /* !< TIM17_TI1 is connected to HSI48/256 */
+#endif
 #define TIM_TIM17_TI1_HSE_32                  0x00000002U                       /* !< TIM17_TI1 is connected to HSE div 32 */
 #define TIM_TIM17_TI1_MCO                     0x00000003U                       /* !< TIM17_TI1 is connected to MCO */
+#if defined(RCC_MCO2_SUPPORT)
+#define TIM_TIM17_TI1_MCO2                    0x00000004U                       /* !< TIM17_TI1 is connected to MCO2 */
+#endif
 /**
   * @}
   */
@@ -233,13 +301,18 @@ TIMEx_BreakInputConfigTypeDef;
 #define IS_TIM_BREAKINPUT(__BREAKINPUT__)  (((__BREAKINPUT__) == TIM_BREAKINPUT_BRK)  || \
                                             ((__BREAKINPUT__) == TIM_BREAKINPUT_BRK2))
 
-#if defined(COMP1) && defined(COMP2)
+#if defined(COMP1) && defined(COMP2) && defined(COMP3)
+#define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  (((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)  || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP1) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP2) || \
+                                              ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP3))
+#elif defined(COMP1) && defined(COMP2)
 #define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  (((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)  || \
                                               ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP1) || \
                                               ((__SOURCE__) == TIM_BREAKINPUTSOURCE_COMP2))
 #else
 #define IS_TIM_BREAKINPUTSOURCE(__SOURCE__)  ((__SOURCE__) == TIM_BREAKINPUTSOURCE_BKIN)
-#endif /* COMP1 && COMP2 */
+#endif /* COMP1 && COMP2 && COMP3 */
 
 #define IS_TIM_BREAKINPUTSOURCE_STATE(__STATE__)  (((__STATE__) == TIM_BREAKINPUTSOURCE_DISABLE)  || \
                                                    ((__STATE__) == TIM_BREAKINPUTSOURCE_ENABLE))
@@ -384,6 +457,7 @@ void HAL_TIMEx_Break2Callback(TIM_HandleTypeDef *htim);
   */
 /* Extended Peripheral State functions  ***************************************/
 HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(TIM_HandleTypeDef *htim,  uint32_t ChannelN);
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_uart.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_uart.h
@@ -50,16 +50,18 @@ typedef struct
                                            The baud rate register is computed using the following formula:
                                            LPUART:
                                            =======
-                                              Baud Rate Register = ((256 * lpuart_ker_ckpres) / ((huart->Init.BaudRate)))
+                                           Baud Rate Register = ((256 * lpuart_ker_ckpres) / ((huart->Init.BaudRate)))
                                            where lpuart_ker_ck_pres is the UART input clock divided by a prescaler
                                            UART:
                                            =====
                                            - If oversampling is 16 or in LIN mode,
                                               Baud Rate Register = ((uart_ker_ckpres) / ((huart->Init.BaudRate)))
                                            - If oversampling is 8,
-                                              Baud Rate Register[15:4] = ((2 * uart_ker_ckpres) / ((huart->Init.BaudRate)))[15:4]
+                                              Baud Rate Register[15:4] = ((2 * uart_ker_ckpres) /
+                                              ((huart->Init.BaudRate)))[15:4]
                                               Baud Rate Register[3] =  0
-                                              Baud Rate Register[2:0] =  (((2 * uart_ker_ckpres) / ((huart->Init.BaudRate)))[3:0]) >> 1
+                                              Baud Rate Register[2:0] =  (((2 * uart_ker_ckpres) /
+                                              ((huart->Init.BaudRate)))[3:0]) >> 1
                                            where uart_ker_ck_pres is the UART input clock divided by a prescaler */
 
   uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
@@ -82,7 +84,8 @@ typedef struct
                                            or disabled.
                                            This parameter can be a value of @ref UART_Hardware_Flow_Control. */
 
-  uint32_t OverSampling;              /*!< Specifies whether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to f_PCLK/8).
+  uint32_t OverSampling;              /*!< Specifies whether the Over sampling 8 is enabled or disabled,
+                                           to achieve higher speed (up to f_PCLK/8).
                                            This parameter can be a value of @ref UART_Over_Sampling. */
 
   uint32_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
@@ -101,7 +104,8 @@ typedef struct
 {
   uint32_t AdvFeatureInit;        /*!< Specifies which advanced UART features is initialized. Several
                                        Advanced Features may be initialized at the same time .
-                                       This parameter can be a value of @ref UART_Advanced_Features_Initialization_Type. */
+                                       This parameter can be a value of
+                                       @ref UART_Advanced_Features_Initialization_Type. */
 
   uint32_t TxPinLevelInvert;      /*!< Specifies whether the TX pin active level is inverted.
                                        This parameter can be a value of @ref UART_Tx_Inv. */
@@ -133,11 +137,10 @@ typedef struct
                                        This parameter can be a value of @ref UART_MSB_First. */
 } UART_AdvFeatureInitTypeDef;
 
-
-
 /**
   * @brief HAL UART State definition
-  * @note  HAL UART State value is a combination of 2 different substates: gState and RxState (see @ref UART_State_Definition).
+  * @note  HAL UART State value is a combination of 2 different substates:
+  *        gState and RxState (see @ref UART_State_Definition).
   *        - gState contains UART state information related to global Handle management
   *          and also information related to Tx operations.
   *          gState value coding follow below described bitmap :
@@ -189,6 +192,17 @@ typedef enum
 } UART_ClockSourceTypeDef;
 
 /**
+  * @brief HAL UART Reception type definition
+  * @note  HAL UART Reception type value aims to identify which type of Reception is ongoing.
+  *        It is expected to admit following values :
+  *           HAL_UART_RECEPTION_STANDARD         = 0x00U,
+  *           HAL_UART_RECEPTION_TOIDLE           = 0x01U,
+  *           HAL_UART_RECEPTION_TORTO            = 0x02U,
+  *           HAL_UART_RECEPTION_TOCHARMATCH      = 0x03U,
+  */
+typedef uint32_t HAL_UART_RxTypeTypeDef;
+
+/**
   * @brief  UART handle Structure definition
   */
 typedef struct __UART_HandleTypeDef
@@ -220,9 +234,11 @@ typedef struct __UART_HandleTypeDef
 
   uint16_t                 NbTxDataToProcess;        /*!< Number of data to process during TX ISR execution */
 
-  void (*RxISR)(struct __UART_HandleTypeDef *huart); /*!< Function pointer on Rx IRQ handler   */
+  __IO HAL_UART_RxTypeTypeDef ReceptionType;         /*!< Type of ongoing reception          */
 
-  void (*TxISR)(struct __UART_HandleTypeDef *huart); /*!< Function pointer on Tx IRQ handler   */
+  void (*RxISR)(struct __UART_HandleTypeDef *huart); /*!< Function pointer on Rx IRQ handler */
+
+  void (*TxISR)(struct __UART_HandleTypeDef *huart); /*!< Function pointer on Tx IRQ handler */
 
   DMA_HandleTypeDef        *hdmatx;                  /*!< UART Tx DMA Handle parameters      */
 
@@ -231,11 +247,11 @@ typedef struct __UART_HandleTypeDef
   HAL_LockTypeDef           Lock;                    /*!< Locking object                     */
 
   __IO HAL_UART_StateTypeDef    gState;              /*!< UART state information related to global Handle management
-                                                          and also related to Tx operations.
-                                                          This parameter can be a value of @ref HAL_UART_StateTypeDef */
+                                                          and also related to Tx operations. This parameter
+                                                          can be a value of @ref HAL_UART_StateTypeDef */
 
-  __IO HAL_UART_StateTypeDef    RxState;             /*!< UART state information related to Rx operations.
-                                                          This parameter can be a value of @ref HAL_UART_StateTypeDef */
+  __IO HAL_UART_StateTypeDef    RxState;             /*!< UART state information related to Rx operations. This
+                                                          parameter can be a value of @ref HAL_UART_StateTypeDef */
 
   __IO uint32_t                 ErrorCode;           /*!< UART Error code                    */
 
@@ -251,6 +267,7 @@ typedef struct __UART_HandleTypeDef
   void (* WakeupCallback)(struct __UART_HandleTypeDef *huart);            /*!< UART Wakeup Callback                  */
   void (* RxFifoFullCallback)(struct __UART_HandleTypeDef *huart);        /*!< UART Rx Fifo Full Callback            */
   void (* TxFifoEmptyCallback)(struct __UART_HandleTypeDef *huart);       /*!< UART Tx Fifo Empty Callback           */
+  void (* RxEventCallback)(struct __UART_HandleTypeDef *huart, uint16_t Pos); /*!< UART Reception Event Callback     */
 
   void (* MspInitCallback)(struct __UART_HandleTypeDef *huart);           /*!< UART Msp Init callback                */
   void (* MspDeInitCallback)(struct __UART_HandleTypeDef *huart);         /*!< UART Msp DeInit callback              */
@@ -285,6 +302,7 @@ typedef enum
   * @brief  HAL UART Callback pointer definition
   */
 typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer to an UART callback function */
+typedef  void (*pUART_RxEventCallbackTypeDef)(struct __UART_HandleTypeDef *huart, uint16_t Pos);   /*!< pointer to a UART Rx Event specific callback function */
 
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 
@@ -311,8 +329,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 #define  HAL_UART_STATE_BUSY_RX       0x00000022U    /*!< Data Reception process is ongoing
                                                           Value is allowed for RxState only */
 #define  HAL_UART_STATE_BUSY_TX_RX    0x00000023U    /*!< Data Transmission and Reception process is ongoing
-                                                          Not to be used for neither gState nor RxState.
-                                                          Value is result of combination (Or) between gState and RxState values */
+                                                          Not to be used for neither gState nor RxState.Value is result
+                                                          of combination (Or) between gState and RxState values */
 #define  HAL_UART_STATE_TIMEOUT       0x000000A0U    /*!< Timeout state
                                                           Value is allowed for gState only */
 #define  HAL_UART_STATE_ERROR         0x000000E0U    /*!< Error
@@ -330,8 +348,10 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 #define  HAL_UART_ERROR_FE               ((uint32_t)0x00000004U)    /*!< Frame error             */
 #define  HAL_UART_ERROR_ORE              ((uint32_t)0x00000008U)    /*!< Overrun error           */
 #define  HAL_UART_ERROR_DMA              ((uint32_t)0x00000010U)    /*!< DMA transfer error      */
+#define  HAL_UART_ERROR_RTO              ((uint32_t)0x00000020U)    /*!< Receiver Timeout error  */
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-#define  HAL_UART_ERROR_INVALID_CALLBACK ((uint32_t)0x00000020U)    /*!< Invalid Callback error  */
+#define  HAL_UART_ERROR_INVALID_CALLBACK ((uint32_t)0x00000040U)    /*!< Invalid Callback error  */
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 /**
   * @}
@@ -428,19 +448,23 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_AutoBaud_Rate_Mode    UART Advanced Feature AutoBaud Rate Mode
   * @{
   */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    0x00000000U           /*!< Auto Baud rate detection on start bit            */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE USART_CR2_ABRMODE_0   /*!< Auto Baud rate detection on falling edge         */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   USART_CR2_ABRMODE_1   /*!< Auto Baud rate detection on 0x7F frame detection */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   USART_CR2_ABRMODE     /*!< Auto Baud rate detection on 0x55 frame detection */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    0x00000000U           /*!< Auto Baud rate detection
+                                                                              on start bit              */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE USART_CR2_ABRMODE_0   /*!< Auto Baud rate detection
+                                                                              on falling edge           */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   USART_CR2_ABRMODE_1   /*!< Auto Baud rate detection
+                                                                              on 0x7F frame detection   */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   USART_CR2_ABRMODE     /*!< Auto Baud rate detection
+                                                                              on 0x55 frame detection   */
 /**
   * @}
   */
 
-/** @defgroup UART_Receiver_TimeOut UART Receiver TimeOut
+/** @defgroup UART_Receiver_Timeout UART Receiver Timeout
   * @{
   */
-#define UART_RECEIVER_TIMEOUT_DISABLE       0x00000000U                 /*!< UART receiver timeout disable */
-#define UART_RECEIVER_TIMEOUT_ENABLE        USART_CR2_RTOEN             /*!< UART receiver timeout enable  */
+#define UART_RECEIVER_TIMEOUT_DISABLE       0x00000000U                /*!< UART Receiver Timeout disable */
+#define UART_RECEIVER_TIMEOUT_ENABLE        USART_CR2_RTOEN            /*!< UART Receiver Timeout enable  */
 /**
   * @}
   */
@@ -593,8 +617,10 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_MSB_First   UART Advanced Feature MSB First
   * @{
   */
-#define UART_ADVFEATURE_MSBFIRST_DISABLE    0x00000000U             /*!< Most significant bit sent/received first disable */
-#define UART_ADVFEATURE_MSBFIRST_ENABLE     USART_CR2_MSBFIRST      /*!< Most significant bit sent/received first enable  */
+#define UART_ADVFEATURE_MSBFIRST_DISABLE    0x00000000U             /*!< Most significant bit sent/received
+                                                                         first disable                      */
+#define UART_ADVFEATURE_MSBFIRST_ENABLE     USART_CR2_MSBFIRST      /*!< Most significant bit sent/received
+                                                                         first enable                       */
 /**
   * @}
   */
@@ -620,7 +646,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_CR2_ADDRESS_LSB_POS    UART Address-matching LSB Position In CR2 Register
   * @{
   */
-#define UART_CR2_ADDRESS_LSB_POS             24U                                /*!< UART address-matching LSB position in CR2 register */
+#define UART_CR2_ADDRESS_LSB_POS             24U             /*!< UART address-matching LSB position in CR2 register */
 /**
   * @}
   */
@@ -628,9 +654,10 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_WakeUp_from_Stop_Selection   UART WakeUp From Stop Selection
   * @{
   */
-#define UART_WAKEUP_ON_ADDRESS              0x00000000U             /*!< UART wake-up on address                         */
-#define UART_WAKEUP_ON_STARTBIT             USART_CR3_WUS_1         /*!< UART wake-up on start bit                       */
-#define UART_WAKEUP_ON_READDATA_NONEMPTY    USART_CR3_WUS           /*!< UART wake-up on receive data register not empty or RXFIFO is not empty */
+#define UART_WAKEUP_ON_ADDRESS              0x00000000U             /*!< UART wake-up on address                     */
+#define UART_WAKEUP_ON_STARTBIT             USART_CR3_WUS_1         /*!< UART wake-up on start bit                   */
+#define UART_WAKEUP_ON_READDATA_NONEMPTY    USART_CR3_WUS           /*!< UART wake-up on receive data register
+                                                                         not empty or RXFIFO is not empty            */
 /**
   * @}
   */
@@ -647,7 +674,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_CR1_DEAT_ADDRESS_LSB_POS    UART Driver Enable Assertion Time LSB Position In CR1 Register
   * @{
   */
-#define UART_CR1_DEAT_ADDRESS_LSB_POS       21U      /*!< UART Driver Enable assertion time LSB position in CR1 register */
+#define UART_CR1_DEAT_ADDRESS_LSB_POS       21U      /*!< UART Driver Enable assertion time LSB
+                                                          position in CR1 register */
 /**
   * @}
   */
@@ -655,7 +683,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_CR1_DEDT_ADDRESS_LSB_POS    UART Driver Enable DeAssertion Time LSB Position In CR1 Register
   * @{
   */
-#define UART_CR1_DEDT_ADDRESS_LSB_POS       16U      /*!< UART Driver Enable de-assertion time LSB position in CR1 register */
+#define UART_CR1_DEDT_ADDRESS_LSB_POS       16U      /*!< UART Driver Enable de-assertion time LSB
+                                                          position in CR1 register */
 /**
   * @}
   */
@@ -694,6 +723,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 #define UART_FLAG_BUSY                      USART_ISR_BUSY          /*!< UART busy flag                            */
 #define UART_FLAG_ABRF                      USART_ISR_ABRF          /*!< UART auto Baud rate flag                  */
 #define UART_FLAG_ABRE                      USART_ISR_ABRE          /*!< UART auto Baud rate error                 */
+#define UART_FLAG_RTOF                      USART_ISR_RTOF          /*!< UART receiver timeout flag                */
 #define UART_FLAG_CTS                       USART_ISR_CTS           /*!< UART clear to send flag                   */
 #define UART_FLAG_CTSIF                     USART_ISR_CTSIF         /*!< UART clear to send interrupt flag         */
 #define UART_FLAG_LBDF                      USART_ISR_LBDF          /*!< UART LIN break detection flag             */
@@ -729,27 +759,28 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *           - ZZZZ  : Flag position in the ISR register(4bits)
   * @{
   */
-#define UART_IT_PE                          0x0028U                  /*!< UART parity error interruption                 */
-#define UART_IT_TXE                         0x0727U                  /*!< UART transmit data register empty interruption */
-#define UART_IT_TXFNF                       0x0727U                  /*!< UART TX FIFO not full interruption             */
-#define UART_IT_TC                          0x0626U                  /*!< UART transmission complete interruption        */
-#define UART_IT_RXNE                        0x0525U                  /*!< UART read data register not empty interruption */
-#define UART_IT_RXFNE                       0x0525U                  /*!< UART RXFIFO not empty interruption             */
-#define UART_IT_IDLE                        0x0424U                  /*!< UART idle interruption                         */
-#define UART_IT_LBD                         0x0846U                  /*!< UART LIN break detection interruption          */
-#define UART_IT_CTS                         0x096AU                  /*!< UART CTS interruption                          */
-#define UART_IT_CM                          0x112EU                  /*!< UART character match interruption              */
-#define UART_IT_WUF                         0x1476U                  /*!< UART wake-up from stop mode interruption       */
-#define UART_IT_RXFF                        0x183FU                  /*!< UART RXFIFO full interruption                  */
-#define UART_IT_TXFE                        0x173EU                  /*!< UART TXFIFO empty interruption                 */
-#define UART_IT_RXFT                        0x1A7CU                  /*!< UART RXFIFO threshold reached interruption     */
-#define UART_IT_TXFT                        0x1B77U                  /*!< UART TXFIFO threshold reached interruption     */
+#define UART_IT_PE                          0x0028U              /*!< UART parity error interruption                 */
+#define UART_IT_TXE                         0x0727U              /*!< UART transmit data register empty interruption */
+#define UART_IT_TXFNF                       0x0727U              /*!< UART TX FIFO not full interruption             */
+#define UART_IT_TC                          0x0626U              /*!< UART transmission complete interruption        */
+#define UART_IT_RXNE                        0x0525U              /*!< UART read data register not empty interruption */
+#define UART_IT_RXFNE                       0x0525U              /*!< UART RXFIFO not empty interruption             */
+#define UART_IT_IDLE                        0x0424U              /*!< UART idle interruption                         */
+#define UART_IT_LBD                         0x0846U              /*!< UART LIN break detection interruption          */
+#define UART_IT_CTS                         0x096AU              /*!< UART CTS interruption                          */
+#define UART_IT_CM                          0x112EU              /*!< UART character match interruption              */
+#define UART_IT_WUF                         0x1476U              /*!< UART wake-up from stop mode interruption       */
+#define UART_IT_RXFF                        0x183FU              /*!< UART RXFIFO full interruption                  */
+#define UART_IT_TXFE                        0x173EU              /*!< UART TXFIFO empty interruption                 */
+#define UART_IT_RXFT                        0x1A7CU              /*!< UART RXFIFO threshold reached interruption     */
+#define UART_IT_TXFT                        0x1B77U              /*!< UART TXFIFO threshold reached interruption     */
+#define UART_IT_RTO                         0x0B3AU              /*!< UART receiver timeout interruption             */
 
-#define UART_IT_ERR                         0x0060U                  /*!< UART error interruption         */
+#define UART_IT_ERR                         0x0060U              /*!< UART error interruption                        */
 
-#define UART_IT_ORE                         0x0300U                  /*!< UART overrun error interruption */
-#define UART_IT_NE                          0x0200U                  /*!< UART noise error interruption   */
-#define UART_IT_FE                          0x0100U                  /*!< UART frame error interruption   */
+#define UART_IT_ORE                         0x0300U              /*!< UART overrun error interruption                */
+#define UART_IT_NE                          0x0200U              /*!< UART noise error interruption                  */
+#define UART_IT_FE                          0x0100U              /*!< UART frame error interruption                  */
 /**
   * @}
   */
@@ -768,10 +799,21 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 #define UART_CLEAR_CTSF                      USART_ICR_CTSCF           /*!< CTS Interrupt Clear Flag          */
 #define UART_CLEAR_CMF                       USART_ICR_CMCF            /*!< Character Match Clear Flag        */
 #define UART_CLEAR_WUF                       USART_ICR_WUCF            /*!< Wake Up from stop mode Clear Flag */
+#define UART_CLEAR_RTOF                      USART_ICR_RTOCF           /*!< UART receiver timeout clear flag  */
 /**
   * @}
   */
 
+/** @defgroup UART_RECEPTION_TYPE_Values  UART Reception type values
+  * @{
+  */
+#define HAL_UART_RECEPTION_STANDARD          (0x00000000U)             /*!< Standard reception                       */
+#define HAL_UART_RECEPTION_TOIDLE            (0x00000001U)             /*!< Reception till completion or IDLE event  */
+#define HAL_UART_RECEPTION_TORTO             (0x00000002U)             /*!< Reception till completion or RTO event   */
+#define HAL_UART_RECEPTION_TOCHARMATCH       (0x00000003U)             /*!< Reception till completion or CM event    */
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -821,6 +863,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_CLEAR_IDLEF    IDLE line detected Clear Flag
   *            @arg @ref UART_CLEAR_TXFECF   TXFIFO empty clear Flag
   *            @arg @ref UART_CLEAR_TCF      Transmission Complete Clear Flag
+  *            @arg @ref UART_CLEAR_RTOF     Receiver Timeout clear flag
   *            @arg @ref UART_CLEAR_LBDF     LIN Break Detection Clear Flag
   *            @arg @ref UART_CLEAR_CTSF     CTS Interrupt Clear Flag
   *            @arg @ref UART_CLEAR_CMF      Character Match Clear Flag
@@ -889,6 +932,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_FLAG_TC    Transmission Complete flag
   *            @arg @ref UART_FLAG_RXNE  Receive data register not empty flag
   *            @arg @ref UART_FLAG_RXFNE UART RXFIFO not empty flag
+  *            @arg @ref UART_FLAG_RTOF  Receiver Timeout flag
   *            @arg @ref UART_FLAG_IDLE  Idle Line detection flag
   *            @arg @ref UART_FLAG_ORE   Overrun Error flag
   *            @arg @ref UART_FLAG_NE    Noise Error flag
@@ -915,15 +959,21 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_TC    Transmission complete interrupt
   *            @arg @ref UART_IT_RXNE  Receive Data register not empty interrupt
   *            @arg @ref UART_IT_RXFNE RXFIFO not empty interrupt
+  *            @arg @ref UART_IT_RTO   Receive Timeout interrupt
   *            @arg @ref UART_IT_IDLE  Idle line detection interrupt
   *            @arg @ref UART_IT_PE    Parity Error interrupt
   *            @arg @ref UART_IT_ERR   Error interrupt (frame error, noise error, overrun error)
   * @retval None
   */
-#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)? ((__HANDLE__)->Instance->CR1 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)? ((__HANDLE__)->Instance->CR2 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((__HANDLE__)->Instance->CR3 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))))
-
+#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (\
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)?\
+                                                           ((__HANDLE__)->Instance->CR1 |= (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)?\
+                                                           ((__HANDLE__)->Instance->CR2 |= (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 |= (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))))
 
 /** @brief  Disable the specified UART interrupt.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -942,14 +992,21 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_TC    Transmission complete interrupt
   *            @arg @ref UART_IT_RXNE  Receive Data register not empty interrupt
   *            @arg @ref UART_IT_RXFNE RXFIFO not empty interrupt
+  *            @arg @ref UART_IT_RTO   Receive Timeout interrupt
   *            @arg @ref UART_IT_IDLE  Idle line detection interrupt
   *            @arg @ref UART_IT_PE    Parity Error interrupt
   *            @arg @ref UART_IT_ERR   Error interrupt (Frame error, noise error, overrun error)
   * @retval None
   */
-#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)? ((__HANDLE__)->Instance->CR1 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)? ((__HANDLE__)->Instance->CR2 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))))
+#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (\
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)?\
+                                                           ((__HANDLE__)->Instance->CR1 &= ~ (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)?\
+                                                           ((__HANDLE__)->Instance->CR2 &= ~ (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))))
 
 /** @brief  Check whether the specified UART interrupt has occurred or not.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -968,6 +1025,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_TC    Transmission complete interrupt
   *            @arg @ref UART_IT_RXNE  Receive Data register not empty interrupt
   *            @arg @ref UART_IT_RXFNE RXFIFO not empty interrupt
+  *            @arg @ref UART_IT_RTO   Receive Timeout interrupt
   *            @arg @ref UART_IT_IDLE  Idle line detection interrupt
   *            @arg @ref UART_IT_PE    Parity Error interrupt
   *            @arg @ref UART_IT_ERR   Error interrupt (Frame error, noise error, overrun error)
@@ -993,14 +1051,19 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_TC    Transmission complete interrupt
   *            @arg @ref UART_IT_RXNE  Receive Data register not empty interrupt
   *            @arg @ref UART_IT_RXFNE RXFIFO not empty interrupt
+  *            @arg @ref UART_IT_RTO   Receive Timeout interrupt
   *            @arg @ref UART_IT_IDLE  Idle line detection interrupt
   *            @arg @ref UART_IT_PE    Parity Error interrupt
   *            @arg @ref UART_IT_ERR   Error interrupt (Frame error, noise error, overrun error)
   * @retval The new state of __INTERRUPT__ (SET or RESET).
   */
-#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U) ? (__HANDLE__)->Instance->CR1 : \
-                                                                (((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U) ? (__HANDLE__)->Instance->CR2 : \
-                                                                 (__HANDLE__)->Instance->CR3)) & (1U << (((uint16_t)(__INTERRUPT__)) & UART_IT_MASK)))  != RESET) ? SET : RESET)
+#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U) ?\
+                                                                (__HANDLE__)->Instance->CR1 : \
+                                                                (((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U) ?\
+                                                                 (__HANDLE__)->Instance->CR2 : \
+                                                                 (__HANDLE__)->Instance->CR3)) & (1U <<\
+                                                                     (((uint16_t)(__INTERRUPT__)) &\
+                                                                      UART_IT_MASK)))  != RESET) ? SET : RESET)
 
 /** @brief  Clear the specified UART ISR flag, in setting the proper ICR register flag.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -1012,6 +1075,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_CLEAR_NEF    Noise detected Clear Flag
   *            @arg @ref UART_CLEAR_OREF   Overrun Error Clear Flag
   *            @arg @ref UART_CLEAR_IDLEF  IDLE line detected Clear Flag
+  *            @arg @ref UART_CLEAR_RTOF   Receiver timeout clear flag
   *            @arg @ref UART_CLEAR_TXFECF TXFIFO empty Clear Flag
   *            @arg @ref UART_CLEAR_TCF    Transmission Complete Clear Flag
   *            @arg @ref UART_CLEAR_LBDF   LIN Break Detection Clear Flag
@@ -1066,8 +1130,9 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
@@ -1084,8 +1149,9 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
@@ -1102,8 +1168,9 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
@@ -1120,8 +1187,9 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
@@ -1162,8 +1230,10 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval Division result
   */
-#define UART_DIV_LPUART(__PCLK__, __BAUD__, __CLOCKPRESCALER__)      ((uint32_t)(((((uint64_t)(__PCLK__)/UART_GET_DIV_FACTOR((__CLOCKPRESCALER__)))*256U)\
-                                                                      + (uint32_t)((__BAUD__)/2U)) / (__BAUD__)))
+#define UART_DIV_LPUART(__PCLK__, __BAUD__, __CLOCKPRESCALER__)                        \
+  ((uint32_t)((((((uint64_t)(__PCLK__))/(UARTPrescTable[(__CLOCKPRESCALER__)]))*256U)+ \
+               (uint32_t)((__BAUD__)/2U)) / (__BAUD__))                                \
+  )
 
 /** @brief  BRR division operation to set BRR register in 8-bit oversampling mode.
   * @param  __PCLK__ UART clock.
@@ -1171,8 +1241,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval Division result
   */
-#define UART_DIV_SAMPLING8(__PCLK__, __BAUD__, __CLOCKPRESCALER__)   (((((__PCLK__)/UART_GET_DIV_FACTOR((__CLOCKPRESCALER__)))*2U)\
-                                                                       + ((__BAUD__)/2U)) / (__BAUD__))
+#define UART_DIV_SAMPLING8(__PCLK__, __BAUD__, __CLOCKPRESCALER__)                        \
+  (((((__PCLK__)/UARTPrescTable[(__CLOCKPRESCALER__)])*2U) + ((__BAUD__)/2U)) / (__BAUD__))
 
 /** @brief  BRR division operation to set BRR register in 16-bit oversampling mode.
   * @param  __PCLK__ UART clock.
@@ -1180,8 +1250,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval Division result
   */
-#define UART_DIV_SAMPLING16(__PCLK__, __BAUD__, __CLOCKPRESCALER__)  ((((__PCLK__)/UART_GET_DIV_FACTOR((__CLOCKPRESCALER__)))\
-                                                                       + ((__BAUD__)/2U)) / (__BAUD__))
+#define UART_DIV_SAMPLING16(__PCLK__, __BAUD__, __CLOCKPRESCALER__)                       \
+  ((((__PCLK__)/UARTPrescTable[(__CLOCKPRESCALER__)]) + ((__BAUD__)/2U)) / (__BAUD__))
 
 /** @brief  Check whether or not UART instance is Low Power UART.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -1293,8 +1363,15 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param __TIMEOUT__ UART receiver timeout setting.
   * @retval SET (__TIMEOUT__ is valid) or RESET (__TIMEOUT__ is invalid)
   */
-#define IS_UART_RECEIVER_TIMEOUT(__TIMEOUT__) (((__TIMEOUT__) == UART_RECEIVER_TIMEOUT_DISABLE) || \
-                                               ((__TIMEOUT__) == UART_RECEIVER_TIMEOUT_ENABLE))
+#define IS_UART_RECEIVER_TIMEOUT(__TIMEOUT__)  (((__TIMEOUT__) == UART_RECEIVER_TIMEOUT_DISABLE) || \
+                                                ((__TIMEOUT__) == UART_RECEIVER_TIMEOUT_ENABLE))
+
+/** @brief  Check the receiver timeout value.
+  * @note   The maximum UART receiver timeout value is 0xFFFFFF.
+  * @param  __TIMEOUTVALUE__ receiver timeout value.
+  * @retval Test result (TRUE or FALSE)
+  */
+#define IS_UART_RECEIVER_TIMEOUT_VALUE(__TIMEOUTVALUE__)  ((__TIMEOUTVALUE__) <= 0xFFFFFFU)
 
 /**
   * @brief Ensure that UART LIN state is valid.
@@ -1415,8 +1492,9 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param __AUTOBAUDRATE__ UART auto Baud rate state.
   * @retval SET (__AUTOBAUDRATE__ is valid) or RESET (__AUTOBAUDRATE__ is invalid)
   */
-#define IS_UART_ADVFEATURE_AUTOBAUDRATE(__AUTOBAUDRATE__)  (((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
-                                                            ((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
+#define IS_UART_ADVFEATURE_AUTOBAUDRATE(__AUTOBAUDRATE__) (((__AUTOBAUDRATE__) == \
+                                                            UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
+                                                           ((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
 
 /**
   * @brief Ensure that UART DMA enabling or disabling on error setting is valid.
@@ -1493,6 +1571,11 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 #include "stm32g0xx_hal_uart_ex.h"
 
 
+/* Prescaler Table used in BRR computation macros.
+   Declared as extern here to allow use of private UART macros, outside of HAL UART functions */
+extern const uint16_t UARTPrescTable[12];
+
+
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup UART_Exported_Functions UART Exported Functions
   * @{
@@ -1516,6 +1599,9 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UART_RegisterCallback(UART_HandleTypeDef *huart, HAL_UART_CallbackIDTypeDef CallbackID,
                                             pUART_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UART_CallbackIDTypeDef CallbackID);
+
+HAL_StatusTypeDef HAL_UART_RegisterRxEventCallback(UART_HandleTypeDef *huart, pUART_RxEventCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_UART_UnRegisterRxEventCallback(UART_HandleTypeDef *huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 
 /**
@@ -1554,6 +1640,8 @@ void HAL_UART_AbortCpltCallback(UART_HandleTypeDef *huart);
 void HAL_UART_AbortTransmitCpltCallback(UART_HandleTypeDef *huart);
 void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart);
 
+void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size);
+
 /**
   * @}
   */
@@ -1563,6 +1651,10 @@ void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart);
   */
 
 /* Peripheral Control functions  ************************************************/
+void HAL_UART_ReceiverTimeout_Config(UART_HandleTypeDef *huart, uint32_t TimeoutValue);
+HAL_StatusTypeDef HAL_UART_EnableReceiverTimeout(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DisableReceiverTimeout(UART_HandleTypeDef *huart);
+
 HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart);
@@ -1595,13 +1687,15 @@ uint32_t              HAL_UART_GetError(UART_HandleTypeDef *huart);
   * @{
   */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-void UART_InitCallbacksToDefault(UART_HandleTypeDef *huart);
+void              UART_InitCallbacksToDefault(UART_HandleTypeDef *huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status,
                                               uint32_t Tickstart, uint32_t Timeout);
-void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+void              UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_Start_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef UART_Start_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_uart_ex.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_uart_ex.h
@@ -69,9 +69,9 @@ typedef struct
 /** @defgroup UARTEx_Word_Length UARTEx Word Length
   * @{
   */
-#define UART_WORDLENGTH_7B                  USART_CR1_M1   /*!< 7-bit long UART frame */
-#define UART_WORDLENGTH_8B                  0x00000000U    /*!< 8-bit long UART frame */
-#define UART_WORDLENGTH_9B                  USART_CR1_M0   /*!< 9-bit long UART frame */
+#define UART_WORDLENGTH_7B          USART_CR1_M1   /*!< 7-bit long UART frame */
+#define UART_WORDLENGTH_8B          0x00000000U    /*!< 8-bit long UART frame */
+#define UART_WORDLENGTH_9B          USART_CR1_M0   /*!< 9-bit long UART frame */
 /**
   * @}
   */
@@ -79,8 +79,8 @@ typedef struct
 /** @defgroup UARTEx_WakeUp_Address_Length UARTEx WakeUp Address Length
   * @{
   */
-#define UART_ADDRESS_DETECT_4B              0x00000000U      /*!< 4-bit long wake-up address */
-#define UART_ADDRESS_DETECT_7B              USART_CR2_ADDM7  /*!< 7-bit long wake-up address */
+#define UART_ADDRESS_DETECT_4B      0x00000000U      /*!< 4-bit long wake-up address */
+#define UART_ADDRESS_DETECT_7B      USART_CR2_ADDM7  /*!< 7-bit long wake-up address */
 /**
   * @}
   */
@@ -89,8 +89,8 @@ typedef struct
   * @brief    UART FIFO mode
   * @{
   */
-#define UART_FIFOMODE_DISABLE        0x00000000U       /*!< FIFO mode disable */
-#define UART_FIFOMODE_ENABLE         USART_CR1_FIFOEN  /*!< FIFO mode enable  */
+#define UART_FIFOMODE_DISABLE       0x00000000U       /*!< FIFO mode disable */
+#define UART_FIFOMODE_ENABLE        USART_CR1_FIFOEN  /*!< FIFO mode enable  */
 /**
   * @}
   */
@@ -166,11 +166,18 @@ void HAL_UARTEx_TxFifoEmptyCallback(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
 HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart);
+
 HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength);
+
 HAL_StatusTypeDef HAL_UARTEx_EnableFifoMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UARTEx_DisableFifoMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UARTEx_SetTxFifoThreshold(UART_HandleTypeDef *huart, uint32_t Threshold);
 HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint32_t Threshold);
+
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint16_t *RxLen, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+
 
 /**
   * @}
@@ -185,7 +192,225 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
   * @{
   */
 
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/** @brief  Report the UART clock source.
+  * @param  __HANDLE__ specifies the UART Handle.
+  * @param  __CLOCKSOURCE__ output variable.
+  * @retval UART clocking source, written in __CLOCKSOURCE__.
+  */
+#define UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                   \
+      {                                                       \
+        case RCC_USART1CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                   \
+      {                                                       \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART3)                 \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                   \
+      {                                                       \
+        case RCC_USART3CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART4)                 \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;             \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART5)                 \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;             \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART6)                 \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;             \
+    }                                                         \
+    else if((__HANDLE__)->Instance == LPUART1)                \
+    {                                                         \
+      switch(__HAL_RCC_GET_LPUART1_SOURCE())                  \
+      {                                                       \
+        case RCC_LPUART1CLKSOURCE_PCLK1:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_HSI:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_SYSCLK:                     \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_LSE:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == LPUART2)                \
+    {                                                         \
+      switch(__HAL_RCC_GET_LPUART2_SOURCE())                  \
+      {                                                       \
+        case RCC_LPUART2CLKSOURCE_PCLK1:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_LPUART2CLKSOURCE_HSI:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_LPUART2CLKSOURCE_SYSCLK:                     \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_LPUART2CLKSOURCE_LSE:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else                                                      \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;         \
+    }                                                         \
+  } while(0U)
+#elif defined(STM32G0B0xx)
+/** @brief  Report the UART clock source.
+  * @param  __HANDLE__ specifies the UART Handle.
+  * @param  __CLOCKSOURCE__ output variable.
+  * @retval UART clocking source, written in __CLOCKSOURCE__.
+  */
+#define UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                   \
+      {                                                       \
+        case RCC_USART1CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                   \
+      {                                                       \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART3)                 \
+    {                                                         \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                   \
+      {                                                       \
+        case RCC_USART3CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART3CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                              \
+      }                                                       \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART4)                 \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;             \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART5)                 \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;             \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART6)                 \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;             \
+    }                                                         \
+    else                                                      \
+    {                                                         \
+      (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;         \
+    }                                                         \
+  } while(0U)
+#elif defined(STM32G081xx) || defined(STM32G071xx)
 /** @brief  Report the UART clock source.
   * @param  __HANDLE__ specifies the UART Handle.
   * @param  __CLOCKSOURCE__ output variable.
@@ -332,7 +557,7 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
       (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;         \
     }                                                         \
   } while(0U)
-#elif defined(STM32G041xx) || defined(STM32G031xx)
+#elif defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G051xx) || defined(STM32G061xx)
 /** @brief  Report the UART clock source.
   * @param  __HANDLE__ specifies the UART Handle.
   * @param  __CLOCKSOURCE__ output variable.
@@ -391,7 +616,7 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
       (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;         \
     }                                                         \
   } while(0U)
-#elif defined(STM32G030xx)
+#elif defined(STM32G030xx) || defined(STM32G050xx)
 /** @brief  Report the UART clock source.
   * @param  __HANDLE__ specifies the UART Handle.
   * @param  __CLOCKSOURCE__ output variable.
@@ -429,7 +654,7 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
       (__CLOCKSOURCE__) = UART_CLOCKSOURCE_UNDEFINED;         \
     }                                                         \
   } while(0U)
-#endif /* STM32G081xx || STM32G071xx */
+#endif
 
 /** @brief  Report the UART mask to apply to retrieve the received data
   *         according to the word length and to the parity bits activation.

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_usart.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_usart.h
@@ -138,7 +138,7 @@ typedef struct __USART_HandleTypeDef
 
   uint16_t                      NbTxDataToProcess;       /*!< Number of data to process during TX ISR execution */
 
-  uint32_t                      SlaveMode;               /*!< Enable/Disable UART SPI Slave Mode. This parameter can be a value
+  uint32_t                      SlaveMode;               /*!< Enable/Disable USART SPI Slave Mode. This parameter can be a value
                                                               of @ref USARTEx_Slave_Mode */
 
   uint32_t                      FifoMode;                /*!< Specifies if the FIFO mode will be used. This parameter can be a value
@@ -700,7 +700,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 /** @brief  BRR division operation to set BRR register in 8-bit oversampling mode.
   * @param  __PCLK__ USART clock.
   * @param  __BAUD__ Baud rate set by the user.
-  * @param  __CLOCKPRESCALER__ UART prescaler value.
+  * @param  __CLOCKPRESCALER__ USART prescaler value.
   * @retval Division result
   */
 #define USART_DIV_SAMPLING8(__PCLK__, __BAUD__, __CLOCKPRESCALER__)   (((((__PCLK__)/USART_GET_DIV_FACTOR(__CLOCKPRESCALER__))*2U)\
@@ -711,7 +711,90 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
   * @param  __CLOCKSOURCE__ output variable.
   * @retval the USART clocking source, written in __CLOCKSOURCE__.
   */
-#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define USART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
+  do {                                                         \
+    if((__HANDLE__)->Instance == USART1)                       \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                    \
+      {                                                        \
+        case RCC_USART1CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_SYSCLK;        \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART2)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART2_SOURCE())                    \
+      {                                                        \
+        case RCC_USART2CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_SYSCLK;        \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART3)                  \
+    {                                                          \
+      switch(__HAL_RCC_GET_USART3_SOURCE())                    \
+      {                                                        \
+        case RCC_USART3CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_SYSCLK;        \
+          break;                                               \
+        case RCC_USART3CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        default:                                               \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;     \
+          break;                                               \
+      }                                                        \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART4)                  \
+    {                                                          \
+      (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;             \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART5)                  \
+    {                                                          \
+      (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;             \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART6)                  \
+    {                                                          \
+      (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;             \
+    }                                                          \
+    else                                                       \
+    {                                                          \
+      (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;         \
+    }                                                          \
+  } while(0U)
+#elif defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
 #define USART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
   do {                                                         \
     if((__HANDLE__)->Instance == USART1)                       \
@@ -769,7 +852,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
       (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;         \
     }                                                          \
   } while(0U)
-#elif defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#else
 #define USART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__)       \
   do {                                                         \
     if((__HANDLE__)->Instance == USART1)                       \
@@ -802,7 +885,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
       (__CLOCKSOURCE__) = USART_CLOCKSOURCE_UNDEFINED;         \
     }                                                          \
   } while(0U)
-#endif /* STM32G081xx || STM32G071xx || STM32G070xx */
+#endif
 
 /** @brief  Check USART Baud rate.
   * @param  __BAUDRATE__ Baudrate specified by the user.

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_wwdg.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_hal_wwdg.h
@@ -22,7 +22,7 @@
 #define STM32G0xx_HAL_WWDG_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -56,7 +56,7 @@ typedef struct
   uint32_t Counter;       /*!< Specifies the WWDG free-running downcounter  value.
                                This parameter must be a number between Min_Data = 0x40 and Max_Data = 0x7F */
 
-  uint32_t EWIMode ;      /*!< Specifies if WWDG Early Wakeup Interupt is enable or not.
+  uint32_t EWIMode ;      /*!< Specifies if WWDG Early Wakeup Interrupt is enable or not.
                                This parameter can be a value of @ref WWDG_EWI_Mode */
 
 } WWDG_InitTypeDef;
@@ -68,17 +68,17 @@ typedef struct
 typedef struct __WWDG_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
 {
   WWDG_TypeDef      *Instance;  /*!< Register base address */
 
   WWDG_InitTypeDef  Init;       /*!< WWDG required parameters */
 
 #if (USE_HAL_WWDG_REGISTER_CALLBACKS == 1)
-  void              (* EwiCallback)(struct __WWDG_HandleTypeDef *hwwdg);     /*!< WWDG Early WakeUp Interrupt callback */
+  void (* EwiCallback)(struct __WWDG_HandleTypeDef *hwwdg);                  /*!< WWDG Early WakeUp Interrupt callback */
 
-  void              (* MspInitCallback)(struct __WWDG_HandleTypeDef *hwwdg); /*!< WWDG Msp Init callback */
-#endif
+  void (* MspInitCallback)(struct __WWDG_HandleTypeDef *hwwdg);              /*!< WWDG Msp Init callback */
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
 } WWDG_HandleTypeDef;
 
 #if (USE_HAL_WWDG_REGISTER_CALLBACKS == 1)
@@ -87,16 +87,16 @@ typedef struct
   */
 typedef enum
 {
-  HAL_WWDG_EWI_CB_ID          = 0x00u,    /*!< WWDG EWI callback ID */
-  HAL_WWDG_MSPINIT_CB_ID      = 0x01u,    /*!< WWDG MspInit callback ID */
-}HAL_WWDG_CallbackIDTypeDef;
+  HAL_WWDG_EWI_CB_ID          = 0x00U,    /*!< WWDG EWI callback ID */
+  HAL_WWDG_MSPINIT_CB_ID      = 0x01U,    /*!< WWDG MspInit callback ID */
+} HAL_WWDG_CallbackIDTypeDef;
 
 /**
   * @brief  HAL WWDG Callback pointer definition
   */
-typedef void (*pWWDG_CallbackTypeDef)(WWDG_HandleTypeDef * hppp); /*!< pointer to a WWDG common callback functions */
+typedef void (*pWWDG_CallbackTypeDef)(WWDG_HandleTypeDef *hppp);  /*!< pointer to a WWDG common callback functions */
 
-#endif
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
 /**
   * @}
   */
@@ -247,7 +247,8 @@ typedef void (*pWWDG_CallbackTypeDef)(WWDG_HandleTypeDef * hppp); /*!< pointer t
   *            @arg WWDG_IT_EWI: Early Wakeup Interrupt
   * @retval state of __INTERRUPT__ (TRUE or FALSE).
   */
-#define __HAL_WWDG_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CFR & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_WWDG_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CFR\
+                                                              & (__INTERRUPT__)) == (__INTERRUPT__))
 
 /**
   * @}
@@ -267,9 +268,10 @@ HAL_StatusTypeDef     HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg);
 void                  HAL_WWDG_MspInit(WWDG_HandleTypeDef *hwwdg);
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_WWDG_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef     HAL_WWDG_RegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWDG_CallbackIDTypeDef CallbackID, pWWDG_CallbackTypeDef pCallback);
+HAL_StatusTypeDef     HAL_WWDG_RegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWDG_CallbackIDTypeDef CallbackID,
+                                                pWWDG_CallbackTypeDef pCallback);
 HAL_StatusTypeDef     HAL_WWDG_UnRegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWDG_CallbackIDTypeDef CallbackID);
-#endif
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_adc.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_adc.h
@@ -101,9 +101,10 @@ extern "C" {
 /*   GPIO pins) and internal channels (connected to internal paths)           */
 #define ADC_CHANNEL_ID_NUMBER_MASK         (ADC_CFGR1_AWD1CH)
 #define ADC_CHANNEL_ID_BITFIELD_MASK       (ADC_CHSELR_CHSEL)
-#define ADC_CHANNEL_ID_NUMBER_MASK_SEQ     (ADC_CHSELR_SQ1 << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) /* Value equivalent to ADC_CHANNEL_ID_NUMBER_MASK with reduced range: on this STM32 serie, ADC group regular sequencer, if set to mode "fully configurable", can contain channels with a restricted channel number. Refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). */
+#define ADC_CHANNEL_ID_NUMBER_MASK_SEQ     (ADC_CHSELR_SQ1 << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) /* Value equivalent to ADC_CHANNEL_ID_NUMBER_MASK with reduced range: on this STM32 series, ADC group regular sequencer, if set to mode "fully configurable", can contain channels with a restricted channel number. Refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). */
 #define ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS (26UL)/* Value equivalent to bitfield "ADC_CHANNEL_ID_NUMBER_MASK" position in register */
-#define ADC_CHANNEL_ID_MASK                (ADC_CHANNEL_ID_NUMBER_MASK | ADC_CHANNEL_ID_BITFIELD_MASK | ADC_CHANNEL_ID_INTERNAL_CH_MASK)
+#define ADC_CHANNEL_ID_MASK                (ADC_CHANNEL_ID_NUMBER_MASK | ADC_CHANNEL_ID_BITFIELD_MASK | \
+                                            ADC_CHANNEL_ID_INTERNAL_CH_MASK)
 /* Equivalent mask of ADC_CHANNEL_NUMBER_MASK aligned on register LSB (bit 0) */
 #define ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 (0x0000001FUL) /* Equivalent to shift: (ADC_CHANNEL_NUMBER_MASK >> [Position of bitfield "ADC_CHANNEL_NUMBER_MASK" in register]) */
 
@@ -114,24 +115,25 @@ extern "C" {
 /* Definition of channels ID number information to be inserted into           */
 /* channels literals definition.                                              */
 #define ADC_CHANNEL_0_NUMBER               (0x00000000UL)
-#define ADC_CHANNEL_1_NUMBER               (                                                                                    ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_2_NUMBER               (                                                               ADC_CFGR1_AWD1CH_1                     )
-#define ADC_CHANNEL_3_NUMBER               (                                                               ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_4_NUMBER               (                                          ADC_CFGR1_AWD1CH_2                                          )
-#define ADC_CHANNEL_5_NUMBER               (                                          ADC_CFGR1_AWD1CH_2                      | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_6_NUMBER               (                                          ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1                     )
-#define ADC_CHANNEL_7_NUMBER               (                                          ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_8_NUMBER               (                     ADC_CFGR1_AWD1CH_3                                                               )
-#define ADC_CHANNEL_9_NUMBER               (                     ADC_CFGR1_AWD1CH_3                                           | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_10_NUMBER              (                     ADC_CFGR1_AWD1CH_3                      | ADC_CFGR1_AWD1CH_1                     )
-#define ADC_CHANNEL_11_NUMBER              (                     ADC_CFGR1_AWD1CH_3                      | ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_12_NUMBER              (                     ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2                                          )
-#define ADC_CHANNEL_13_NUMBER              (                     ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2                      | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_14_NUMBER              (                     ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1                     )
-#define ADC_CHANNEL_15_NUMBER              (                     ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_16_NUMBER              (ADC_CFGR1_AWD1CH_4                                                                                    )
-#define ADC_CHANNEL_17_NUMBER              (ADC_CFGR1_AWD1CH_4                                                                | ADC_CFGR1_AWD1CH_0)
-#define ADC_CHANNEL_18_NUMBER              (ADC_CFGR1_AWD1CH_4                                           | ADC_CFGR1_AWD1CH_1                     )
+#define ADC_CHANNEL_1_NUMBER               (ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_2_NUMBER               (ADC_CFGR1_AWD1CH_1)
+#define ADC_CHANNEL_3_NUMBER               (ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_4_NUMBER               (ADC_CFGR1_AWD1CH_2)
+#define ADC_CHANNEL_5_NUMBER               (ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_6_NUMBER               (ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1)
+#define ADC_CHANNEL_7_NUMBER               (ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_8_NUMBER               (ADC_CFGR1_AWD1CH_3)
+#define ADC_CHANNEL_9_NUMBER               (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_10_NUMBER              (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_1)
+#define ADC_CHANNEL_11_NUMBER              (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_12_NUMBER              (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2)
+#define ADC_CHANNEL_13_NUMBER              (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_14_NUMBER              (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2 | ADC_CFGR1_AWD1CH_1)
+#define ADC_CHANNEL_15_NUMBER              (ADC_CFGR1_AWD1CH_3 | ADC_CFGR1_AWD1CH_2 | \
+                                            ADC_CFGR1_AWD1CH_1 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_16_NUMBER              (ADC_CFGR1_AWD1CH_4)
+#define ADC_CHANNEL_17_NUMBER              (ADC_CFGR1_AWD1CH_4 | ADC_CFGR1_AWD1CH_0)
+#define ADC_CHANNEL_18_NUMBER              (ADC_CFGR1_AWD1CH_4 | ADC_CFGR1_AWD1CH_1)
 
 /* Definition of channels ID bitfield information to be inserted into         */
 /* channels literals definition.                                              */
@@ -242,7 +244,7 @@ extern "C" {
 
 /* ADC internal channels related definitions */
 /* Internal voltage reference VrefInt */
-#define VREFINT_CAL_ADDR                   ((uint16_t*) (0x1FFF75AAUL)) /* Internal voltage reference, address of parameter VREFINT_CAL: VrefInt ADC raw data acquired at temperature 30 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+#define VREFINT_CAL_ADDR                   ((uint16_t*) (0x1FFF75AAUL)) /* Internal voltage reference, address of parameter VREFINT_CAL: VrefInt ADC raw data acquired at temperature 30 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
 #define VREFINT_CAL_VREF                   ( 3000UL)                    /* Analog voltage reference (Vref+) voltage with which VrefInt has been calibrated in production (tolerance: +-10 mV) (unit: mV). */
 /* Temperature sensor */
 #define TEMPSENSOR_CAL1_ADDR               ((uint16_t*) (0x1FFF75A8UL)) /* Internal temperature sensor, address of parameter TS_CAL1: On STM32G0, temperature sensor ADC raw data acquired at temperature  30 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
@@ -250,7 +252,6 @@ extern "C" {
 #define TEMPSENSOR_CAL1_TEMP               (( int32_t)   30)            /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL1_ADDR (tolerance: +-5 DegC) (unit: DegC). */
 #define TEMPSENSOR_CAL2_TEMP               (( int32_t)  130)            /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL2_ADDR (tolerance: +-5 DegC) (unit: DegC). */
 #define TEMPSENSOR_CAL_VREFANALOG          ( 3000UL)                    /* Analog voltage reference (Vref+) voltage with which temperature sensor has been calibrated in production (tolerance: +-10 mV) (unit: mV). */
-
 
 /**
   * @}
@@ -271,7 +272,7 @@ extern "C" {
   * @retval Pointer to register address
   */
 #define __ADC_PTR_REG_OFFSET(__REG__, __REG_OFFFSET__)                         \
- ((__IO uint32_t *)((uint32_t) ((uint32_t)(&(__REG__)) + ((__REG_OFFFSET__) << 2UL))))
+  ((__IO uint32_t *)((uint32_t) ((uint32_t)(&(__REG__)) + ((__REG_OFFFSET__) << 2UL))))
 
 /**
   * @}
@@ -325,7 +326,7 @@ typedef struct
 {
   uint32_t Clock;                       /*!< Set ADC instance clock source and prescaler.
                                              This parameter can be a value of @ref ADC_LL_EC_CLOCK_SOURCE
-                                             @note On this STM32 serie, this parameter has some clock ratio constraints:
+                                             @note On this STM32 series, this parameter has some clock ratio constraints:
                                                    ADC clock synchronous (from PCLK) with prescaler 1 must be enabled only if PCLK has a 50% duty clock cycle
                                                    (APB prescaler configured inside the RCC must be bypassed and the system clock must by 50% duty cycle).
 
@@ -373,13 +374,14 @@ typedef struct
 {
   uint32_t TriggerSource;               /*!< Set ADC group regular conversion trigger source: internal (SW start) or from external peripheral (timer event, external interrupt line).
                                              This parameter can be a value of @ref ADC_LL_EC_REG_TRIGGER_SOURCE
-                                             @note On this STM32 serie, setting trigger source to external trigger also set trigger polarity to rising edge
+                                             @note On this STM32 series, setting trigger source to external trigger also set trigger polarity to rising edge
                                                    (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value).
                                                    In case of need to modify trigger edge, use function @ref LL_ADC_REG_SetTriggerEdge().
 
                                              This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetTriggerSource(). */
 
   uint32_t SequencerLength;             /*!< Set ADC group regular sequencer length.
+                                             @note This parameter has an effect only if group regular sequencer is set to mode "fully configurable". Refer to function @ref LL_ADC_REG_SetSequencerConfigurable().
                                              This parameter can be a value of @ref ADC_LL_EC_REG_SEQ_SCAN_LENGTH
 
                                              This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetSequencerLength(). */
@@ -503,7 +505,7 @@ typedef struct
 /*       If they are not listed below, they do not require any specific       */
 /*       path enable. In this case, Access to measurement path is done        */
 /*       only by selecting the corresponding ADC internal channel.            */
-#define LL_ADC_PATH_INTERNAL_NONE          (0x00000000UL)         /*!< ADC measurement pathes all disabled */
+#define LL_ADC_PATH_INTERNAL_NONE          (0x00000000UL)         /*!< ADC measurement paths all disabled */
 #define LL_ADC_PATH_INTERNAL_VREFINT       (ADC_CCR_VREFEN)       /*!< ADC measurement path to internal channel VrefInt */
 #define LL_ADC_PATH_INTERNAL_TEMPSENSOR    (ADC_CCR_TSEN)         /*!< ADC measurement path to internal channel temperature sensor */
 #define LL_ADC_PATH_INTERNAL_VBAT          (ADC_CCR_VBATEN)       /*!< ADC measurement path to internal channel Vbat */
@@ -537,7 +539,7 @@ typedef struct
   * @{
   */
 #define LL_ADC_DATA_ALIGN_RIGHT            (0x00000000UL)         /*!< ADC conversion data alignment: right aligned (alignment on data register LSB bit 0)*/
-#define LL_ADC_DATA_ALIGN_LEFT             (ADC_CFGR1_ALIGN)      /*!< ADC conversion data alignment: left aligned (aligment on data register MSB bit 15)*/
+#define LL_ADC_DATA_ALIGN_LEFT             (ADC_CFGR1_ALIGN)      /*!< ADC conversion data alignment: left aligned (alignment on data register MSB bit 15)*/
 /**
   * @}
   */
@@ -563,8 +565,8 @@ typedef struct
   */
 
 /** @defgroup ADC_LL_EC_SAMPLINGTIME_COMMON  ADC instance - Sampling time common to a group of channels
-* @{
-*/
+  * @{
+  */
 #define LL_ADC_SAMPLINGTIME_COMMON_1       (ADC_SMPR_SMP1_BITOFFSET_POS)                             /*!< Set sampling time common to a group of channels: sampling time nb 1 */
 #define LL_ADC_SAMPLINGTIME_COMMON_2       (ADC_SMPR_SMP2_BITOFFSET_POS | ADC_SAMPLING_TIME_CH_MASK) /*!< Set sampling time common to a group of channels: sampling time nb 2 */
 /**
@@ -618,6 +620,9 @@ typedef struct
 #define LL_ADC_REG_TRIG_EXT_TIM2_TRGO      (                     ADC_CFGR1_EXTSEL_1                      | ADC_REG_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group regular conversion trigger from external peripheral: TIM2 TRGO. Trigger edge set to rising edge (default setting). */
 #endif
 #define LL_ADC_REG_TRIG_EXT_TIM3_TRGO      (                     ADC_CFGR1_EXTSEL_1 | ADC_CFGR1_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group regular conversion trigger from external peripheral: TIM3 TRGO. Trigger edge set to rising edge (default setting). */
+#if defined(TIM4)
+#define LL_ADC_REG_TRIG_EXT_TIM4_TRGO      (ADC_CFGR1_EXTSEL_2 | ADC_CFGR1_EXTSEL_1                      | ADC_REG_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group regular conversion trigger from external peripheral: TIM4 TRGO. Trigger edge set to rising edge (default setting). */
+#endif
 #if defined(TIM6)
 #define LL_ADC_REG_TRIG_EXT_TIM6_TRGO      (ADC_CFGR1_EXTSEL_2                      | ADC_CFGR1_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group regular conversion trigger from external peripheral: TIM6 TRGO. Trigger edge set to rising edge (default setting). */
 #endif
@@ -640,8 +645,8 @@ typedef struct
   */
 
 /** @defgroup ADC_LL_EC_REG_CONTINUOUS_MODE  ADC group regular - Continuous mode
-* @{
-*/
+  * @{
+  */
 #define LL_ADC_REG_CONV_SINGLE             (0x00000000UL)          /*!< ADC conversions are performed in single mode: one conversion per trigger */
 #define LL_ADC_REG_CONV_CONTINUOUS         (ADC_CFGR1_CONT)        /*!< ADC conversions are performed in continuous mode: after the first trigger, following conversions launched successively automatically */
 /**
@@ -659,8 +664,8 @@ typedef struct
   */
 
 /** @defgroup ADC_LL_EC_REG_OVR_DATA_BEHAVIOR  ADC group regular - Overrun behavior on conversion data
-* @{
-*/
+  * @{
+  */
 #define LL_ADC_REG_OVR_DATA_PRESERVED      (0x00000000UL)         /*!< ADC group regular behavior in case of overrun: data preserved */
 #define LL_ADC_REG_OVR_DATA_OVERWRITTEN    (ADC_CFGR1_OVRMOD)     /*!< ADC group regular behavior in case of overrun: data overwritten */
 /**
@@ -668,8 +673,8 @@ typedef struct
   */
 
 /** @defgroup ADC_LL_EC_REG_SEQ_MODE  ADC group regular - Sequencer configuration flexibility
-* @{
-*/
+  * @{
+  */
 #define LL_ADC_REG_SEQ_FIXED               (0x00000000UL)         /*!< Sequencer configured to not fully configurable: sequencer length and each rank affectation to a channel are fixed by channel HW number. Refer to description of function @ref LL_ADC_REG_SetSequencerChannels(). */
 #define LL_ADC_REG_SEQ_CONFIGURABLE        (ADC_CFGR1_CHSELRMOD)  /*!< Sequencer configured to fully configurable: sequencer length and each rank affectation to a channel are configurable. Refer to description of function @ref LL_ADC_REG_SetSequencerLength(). */
 /**
@@ -694,8 +699,8 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_SEQ_SCAN_DIRECTION  ADC group regular - Sequencer scan direction
   * @{
   */
-#define LL_ADC_REG_SEQ_SCAN_DIR_FORWARD    (0x00000000UL)         /*!< On this STM32 serie, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction forward: from lowest channel number to highest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer). On some other STM32 families, this setting is not available and the default scan direction is forward. */
-#define LL_ADC_REG_SEQ_SCAN_DIR_BACKWARD   (ADC_CFGR1_SCANDIR)    /*!< On this STM32 serie, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction backward: from highest channel number to lowest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer) */
+#define LL_ADC_REG_SEQ_SCAN_DIR_FORWARD    (0x00000000UL)         /*!< On this STM32 series, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction forward: from lowest channel number to highest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer). On some other STM32 families, this setting is not available and the default scan direction is forward. */
+#define LL_ADC_REG_SEQ_SCAN_DIR_BACKWARD   (ADC_CFGR1_SCANDIR)    /*!< On this STM32 series, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction backward: from highest channel number to lowest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer) */
 /**
   * @}
   */
@@ -839,6 +844,13 @@ typedef struct
   * @}
   */
 
+/** @defgroup ADC_LL_EC_HELPER_MACRO  Definitions of constants used by helper macro
+  * @{
+  */
+#define LL_ADC_TEMPERATURE_CALC_ERROR     ((int16_t)0x7FFF) /* Temperature calculation error using helper macro @ref __LL_ADC_CALC_TEMPERATURE(), due to issue on calibration parameters. This value is coded on 16 bits (to fit on signed word or double word) and corresponds to an inconsistent temperature value. */
+/**
+  * @}
+  */
 
 /** @defgroup ADC_LL_EC_HW_DELAYS  Definitions of ADC hardware constraints delays
   * @note   Only ADC peripheral HW delays are defined in ADC LL driver driver,
@@ -854,7 +866,7 @@ typedef struct
 /*       configuration (system clock versus ADC clock),                       */
 /*       and therefore must be defined in user application.                   */
 /*       Indications for estimation of ADC timeout delays, for this           */
-/*       STM32 serie:                                                         */
+/*       STM32 series:                                                        */
 /*       - ADC calibration time: maximum delay is 82/fADC.                    */
 /*         (refer to device datasheet, parameter "tCAL")                      */
 /*       - ADC enable time: maximum delay is 1 conversion cycle.              */
@@ -876,22 +888,23 @@ typedef struct
 /* Delay set to maximum value (refer to device datasheet,                     */
 /* parameter "tstart_vrefint").                                               */
 /* Unit: us                                                                   */
-#define LL_ADC_DELAY_VREFINT_STAB_US       ( 12UL)  /*!< Delay for internal voltage reference stabilization time */
+#define LL_ADC_DELAY_VREFINT_STAB_US           ( 12UL)  /*!< Delay for internal voltage reference stabilization time */
 
 /* Delay for temperature sensor stabilization time.                           */
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tSTART").                                                       */
 /* Unit: us                                                                   */
-#define LL_ADC_DELAY_TEMPSENSOR_STAB_US    ( 10UL)  /*!< Delay for temperature sensor stabilization time */
+#define LL_ADC_DELAY_TEMPSENSOR_STAB_US        (120UL)  /*!< Delay for temperature sensor stabilization time (starting from temperature sensor enable, refer to @ref LL_ADC_SetCommonPathInternalCh()) */
+#define LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US ( 15UL)  /*!< Delay for temperature sensor buffer stabilization time (starting from ADC enable, refer to @ref LL_ADC_Enable()) */
 
 /* Delay required between ADC end of calibration and ADC enable.              */
-/* Note: On this STM32 serie, a minimum number of ADC clock cycles            */
+/* Note: On this STM32 series, a minimum number of ADC clock cycles           */
 /*       are required between ADC end of calibration and ADC enable.          */
 /*       Wait time can be computed in user application by waiting for the     */
 /*       equivalent number of CPU cycles, by taking into account              */
 /*       ratio of CPU clock versus ADC clock prescalers.                      */
 /* Unit: ADC clock cycles.                                                    */
-#define LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES (  2UL)  /*!< Delay required between ADC end of calibration and ADC enable */
+#define LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES   (  2UL)  /*!< Delay required between ADC end of calibration and ADC enable */
 
 /**
   * @}
@@ -973,71 +986,32 @@ typedef struct
   *             refer to function @ref LL_ADC_REG_SetSequencerConfigurable().
   * @retval Value between Min_Data=0 and Max_Data=18
   */
-#define __LL_ADC_CHANNEL_TO_DECIMAL_NB(__CHANNEL__)                                                               \
-  ((((__CHANNEL__) & ADC_CHANNEL_ID_BITFIELD_MASK) == 0UL)                                                        \
-    ? (                                                                                                           \
-       ((__CHANNEL__) & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS                        \
-      )                                                                                                           \
-      :                                                                                                           \
-      (                                                                                                           \
-       (((__CHANNEL__) & ADC_CHSELR_CHSEL0) == ADC_CHSELR_CHSEL0) ? (0UL) :                                       \
-        (                                                                                                         \
-         (((__CHANNEL__) & ADC_CHSELR_CHSEL1) == ADC_CHSELR_CHSEL1) ? (1UL) :                                     \
-          (                                                                                                       \
-           (((__CHANNEL__) & ADC_CHSELR_CHSEL2) == ADC_CHSELR_CHSEL2) ? (2UL) :                                   \
-            (                                                                                                     \
-             (((__CHANNEL__) & ADC_CHSELR_CHSEL3) == ADC_CHSELR_CHSEL3) ? (3UL) :                                 \
-              (                                                                                                   \
-               (((__CHANNEL__) & ADC_CHSELR_CHSEL4) == ADC_CHSELR_CHSEL4) ? (4UL) :                               \
-                (                                                                                                 \
-                 (((__CHANNEL__) & ADC_CHSELR_CHSEL5) == ADC_CHSELR_CHSEL5) ? (5UL) :                             \
-                  (                                                                                               \
-                   (((__CHANNEL__) & ADC_CHSELR_CHSEL6) == ADC_CHSELR_CHSEL6) ? (6UL) :                           \
-                    (                                                                                             \
-                     (((__CHANNEL__) & ADC_CHSELR_CHSEL7) == ADC_CHSELR_CHSEL7) ? (7UL) :                         \
-                      (                                                                                           \
-                       (((__CHANNEL__) & ADC_CHSELR_CHSEL8) == ADC_CHSELR_CHSEL8) ? (8UL) :                       \
-                        (                                                                                         \
-                         (((__CHANNEL__) & ADC_CHSELR_CHSEL9) == ADC_CHSELR_CHSEL9) ? (9UL) :                     \
-                          (                                                                                       \
-                           (((__CHANNEL__) & ADC_CHSELR_CHSEL10) == ADC_CHSELR_CHSEL10) ? (10UL) :                \
-                            (                                                                                     \
-                             (((__CHANNEL__) & ADC_CHSELR_CHSEL11) == ADC_CHSELR_CHSEL11) ? (11UL) :              \
-                              (                                                                                   \
-                               (((__CHANNEL__) & ADC_CHSELR_CHSEL12) == ADC_CHSELR_CHSEL12) ? (12UL) :            \
-                                (                                                                                 \
-                                 (((__CHANNEL__) & ADC_CHSELR_CHSEL13) == ADC_CHSELR_CHSEL13) ? (13UL) :          \
-                                  (                                                                               \
-                                   (((__CHANNEL__) & ADC_CHSELR_CHSEL14) == ADC_CHSELR_CHSEL14) ? (14UL) :        \
-                                    (                                                                             \
-                                     (((__CHANNEL__) & ADC_CHSELR_CHSEL15) == ADC_CHSELR_CHSEL15) ? (15UL) :      \
-                                      (                                                                           \
-                                       (((__CHANNEL__) & ADC_CHSELR_CHSEL16) == ADC_CHSELR_CHSEL16) ? (16UL) :    \
-                                        (                                                                         \
-                                         (((__CHANNEL__) & ADC_CHSELR_CHSEL17) == ADC_CHSELR_CHSEL17) ? (17UL) :  \
-                                          (                                                                       \
-                                           (((__CHANNEL__) & ADC_CHSELR_CHSEL18) == ADC_CHSELR_CHSEL18) ? (18UL) :\
-                                            (0UL)                                                                 \
-                                          )                                                                       \
-                                        )                                                                         \
-                                      )                                                                           \
-                                    )                                                                             \
-                                  )                                                                               \
-                                )                                                                                 \
-                              )                                                                                   \
-                            )                                                                                     \
-                          )                                                                                       \
-                        )                                                                                         \
-                      )                                                                                           \
-                    )                                                                                             \
-                  )                                                                                               \
-                )                                                                                                 \
-              )                                                                                                   \
-            )                                                                                                     \
-          )                                                                                                       \
-        )                                                                                                         \
-      )                                                                                                           \
-  )
+#define __LL_ADC_CHANNEL_TO_DECIMAL_NB(__CHANNEL__)                                                     \
+  ((((__CHANNEL__) & ADC_CHANNEL_ID_BITFIELD_MASK) == 0UL) ?                                            \
+   (                                                                                                    \
+       ((__CHANNEL__) & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS              \
+   )                                                                                                    \
+   :                                                                                                    \
+   ((((__CHANNEL__) & ADC_CHANNEL_0_BITFIELD) == ADC_CHANNEL_0_BITFIELD) ? (0UL) :                      \
+    ((((__CHANNEL__) & ADC_CHANNEL_1_BITFIELD) == ADC_CHANNEL_1_BITFIELD) ? (1UL) :                     \
+     ((((__CHANNEL__) & ADC_CHANNEL_2_BITFIELD) == ADC_CHANNEL_2_BITFIELD) ? (2UL) :                    \
+      ((((__CHANNEL__) & ADC_CHANNEL_3_BITFIELD) == ADC_CHANNEL_3_BITFIELD) ? (3UL) :                   \
+       ((((__CHANNEL__) & ADC_CHANNEL_4_BITFIELD) == ADC_CHANNEL_4_BITFIELD) ? (4UL) :                  \
+        ((((__CHANNEL__) & ADC_CHANNEL_5_BITFIELD) == ADC_CHANNEL_5_BITFIELD) ? (5UL) :                 \
+         ((((__CHANNEL__) & ADC_CHANNEL_6_BITFIELD) == ADC_CHANNEL_6_BITFIELD) ? (6UL) :                \
+          ((((__CHANNEL__) & ADC_CHANNEL_7_BITFIELD) == ADC_CHANNEL_7_BITFIELD) ? (7UL) :               \
+           ((((__CHANNEL__) & ADC_CHANNEL_8_BITFIELD) == ADC_CHANNEL_8_BITFIELD) ? (8UL) :              \
+            ((((__CHANNEL__) & ADC_CHANNEL_9_BITFIELD) == ADC_CHANNEL_9_BITFIELD) ? (9UL) :             \
+             ((((__CHANNEL__) & ADC_CHANNEL_10_BITFIELD) == ADC_CHANNEL_10_BITFIELD) ? (10UL) :         \
+              ((((__CHANNEL__) & ADC_CHANNEL_11_BITFIELD) == ADC_CHANNEL_11_BITFIELD) ? (11UL) :        \
+               ((((__CHANNEL__) & ADC_CHANNEL_12_BITFIELD) == ADC_CHANNEL_12_BITFIELD) ? (12UL) :       \
+                ((((__CHANNEL__) & ADC_CHANNEL_13_BITFIELD) == ADC_CHANNEL_13_BITFIELD) ? (13UL) :      \
+                 ((((__CHANNEL__) & ADC_CHANNEL_14_BITFIELD) == ADC_CHANNEL_14_BITFIELD) ? (14UL) :     \
+                  ((((__CHANNEL__) & ADC_CHANNEL_15_BITFIELD) == ADC_CHANNEL_15_BITFIELD) ? (15UL) :    \
+                   ((((__CHANNEL__) & ADC_CHANNEL_16_BITFIELD) == ADC_CHANNEL_16_BITFIELD) ? (16UL) :   \
+                    ((((__CHANNEL__) & ADC_CHANNEL_17_BITFIELD) == ADC_CHANNEL_17_BITFIELD) ? (17UL) :  \
+                     ((((__CHANNEL__) & ADC_CHANNEL_18_BITFIELD) == ADC_CHANNEL_18_BITFIELD) ? (18UL) : \
+                      (0UL)))))))))))))))))))))
 
 /**
   * @brief  Helper macro to get ADC channel in literal format LL_ADC_CHANNEL_x
@@ -1078,10 +1052,8 @@ typedef struct
   *             using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
   */
 #define __LL_ADC_DECIMAL_NB_TO_CHANNEL(__DECIMAL_NB__)                         \
-  (                                                                            \
-   ((__DECIMAL_NB__) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) |                 \
-   (ADC_CHSELR_CHSEL0 << (__DECIMAL_NB__))                                     \
-  )
+  (((__DECIMAL_NB__) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) |                 \
+   (ADC_CHSELR_CHSEL0 << (__DECIMAL_NB__)))
 
 /**
   * @brief  Helper macro to determine whether the selected channel
@@ -1219,11 +1191,9 @@ typedef struct
   *         Value "1" if the internal channel selected is available on the ADC instance selected.
   */
 #define __LL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE(__ADC_INSTANCE__, __CHANNEL__)  \
-  (                                                                            \
-    ((__CHANNEL__) == LL_ADC_CHANNEL_VREFINT)    ||                            \
-    ((__CHANNEL__) == LL_ADC_CHANNEL_TEMPSENSOR) ||                            \
-    ((__CHANNEL__) == LL_ADC_CHANNEL_VBAT)                                     \
-  )
+  (((__CHANNEL__) == LL_ADC_CHANNEL_VREFINT)    ||                             \
+   ((__CHANNEL__) == LL_ADC_CHANNEL_TEMPSENSOR) ||                             \
+   ((__CHANNEL__) == LL_ADC_CHANNEL_VBAT))
 
 /**
   * @brief  Helper macro to define ADC analog watchdog parameter:
@@ -1424,11 +1394,11 @@ typedef struct
   */
 #define __LL_ADC_CONVERT_DATA_RESOLUTION(__DATA__,\
                                          __ADC_RESOLUTION_CURRENT__,\
-                                         __ADC_RESOLUTION_TARGET__)            \
-  (((__DATA__)                                                                 \
-    << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR1_RES_BITOFFSET_POS - 1UL)))  \
-   >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR1_RES_BITOFFSET_POS - 1UL))     \
-  )
+                                         __ADC_RESOLUTION_TARGET__)          \
+(((__DATA__)                                                                 \
+  << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR1_RES_BITOFFSET_POS - 1UL)))  \
+ >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR1_RES_BITOFFSET_POS - 1UL))     \
+)
 
 /**
   * @brief  Helper macro to calculate the voltage (unit: mVolt)
@@ -1448,10 +1418,10 @@ typedef struct
   */
 #define __LL_ADC_CALC_DATA_TO_VOLTAGE(__VREFANALOG_VOLTAGE__,\
                                       __ADC_DATA__,\
-                                      __ADC_RESOLUTION__)                      \
-  ((__ADC_DATA__) * (__VREFANALOG_VOLTAGE__)                                   \
-   / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                                \
-  )
+                                      __ADC_RESOLUTION__)                    \
+((__ADC_DATA__) * (__VREFANALOG_VOLTAGE__)                                   \
+ / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                                \
+)
 
 /**
   * @brief  Helper macro to calculate analog reference voltage (Vref+)
@@ -1463,7 +1433,7 @@ typedef struct
   *         connected to pin Vref+.
   *         On devices with small package, the pin Vref+ is not present
   *         and internally bonded to pin Vdda.
-  * @note   On this STM32 serie, calibration data of internal voltage reference
+  * @note   On this STM32 series, calibration data of internal voltage reference
   *         VrefInt corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         internal voltage reference VrefInt.
@@ -1479,12 +1449,12 @@ typedef struct
   * @retval Analog reference voltage (unit: mV)
   */
 #define __LL_ADC_CALC_VREFANALOG_VOLTAGE(__VREFINT_ADC_DATA__,\
-                                         __ADC_RESOLUTION__)                   \
-  (((uint32_t)(*VREFINT_CAL_ADDR) * VREFINT_CAL_VREF)                          \
-    / __LL_ADC_CONVERT_DATA_RESOLUTION((__VREFINT_ADC_DATA__),                 \
-                                       (__ADC_RESOLUTION__),                   \
-                                       LL_ADC_RESOLUTION_12B)                  \
-  )
+                                         __ADC_RESOLUTION__)                 \
+(((uint32_t)(*VREFINT_CAL_ADDR) * VREFINT_CAL_VREF)                          \
+ / __LL_ADC_CONVERT_DATA_RESOLUTION((__VREFINT_ADC_DATA__),                  \
+                                    (__ADC_RESOLUTION__),                    \
+                                    LL_ADC_RESOLUTION_12B)                   \
+)
 
 /**
   * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
@@ -1513,7 +1483,7 @@ typedef struct
   * @note   Analog reference voltage (Vref+) must be either known from
   *         user board environment or can be calculated using ADC measurement
   *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
-  * @note   On this STM32 serie, calibration data of temperature sensor
+  * @note   On this STM32 series, calibration data of temperature sensor
   *         corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         temperature sensor.
@@ -1530,10 +1500,12 @@ typedef struct
   *         @arg @ref LL_ADC_RESOLUTION_8B
   *         @arg @ref LL_ADC_RESOLUTION_6B
   * @retval Temperature (unit: degree Celsius)
+  *         In case or error, value LL_ADC_TEMPERATURE_CALC_ERROR is returned (inconsistent temperature value)
   */
 #define __LL_ADC_CALC_TEMPERATURE(__VREFANALOG_VOLTAGE__,\
                                   __TEMPSENSOR_ADC_DATA__,\
-                                  __ADC_RESOLUTION__)                              \
+                                  __ADC_RESOLUTION__)\
+((((int32_t)*TEMPSENSOR_CAL2_ADDR - (int32_t)*TEMPSENSOR_CAL1_ADDR) != 0) ?        \
   (((( ((int32_t)((__LL_ADC_CONVERT_DATA_RESOLUTION((__TEMPSENSOR_ADC_DATA__),     \
                                                     (__ADC_RESOLUTION__),          \
                                                     LL_ADC_RESOLUTION_12B)         \
@@ -1543,7 +1515,10 @@ typedef struct
      ) * (int32_t)(TEMPSENSOR_CAL2_TEMP - TEMPSENSOR_CAL1_TEMP)                    \
     ) / (int32_t)((int32_t)*TEMPSENSOR_CAL2_ADDR - (int32_t)*TEMPSENSOR_CAL1_ADDR) \
    ) + TEMPSENSOR_CAL1_TEMP                                                        \
-  )
+  )                                                                                \
+  :                                                                                \
+  ((int32_t)LL_ADC_TEMPERATURE_CALC_ERROR)                                         \
+)
 
 /**
   * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
@@ -1594,18 +1569,17 @@ typedef struct
                                              __TEMPSENSOR_CALX_TEMP__,\
                                              __VREFANALOG_VOLTAGE__,\
                                              __TEMPSENSOR_ADC_DATA__,\
-                                             __ADC_RESOLUTION__)               \
-  ((( (                                                                        \
-       (int32_t)((((__TEMPSENSOR_ADC_DATA__) * (__VREFANALOG_VOLTAGE__))       \
-                  / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__))                \
-                 * 1000UL)                                                     \
-       -                                                                       \
-       (int32_t)(((__TEMPSENSOR_TYP_CALX_V__))                                 \
-                 * 1000UL)                                                     \
-      )                                                                        \
-    ) / (int32_t)(__TEMPSENSOR_TYP_AVGSLOPE__)                                 \
-   ) + (int32_t)(__TEMPSENSOR_CALX_TEMP__)                                     \
-  )
+                                             __ADC_RESOLUTION__)            \
+(((((int32_t)((((__TEMPSENSOR_ADC_DATA__) * (__VREFANALOG_VOLTAGE__))       \
+               / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__))                \
+              * 1000UL)                                                     \
+    -                                                                       \
+    (int32_t)(((__TEMPSENSOR_TYP_CALX_V__))                                 \
+              * 1000UL)                                                     \
+   )                                                                        \
+  ) / (int32_t)(__TEMPSENSOR_TYP_AVGSLOPE__)                                \
+ ) + (int32_t)(__TEMPSENSOR_CALX_TEMP__)                                    \
+)
 
 /**
   * @}
@@ -1659,7 +1633,7 @@ __STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(ADC_TypeDef *ADCx, uint32_t Regis
   (void)(Register);
 
   /* Retrieve address of register DR */
-  return (uint32_t)&(ADCx->DR);
+  return (uint32_t) &(ADCx->DR);
 }
 
 /**
@@ -1672,7 +1646,7 @@ __STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(ADC_TypeDef *ADCx, uint32_t Regis
 
 /**
   * @brief  Set parameter common to several ADC: Clock source and prescaler.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         All ADC instances of the ADC common group must be disabled.
   *         This check can be done with function @ref LL_ADC_IsEnabled() for each
@@ -1739,7 +1713,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetCommonClock(ADC_Common_TypeDef *ADCxy_COMMON)
   * @brief  Legacy feature, useless on STM32G0 (ADC common clock low frequency
             mode is automatically managed by ADC peripheral on STM32G0).
             Function kept for legacy purpose.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -1773,23 +1747,26 @@ __STATIC_INLINE uint32_t LL_ADC_GetCommonFrequencyMode(ADC_Common_TypeDef *ADCxy
 }
 
 /**
-  * @brief  Set parameter common to several ADC: measurement path to internal
-  *         channels (VrefInt, temperature sensor, ...).
+  * @brief  Set parameter common to several ADC: measurement path to
+  *         internal channels (VrefInt, temperature sensor, ...).
+  *         Configure all paths (overwrite current configuration).
   * @note   One or several values can be selected.
   *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
   *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  *         The values not selected are removed from configuration.
   * @note   Stabilization time of measurement path to internal channel:
   *         After enabling internal paths, before starting ADC conversion,
   *         a delay is required for internal voltage reference and
   *         temperature sensor stabilization time.
   *         Refer to device datasheet.
   *         Refer to literal @ref LL_ADC_DELAY_VREFINT_STAB_US.
-  *         Refer to literal @ref LL_ADC_DELAY_TEMPSENSOR_STAB_US.
+  *         Refer to literals @ref LL_ADC_DELAY_TEMPSENSOR_STAB_US,
+  *         @ref LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US.
   * @note   ADC internal channel sampling time constraint:
   *         For ADC conversion of internal channels,
   *         a sampling time minimum value is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         All ADC instances of the ADC common group must be disabled.
   *         This check can be done with function @ref LL_ADC_IsEnabled() for each
@@ -1810,6 +1787,78 @@ __STATIC_INLINE uint32_t LL_ADC_GetCommonFrequencyMode(ADC_Common_TypeDef *ADCxy
 __STATIC_INLINE void LL_ADC_SetCommonPathInternalCh(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t PathInternal)
 {
   MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_VREFEN | ADC_CCR_TSEN | ADC_CCR_VBATEN, PathInternal);
+}
+
+/**
+  * @brief  Set parameter common to several ADC: measurement path to
+  *         internal channels (VrefInt, temperature sensor, ...).
+  *         Add paths to the current configuration.
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
+  *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  * @note   Stabilization time of measurement path to internal channel:
+  *         After enabling internal paths, before starting ADC conversion,
+  *         a delay is required for internal voltage reference and
+  *         temperature sensor stabilization time.
+  *         Refer to device datasheet.
+  *         Refer to literal @ref LL_ADC_DELAY_VREFINT_STAB_US.
+  *         Refer to literals @ref LL_ADC_DELAY_TEMPSENSOR_STAB_US,
+  *         @ref LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US.
+  * @note   ADC internal channel sampling time constraint:
+  *         For ADC conversion of internal channels,
+  *         a sampling time minimum value is required.
+  *         Refer to device datasheet.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         This check can be done with function @ref LL_ADC_IsEnabled() for each
+  *         ADC instance or by using helper macro helper macro
+  *         @ref __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE().
+  * @rmtoll CCR      VREFEN         LL_ADC_SetCommonPathInternalChAdd\n
+  *         CCR      TSEN           LL_ADC_SetCommonPathInternalChAdd\n
+  *         CCR      VBATEN         LL_ADC_SetCommonPathInternalChAdd
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  PathInternal This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_PATH_INTERNAL_NONE
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VREFINT
+  *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCommonPathInternalChAdd(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t PathInternal)
+{
+  SET_BIT(ADCxy_COMMON->CCR, PathInternal);
+}
+
+/**
+  * @brief  Set parameter common to several ADC: measurement path to
+  *         internal channels (VrefInt, temperature sensor, ...).
+  *         Remove paths to the current configuration.
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
+  *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         This check can be done with function @ref LL_ADC_IsEnabled() for each
+  *         ADC instance or by using helper macro helper macro
+  *         @ref __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE().
+  * @rmtoll CCR      VREFEN         LL_ADC_SetCommonPathInternalChRem\n
+  *         CCR      TSEN           LL_ADC_SetCommonPathInternalChRem\n
+  *         CCR      VBATEN         LL_ADC_SetCommonPathInternalChRem
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  PathInternal This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_PATH_INTERNAL_NONE
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VREFINT
+  *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCommonPathInternalChRem(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t PathInternal)
+{
+  CLEAR_BIT(ADCxy_COMMON->CCR, PathInternal);
 }
 
 /**
@@ -1844,7 +1893,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetCommonPathInternalCh(ADC_Common_TypeDef *ADCx
 
 /**
   * @brief  Set ADC instance clock source and prescaler.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled.
   * @rmtoll CFGR2    CKMODE         LL_ADC_SetClock
@@ -1900,7 +1949,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetClock(ADC_TypeDef *ADCx)
   * @note   This function is intended to set calibration parameters
   *         without having to perform a new calibration using
   *         @ref LL_ADC_StartCalibration().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled, without calibration on going, without conversion
   *         on going on group regular.
@@ -1934,7 +1983,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(ADC_TypeDef *ADCx)
   * @brief  Set ADC resolution.
   *         Refer to reference manual for alignments formats
   *         dependencies to ADC resolutions.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -1973,7 +2022,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetResolution(ADC_TypeDef *ADCx)
   * @brief  Set ADC conversion data alignment.
   * @note   Refer to reference manual for alignments formats
   *         dependencies to ADC resolutions.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2020,9 +2069,12 @@ __STATIC_INLINE uint32_t LL_ADC_GetDataAlignment(ADC_TypeDef *ADCx)
   *           Moreover, this avoids risk of overrun for low frequency
   *           applications.
   *           How to use this low power mode:
-  *           - Do not use with interruption or DMA since these modes
-  *             have to clear immediately the EOC flag to free the
-  *             IRQ vector sequencer.
+  *           - It is not recommended to use with interruption or DMA
+  *             since these modes have to clear immediately the EOC flag
+  *             (by CPU to free the IRQ pending event or by DMA).
+  *             Auto wait will work but fort a very short time, discarding
+  *             its intended benefit (except specific case of high load of CPU
+  *             or DMA transfers which can justify usage of auto wait).
   *           - Do use with polling: 1. Start conversion,
   *             2. Later on, when conversion data is needed: poll for end of
   *             conversion  to ensure that conversion is completed and
@@ -2040,7 +2092,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetDataAlignment(ADC_TypeDef *ADCx)
   *         Therefore, the ADC conversion data may be outdated: does not
   *         correspond to the current voltage level on the selected
   *         ADC channel.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2075,9 +2127,12 @@ __STATIC_INLINE void LL_ADC_SetLowPowerMode(ADC_TypeDef *ADCx, uint32_t LowPower
   *           Moreover, this avoids risk of overrun for low frequency
   *           applications.
   *           How to use this low power mode:
-  *           - Do not use with interruption or DMA since these modes
-  *             have to clear immediately the EOC flag to free the
-  *             IRQ vector sequencer.
+  *           - It is not recommended to use with interruption or DMA
+  *             since these modes have to clear immediately the EOC flag
+  *             (by CPU to free the IRQ pending event or by DMA).
+  *             Auto wait will work but fort a very short time, discarding
+  *             its intended benefit (except specific case of high load of CPU
+  *             or DMA transfers which can justify usage of auto wait).
   *           - Do use with polling: 1. Start conversion,
   *             2. Later on, when conversion data is needed: poll for end of
   *             conversion  to ensure that conversion is completed and
@@ -2124,10 +2179,9 @@ __STATIC_INLINE uint32_t LL_ADC_GetLowPowerMode(ADC_TypeDef *ADCx)
   *           start trigger inserts the rearm delay.
   *         - Low power mode auto power-off: ADC trigger frequency mode
   *           is discarded.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
-  *         ADC must be disabled or enabled without conversion on going
-  *         on group regular.
+  *         ADC must be disabled.
   * @rmtoll CFGR2    LFTRIG         LL_ADC_SetTriggerFrequencyMode
   * @param  ADCx ADC instance
   * @param  TriggerFrequencyMode This parameter can be one of the following values:
@@ -2156,7 +2210,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
 /**
   * @brief  Set sampling time common to a group of channels.
   * @note   Unit: ADC clock cycles.
-  * @note   On this STM32 serie, sampling time scope is on ADC instance:
+  * @note   On this STM32 series, sampling time scope is on ADC instance:
   *         Sampling time common to all channels.
   *         (on some other STM32 families, sampling time is channel wise)
   * @note   In case of internal channel (VrefInt, TempSensor, ...) to be
@@ -2167,7 +2221,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
   *         Refer to device datasheet for timings values (parameters TS_vrefint,
   *         TS_temp, ...).
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -2176,7 +2230,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
   *         temperature sensor, ...), a sampling time minimum value
   *         is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2197,7 +2251,8 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_SAMPLINGTIME_160CYCLES_5
   * @retval None
   */
-__STATIC_INLINE void LL_ADC_SetSamplingTimeCommonChannels(ADC_TypeDef *ADCx, uint32_t SamplingTimeY, uint32_t SamplingTime)
+__STATIC_INLINE void LL_ADC_SetSamplingTimeCommonChannels(ADC_TypeDef *ADCx, uint32_t SamplingTimeY,
+                                                          uint32_t SamplingTime)
 {
   MODIFY_REG(ADCx->SMPR,
              ADC_SMPR_SMP1 << (SamplingTimeY & ADC_SAMPLING_TIME_SMP_SHIFT_MASK),
@@ -2207,12 +2262,12 @@ __STATIC_INLINE void LL_ADC_SetSamplingTimeCommonChannels(ADC_TypeDef *ADCx, uin
 /**
   * @brief  Get sampling time common to a group of channels.
   * @note   Unit: ADC clock cycles.
-  * @note   On this STM32 serie, sampling time scope is on ADC instance:
+  * @note   On this STM32 series, sampling time scope is on ADC instance:
   *         Sampling time common to all channels.
   *         (on some other STM32 families, sampling time is channel wise)
   * @note   Conversion time is the addition of sampling time and processing time.
   *         Refer to reference manual for ADC processing time of
-  *         this STM32 serie.
+  *         this STM32 series.
   * @rmtoll SMPR     SMP1           LL_ADC_GetSamplingTimeCommonChannels\n
   * @rmtoll SMPR     SMP2           LL_ADC_GetSamplingTimeCommonChannels
   * @param  ADCx ADC instance
@@ -2247,19 +2302,19 @@ __STATIC_INLINE uint32_t LL_ADC_GetSamplingTimeCommonChannels(ADC_TypeDef *ADCx,
   * @brief  Set ADC group regular conversion trigger source:
   *         internal (SW start) or from external peripheral (timer event,
   *         external interrupt line).
-  * @note   On this STM32 serie, setting trigger source to external trigger
+  * @note   On this STM32 series, setting trigger source to external trigger
   *         also set trigger polarity to rising edge
   *         (default setting for compatibility with some ADC on other
   *         STM32 families having this setting set by HW default value).
   *         In case of need to modify trigger edge, use
   *         function @ref LL_ADC_REG_SetTriggerEdge().
-  * @note   On this STM32 serie, ADC trigger frequency mode must be set
+  * @note   On this STM32 series, ADC trigger frequency mode must be set
   *         in function of frequency of ADC group regular conversion trigger.
   *         Refer to description of function
   *         @ref LL_ADC_SetTriggerFrequencyMode().
   * @note   Availability of parameters of trigger sources from timer
   *         depends on timers availability on the selected device.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2313,11 +2368,11 @@ __STATIC_INLINE void LL_ADC_REG_SetTriggerSource(ADC_TypeDef *ADCx, uint32_t Tri
   */
 __STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerSource(ADC_TypeDef *ADCx)
 {
-  register __IO uint32_t TriggerSource = READ_BIT(ADCx->CFGR1, ADC_CFGR1_EXTSEL | ADC_CFGR1_EXTEN);
+  __IO uint32_t TriggerSource = READ_BIT(ADCx->CFGR1, ADC_CFGR1_EXTSEL | ADC_CFGR1_EXTEN);
 
   /* Value for shift of {0; 4; 8; 12} depending on value of bitfield          */
   /* corresponding to ADC_CFGR1_EXTEN {0; 1; 2; 3}.                           */
-  register uint32_t ShiftExten = ((TriggerSource & ADC_CFGR1_EXTEN) >> (ADC_REG_TRIG_EXTEN_BITOFFSET_POS - 2UL));
+  uint32_t ShiftExten = ((TriggerSource & ADC_CFGR1_EXTEN) >> (ADC_REG_TRIG_EXTEN_BITOFFSET_POS - 2UL));
 
   /* Set bitfield corresponding to ADC_CFGR1_EXTEN and ADC_CFGR1_EXTSEL       */
   /* to match with triggers literals definition.                              */
@@ -2346,7 +2401,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_IsTriggerSourceSWStart(ADC_TypeDef *ADCx)
 /**
   * @brief  Set ADC group regular conversion trigger polarity.
   * @note   Applicable only for trigger source set to external trigger.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2380,7 +2435,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerEdge(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Set ADC group regular sequencer configuration flexibility.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable" are
   *         available:
   *         - sequencer configured to fully configurable:
@@ -2393,7 +2448,14 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerEdge(ADC_TypeDef *ADCx)
   *           are fixed by channel HW number.
   *           Refer to description of function
   *           @ref LL_ADC_REG_SetSequencerChannels().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, after modifying sequencer (functions
+  *         @ref LL_ADC_REG_SetSequencerLength()
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
+  *         it is mandatory to wait for the assertion of CCRDY flag
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2411,7 +2473,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerConfigurable(ADC_TypeDef *ADCx, uint
 
 /**
   * @brief  Get ADC group regular sequencer configuration flexibility.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable" are
   *         available:
   *         - sequencer configured to fully configurable:
@@ -2464,21 +2526,21 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerConfigurable(ADC_TypeDef *ADCx)
   *           function "LL_ADC_REG_SetSequencerChannels()".
   *           To set scan direction differently, refer to function
   *           @ref LL_ADC_REG_SetSequencerScanDirection().
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
-  * @note   On this STM32 serie, after calling functions
+  * @note   On this STM32 series, after modifying sequencer (functions
   *         @ref LL_ADC_REG_SetSequencerLength()
-  *         or @ref LL_ADC_REG_SetSequencerRanks(),
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
   *         it is mandatory to wait for the assertion of CCRDY flag
   *         using @ref LL_ADC_IsActiveFlag_CCRDY().
-  *         Otherwise, performing some actions (configuration update,
-  *         ADC conversion start, ... ) will be ignored.
-  *         Refer to reference manual for more details.
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
   * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
   *         ADC conversion on only 1 channel.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2536,7 +2598,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   *           function "LL_ADC_REG_SetSequencerChannels()".
   *          To set scan direction differently, refer to function
   *          @ref LL_ADC_REG_SetSequencerScanDirection().
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
@@ -2563,14 +2625,14 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   */
 __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerLength(ADC_TypeDef *ADCx)
 {
-  register __IO uint32_t ChannelsRanks = READ_BIT(ADCx->CHSELR, ADC_CHSELR_SQ_ALL);
-  register uint32_t SequencerLength = LL_ADC_REG_SEQ_SCAN_ENABLE_8RANKS;
-  register uint32_t RankIndex;
+  __IO uint32_t ChannelsRanks = READ_BIT(ADCx->CHSELR, ADC_CHSELR_SQ_ALL);
+  uint32_t SequencerLength = LL_ADC_REG_SEQ_SCAN_ENABLE_8RANKS;
+  uint32_t RankIndex;
 
   /* Parse register for end of sequence identifier */
-  for(RankIndex = 0UL; RankIndex < (32U - 4U); RankIndex+=4U)
+  for (RankIndex = 0UL; RankIndex < (32U - 4U); RankIndex += 4U)
   {
-    if((ChannelsRanks & (ADC_CHSELR_SQ2 << RankIndex)) == (ADC_CHSELR_SQ2 << RankIndex))
+    if ((ChannelsRanks & (ADC_CHSELR_SQ2 << RankIndex)) == (ADC_CHSELR_SQ2 << RankIndex))
     {
       SequencerLength = (ADC_CHSELR_SQ2 << RankIndex);
       break;
@@ -2582,12 +2644,20 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerLength(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Set ADC group regular sequencer scan direction.
-  * @note   On this STM32 serie, parameter relevant only is sequencer is set
+  * @note   On this STM32 series, parameter relevant only is sequencer is set
   *         to mode not fully configurable,
   *         refer to function @ref LL_ADC_REG_SetSequencerConfigurable().
-  * @note   On some other STM32 families, this setting is not available and
+  * @note   On some other STM32 series, this setting is not available and
   *         the default scan direction is forward.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, after modifying sequencer (functions
+  *         @ref LL_ADC_REG_SetSequencerLength()
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
+  *         it is mandatory to wait for the assertion of CCRDY flag
+  *         using @ref LL_ADC_IsActiveFlag_CCRDY().
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2605,7 +2675,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerScanDirection(ADC_TypeDef *ADCx, uin
 
 /**
   * @brief  Get ADC group regular sequencer scan direction.
-  * @note   On this STM32 serie, parameter relevant only is sequencer is set
+  * @note   On this STM32 series, parameter relevant only is sequencer is set
   *         to mode not fully configurable,
   *         refer to function @ref LL_ADC_REG_SetSequencerConfigurable().
   * @note   On some other STM32 families, this setting is not available and
@@ -2627,7 +2697,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerScanDirection(ADC_TypeDef *ADCx)
   *         number of ranks.
   * @note   It is not possible to enable both ADC group regular
   *         continuous mode and sequencer discontinuous mode.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2664,25 +2734,25 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(ADC_TypeDef *ADCx)
   * @note   This function performs configuration of:
   *         - Channels ordering into each rank of scan sequence:
   *           whatever channel can be placed into whatever rank.
-  * @note   On this STM32 serie, ADC group regular sequencer is
+  * @note   On this STM32 series, ADC group regular sequencer is
   *         fully configurable: sequencer length and each rank
   *         affectation to a channel are configurable.
   *         Refer to description of function @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On this STM32 serie, after calling functions
+  * @note   On this STM32 series, after modifying sequencer (functions
   *         @ref LL_ADC_REG_SetSequencerLength()
-  *         or @ref LL_ADC_REG_SetSequencerRanks(),
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
   *         it is mandatory to wait for the assertion of CCRDY flag
   *         using @ref LL_ADC_IsActiveFlag_CCRDY().
-  *         Otherwise, performing some actions (configuration update,
-  *         ADC conversion start, ... ) will be ignored.
-  *         Refer to reference manual for more details.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2747,7 +2817,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
 /**
   * @brief  Get ADC group regular sequence: channel on the selected
   *         scan sequence rank.
-  * @note   On this STM32 serie, ADC group regular sequencer is
+  * @note   On this STM32 series, ADC group regular sequencer is
   *         fully configurable: sequencer length and each rank
   *         affectation to a channel are configurable.
   *         Refer to description of function @ref LL_ADC_REG_SetSequencerLength().
@@ -2815,11 +2885,11 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   */
 __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank)
 {
-  return (uint32_t) ((READ_BIT(ADCx->CHSELR,
-                               ADC_CHSELR_SQ1 << (Rank & ADC_REG_RANK_ID_SQRX_MASK))
-                      >> (Rank & ADC_REG_RANK_ID_SQRX_MASK)
-                     ) << (ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS)
-                    );
+  return (uint32_t)((READ_BIT(ADCx->CHSELR,
+                              ADC_CHSELR_SQ1 << (Rank & ADC_REG_RANK_ID_SQRX_MASK))
+                     >> (Rank & ADC_REG_RANK_ID_SQRX_MASK)
+                    ) << (ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS)
+                   );
 }
 
 /**
@@ -2831,20 +2901,28 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
   *         - Set channels selected by overwriting the current sequencer
   *           configuration.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
   *         This function can be used with setting "not fully configurable".
   *         Refer to description of functions @ref LL_ADC_REG_SetSequencerConfigurable()
   *         and @ref LL_ADC_REG_SetSequencerLength().
+  * @note   On this STM32 series, after modifying sequencer (functions
+  *         @ref LL_ADC_REG_SetSequencerLength()
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
+  *         it is mandatory to wait for the assertion of CCRDY flag
+  *         using @ref LL_ADC_IsActiveFlag_CCRDY().
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2915,20 +2993,28 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChannels(ADC_TypeDef *ADCx, uint32_t
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
   *         - Set channels selected by adding them to the current sequencer
   *           configuration.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
   *         This function can be used with setting "not fully configurable".
   *         Refer to description of functions @ref LL_ADC_REG_SetSequencerConfigurable()
   *         and @ref LL_ADC_REG_SetSequencerLength().
+  * @note   On this STM32 series, after modifying sequencer (functions
+  *         @ref LL_ADC_REG_SetSequencerLength()
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
+  *         it is mandatory to wait for the assertion of CCRDY flag
+  *         using @ref LL_ADC_IsActiveFlag_CCRDY().
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -2999,20 +3085,28 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChAdd(ADC_TypeDef *ADCx, uint32_t Ch
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
   *         - Set channels selected by removing them to the current sequencer
   *           configuration.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
   *         This function can be used with setting "not fully configurable".
   *         Refer to description of functions @ref LL_ADC_REG_SetSequencerConfigurable()
   *         and @ref LL_ADC_REG_SetSequencerLength().
+  * @note   On this STM32 series, after modifying sequencer (functions
+  *         @ref LL_ADC_REG_SetSequencerLength()
+  *         @ref LL_ADC_REG_SetSequencerRanks(), ...)
+  *         it is mandatory to wait for the assertion of CCRDY flag
+  *         using @ref LL_ADC_IsActiveFlag_CCRDY().
+  *         Otherwise, some actions may be ignored.
+  *         Refer to description of @ref LL_ADC_IsActiveFlag_CCRDY
+  *         for more details.
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3081,7 +3175,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChRem(ADC_TypeDef *ADCx, uint32_t Ch
   *         - Channels order reading into each rank of scan sequence:
   *           rank of each channel is fixed by channel HW number
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
@@ -3090,11 +3184,11 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChRem(ADC_TypeDef *ADCx, uint32_t Ch
   *         and @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3150,28 +3244,28 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChRem(ADC_TypeDef *ADCx, uint32_t Ch
   */
 __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerChannels(ADC_TypeDef *ADCx)
 {
-  register uint32_t ChannelsBitfield = (uint32_t)READ_BIT(ADCx->CHSELR, ADC_CHSELR_CHSEL);
+  uint32_t ChannelsBitfield = (uint32_t)READ_BIT(ADCx->CHSELR, ADC_CHSELR_CHSEL);
 
-  return (   (((ChannelsBitfield & ADC_CHSELR_CHSEL0) >> ADC_CHSELR_CHSEL0_BITOFFSET_POS) * LL_ADC_CHANNEL_0)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL1) >> ADC_CHSELR_CHSEL1_BITOFFSET_POS) * LL_ADC_CHANNEL_1)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL2) >> ADC_CHSELR_CHSEL2_BITOFFSET_POS) * LL_ADC_CHANNEL_2)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL3) >> ADC_CHSELR_CHSEL3_BITOFFSET_POS) * LL_ADC_CHANNEL_3)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL4) >> ADC_CHSELR_CHSEL4_BITOFFSET_POS) * LL_ADC_CHANNEL_4)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL5) >> ADC_CHSELR_CHSEL5_BITOFFSET_POS) * LL_ADC_CHANNEL_5)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL6) >> ADC_CHSELR_CHSEL6_BITOFFSET_POS) * LL_ADC_CHANNEL_6)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL7) >> ADC_CHSELR_CHSEL7_BITOFFSET_POS) * LL_ADC_CHANNEL_7)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL8) >> ADC_CHSELR_CHSEL8_BITOFFSET_POS) * LL_ADC_CHANNEL_8)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL9) >> ADC_CHSELR_CHSEL9_BITOFFSET_POS) * LL_ADC_CHANNEL_9)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL10) >> ADC_CHSELR_CHSEL10_BITOFFSET_POS) * LL_ADC_CHANNEL_10)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL11) >> ADC_CHSELR_CHSEL11_BITOFFSET_POS) * LL_ADC_CHANNEL_11)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL12) >> ADC_CHSELR_CHSEL12_BITOFFSET_POS) * LL_ADC_CHANNEL_12)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL13) >> ADC_CHSELR_CHSEL13_BITOFFSET_POS) * LL_ADC_CHANNEL_13)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL14) >> ADC_CHSELR_CHSEL14_BITOFFSET_POS) * LL_ADC_CHANNEL_14)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL15) >> ADC_CHSELR_CHSEL15_BITOFFSET_POS) * LL_ADC_CHANNEL_15)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL16) >> ADC_CHSELR_CHSEL16_BITOFFSET_POS) * LL_ADC_CHANNEL_16)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL17) >> ADC_CHSELR_CHSEL17_BITOFFSET_POS) * LL_ADC_CHANNEL_17)
+  return ((((ChannelsBitfield & ADC_CHSELR_CHSEL0) >> ADC_CHSELR_CHSEL0_BITOFFSET_POS) * LL_ADC_CHANNEL_0)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL1) >> ADC_CHSELR_CHSEL1_BITOFFSET_POS) * LL_ADC_CHANNEL_1)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL2) >> ADC_CHSELR_CHSEL2_BITOFFSET_POS) * LL_ADC_CHANNEL_2)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL3) >> ADC_CHSELR_CHSEL3_BITOFFSET_POS) * LL_ADC_CHANNEL_3)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL4) >> ADC_CHSELR_CHSEL4_BITOFFSET_POS) * LL_ADC_CHANNEL_4)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL5) >> ADC_CHSELR_CHSEL5_BITOFFSET_POS) * LL_ADC_CHANNEL_5)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL6) >> ADC_CHSELR_CHSEL6_BITOFFSET_POS) * LL_ADC_CHANNEL_6)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL7) >> ADC_CHSELR_CHSEL7_BITOFFSET_POS) * LL_ADC_CHANNEL_7)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL8) >> ADC_CHSELR_CHSEL8_BITOFFSET_POS) * LL_ADC_CHANNEL_8)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL9) >> ADC_CHSELR_CHSEL9_BITOFFSET_POS) * LL_ADC_CHANNEL_9)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL10) >> ADC_CHSELR_CHSEL10_BITOFFSET_POS) * LL_ADC_CHANNEL_10)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL11) >> ADC_CHSELR_CHSEL11_BITOFFSET_POS) * LL_ADC_CHANNEL_11)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL12) >> ADC_CHSELR_CHSEL12_BITOFFSET_POS) * LL_ADC_CHANNEL_12)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL13) >> ADC_CHSELR_CHSEL13_BITOFFSET_POS) * LL_ADC_CHANNEL_13)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL14) >> ADC_CHSELR_CHSEL14_BITOFFSET_POS) * LL_ADC_CHANNEL_14)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL15) >> ADC_CHSELR_CHSEL15_BITOFFSET_POS) * LL_ADC_CHANNEL_15)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL16) >> ADC_CHSELR_CHSEL16_BITOFFSET_POS) * LL_ADC_CHANNEL_16)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL17) >> ADC_CHSELR_CHSEL17_BITOFFSET_POS) * LL_ADC_CHANNEL_17)
 #if defined(ADC_CCR_VBATEN)
-           | (((ChannelsBitfield & ADC_CHSELR_CHSEL18) >> ADC_CHSELR_CHSEL18_BITOFFSET_POS) * LL_ADC_CHANNEL_18)
+          | (((ChannelsBitfield & ADC_CHSELR_CHSEL18) >> ADC_CHSELR_CHSEL18_BITOFFSET_POS) * LL_ADC_CHANNEL_18)
 #endif
          );
 }
@@ -3184,7 +3278,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerChannels(ADC_TypeDef *ADCx)
   *           conversions launched successively automatically.
   * @note   It is not possible to enable both ADC group regular
   *         continuous mode and sequencer discontinuous mode.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3237,7 +3331,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetContinuousMode(ADC_TypeDef *ADCx)
   *        (overrun flag and interruption if enabled).
   * @note   To configure DMA source address (peripheral address),
   *         use function @ref LL_ADC_DMA_GetRegAddr().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3297,7 +3391,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetDMATransfer(ADC_TypeDef *ADCx)
   *         The default setting of overrun is data preserved.
   *         Therefore, for compatibility with all devices, parameter
   *         overrun should be set to data overwritten.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3349,12 +3443,12 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetOverrun(ADC_TypeDef *ADCx)
   *         TS_temp, ...).
   * @note   Conversion time is the addition of sampling time and processing time.
   *         Refer to reference manual for ADC processing time of
-  *         this STM32 serie.
+  *         this STM32 series.
   * @note   In case of ADC conversion of internal channel (VrefInt,
   *         temperature sensor, ...), a sampling time minimum value
   *         is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3427,7 +3521,7 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   *         of channel mapped on ADC group regular or injected.
   * @note   Conversion time is the addition of sampling time and processing time.
   *         Refer to reference manual for ADC processing time of
-  *         this STM32 serie.
+  *         this STM32 series.
   * @rmtoll SMPR     SMPSEL0        LL_ADC_GetChannelSamplingTime\n
   *         SMPR     SMPSEL1        LL_ADC_GetChannelSamplingTime\n
   *         SMPR     SMPSEL2        LL_ADC_GetChannelSamplingTime\n
@@ -3481,16 +3575,17 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   */
 __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t Channel)
 {
-  register __IO uint32_t smpr = READ_REG(ADCx->SMPR);
+  __IO uint32_t smpr = READ_REG(ADCx->SMPR);
 
   /* Retrieve sampling time bit corresponding to the selected channel            */
   /* and shift it to position 0.                                                 */
-  register uint32_t smp_channel_posbit0 = ((smpr & ADC_SAMPLING_TIME_CH_MASK)
-                                           >> ((((Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) + ADC_SMPR_SMPSEL0_BITOFFSET_POS) & 0x1FUL));
+  uint32_t smp_channel_posbit0 = ((smpr & ADC_SAMPLING_TIME_CH_MASK)
+                                  >> ((((Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) + ADC_SMPR_SMPSEL0_BITOFFSET_POS) &
+                                      0x1FUL));
 
   /* Select sampling time bitfield depending on sampling time bit value 0 or 1.  */
-  return(  (~(smp_channel_posbit0) * LL_ADC_SAMPLINGTIME_COMMON_1)
-         | (smp_channel_posbit0 * LL_ADC_SAMPLINGTIME_COMMON_2)   );
+  return ((~(smp_channel_posbit0) * LL_ADC_SAMPLINGTIME_COMMON_1)
+          | (smp_channel_posbit0 * LL_ADC_SAMPLINGTIME_COMMON_2));
 }
 
 /**
@@ -3510,7 +3605,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
   * @note   In case of need to define a single channel to monitor
   *         with analog watchdog from sequencer channel definition,
   *         use helper macro @ref __LL_ADC_ANALOGWD_CHANNEL_GROUP().
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -3530,7 +3625,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
   *             LL_ADC_AWD_CHANNELxx_REG and LL_ADC_AWD_CHANNELxx_INJ)
   *           - resolution: resolution is not limited (corresponds to
   *             ADC resolution configured).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3577,9 +3672,9 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   /* in register and register position depending on parameter "AWDy".         */
   /* Parameters "AWDChannelGroup" and "AWDy" are used with masks because      */
   /* containing other bits reserved for other purpose.                        */
-  register __IO uint32_t *preg;
+  __IO uint32_t *preg;
 
-  if(AWDy == LL_ADC_AWD1)
+  if (AWDy == LL_ADC_AWD1)
   {
     preg = __ADC_PTR_REG_OFFSET(ADCx->CFGR1, 0UL);
   }
@@ -3608,7 +3703,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
   *           Applicable only when the analog watchdog is set to monitor
   *           one channel.
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -3628,7 +3723,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   *             LL_ADC_AWD_CHANNELxx_REG and LL_ADC_AWD_CHANNELxx_INJ)
   *           - resolution: resolution is not limited (corresponds to
   *             ADC resolution configured).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3673,23 +3768,23 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   */
 __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t AWDy)
 {
-  register __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->CFGR1, ((AWDy & ADC_AWD_CRX_REGOFFSET_MASK) >> ADC_AWD_CRX_REGOFFSET_POS)
-                                                                   + ((AWDy & ADC_AWD_CR12_REGOFFSETGAP_MASK) * ADC_AWD_CR12_REGOFFSETGAP_VAL));
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->CFGR1, ((AWDy & ADC_AWD_CRX_REGOFFSET_MASK) >> ADC_AWD_CRX_REGOFFSET_POS)
+                                             + ((AWDy & ADC_AWD_CR12_REGOFFSETGAP_MASK) * ADC_AWD_CR12_REGOFFSETGAP_VAL));
 
-  register uint32_t AnalogWDMonitChannels = (READ_BIT(*preg, AWDy) & AWDy & ADC_AWD_CR_ALL_CHANNEL_MASK);
+  uint32_t AnalogWDMonitChannels = (READ_BIT(*preg, AWDy) & AWDy & ADC_AWD_CR_ALL_CHANNEL_MASK);
 
   /* If "AnalogWDMonitChannels" == 0, then the selected AWD is disabled       */
   /* (parameter value LL_ADC_AWD_DISABLE).                                    */
   /* Else, the selected AWD is enabled and is monitoring a group of channels  */
   /* or a single channel.                                                     */
-  if(AnalogWDMonitChannels != 0UL)
+  if (AnalogWDMonitChannels != 0UL)
   {
-    if(AWDy == LL_ADC_AWD1)
+    if (AWDy == LL_ADC_AWD1)
     {
-      if((AnalogWDMonitChannels & ADC_CFGR1_AWD1SGL) == 0UL)
+      if ((AnalogWDMonitChannels & ADC_CFGR1_AWD1SGL) == 0UL)
       {
         /* AWD monitoring a group of channels */
-        AnalogWDMonitChannels = ((  AnalogWDMonitChannels
+        AnalogWDMonitChannels = ((AnalogWDMonitChannels
                                   | (ADC_AWD_CR23_CHANNEL_MASK)
                                  )
                                  & (~(ADC_CFGR1_AWD1CH))
@@ -3705,10 +3800,10 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
     }
     else
     {
-      if((AnalogWDMonitChannels & ADC_AWD_CR23_CHANNEL_MASK) == ADC_AWD_CR23_CHANNEL_MASK)
+      if ((AnalogWDMonitChannels & ADC_AWD_CR23_CHANNEL_MASK) == ADC_AWD_CR23_CHANNEL_MASK)
       {
         /* AWD monitoring a group of channels */
-        AnalogWDMonitChannels = (  ADC_AWD_CR23_CHANNEL_MASK
+        AnalogWDMonitChannels = (ADC_AWD_CR23_CHANNEL_MASK
                                  | (ADC_CFGR1_AWD1EN)
                                 );
       }
@@ -3716,7 +3811,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
       {
         /* AWD monitoring a single channel */
         /* AWD monitoring a group of channels */
-        AnalogWDMonitChannels = (  AnalogWDMonitChannels
+        AnalogWDMonitChannels = (AnalogWDMonitChannels
                                  | (ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL)
                                  | (__LL_ADC_CHANNEL_TO_DECIMAL_NB(AnalogWDMonitChannels) << ADC_CFGR1_AWD1CH_Pos)
                                 );
@@ -3735,7 +3830,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   * @note   In case of ADC resolution different of 12 bits,
   *         analog watchdog thresholds data require a specific shift.
   *         Use helper macro @ref __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION().
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -3769,7 +3864,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   *         - Oversampling ratio and shift selected to have ADC conversion data
   *           on 16 bits (ratio 16 and shift none, or ratio 32 and shift 1, ...):
   *           ADC analog watchdog thresholds match directly to ADC data register.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3788,14 +3883,15 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   * @param  AWDThresholdLowValue Value between Min_Data=0x000 and Max_Data=0xFFF
   * @retval None
   */
-__STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdHighValue, uint32_t AWDThresholdLowValue)
+__STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdHighValue,
+                                                     uint32_t AWDThresholdLowValue)
 {
   /* Set bits with content of parameter "AWDThresholdxxxValue" with bits      */
   /* position in register and register position depending on parameter        */
   /* "AWDy".                                                                  */
   /* Parameters "AWDy" and "AWDThresholdxxxValue" are used with masks because */
   /* containing other bits reserved for other purpose.                        */
-  register __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK)) >> (ADC_AWD_TRX_REGOFFSET_BITOFFSET_POS)) + ((ADC_AWD_CR3_REGOFFSET & AWDy) >> (ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS + 1UL)));
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK)) >> (ADC_AWD_TRX_REGOFFSET_BITOFFSET_POS)) + ((ADC_AWD_CR3_REGOFFSET & AWDy) >> (ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS + 1UL)));
 
   MODIFY_REG(*preg,
              ADC_TR1_HT1 | ADC_TR1_LT1,
@@ -3810,7 +3906,7 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   * @note   In case of ADC resolution different of 12 bits,
   *         analog watchdog thresholds data require a specific shift.
   *         Use helper macro @ref __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION().
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -3844,7 +3940,7 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   *         - Oversampling ratio and shift selected to have ADC conversion data
   *           on 16 bits (ratio 16 and shift none, or ratio 32 and shift 1, ...):
   *           ADC analog watchdog thresholds match directly to ADC data register.
-  * @note   On this STM32 serie, setting of this feature is not conditioned to
+  * @note   On this STM32 series, setting of this feature is not conditioned to
   *         ADC state:
   *         ADC can be disabled, enabled with or without conversion on going
   *         on ADC group regular.
@@ -3865,14 +3961,17 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   * @param  AWDThresholdValue Value between Min_Data=0x000 and Max_Data=0xFFF
   * @retval None
   */
-__STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow, uint32_t AWDThresholdValue)
+__STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow,
+                                                  uint32_t AWDThresholdValue)
 {
   /* Set bits with content of parameter "AWDThresholdValue" with bits         */
   /* position in register and register position depending on parameters       */
   /* "AWDThresholdsHighLow" and "AWDy".                                       */
   /* Parameters "AWDy" and "AWDThresholdValue" are used with masks because    */
   /* containing other bits reserved for other purpose.                        */
-  register __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK)) >> (ADC_AWD_TRX_REGOFFSET_BITOFFSET_POS)) + ((ADC_AWD_CR3_REGOFFSET & AWDy) >> (ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS + 1UL)));
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1,
+                                             (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK)) >> (ADC_AWD_TRX_REGOFFSET_BITOFFSET_POS))
+                                             + ((ADC_AWD_CR3_REGOFFSET & AWDy) >> (ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS + 1UL)));
 
   MODIFY_REG(*preg,
              AWDThresholdsHighLow,
@@ -3906,7 +4005,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AW
   *         @arg @ref LL_ADC_AWD_THRESHOLD_LOW
   *         @arg @ref LL_ADC_AWD_THRESHOLDS_HIGH_LOW
   * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
-*/
+  */
 __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow)
 {
   /* Set bits with content of parameter "AWDThresholdValue" with bits         */
@@ -3914,12 +4013,14 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_
   /* "AWDThresholdsHighLow" and "AWDy".                                       */
   /* Parameters "AWDy" and "AWDThresholdValue" are used with masks because    */
   /* containing other bits reserved for other purpose.                        */
-  register const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK)) >> (ADC_AWD_TRX_REGOFFSET_BITOFFSET_POS)) + ((ADC_AWD_CR3_REGOFFSET & AWDy) >> (ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS + 1UL)));
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1,
+                                                   (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK)) >> (ADC_AWD_TRX_REGOFFSET_BITOFFSET_POS))
+                                                   + ((ADC_AWD_CR3_REGOFFSET & AWDy) >> (ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS + 1UL)));
 
   return (uint32_t)(READ_BIT(*preg,
                              (AWDThresholdsHighLow | ADC_TR1_LT1))
-                    >> (((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4) & ~(AWDThresholdsHighLow & ADC_TR1_LT1))
-                   );
+                    >> (((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4)
+                        & ~(AWDThresholdsHighLow & ADC_TR1_LT1)));
 }
 
 /**
@@ -3932,10 +4033,9 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_
 
 /**
   * @brief  Set ADC oversampling scope.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
-  *         ADC must be disabled or enabled without conversion on going
-  *         on group regular.
+  *         ADC must be disabled.
   * @rmtoll CFGR2    OVSE           LL_ADC_SetOverSamplingScope
   * @param  ADCx ADC instance
   * @param  OvsScope This parameter can be one of the following values:
@@ -3969,7 +4069,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingScope(ADC_TypeDef *ADCx)
   *           are done from 1 trigger)
   *         - discontinuous mode (each conversion of oversampling ratio
   *           needs a trigger)
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4009,10 +4109,9 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(ADC_TypeDef *ADCx)
   * @note   This function set the 2 items of oversampling configuration:
   *         - ratio
   *         - shift
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
-  *         ADC must be disabled or enabled without conversion on going
-  *         on group regular.
+  *         ADC must be disabled.
   * @rmtoll CFGR2    OVSS           LL_ADC_ConfigOverSamplingRatioShift\n
   *         CFGR2    OVSR           LL_ADC_ConfigOverSamplingRatioShift
   * @param  ADCx ADC instance
@@ -4055,7 +4154,7 @@ __STATIC_INLINE void LL_ADC_ConfigOverSamplingRatioShift(ADC_TypeDef *ADCx, uint
   *         @arg @ref LL_ADC_OVS_RATIO_64
   *         @arg @ref LL_ADC_OVS_RATIO_128
   *         @arg @ref LL_ADC_OVS_RATIO_256
-*/
+  */
 __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSR));
@@ -4075,7 +4174,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_6
   *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_7
   *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_8
-*/
+  */
 __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSS));
@@ -4091,7 +4190,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Enable ADC instance internal voltage regulator.
-  * @note   On this STM32 serie, there are three possibilities to enable
+  * @note   On this STM32 series, there are three possibilities to enable
   *         the voltage regulator:
   *         - by enabling it manually
   *           using function @ref LL_ADC_EnableInternalRegulator().
@@ -4099,12 +4198,12 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(ADC_TypeDef *ADCx)
   *           using function @ref LL_ADC_StartCalibration().
   *         - by enabling the ADC
   *           using function @ref LL_ADC_Enable().
-  * @note   On this STM32 serie, after ADC internal voltage regulator enable,
+  * @note   On this STM32 series, after ADC internal voltage regulator enable,
   *         a delay for ADC internal voltage regulator stabilization
   *         is required before performing a ADC calibration or ADC enable.
   *         Refer to device datasheet, parameter "tADCVREG_STUP".
   *         Refer to literal @ref LL_ADC_DELAY_INTERNAL_REGUL_STAB_US.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       ADVREGEN       LL_ADC_EnableInternalRegulator
@@ -4123,7 +4222,7 @@ __STATIC_INLINE void LL_ADC_EnableInternalRegulator(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Disable ADC internal voltage regulator.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       ADVREGEN       LL_ADC_DisableInternalRegulator
@@ -4148,14 +4247,14 @@ __STATIC_INLINE uint32_t LL_ADC_IsInternalRegulatorEnabled(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Enable the selected ADC instance.
-  * @note   On this STM32 serie, after ADC enable, a delay for
+  * @note   On this STM32 series, after ADC enable, a delay for
   *         ADC internal analog stabilization is required before performing a
   *         ADC conversion start.
   *         Refer to device datasheet, parameter tSTAB.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled and ADC internal voltage regulator enabled.
   * @rmtoll CR       ADEN           LL_ADC_Enable
@@ -4174,7 +4273,7 @@ __STATIC_INLINE void LL_ADC_Enable(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Disable the selected ADC instance.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be not disabled. Must be enabled without conversion on going
   *         on group regular.
@@ -4194,7 +4293,7 @@ __STATIC_INLINE void LL_ADC_Disable(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Get the selected ADC instance enable state.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
   * @rmtoll CR       ADEN           LL_ADC_IsEnabled
@@ -4220,14 +4319,14 @@ __STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
 /**
   * @brief  Start ADC calibration in the mode single-ended
   *         or differential (for devices with differential mode available).
-  * @note   On this STM32 serie, a minimum number of ADC clock cycles
+  * @note   On this STM32 series, a minimum number of ADC clock cycles
   *         are required between ADC end of calibration and ADC enable.
   *         Refer to literal @ref LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES.
   * @note   In case of usage of ADC with DMA transfer:
-  *         On this STM32 serie, ADC DMA transfer request should be disabled
+  *         On this STM32 series, ADC DMA transfer request should be disabled
   *         during calibration:
   *         Calibration factor is available in data register
-  *         and also transfered by DMA.
+  *         and also transferred by DMA.
   *         To not insert ADC calibration factor among ADC conversion data
   *         in array variable, DMA transfer must be disabled during
   *         calibration.
@@ -4235,7 +4334,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
   *         DMA transfer setting restore after calibration.
   *         Refer to functions @ref LL_ADC_REG_GetDMATransfer(),
   *         @ref LL_ADC_REG_SetDMATransfer() ).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       ADCAL          LL_ADC_StartCalibration
@@ -4273,14 +4372,14 @@ __STATIC_INLINE uint32_t LL_ADC_IsCalibrationOnGoing(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Start ADC group regular conversion.
-  * @note   On this STM32 serie, this function is relevant for both
+  * @note   On this STM32 series, this function is relevant for both
   *         internal trigger (SW start) and external trigger:
   *         - If ADC trigger has been set to software start, ADC conversion
   *           starts immediately.
   *         - If ADC trigger has been set to external trigger, ADC conversion
   *           will start at next trigger event (on the selected trigger edge)
   *           following the ADC start conversion command.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled without conversion on going on group regular,
   *         without conversion stop command on going on group regular,
@@ -4301,7 +4400,7 @@ __STATIC_INLINE void LL_ADC_REG_StartConversion(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Stop ADC group regular conversion.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled with conversion on going on group regular,
   *         without ADC disable command on going.
@@ -4425,7 +4524,7 @@ __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData6(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Get flag ADC ready.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
   * @rmtoll ISR      ADRDY          LL_ADC_IsActiveFlag_ADRDY
@@ -4439,6 +4538,19 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_ADRDY(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Get flag ADC channel configuration ready.
+  * @note   On this STM32 series, after modifying sequencer
+  *         it is mandatory to wait for the assertion of CCRDY flag
+  *         using @ref LL_ADC_IsActiveFlag_CCRDY().
+  *         Otherwise, performing some actions (configuration update,
+  *         ADC conversion start, ... ) will be ignored.
+  *         Functions requiring wait for CCRDY flag are:
+  *         @ref LL_ADC_REG_SetSequencerLength()
+  *         @ref LL_ADC_REG_SetSequencerRanks()
+  *         @ref LL_ADC_REG_SetSequencerChannels()
+  *         @ref LL_ADC_REG_SetSequencerChAdd()
+  *         @ref LL_ADC_REG_SetSequencerChRem()
+  *         @ref LL_ADC_REG_SetSequencerScanDirection()
+  *         @ref LL_ADC_REG_SetSequencerConfigurable()
   * @note   Duration of ADC channel configuration ready: CCRDY handshake
   *         requires 1APB + 2 ADC + 3 APB cycles after the channel configuration
   *         has been changed.
@@ -4541,7 +4653,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOCAL(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Clear flag ADC ready.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
   * @rmtoll ISR      ADRDY          LL_ADC_ClearFlag_ADRDY

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_bus.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_bus.h
@@ -73,17 +73,20 @@ extern "C" {
   */
 #define LL_AHB1_GRP1_PERIPH_ALL            0xFFFFFFFFU
 #define LL_AHB1_GRP1_PERIPH_DMA1           RCC_AHBENR_DMA1EN
+#if defined(DMA2)
+#define LL_AHB1_GRP1_PERIPH_DMA2           RCC_AHBENR_DMA2EN
+#endif /* DMA2 */
 #define LL_AHB1_GRP1_PERIPH_FLASH          RCC_AHBENR_FLASHEN
 #define LL_AHB1_GRP1_PERIPH_SRAM           RCC_AHBSMENR_SRAMSMEN
 #if defined(CRC)
 #define LL_AHB1_GRP1_PERIPH_CRC            RCC_AHBENR_CRCEN
-#endif
+#endif /* CRC */
 #if defined(AES)
 #define LL_AHB1_GRP1_PERIPH_CRYP           RCC_AHBENR_AESEN
 #endif /* AES */
 #if defined(RNG)
 #define LL_AHB1_GRP1_PERIPH_RNG            RCC_AHBENR_RNGEN
-#endif
+#endif /* RNG */
 /**
   * @}
   */
@@ -99,47 +102,74 @@ extern "C" {
 #if defined(TIM3)
 #define LL_APB1_GRP1_PERIPH_TIM3           RCC_APBENR1_TIM3EN
 #endif /* TIM3 */
+#if defined(TIM4)
+#define LL_APB1_GRP1_PERIPH_TIM4           RCC_APBENR1_TIM4EN
+#endif /* TIM4 */
 #if defined(TIM6)
 #define LL_APB1_GRP1_PERIPH_TIM6           RCC_APBENR1_TIM6EN
 #endif /* TIM6 */
 #if defined(TIM7)
 #define LL_APB1_GRP1_PERIPH_TIM7           RCC_APBENR1_TIM7EN
 #endif /* TIM7 */
+#if defined(LPUART2)
+#define LL_APB1_GRP1_PERIPH_LPUART2        RCC_APBENR1_LPUART2EN
+#endif /* LPUART2 */
+#if defined(USART5)
+#define LL_APB1_GRP1_PERIPH_USART5         RCC_APBENR1_USART5EN
+#endif /* USART5 */
+#if defined(USART6)
+#define LL_APB1_GRP1_PERIPH_USART6         RCC_APBENR1_USART6EN
+#endif /* USART6 */
 #define LL_APB1_GRP1_PERIPH_RTC            RCC_APBENR1_RTCAPBEN
 #define LL_APB1_GRP1_PERIPH_WWDG           RCC_APBENR1_WWDGEN
+#if defined(FDCAN1) || defined(FDCAN2)
+#define LL_APB1_GRP1_PERIPH_FDCAN          RCC_APBENR1_FDCANEN
+#endif /* FDCAN1 */
+#if defined(USB_DRD_FS)
+#define LL_APB1_GRP1_PERIPH_USB            RCC_APBENR1_USBEN
+#endif /* USB_DRD_FS */
 #define LL_APB1_GRP1_PERIPH_SPI2           RCC_APBENR1_SPI2EN
+#if defined(SPI3)
+#define LL_APB1_GRP1_PERIPH_SPI3           RCC_APBENR1_SPI3EN
+#endif /* SPI3 */
+#if defined(CRS)
+#define LL_APB1_GRP1_PERIPH_CRS            RCC_APBENR1_CRSEN
+#endif /* CRS */
 #define LL_APB1_GRP1_PERIPH_USART2         RCC_APBENR1_USART2EN
 #if defined(USART3)
 #define LL_APB1_GRP1_PERIPH_USART3         RCC_APBENR1_USART3EN
-#endif
+#endif /* USART3 */
 #if defined(USART4)
 #define LL_APB1_GRP1_PERIPH_USART4         RCC_APBENR1_USART4EN
 #endif /* USART4 */
 #if defined(LPUART1)
 #define LL_APB1_GRP1_PERIPH_LPUART1        RCC_APBENR1_LPUART1EN
-#endif
+#endif /* LPUART1 */
 #define LL_APB1_GRP1_PERIPH_I2C1           RCC_APBENR1_I2C1EN
 #define LL_APB1_GRP1_PERIPH_I2C2           RCC_APBENR1_I2C2EN
+#if defined(I2C3)
+#define LL_APB1_GRP1_PERIPH_I2C3           RCC_APBENR1_I2C3EN
+#endif /* I2C3 */
 #if defined(CEC)
 #define LL_APB1_GRP1_PERIPH_CEC            RCC_APBENR1_CECEN
 #endif /* CEC */
 #if defined(UCPD1)
 #define LL_APB1_GRP1_PERIPH_UCPD1          RCC_APBENR1_UCPD1EN
-#endif
+#endif /* UCPD1 */
 #if defined(UCPD2)
 #define LL_APB1_GRP1_PERIPH_UCPD2          RCC_APBENR1_UCPD2EN
-#endif
+#endif /* UCPD2 */
 #define LL_APB1_GRP1_PERIPH_DBGMCU         RCC_APBENR1_DBGEN
 #define LL_APB1_GRP1_PERIPH_PWR            RCC_APBENR1_PWREN
 #if defined(DAC1)
 #define LL_APB1_GRP1_PERIPH_DAC1           RCC_APBENR1_DAC1EN
-#endif
+#endif /* DAC1 */
 #if defined(LPTIM2)
 #define LL_APB1_GRP1_PERIPH_LPTIM2         RCC_APBENR1_LPTIM2EN
-#endif
+#endif /* LPTIM2 */
 #if defined(LPTIM1)
 #define LL_APB1_GRP1_PERIPH_LPTIM1         RCC_APBENR1_LPTIM1EN
-#endif
+#endif /* LPTIM1 */
 /**
   * @}
   */
@@ -157,16 +187,16 @@ extern "C" {
 #endif /* TIM14 */
 #if defined(TIM15)
 #define LL_APB2_GRP1_PERIPH_TIM15          RCC_APBENR2_TIM15EN
-#endif
+#endif /* TIM15 */
 #if defined(TIM16)
 #define LL_APB2_GRP1_PERIPH_TIM16          RCC_APBENR2_TIM16EN
-#endif
+#endif /* TIM16 */
 #if defined(TIM17)
 #define LL_APB2_GRP1_PERIPH_TIM17          RCC_APBENR2_TIM17EN
 #endif /* TIM17 */
 #if defined(ADC)
 #define LL_APB2_GRP1_PERIPH_ADC            RCC_APBENR2_ADCEN
-#endif
+#endif /* ADC */
 /**
   * @}
   */
@@ -218,7 +248,7 @@ extern "C" {
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_AHB1_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -243,7 +273,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_EnableClock(uint32_t Periphs)
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval State of Periphs (1 or 0).
-*/
+  */
 __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClock(uint32_t Periphs)
 {
   return ((READ_BIT(RCC->AHBENR, Periphs) == Periphs) ? 1UL : 0UL);
@@ -264,7 +294,7 @@ __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClock(uint32_t Periphs)
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_AHB1_GRP1_DisableClock(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->AHBENR, Periphs);
@@ -286,7 +316,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_AHB1_GRP1_ForceReset(uint32_t Periphs)
 {
   SET_BIT(RCC->AHBRSTR, Periphs);
@@ -308,7 +338,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_ForceReset(uint32_t Periphs)
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_AHB1_GRP1_ReleaseReset(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->AHBRSTR, Periphs);
@@ -331,7 +361,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_ReleaseReset(uint32_t Periphs)
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_AHB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -358,7 +388,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
   *         @arg @ref LL_AHB1_GRP1_PERIPH_RNG  (*)
   * @note   (*) RNG & CRYP Peripherals available only on STM32G081xx
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_AHB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->AHBSMENR, Periphs);
@@ -376,20 +406,28 @@ __STATIC_INLINE void LL_AHB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
   * @brief  Enable APB1 peripherals clock.
   * @rmtoll APBENR1      TIM2EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      TIM3EN        LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      TIM4EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      TIM6EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      TIM7EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      RTCAPBEN      LL_APB1_GRP1_EnableClock\n
   *         APBENR1      WWDGEN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      SPI2EN        LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      SPI3EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      USART2EN      LL_APB1_GRP1_EnableClock\n
   *         APBENR1      USART3EN      LL_APB1_GRP1_EnableClock\n
   *         APBENR1      USART4EN      LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      USART5EN      LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      USART6EN      LL_APB1_GRP1_EnableClock\n
   *         APBENR1      LPUART1EN     LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      LPUART2EN     LL_APB1_GRP1_EnableClock\n
   *         APBENR1      I2C1EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      I2C2EN        LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      I2C3EN        LL_APB1_GRP1_EnableClock\n
   *         APBENR1      CECEN         LL_APB1_GRP1_EnableClock\n
   *         APBENR1      UCPD1EN       LL_APB1_GRP1_EnableClock\n
   *         APBENR1      UCPD2EN       LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      USBEN         LL_APB1_GRP1_EnableClock\n
+  *         APBENR1      FDCANEN       LL_APB1_GRP1_EnableClock\n
   *         APBENR1      DBGEN         LL_APB1_GRP1_EnableClock\n
   *         APBENR1      PWREN         LL_APB1_GRP1_EnableClock\n
   *         APBENR1      DAC1EN        LL_APB1_GRP1_EnableClock\n
@@ -398,20 +436,28 @@ __STATIC_INLINE void LL_AHB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -419,7 +465,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB1_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -433,20 +479,28 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClock(uint32_t Periphs)
   * @brief  Check if APB1 peripheral clock is enabled or not
   * @rmtoll APBENR1      TIM2EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      TIM3EN        LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      TIM4EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      TIM6EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      TIM7EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      RTCAPBEN      LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      WWDGEN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      SPI2EN        LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      SPI3EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      USART2EN      LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      USART3EN      LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      USART4EN      LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      USART5EN      LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      USART6EN      LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      LPUART1EN     LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      LPUART2EN     LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      I2C1EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      I2C2EN        LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      I2C3EN        LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      CECEN         LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      UCPD1EN       LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      UCPD2EN       LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      USBEN         LL_APB1_GRP1_IsEnabledClock\n
+  *         APBENR1      FDCANEN       LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      DBGEN         LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      PWREN         LL_APB1_GRP1_IsEnabledClock\n
   *         APBENR1      DAC1EN        LL_APB1_GRP1_IsEnabledClock\n
@@ -455,20 +509,28 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClock(uint32_t Periphs)
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -476,7 +538,7 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClock(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval State of Periphs (1 or 0).
-*/
+  */
 __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClock(uint32_t Periphs)
 {
   return ((READ_BIT(RCC->APBENR1, Periphs) == (Periphs)) ? 1UL : 0UL);
@@ -486,20 +548,28 @@ __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClock(uint32_t Periphs)
   * @brief  Disable APB1 peripherals clock.
   * @rmtoll APBENR1      TIM2EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      TIM3EN        LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      TIM4EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      TIM6EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      TIM7EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      RTCAPBEN      LL_APB1_GRP1_DisableClock\n
   *         APBENR1      WWDGEN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      SPI2EN        LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      SPI3EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      USART2EN      LL_APB1_GRP1_DisableClock\n
   *         APBENR1      USART3EN      LL_APB1_GRP1_DisableClock\n
   *         APBENR1      USART4EN      LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      USART5EN      LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      USART6EN      LL_APB1_GRP1_DisableClock\n
   *         APBENR1      LPUART1EN     LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      LPUART2EN     LL_APB1_GRP1_DisableClock\n
   *         APBENR1      I2C1EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      I2C2EN        LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      I2C3EN        LL_APB1_GRP1_DisableClock\n
   *         APBENR1      CECEN         LL_APB1_GRP1_DisableClock\n
   *         APBENR1      UCPD1EN       LL_APB1_GRP1_DisableClock\n
   *         APBENR1      UCPD2EN       LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      USBEN         LL_APB1_GRP1_DisableClock\n
+  *         APBENR1      FDCANEN       LL_APB1_GRP1_DisableClock\n
   *         APBENR1      DBGEN         LL_APB1_GRP1_DisableClock\n
   *         APBENR1      PWREN         LL_APB1_GRP1_DisableClock\n
   *         APBENR1      DAC1EN        LL_APB1_GRP1_DisableClock\n
@@ -508,20 +578,28 @@ __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClock(uint32_t Periphs)
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -529,7 +607,7 @@ __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClock(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB1_GRP1_DisableClock(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->APBENR1, Periphs);
@@ -539,43 +617,58 @@ __STATIC_INLINE void LL_APB1_GRP1_DisableClock(uint32_t Periphs)
   * @brief  Force APB1 peripherals reset.
   * @rmtoll APBRSTR1     TIM2RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     TIM3RST       LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     TIM4RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     TIM6RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     TIM7RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     RTCRST        LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     WWDGRST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     SPI2RST       LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     SPI3RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     USART2RST     LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     USART3RST     LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     USART4RST     LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     USART5RST     LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     USART6RST     LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     LPUART1RST    LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     LPUART2RST    LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     I2C1RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     I2C2RST       LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     I2C3RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     CECRST        LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     UCPD1RST      LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     UCPD2RST      LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     USBRST        LL_APB1_GRP1_ForceReset\n
+  *         APBRSTR1     FDCANRST      LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     DBGRST        LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     PWRRST        LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     DAC1RST       LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     LPTIM2RST     LL_APB1_GRP1_ForceReset\n
   *         APBRSTR1     LPTIM1RST     LL_APB1_GRP1_ForceReset
   * @param  Periphs This parameter can be a combination of the following values:
-  *         @arg @ref LL_APB1_GRP1_PERIPH_ALL
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -583,7 +676,7 @@ __STATIC_INLINE void LL_APB1_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB1_GRP1_ForceReset(uint32_t Periphs)
 {
   SET_BIT(RCC->APBRSTR1, Periphs);
@@ -592,44 +685,58 @@ __STATIC_INLINE void LL_APB1_GRP1_ForceReset(uint32_t Periphs)
 /**
   * @brief  Release APB1 peripherals reset.
   * @rmtoll APBRSTR1     TIM2RST       LL_APB1_GRP1_ReleaseReset\n
-  *         APBRSTR1     TIM3RST       LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     TIM4RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     TIM6RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     TIM7RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     RTCRST        LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     WWDGRST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     SPI2RST       LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     SPI3RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     USART2RST     LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     USART3RST     LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     USART4RST     LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     USART5RST     LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     USART6RST     LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     LPUART1RST    LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     LPUART2RST    LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     I2C1RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     I2C2RST       LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     I2C3RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     CECRST        LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     UCPD1RST      LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     UCPD2RST      LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     USBRST        LL_APB1_GRP1_ReleaseReset\n
+  *         APBRSTR1     FDCANRST      LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     DBGRST        LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     PWRRST        LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     DAC1RST       LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     LPTIM2RST     LL_APB1_GRP1_ReleaseReset\n
   *         APBRSTR1     LPTIM1RST     LL_APB1_GRP1_ReleaseReset
   * @param  Periphs This parameter can be a combination of the following values:
-  *         @arg @ref LL_APB1_GRP1_PERIPH_ALL
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -637,7 +744,7 @@ __STATIC_INLINE void LL_APB1_GRP1_ForceReset(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB1_GRP1_ReleaseReset(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->APBRSTR1, Periphs);
@@ -647,20 +754,28 @@ __STATIC_INLINE void LL_APB1_GRP1_ReleaseReset(uint32_t Periphs)
   * @brief  Enable APB1 peripheral clocks in Sleep and Stop modes
   * @rmtoll APBSMENR1    TIM2SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    TIM3SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    TIM4SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    TIM6SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    TIM7SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    RTCAPBSMEN    LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    WWDGSMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    SPI2SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    SPI3SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    USART2SMEN    LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    USART3SMEN    LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    USART4SMEN    LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    USART5SMEN    LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    USART6SMEN    LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    LPUART1SMEN   LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    LPUART2SMEN   LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    I2C1SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    I2C2SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    I2C3SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    CECSMEN       LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    UCPD1SMEN     LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    UCPD2SMEN     LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    USBSMEN       LL_APB1_GRP1_EnableClockStopSleep\n
+  *         APBSMENR1    FDCANSMEN     LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    DBGSMEN       LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    PWRSMEN       LL_APB1_GRP1_EnableClockStopSleep\n
   *         APBSMENR1    DAC1SMEN      LL_APB1_GRP1_EnableClockStopSleep\n
@@ -669,20 +784,28 @@ __STATIC_INLINE void LL_APB1_GRP1_ReleaseReset(uint32_t Periphs)
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -690,7 +813,7 @@ __STATIC_INLINE void LL_APB1_GRP1_ReleaseReset(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -704,20 +827,28 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
   * @brief  Disable APB1 peripheral clocks in Sleep and Stop modes
   * @rmtoll APBSMENR1    TIM2SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    TIM3SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    TIM'SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    TIM6SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    TIM7SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    RTCAPBSMEN    LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    WWDGSMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    SPI2SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    SPI3SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    USART2SMEN    LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    USART3SMEN    LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    USART4SMEN    LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    USART5SMEN    LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    USART6SMEN    LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    LPUART1SMEN   LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    LPUART2SMEN   LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    I2C1SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    I2C2SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    I2C3SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    CECSMEN       LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    UCPD1SMEN     LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    UCPD2SMEN     LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    USBSMEN       LL_APB1_GRP1_DisableClockStopSleep\n
+  *         APBSMENR1    FSCANSMEN     LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    DBGSMEN       LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    PWRSMEN       LL_APB1_GRP1_DisableClockStopSleep\n
   *         APBSMENR1    DAC1SMEN      LL_APB1_GRP1_DisableClockStopSleep\n
@@ -726,20 +857,28 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM2    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM3
+  *         @arg @ref LL_APB1_GRP1_PERIPH_TIM4    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM6    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_TIM7    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_RTC
   *         @arg @ref LL_APB1_GRP1_PERIPH_WWDG
   *         @arg @ref LL_APB1_GRP1_PERIPH_SPI2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_SPI3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART2
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART3  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_USART4  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART5  (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USART6  (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART1 (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_LPUART2 (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C1
   *         @arg @ref LL_APB1_GRP1_PERIPH_I2C2
+  *         @arg @ref LL_APB1_GRP1_PERIPH_I2C3    (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_CEC     (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD1   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_UCPD2   (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_USB     (1)
+  *         @arg @ref LL_APB1_GRP1_PERIPH_FDCAN   (1)
   *         @arg @ref LL_APB1_GRP1_PERIPH_DBGMCU
   *         @arg @ref LL_APB1_GRP1_PERIPH_PWR
   *         @arg @ref LL_APB1_GRP1_PERIPH_DAC1    (1)
@@ -747,7 +886,7 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
   *         @arg @ref LL_APB1_GRP1_PERIPH_LPTIM1  (1)
   * @note Peripheral marked with (1) are not available all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->APBSMENR1, Periphs);
@@ -768,7 +907,7 @@ __STATIC_INLINE void LL_APB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
   *         APBENR2      SPI1EN        LL_APB2_GRP1_EnableClock\n
   *         APBENR2      USART1EN      LL_APB2_GRP1_EnableClock\n
   *         APBENR2      TIM14EN       LL_APB2_GRP1_EnableClock\n
-  *         APBENR2      TIM15EN       LL_APB2_GRP1_EnableClock\n (*)
+  *         APBENR2      TIM15EN       LL_APB2_GRP1_EnableClock\n
   *         APBENR2      TIM16EN       LL_APB2_GRP1_EnableClock\n
   *         APBENR2      TIM17EN       LL_APB2_GRP1_EnableClock\n
   *         APBENR2      ADCEN         LL_APB2_GRP1_EnableClock
@@ -784,7 +923,7 @@ __STATIC_INLINE void LL_APB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB2_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -801,7 +940,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClock(uint32_t Periphs)
   *         APBENR2      SPI1EN        LL_APB2_GRP1_IsEnabledClock\n
   *         APBENR2      USART1EN      LL_APB2_GRP1_IsEnabledClock\n
   *         APBENR2      TIM14EN       LL_APB2_GRP1_IsEnabledClock\n
-  *         APBENR2      TIM15EN       LL_APB2_GRP1_IsEnabledClock\n (*)
+  *         APBENR2      TIM15EN       LL_APB2_GRP1_IsEnabledClock\n
   *         APBENR2      TIM16EN       LL_APB2_GRP1_IsEnabledClock\n
   *         APBENR2      TIM17EN       LL_APB2_GRP1_IsEnabledClock\n
   *         APBENR2      ADCEN         LL_APB2_GRP1_IsEnabledClock
@@ -817,7 +956,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClock(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval State of Periphs (1 or 0).
-*/
+  */
 __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClock(uint32_t Periphs)
 {
   return ((READ_BIT(RCC->APBENR2, Periphs) == (Periphs)) ? 1UL : 0UL);
@@ -830,7 +969,7 @@ __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClock(uint32_t Periphs)
   *         APBENR2      SPI1EN        LL_APB2_GRP1_DisableClock\n
   *         APBENR2      USART1EN      LL_APB2_GRP1_DisableClock\n
   *         APBENR2      TIM14EN       LL_APB2_GRP1_DisableClock\n
-  *         APBENR2      TIM15EN       LL_APB2_GRP1_DisableClock\n (*)
+  *         APBENR2      TIM15EN       LL_APB2_GRP1_DisableClock\n
   *         APBENR2      TIM16EN       LL_APB2_GRP1_DisableClock\n
   *         APBENR2      TIM17EN       LL_APB2_GRP1_DisableClock\n
   *         APBENR2      ADCEN         LL_APB2_GRP1_DisableClock
@@ -846,7 +985,7 @@ __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClock(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB2_GRP1_DisableClock(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->APBENR2, Periphs);
@@ -859,7 +998,7 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClock(uint32_t Periphs)
   *         APBRSTR2     SPI1RST       LL_APB2_GRP1_ForceReset\n
   *         APBRSTR2     USART1RST     LL_APB2_GRP1_ForceReset\n
   *         APBRSTR2     TIM14RST      LL_APB2_GRP1_ForceReset\n
-  *         APBRSTR2     TIM15RST      LL_APB2_GRP1_ForceReset\n (*)
+  *         APBRSTR2     TIM15RST      LL_APB2_GRP1_ForceReset\n
   *         APBRSTR2     TIM16RST      LL_APB2_GRP1_ForceReset\n
   *         APBRSTR2     TIM17RST      LL_APB2_GRP1_ForceReset\n
   *         APBRSTR2     ADCRST        LL_APB2_GRP1_ForceReset
@@ -876,7 +1015,7 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB2_GRP1_ForceReset(uint32_t Periphs)
 {
   SET_BIT(RCC->APBRSTR2, Periphs);
@@ -889,7 +1028,7 @@ __STATIC_INLINE void LL_APB2_GRP1_ForceReset(uint32_t Periphs)
   *         APBRSTR2     SPI1RST       LL_APB2_GRP1_ReleaseReset\n
   *         APBRSTR2     USART1RST     LL_APB2_GRP1_ReleaseReset\n
   *         APBRSTR2     TIM14RST      LL_APB2_GRP1_ReleaseReset\n
-  *         APBRSTR2     TIM15RST      LL_APB2_GRP1_ReleaseReset\n (*)
+  *         APBRSTR2     TIM15RST      LL_APB2_GRP1_ReleaseReset\n
   *         APBRSTR2     TIM16RST      LL_APB2_GRP1_ReleaseReset\n
   *         APBRSTR2     TIM17RST      LL_APB2_GRP1_ReleaseReset\n
   *         APBRSTR2     ADCRST        LL_APB2_GRP1_ReleaseReset
@@ -906,7 +1045,7 @@ __STATIC_INLINE void LL_APB2_GRP1_ForceReset(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB2_GRP1_ReleaseReset(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->APBRSTR2, Periphs);
@@ -919,7 +1058,7 @@ __STATIC_INLINE void LL_APB2_GRP1_ReleaseReset(uint32_t Periphs)
   *         APBSMENR2    SPI1SMEN      LL_APB2_GRP1_EnableClockStopSleep\n
   *         APBSMENR2    USART1SMEN    LL_APB2_GRP1_EnableClockStopSleep\n
   *         APBSMENR2    TIM14SMEN     LL_APB2_GRP1_EnableClockStopSleep\n
-  *         APBSMENR2    TIM15SMEN     LL_APB2_GRP1_EnableClockStopSleep\n (*)
+  *         APBSMENR2    TIM15SMEN     LL_APB2_GRP1_EnableClockStopSleep\n
   *         APBSMENR2    TIM16SMEN     LL_APB2_GRP1_EnableClockStopSleep\n
   *         APBSMENR2    TIM17SMEN     LL_APB2_GRP1_EnableClockStopSleep\n
   *         APBSMENR2    ADCSMEN       LL_APB2_GRP1_EnableClockStopSleep
@@ -935,7 +1074,7 @@ __STATIC_INLINE void LL_APB2_GRP1_ReleaseReset(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -952,7 +1091,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
   *         APBSMENR2    SPI1SMEN      LL_APB2_GRP1_DisableClockStopSleep\n
   *         APBSMENR2    USART1SMEN    LL_APB2_GRP1_DisableClockStopSleep\n
   *         APBSMENR2    TIM14SMEN     LL_APB2_GRP1_DisableClockStopSleep\n
-  *         APBSMENR2    TIM15SMEN     LL_APB2_GRP1_DisableClockStopSleep\n (*)
+  *         APBSMENR2    TIM15SMEN     LL_APB2_GRP1_DisableClockStopSleep\n
   *         APBSMENR2    TIM16SMEN     LL_APB2_GRP1_DisableClockStopSleep\n
   *         APBSMENR2    TIM17SMEN     LL_APB2_GRP1_DisableClockStopSleep\n
   *         APBSMENR2    ADCSMEN       LL_APB2_GRP1_DisableClockStopSleep
@@ -968,7 +1107,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
   *         @arg @ref LL_APB2_GRP1_PERIPH_ADC
   * @note (*) peripheral not available on all devices
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_APB2_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->APBSMENR2, Periphs);
@@ -988,15 +1127,17 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClockStopSleep(uint32_t Periphs)
   *         IOPENR       GPIOBEN       LL_IOP_GRP1_EnableClock\n
   *         IOPENR       GPIOCEN       LL_IOP_GRP1_EnableClock\n
   *         IOPENR       GPIODEN       LL_IOP_GRP1_EnableClock\n
+  *         IOPENR       GPIOEEN       LL_IOP_GRP1_EnableClock\n
   *         IOPENR       GPIOFEN       LL_IOP_GRP1_EnableClock
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOA
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_IOP_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -1012,15 +1153,17 @@ __STATIC_INLINE void LL_IOP_GRP1_EnableClock(uint32_t Periphs)
   *         IOPENR       GPIOBEN       LL_IOP_GRP1_IsEnabledClock\n
   *         IOPENR       GPIOCEN       LL_IOP_GRP1_IsEnabledClock\n
   *         IOPENR       GPIODEN       LL_IOP_GRP1_IsEnabledClock\n
+  *         IOPENR       GPIOEEN       LL_IOP_GRP1_IsEnabledClock\n
   *         IOPENR       GPIOFEN       LL_IOP_GRP1_IsEnabledClock
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOA
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval State of Periphs (1 or 0).
-*/
+  */
 __STATIC_INLINE uint32_t LL_IOP_GRP1_IsEnabledClock(uint32_t Periphs)
 {
   return ((READ_BIT(RCC->IOPENR, Periphs) == Periphs) ? 1UL : 0UL);
@@ -1032,15 +1175,17 @@ __STATIC_INLINE uint32_t LL_IOP_GRP1_IsEnabledClock(uint32_t Periphs)
   *         IOPENR       GPIOBEN       LL_IOP_GRP1_DisableClock\n
   *         IOPENR       GPIOCEN       LL_IOP_GRP1_DisableClock\n
   *         IOPENR       GPIODEN       LL_IOP_GRP1_DisableClock\n
+  *         IOPENR       GPIOEEN       LL_IOP_GRP1_DisableClock\n
   *         IOPENR       GPIOFEN       LL_IOP_GRP1_DisableClock
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOA
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_IOP_GRP1_DisableClock(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->IOPENR, Periphs);
@@ -1052,6 +1197,7 @@ __STATIC_INLINE void LL_IOP_GRP1_DisableClock(uint32_t Periphs)
   *         IOPRSTR      GPIOBRST      LL_IOP_GRP1_ForceReset\n
   *         IOPRSTR      GPIOCRST      LL_IOP_GRP1_ForceReset\n
   *         IOPRSTR      GPIODRST      LL_IOP_GRP1_ForceReset\n
+  *         IOPRSTR      GPIOERST      LL_IOP_GRP1_ForceReset\n
   *         IOPRSTR      GPIOFRST      LL_IOP_GRP1_ForceReset
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_ALL
@@ -1059,9 +1205,10 @@ __STATIC_INLINE void LL_IOP_GRP1_DisableClock(uint32_t Periphs)
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_IOP_GRP1_ForceReset(uint32_t Periphs)
 {
   SET_BIT(RCC->IOPRSTR, Periphs);
@@ -1073,6 +1220,7 @@ __STATIC_INLINE void LL_IOP_GRP1_ForceReset(uint32_t Periphs)
   *         IOPRSTR      GPIOBRST      LL_IOP_GRP1_ReleaseReset\n
   *         IOPRSTR      GPIOCRST      LL_IOP_GRP1_ReleaseReset\n
   *         IOPRSTR      GPIODRST      LL_IOP_GRP1_ReleaseReset\n
+  *         IOPRSTR      GPIOERST      LL_IOP_GRP1_ReleaseReset\n
   *         IOPRSTR      GPIOFRST      LL_IOP_GRP1_ReleaseReset
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_ALL
@@ -1080,9 +1228,10 @@ __STATIC_INLINE void LL_IOP_GRP1_ForceReset(uint32_t Periphs)
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_IOP_GRP1_ReleaseReset(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->IOPRSTR, Periphs);
@@ -1094,15 +1243,17 @@ __STATIC_INLINE void LL_IOP_GRP1_ReleaseReset(uint32_t Periphs)
   *         IOPSMENR     GPIOBSMEN     LL_IOP_GRP1_EnableClockStopSleep\n
   *         IOPSMENR     GPIOCSMEN     LL_IOP_GRP1_EnableClockStopSleep\n
   *         IOPSMENR     GPIODSMEN     LL_IOP_GRP1_EnableClockStopSleep\n
+  *         IOPSMENR     GPIOESMEN     LL_IOP_GRP1_EnableClockStopSleep\n
   *         IOPSMENR     GPIOFSMEN     LL_IOP_GRP1_EnableClockStopSleep
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOA
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_IOP_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
@@ -1118,15 +1269,17 @@ __STATIC_INLINE void LL_IOP_GRP1_EnableClockStopSleep(uint32_t Periphs)
   *         IOPSMENR     GPIOBSMEN     LL_IOP_GRP1_DisableClockStopSleep\n
   *         IOPSMENR     GPIOCSMEN     LL_IOP_GRP1_DisableClockStopSleep\n
   *         IOPSMENR     GPIODSMEN     LL_IOP_GRP1_DisableClockStopSleep\n
+  *         IOPSMENR     GPIOESMEN     LL_IOP_GRP1_DisableClockStopSleep\n
   *         IOPSMENR     GPIOFSMEN     LL_IOP_GRP1_DisableClockStopSleep
   * @param  Periphs This parameter can be a combination of the following values:
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOA
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOB
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOC
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOD
+  *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOE
   *         @arg @ref LL_IOP_GRP1_PERIPH_GPIOF
   * @retval None
-*/
+  */
 __STATIC_INLINE void LL_IOP_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
   CLEAR_BIT(RCC->IOPSMENR, Periphs);
@@ -1145,7 +1298,7 @@ __STATIC_INLINE void LL_IOP_GRP1_DisableClockStopSleep(uint32_t Periphs)
   * @}
   */
 
-#endif /* defined(RCC) */
+#endif /* RCC */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_comp.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_comp.h
@@ -145,7 +145,7 @@ typedef struct
   */
 #define LL_COMP_WINDOWMODE_DISABLE                 (0x00000000UL)                                                   /*!< Window mode disable: Comparators 1 and 2 are independent */
 #define LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON (COMP_CSR_WINMODE | LL_COMP_WINDOWMODE_COMP_EVEN_REGOFFSET_MASK) /*!< Window mode enable: Comparators instances pair COMP1 and COMP2 have their input plus connected together. The common input is COMP1 input plus (COMP2 input plus is no more accessible). */
-#define LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (COMP_CSR_WINMODE | LL_COMP_WINDOWMODE_COMP_ODD_REGOFFSET_MASK)  /*!< Window mode enable: Comparators instances pair COMP1 and COMP2 have their input plus connected together. The common input is COMP2 input plus (COMP1 input plus is no more accessible). */
+#define LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (COMP_CSR_WINMODE | LL_COMP_WINDOWMODE_COMP_ODD_REGOFFSET_MASK)  /*!< Window mode enable: if used from COMP1 or COMP2 instance, comparators instances pair COMP1 and COMP2 have their input plus connected together, the common input is COMP2 input plus (COMP1 input plus is no more accessible). If used from COMP3 instance (when available), comparators instances pair COMP2 and COMP3 have their input plus connected together, the common input is COMP2 input plus (COMP3 input plus is no more accessible). */
 /**
   * @}
   */
@@ -156,7 +156,10 @@ typedef struct
 #define LL_COMP_WINDOWOUTPUT_EACH_COMP               (0x00000000UL)                                                  /*!< Window output default mode: Comparators output are indicating each their own state. To know window mode state: each comparator output must be read, if "((COMPx exclusive or COMPy) == 1)" then monitored signal is within comparators window. The same way, if both comparators output are high, then monitored signal is below window. */
 #define LL_COMP_WINDOWOUTPUT_COMP1                   (COMP_CSR_WINOUT | LL_COMP_WINDOWMODE_COMP_ODD_REGOFFSET_MASK)  /*!< Window output synthetized on COMP1 output: COMP1 output is no more indicating its own state, but global window mode state (logical high means monitored signal is within comparators window). */
 #define LL_COMP_WINDOWOUTPUT_COMP2                   (COMP_CSR_WINOUT | LL_COMP_WINDOWMODE_COMP_EVEN_REGOFFSET_MASK) /*!< Window output synthetized on COMP2 output: COMP2 output is no more indicating its own state, but global window mode state (logical high means monitored signal is within comparators window). */
-#define LL_COMP_WINDOWOUTPUT_BOTH                    (COMP_CSR_WINOUT | LL_COMP_WINDOWMODE_COMP_EVEN_REGOFFSET_MASK | LL_COMP_WINDOWOUTPUT_BOTH_SETTING_MASK)      /*!< Window output synthetized on both COMP1 and COMP2 output: COMP1 and COMP2 outputs are no more indicating their own state, but global window mode state (logical high means monitored signal is within comparators window). This is a specific configuraton (technically possible but not relevant from application point of view: 2 comparators output used for the same signal level), standard configuraton for window mode is one of the 3 settings above. */
+#if defined(COMP3)
+#define LL_COMP_WINDOWOUTPUT_COMP3                   (COMP_CSR_WINOUT | LL_COMP_WINDOWMODE_COMP_ODD_REGOFFSET_MASK)  /*!< Window output synthetized on COMP3 output: COMP3 output is no more indicating its own state, but global window mode state (logical high means monitored signal is within comparators window). Available only on devices featuring COMP3 instance. */
+#endif
+#define LL_COMP_WINDOWOUTPUT_BOTH                    (COMP_CSR_WINOUT | LL_COMP_WINDOWMODE_COMP_EVEN_REGOFFSET_MASK | LL_COMP_WINDOWOUTPUT_BOTH_SETTING_MASK)      /*!< Window output synthetized on both comparators output of pair of comparator selected (COMP1 and COMP2, or COMP2 and COMP3 for devices featuring COMP3 instance): both comparators outputs are no more indicating their own state, but global window mode state (logical high means monitored signal is within comparators window). This is a specific configuration (technically possible but not relevant from application point of view: 2 comparators output used for the same signal level), standard configuration for window mode is one of the settings above. */
 /**
   * @}
   */
@@ -173,9 +176,9 @@ typedef struct
 /** @defgroup COMP_LL_EC_INPUT_PLUS Comparator inputs - Input plus (input non-inverting) selection
   * @{
   */
-#define LL_COMP_INPUT_PLUS_IO1          (0x00000000UL)                          /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1, pin PB4 for COMP2) */
-#define LL_COMP_INPUT_PLUS_IO2          (COMP_CSR_INPSEL_0)                     /*!< Comparator input plus connected to IO2 (pin PB2 for COMP1, pin PB6 for COMP2) */
-#define LL_COMP_INPUT_PLUS_IO3          (COMP_CSR_INPSEL_1)                     /*!< Comparator input plus connected to IO3 (pin PA1 for COMP1, pin PA3 for COMP2) */
+#define LL_COMP_INPUT_PLUS_IO1          (0x00000000UL)                          /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1, pin PB4 for COMP2, pin PB0 for COMP3 (for devices featuring COMP3 instance)) */
+#define LL_COMP_INPUT_PLUS_IO2          (COMP_CSR_INPSEL_0)                     /*!< Comparator input plus connected to IO2 (pin PB2 for COMP1, pin PB6 for COMP2, pin PC1 for COMP3 (for devices featuring COMP3 instance)) */
+#define LL_COMP_INPUT_PLUS_IO3          (COMP_CSR_INPSEL_1)                     /*!< Comparator input plus connected to IO3 (pin PA1 for COMP1, pin PA3 for COMP2, pin PE7 for COMP3 (for devices featuring COMP3 instance)) */
 /**
   * @}
   */
@@ -189,9 +192,9 @@ typedef struct
 #define LL_COMP_INPUT_MINUS_VREFINT     (                                        COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to VrefInt */
 #define LL_COMP_INPUT_MINUS_DAC1_CH1    (                    COMP_CSR_INMSEL_2                                        ) /*!< Comparator input minus connected to DAC1 channel 1 (DAC_OUT1)  */
 #define LL_COMP_INPUT_MINUS_DAC1_CH2    (                    COMP_CSR_INMSEL_2                     | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to DAC1 channel 2 (DAC_OUT2)  */
-#define LL_COMP_INPUT_MINUS_IO1         (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1                    ) /*!< Comparator input minus connected to IO1 (pin PA9 for COMP1, pin PB3 for COMP2) */
-#define LL_COMP_INPUT_MINUS_IO2         (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1, pin PB7 for COMP2) */
-#define LL_COMP_INPUT_MINUS_IO3         (COMP_CSR_INMSEL_3                                                            ) /*!< Comparator input minus connected to IO3 (pin PA0 for COMP1, pin PA2 for COMP2) */
+#define LL_COMP_INPUT_MINUS_IO1         (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1                    ) /*!< Comparator input minus connected to IO1 (pin PB1 for COMP1, pin PB3 for COMP2, pin PB2 for COMP3 (for devices featuring COMP3 instance)) */
+#define LL_COMP_INPUT_MINUS_IO2         (                    COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1, pin PB7 for COMP2, pin PC0 for COMP3 (for devices featuring COMP3 instance)) */
+#define LL_COMP_INPUT_MINUS_IO3         (COMP_CSR_INMSEL_3                                                            ) /*!< Comparator input minus connected to IO3 (pin PA0 for COMP1, pin PA2 for COMP2, pin PE8 for COMP3 (for devices featuring COMP3 instance)) */
 /**
   * @}
   */
@@ -221,11 +224,11 @@ typedef struct
   */
 #define LL_COMP_BLANKINGSRC_NONE            (0x00000000UL)          /*!<Comparator output without blanking */
 /* Note: Output blanking source common to all COMP instances */
-#define LL_COMP_BLANKINGSRC_TIM1_OC4        (COMP_CSR_BLANKING_0)   /*!< Comparator output blanking source TIM1 OC4 (common to all COMP instances: COMP1, COMP2) */
-#define LL_COMP_BLANKINGSRC_TIM1_OC5        (COMP_CSR_BLANKING_1)   /*!< Comparator output blanking source TIM1 OC5 (common to all COMP instances: COMP1, COMP2) */
-#define LL_COMP_BLANKINGSRC_TIM2_OC3        (COMP_CSR_BLANKING_2)   /*!< Comparator output blanking source TIM2 OC3 (common to all COMP instances: COMP1, COMP2) */
-#define LL_COMP_BLANKINGSRC_TIM3_OC3        (COMP_CSR_BLANKING_3)   /*!< Comparator output blanking source TIM3 OC3 (common to all COMP instances: COMP1, COMP2) */
-#define LL_COMP_BLANKINGSRC_TIM15_OC2       (COMP_CSR_BLANKING_4)   /*!< Comparator output blanking source TIM15 OC2 (common to all COMP instances: COMP1, COMP2) */
+#define LL_COMP_BLANKINGSRC_TIM1_OC4        (COMP_CSR_BLANKING_0)   /*!< Comparator output blanking source TIM1 OC4 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define LL_COMP_BLANKINGSRC_TIM1_OC5        (COMP_CSR_BLANKING_1)   /*!< Comparator output blanking source TIM1 OC5 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define LL_COMP_BLANKINGSRC_TIM2_OC3        (COMP_CSR_BLANKING_2)   /*!< Comparator output blanking source TIM2 OC3 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define LL_COMP_BLANKINGSRC_TIM3_OC3        (COMP_CSR_BLANKING_3)   /*!< Comparator output blanking source TIM3 OC3 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
+#define LL_COMP_BLANKINGSRC_TIM15_OC2       (COMP_CSR_BLANKING_4)   /*!< Comparator output blanking source TIM15 OC2 (common to all COMP instances: COMP1, COMP2, COMP3 (when available)) */
 /**
   * @}
   */
@@ -311,8 +314,21 @@ typedef struct
   * @param  __COMPx__ COMP instance
   * @retval COMP common instance or value "0" if there is no COMP common instance.
   */
+#if defined(COMP3)
+#define __LL_COMP_COMMON_INSTANCE(__COMPx__)                                   \
+  ((((__COMPx__) == COMP3))                                                    \
+    ? (                                                                        \
+       (COMP23_COMMON)                                                         \
+      )                                                                        \
+      :                                                                        \
+      (                                                                        \
+       (COMP12_COMMON)                                                         \
+      )                                                                        \
+  )
+#else
 #define __LL_COMP_COMMON_INSTANCE(__COMPx__)                                   \
   (COMP12_COMMON)
+#endif
 
 /**
   * @}
@@ -333,24 +349,42 @@ typedef struct
 
 /**
   * @brief  Set window mode of a pair of comparators instances
-  *         (2 consecutive COMP instances odd and even COMP<x> and COMP<x+1>).
+  *         (2 consecutive COMP instances COMP<x> and COMP<x+1>).
   * @rmtoll CSR      WINMODE        LL_COMP_SetCommonWindowMode
   * @param  COMPxy_COMMON Comparator common instance
   *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_COMP_COMMON_INSTANCE() )
   * @param  WindowMode This parameter can be one of the following values:
   *         @arg @ref LL_COMP_WINDOWMODE_DISABLE
-  *         @arg @ref LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON
-  *         @arg @ref LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON
+  *         @arg @ref LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON (1)
+  *         @arg @ref LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (1)(2)
+  *
+  *         (1) Parameter available on all STM32G0 devices, must be used with comparator common instance COMP12_COMMON
+  *         (2) Parameter specificity on devices STM32G0B1xx and STM32G0C1xx: only parameter that can be used only with comparator common instance COMP23_COMMON
   * @retval None
   */
 __STATIC_INLINE void LL_COMP_SetCommonWindowMode(COMP_Common_TypeDef *COMPxy_COMMON, uint32_t WindowMode)
 {
-  /* Note: On this STM32 serie, window mode can be set from one of the pair   */
-  /*       of COMP instances: COMP1 or COMP2.                                 */
-  register __IO uint32_t *preg = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (WindowMode & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK));
+  uint32_t window_mode_tmp = WindowMode;
+
+  /* Note: On this STM32 series, window mode can be set from any instance     */
+  /*       of the pair of comparator instances.                               */
+#if defined(COMP3)
+  /* Note: Exception for STM32G0 devices featuring ADC3 instance: in common   */
+  /*       group of COMP2 and COMP3, instances odd and even are inverted.     */
+  /*       Perform switch of parameter selected.                              */
+  if(COMPxy_COMMON == COMP23_COMMON)
+  {
+    if(WindowMode == LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON)
+    {
+      window_mode_tmp = LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON;
+    }
+  }
+#endif
+
+  __IO uint32_t *preg = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (window_mode_tmp & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK));
 
   /* Clear the potential previous setting of window mode */
-  register __IO uint32_t *preg_clear = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (~(WindowMode & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK) & 0x1UL));
+  __IO uint32_t *preg_clear = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (~(window_mode_tmp & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK) & 0x1UL));
   CLEAR_BIT(*preg_clear,
             COMP_CSR_WINMODE
            );
@@ -358,27 +392,49 @@ __STATIC_INLINE void LL_COMP_SetCommonWindowMode(COMP_Common_TypeDef *COMPxy_COM
   /* Set window mode */
   MODIFY_REG(*preg,
              COMP_CSR_WINMODE,
-             (WindowMode & LL_COMP_WINDOWMODE_COMPX_SETTING_MASK)
+             (window_mode_tmp & LL_COMP_WINDOWMODE_COMPX_SETTING_MASK)
             );
 }
 
 /**
   * @brief  Get window mode of a pair of comparators instances
-  *         (2 consecutive COMP instances odd and even COMP<x> and COMP<x+1>).
+  *         (2 consecutive COMP instances COMP<x> and COMP<x+1>).
   * @rmtoll CSR      WINMODE        LL_COMP_GetCommonWindowMode
   * @param  COMPxy_COMMON Comparator common instance
   *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_COMP_COMMON_INSTANCE() )
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_COMP_WINDOWMODE_DISABLE
-  *         @arg @ref LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON
-  *         @arg @ref LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON
+  *         @arg @ref LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON (1)
+  *         @arg @ref LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (1)(2)
+  *
+  *         (1) Parameter available on all STM32G0 devices, must be used with comparator common instance COMP12_COMMON
+  *         (2) Parameter specificity on devices STM32G0B1xx and STM32G0C1xx: only parameter that can be used only with comparator common instance COMP23_COMMON
   */
 __STATIC_INLINE uint32_t LL_COMP_GetCommonWindowMode(COMP_Common_TypeDef *COMPxy_COMMON)
 {
-  /* Note: On this STM32 serie, window mode can be set from one of the pair   */
-  /*       of COMP instances: COMP1 or COMP2.                                 */
-  register const uint32_t window_mode_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINMODE);
-  register const uint32_t window_mode_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+  /* Note: On this STM32 series, window mode can be set from any instance     */
+  /*       of the pair of comparator instances.                               */
+#if defined(COMP3)
+  uint32_t window_mode_comp_odd;
+  uint32_t window_mode_comp_even;
+
+  /* Note: Exception for STM32G0 devices featuring ADC3 instance: in common   */
+  /*       group of COMP2 and COMP3, instances odd and even are inverted.     */
+  /*       Perform switch of parameter selected.                              */
+  if(COMPxy_COMMON == COMP23_COMMON)
+  {
+    window_mode_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+    window_mode_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINMODE);
+  }
+  else
+  {
+    window_mode_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINMODE);
+    window_mode_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+  }
+#else
+   const uint32_t window_mode_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINMODE);
+   const uint32_t window_mode_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+#endif
 
   return (uint32_t)(window_mode_comp_odd
                     | window_mode_comp_even
@@ -387,52 +443,102 @@ __STATIC_INLINE uint32_t LL_COMP_GetCommonWindowMode(COMP_Common_TypeDef *COMPxy
 
 /**
   * @brief  Set window output of a pair of comparators instances
-  *         (2 consecutive COMP instances odd and even COMP<x> and COMP<x+1>).
+  *         (2 consecutive COMP instances COMP<x> and COMP<x+1>).
   * @rmtoll CSR      WINOUT         LL_COMP_SetCommonWindowOutput
   * @param  COMPxy_COMMON Comparator common instance
   *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_COMP_COMMON_INSTANCE() )
   * @param  WindowOutput This parameter can be one of the following values:
   *         @arg @ref LL_COMP_WINDOWOUTPUT_EACH_COMP
-  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP1
-  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP2
+  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP1 (1)
+  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP2 (1)
+  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP3 (2)
   *         @arg @ref LL_COMP_WINDOWOUTPUT_BOTH
+  *
+  *         (1) Parameter available on all STM32G0 devices, must be used with comparator common instance COMP12_COMMON
+  *         (2) Parameter available only on devices STM32G0B1xx and STM32G0C1xx, must be used with comparator common instance COMP23_COMMON
   * @retval None
   */
 __STATIC_INLINE void LL_COMP_SetCommonWindowOutput(COMP_Common_TypeDef *COMPxy_COMMON, uint32_t WindowOutput)
 {
-  register __IO uint32_t *preg = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (WindowOutput & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK));
+  uint32_t window_output_tmp = WindowOutput;
+
+#if defined(COMP3)
+  /* Note: Exception for STM32G0 devices featuring ADC3 instance: in common   */
+  /*       group of COMP2 and COMP3, instances odd and even are inverted.     */
+  /*       Perform switch of parameter selected.                              */
+  if(COMPxy_COMMON == COMP23_COMMON)
+  {
+    if(WindowOutput == LL_COMP_WINDOWOUTPUT_COMP2)
+    {
+      window_output_tmp = LL_COMP_WINDOWOUTPUT_COMP3;
+    }
+    else if(WindowOutput == LL_COMP_WINDOWOUTPUT_COMP3)
+    {
+      window_output_tmp = LL_COMP_WINDOWOUTPUT_COMP2;
+    }
+    else
+    {
+      /* No modification of other parameters */
+    }
+  }
+#endif
+
+  __IO uint32_t *preg = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (window_output_tmp & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK));
 
   /* Clear the potential previous setting of window output on the relevant comparator instance */
   /* (clear bit of window output unless specific case of setting of comparator both output selected) */
-  register __IO uint32_t *preg_clear = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (~(WindowOutput & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK) & 0x1UL));
+  __IO uint32_t *preg_clear = __COMP_PTR_REG_OFFSET(COMPxy_COMMON->CSR_ODD, (~(window_output_tmp & LL_COMP_WINDOWMODE_COMPX_REGOFFSET_MASK) & 0x1UL));
   MODIFY_REG(*preg_clear,
              COMP_CSR_WINOUT,
-             ((WindowOutput & LL_COMP_WINDOWOUTPUT_BOTH_SETTING_MASK) >> LL_COMP_WINDOWOUTPUT_BOTH_POS_VS_WINDOW)
+             ((window_output_tmp & LL_COMP_WINDOWOUTPUT_BOTH_SETTING_MASK) >> LL_COMP_WINDOWOUTPUT_BOTH_POS_VS_WINDOW)
             );
 
   /* Set window output */
   MODIFY_REG(*preg,
              COMP_CSR_WINOUT,
-             (WindowOutput & LL_COMP_WINDOWOUTPUT_COMPX_SETTING_MASK)
+             (window_output_tmp & LL_COMP_WINDOWOUTPUT_COMPX_SETTING_MASK)
             );
 }
 
 /**
   * @brief  Get window output of a pair of comparators instances
-  *         (2 consecutive COMP instances odd and even COMP<x> and COMP<x+1>).
+  *         (2 consecutive COMP instances COMP<x> and COMP<x+1>).
   * @rmtoll CSR      WINMODE        LL_COMP_GetCommonWindowOutput
   * @param  COMPxy_COMMON Comparator common instance
   *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_COMP_COMMON_INSTANCE() )
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_COMP_WINDOWOUTPUT_EACH_COMP
-  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP1
-  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP2
+  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP1 (1)
+  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP2 (1)
+  *         @arg @ref LL_COMP_WINDOWOUTPUT_COMP3 (2)
   *         @arg @ref LL_COMP_WINDOWOUTPUT_BOTH
+  *
+  *         (1) Parameter available on all STM32G0 devices, must be used with comparator common instance COMP12_COMMON
+  *         (2) Parameter available only on devices STM32G0B1xx and STM32G0C1xx, must be used with comparator common instance COMP23_COMMON
   */
 __STATIC_INLINE uint32_t LL_COMP_GetCommonWindowOutput(COMP_Common_TypeDef *COMPxy_COMMON)
 {
-  register const uint32_t window_output_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINOUT);
-  register const uint32_t window_output_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINOUT);
+#if defined(COMP3)
+  uint32_t window_output_comp_odd;
+  uint32_t window_output_comp_even;
+
+  /* Note: Exception for STM32G0 devices featuring ADC3 instance: in common   */
+  /*       group of COMP2 and COMP3, instances odd and even are inverted.     */
+  /*       Perform switch of parameter selected.                              */
+  if(COMPxy_COMMON == COMP23_COMMON)
+  {
+    window_output_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINOUT);
+    window_output_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINOUT);
+  }
+  else
+  {
+    window_output_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINOUT);
+    window_output_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINOUT);
+  }
+#else
+  const uint32_t window_output_comp_odd = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_ODD, COMP_CSR_WINOUT);
+  const uint32_t window_output_comp_even = (uint32_t)READ_BIT(COMPxy_COMMON->CSR_EVEN, COMP_CSR_WINOUT);
+#endif
 
   /* Construct value corresponding to LL_COMP_WINDOWOUTPUT_xxx */
   return (uint32_t)(window_output_comp_odd
@@ -489,7 +595,7 @@ __STATIC_INLINE uint32_t LL_COMP_GetPowerMode(COMP_TypeDef *COMPx)
   * @note   In case of comparator input selected to be connected to IO:
   *         GPIO pins are specific to each comparator instance.
   *         Refer to description of parameters or to reference manual.
-  * @note   On this STM32 serie, a voltage scaler is used
+  * @note   On this STM32 series, a voltage scaler is used
   *         when COMP input is based on VrefInt (VrefInt or subdivision
   *         of VrefInt):
   *         Voltage scaler requires a delay for voltage stabilization.
@@ -560,7 +666,7 @@ __STATIC_INLINE uint32_t LL_COMP_GetInputPlus(COMP_TypeDef *COMPx)
   * @note   In case of comparator input selected to be connected to IO:
   *         GPIO pins are specific to each comparator instance.
   *         Refer to description of parameters or to reference manual.
-  * @note   On this STM32 serie, a voltage scaler is used
+  * @note   On this STM32 series, a voltage scaler is used
   *         when COMP input is based on VrefInt (VrefInt or subdivision
   *         of VrefInt):
   *         Voltage scaler requires a delay for voltage stabilization.

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_crs.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_crs.h
@@ -1,0 +1,783 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_ll_crs.h
+  * @author  MCD Application Team
+  * @brief   Header file of CRS LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32G0xx_LL_CRS_H
+#define STM32G0xx_LL_CRS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx.h"
+
+/** @addtogroup STM32G0xx_LL_Driver
+  * @{
+  */
+
+#if defined(CRS)
+
+/** @defgroup CRS_LL CRS
+  * @{
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup CRS_LL_Exported_Constants CRS Exported Constants
+  * @{
+  */
+
+/** @defgroup CRS_LL_EC_GET_FLAG Get Flags Defines
+  * @brief    Flags defines which can be used with LL_CRS_ReadReg function
+  * @{
+  */
+#define LL_CRS_ISR_SYNCOKF                 CRS_ISR_SYNCOKF
+#define LL_CRS_ISR_SYNCWARNF               CRS_ISR_SYNCWARNF
+#define LL_CRS_ISR_ERRF                    CRS_ISR_ERRF
+#define LL_CRS_ISR_ESYNCF                  CRS_ISR_ESYNCF
+#define LL_CRS_ISR_SYNCERR                 CRS_ISR_SYNCERR
+#define LL_CRS_ISR_SYNCMISS                CRS_ISR_SYNCMISS
+#define LL_CRS_ISR_TRIMOVF                 CRS_ISR_TRIMOVF
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EC_IT IT Defines
+  * @brief    IT defines which can be used with LL_CRS_ReadReg and  LL_CRS_WriteReg functions
+  * @{
+  */
+#define LL_CRS_CR_SYNCOKIE                 CRS_CR_SYNCOKIE
+#define LL_CRS_CR_SYNCWARNIE               CRS_CR_SYNCWARNIE
+#define LL_CRS_CR_ERRIE                    CRS_CR_ERRIE
+#define LL_CRS_CR_ESYNCIE                  CRS_CR_ESYNCIE
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EC_SYNC_DIV Synchronization Signal Divider
+  * @{
+  */
+#define LL_CRS_SYNC_DIV_1                  0x00000000U                               /*!< Synchro Signal not divided (default) */
+#define LL_CRS_SYNC_DIV_2                  CRS_CFGR_SYNCDIV_0                        /*!< Synchro Signal divided by 2 */
+#define LL_CRS_SYNC_DIV_4                  CRS_CFGR_SYNCDIV_1                        /*!< Synchro Signal divided by 4 */
+#define LL_CRS_SYNC_DIV_8                  (CRS_CFGR_SYNCDIV_1 | CRS_CFGR_SYNCDIV_0) /*!< Synchro Signal divided by 8 */
+#define LL_CRS_SYNC_DIV_16                 CRS_CFGR_SYNCDIV_2                        /*!< Synchro Signal divided by 16 */
+#define LL_CRS_SYNC_DIV_32                 (CRS_CFGR_SYNCDIV_2 | CRS_CFGR_SYNCDIV_0) /*!< Synchro Signal divided by 32 */
+#define LL_CRS_SYNC_DIV_64                 (CRS_CFGR_SYNCDIV_2 | CRS_CFGR_SYNCDIV_1) /*!< Synchro Signal divided by 64 */
+#define LL_CRS_SYNC_DIV_128                CRS_CFGR_SYNCDIV                          /*!< Synchro Signal divided by 128 */
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EC_SYNC_SOURCE Synchronization Signal Source
+  * @{
+  */
+#define LL_CRS_SYNC_SOURCE_GPIO            0x00000000U             /*!< Synchro Signal source GPIO */
+#define LL_CRS_SYNC_SOURCE_LSE             CRS_CFGR_SYNCSRC_0      /*!< Synchro Signal source LSE */
+#define LL_CRS_SYNC_SOURCE_USB             CRS_CFGR_SYNCSRC_1      /*!< Synchro Signal source USB SOF (default)*/
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EC_SYNC_POLARITY Synchronization Signal Polarity
+  * @{
+  */
+#define LL_CRS_SYNC_POLARITY_RISING        0x00000000U           /*!< Synchro Active on rising edge (default) */
+#define LL_CRS_SYNC_POLARITY_FALLING       CRS_CFGR_SYNCPOL      /*!< Synchro Active on falling edge */
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EC_FREQERRORDIR Frequency Error Direction
+  * @{
+  */
+#define LL_CRS_FREQ_ERROR_DIR_UP           0x00000000U         /*!< Upcounting direction, the actual frequency is above the target */
+#define LL_CRS_FREQ_ERROR_DIR_DOWN         CRS_ISR_FEDIR       /*!< Downcounting direction, the actual frequency is below the target */
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EC_DEFAULTVALUES Default Values
+  * @{
+  */
+/**
+  * @brief Reset value of the RELOAD field
+  * @note The reset value of the RELOAD field corresponds to a target frequency of 48 MHz
+  *       and a synchronization signal frequency of 1 kHz (SOF signal from USB)
+  */
+#define LL_CRS_RELOADVALUE_DEFAULT         0x0000BB7FU
+
+/**
+  * @brief Reset value of Frequency error limit.
+  */
+#define LL_CRS_ERRORLIMIT_DEFAULT          0x00000022U
+
+/**
+  * @brief Reset value of the HSI48 Calibration field
+  * @note The default value is 64, which corresponds to the middle of the trimming interval.
+  *       The trimming step is specified in the product datasheet.
+  *       A higher TRIM value corresponds to a higher output frequency.
+  */
+#define LL_CRS_HSI48CALIBRATION_DEFAULT    0x00000040U
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup CRS_LL_Exported_Macros CRS Exported Macros
+  * @{
+  */
+
+/** @defgroup CRS_LL_EM_WRITE_READ Common Write and read registers Macros
+  * @{
+  */
+
+/**
+  * @brief  Write a value in CRS register
+  * @param  __INSTANCE__ CRS Instance
+  * @param  __REG__ Register to be written
+  * @param  __VALUE__ Value to be written in the register
+  * @retval None
+  */
+#define LL_CRS_WriteReg(__INSTANCE__, __REG__, __VALUE__) WRITE_REG(__INSTANCE__->__REG__, (__VALUE__))
+
+/**
+  * @brief  Read a value in CRS register
+  * @param  __INSTANCE__ CRS Instance
+  * @param  __REG__ Register to be read
+  * @retval Register value
+  */
+#define LL_CRS_ReadReg(__INSTANCE__, __REG__) READ_REG(__INSTANCE__->__REG__)
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EM_Exported_Macros_Calculate_Reload Exported_Macros_Calculate_Reload
+  * @{
+  */
+
+/**
+  * @brief  Macro to calculate reload value to be set in CRS register according to target and sync frequencies
+  * @note   The RELOAD value should be selected according to the ratio between
+  *         the target frequency and the frequency of the synchronization source after
+  *         prescaling. It is then decreased by one in order to reach the expected
+  *         synchronization on the zero value. The formula is the following:
+  *              RELOAD = (fTARGET / fSYNC) -1
+  * @param  __FTARGET__ Target frequency (value in Hz)
+  * @param  __FSYNC__ Synchronization signal frequency (value in Hz)
+  * @retval Reload value (in Hz)
+  */
+#define __LL_CRS_CALC_CALCULATE_RELOADVALUE(__FTARGET__, __FSYNC__) (((__FTARGET__) / (__FSYNC__)) - 1U)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup CRS_LL_Exported_Functions CRS Exported Functions
+  * @{
+  */
+
+/** @defgroup CRS_LL_EF_Configuration Configuration
+  * @{
+  */
+
+/**
+  * @brief  Enable Frequency error counter
+  * @note When this bit is set, the CRS_CFGR register is write-protected and cannot be modified
+  * @rmtoll CR           CEN           LL_CRS_EnableFreqErrorCounter
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_EnableFreqErrorCounter(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_CEN);
+}
+
+/**
+  * @brief  Disable Frequency error counter
+  * @rmtoll CR           CEN           LL_CRS_DisableFreqErrorCounter
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_DisableFreqErrorCounter(void)
+{
+  CLEAR_BIT(CRS->CR, CRS_CR_CEN);
+}
+
+/**
+  * @brief  Check if Frequency error counter is enabled or not
+  * @rmtoll CR           CEN           LL_CRS_IsEnabledFreqErrorCounter
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsEnabledFreqErrorCounter(void)
+{
+  return ((READ_BIT(CRS->CR, CRS_CR_CEN) == (CRS_CR_CEN)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable Automatic trimming counter
+  * @rmtoll CR           AUTOTRIMEN    LL_CRS_EnableAutoTrimming
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_EnableAutoTrimming(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN);
+}
+
+/**
+  * @brief  Disable Automatic trimming counter
+  * @rmtoll CR           AUTOTRIMEN    LL_CRS_DisableAutoTrimming
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_DisableAutoTrimming(void)
+{
+  CLEAR_BIT(CRS->CR, CRS_CR_AUTOTRIMEN);
+}
+
+/**
+  * @brief  Check if Automatic trimming is enabled or not
+  * @rmtoll CR           AUTOTRIMEN    LL_CRS_IsEnabledAutoTrimming
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsEnabledAutoTrimming(void)
+{
+  return ((READ_BIT(CRS->CR, CRS_CR_AUTOTRIMEN) == (CRS_CR_AUTOTRIMEN)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Set HSI48 oscillator smooth trimming
+  * @note   When the AUTOTRIMEN bit is set, this field is controlled by hardware and is read-only
+  * @rmtoll CR           TRIM          LL_CRS_SetHSI48SmoothTrimming
+  * @param  Value a number between Min_Data = 0 and Max_Data = 127
+  * @note   Default value can be set thanks to @ref LL_CRS_HSI48CALIBRATION_DEFAULT
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_SetHSI48SmoothTrimming(uint32_t Value)
+{
+  MODIFY_REG(CRS->CR, CRS_CR_TRIM, Value << CRS_CR_TRIM_Pos);
+}
+
+/**
+  * @brief  Get HSI48 oscillator smooth trimming
+  * @rmtoll CR           TRIM          LL_CRS_GetHSI48SmoothTrimming
+  * @retval a number between Min_Data = 0 and Max_Data = 127
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetHSI48SmoothTrimming(void)
+{
+  return (uint32_t)(READ_BIT(CRS->CR, CRS_CR_TRIM) >> CRS_CR_TRIM_Pos);
+}
+
+/**
+  * @brief  Set counter reload value
+  * @rmtoll CFGR         RELOAD        LL_CRS_SetReloadCounter
+  * @param  Value a number between Min_Data = 0 and Max_Data = 0xFFFF
+  * @note   Default value can be set thanks to @ref LL_CRS_RELOADVALUE_DEFAULT
+  *         Otherwise it can be calculated in using macro @ref __LL_CRS_CALC_CALCULATE_RELOADVALUE (_FTARGET_, _FSYNC_)
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_SetReloadCounter(uint32_t Value)
+{
+  MODIFY_REG(CRS->CFGR, CRS_CFGR_RELOAD, Value);
+}
+
+/**
+  * @brief  Get counter reload value
+  * @rmtoll CFGR         RELOAD        LL_CRS_GetReloadCounter
+  * @retval a number between Min_Data = 0 and Max_Data = 0xFFFF
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetReloadCounter(void)
+{
+  return (uint32_t)(READ_BIT(CRS->CFGR, CRS_CFGR_RELOAD));
+}
+
+/**
+  * @brief  Set frequency error limit
+  * @rmtoll CFGR         FELIM         LL_CRS_SetFreqErrorLimit
+  * @param  Value a number between Min_Data = 0 and Max_Data = 255
+  * @note   Default value can be set thanks to @ref LL_CRS_ERRORLIMIT_DEFAULT
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_SetFreqErrorLimit(uint32_t Value)
+{
+  MODIFY_REG(CRS->CFGR, CRS_CFGR_FELIM, Value << CRS_CFGR_FELIM_Pos);
+}
+
+/**
+  * @brief  Get frequency error limit
+  * @rmtoll CFGR         FELIM         LL_CRS_GetFreqErrorLimit
+  * @retval A number between Min_Data = 0 and Max_Data = 255
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetFreqErrorLimit(void)
+{
+  return (uint32_t)(READ_BIT(CRS->CFGR, CRS_CFGR_FELIM) >> CRS_CFGR_FELIM_Pos);
+}
+
+/**
+  * @brief  Set division factor for SYNC signal
+  * @rmtoll CFGR         SYNCDIV       LL_CRS_SetSyncDivider
+  * @param  Divider This parameter can be one of the following values:
+  *         @arg @ref LL_CRS_SYNC_DIV_1
+  *         @arg @ref LL_CRS_SYNC_DIV_2
+  *         @arg @ref LL_CRS_SYNC_DIV_4
+  *         @arg @ref LL_CRS_SYNC_DIV_8
+  *         @arg @ref LL_CRS_SYNC_DIV_16
+  *         @arg @ref LL_CRS_SYNC_DIV_32
+  *         @arg @ref LL_CRS_SYNC_DIV_64
+  *         @arg @ref LL_CRS_SYNC_DIV_128
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_SetSyncDivider(uint32_t Divider)
+{
+  MODIFY_REG(CRS->CFGR, CRS_CFGR_SYNCDIV, Divider);
+}
+
+/**
+  * @brief  Get division factor for SYNC signal
+  * @rmtoll CFGR         SYNCDIV       LL_CRS_GetSyncDivider
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_CRS_SYNC_DIV_1
+  *         @arg @ref LL_CRS_SYNC_DIV_2
+  *         @arg @ref LL_CRS_SYNC_DIV_4
+  *         @arg @ref LL_CRS_SYNC_DIV_8
+  *         @arg @ref LL_CRS_SYNC_DIV_16
+  *         @arg @ref LL_CRS_SYNC_DIV_32
+  *         @arg @ref LL_CRS_SYNC_DIV_64
+  *         @arg @ref LL_CRS_SYNC_DIV_128
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetSyncDivider(void)
+{
+  return (uint32_t)(READ_BIT(CRS->CFGR, CRS_CFGR_SYNCDIV));
+}
+
+/**
+  * @brief  Set SYNC signal source
+  * @rmtoll CFGR         SYNCSRC       LL_CRS_SetSyncSignalSource
+  * @param  Source This parameter can be one of the following values:
+  *         @arg @ref LL_CRS_SYNC_SOURCE_GPIO
+  *         @arg @ref LL_CRS_SYNC_SOURCE_LSE
+  *         @arg @ref LL_CRS_SYNC_SOURCE_USB
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_SetSyncSignalSource(uint32_t Source)
+{
+  MODIFY_REG(CRS->CFGR, CRS_CFGR_SYNCSRC, Source);
+}
+
+/**
+  * @brief  Get SYNC signal source
+  * @rmtoll CFGR         SYNCSRC       LL_CRS_GetSyncSignalSource
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_CRS_SYNC_SOURCE_GPIO
+  *         @arg @ref LL_CRS_SYNC_SOURCE_LSE
+  *         @arg @ref LL_CRS_SYNC_SOURCE_USB
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetSyncSignalSource(void)
+{
+  return (uint32_t)(READ_BIT(CRS->CFGR, CRS_CFGR_SYNCSRC));
+}
+
+/**
+  * @brief  Set input polarity for the SYNC signal source
+  * @rmtoll CFGR         SYNCPOL       LL_CRS_SetSyncPolarity
+  * @param  Polarity This parameter can be one of the following values:
+  *         @arg @ref LL_CRS_SYNC_POLARITY_RISING
+  *         @arg @ref LL_CRS_SYNC_POLARITY_FALLING
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_SetSyncPolarity(uint32_t Polarity)
+{
+  MODIFY_REG(CRS->CFGR, CRS_CFGR_SYNCPOL, Polarity);
+}
+
+/**
+  * @brief  Get input polarity for the SYNC signal source
+  * @rmtoll CFGR         SYNCPOL       LL_CRS_GetSyncPolarity
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_CRS_SYNC_POLARITY_RISING
+  *         @arg @ref LL_CRS_SYNC_POLARITY_FALLING
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetSyncPolarity(void)
+{
+  return (uint32_t)(READ_BIT(CRS->CFGR, CRS_CFGR_SYNCPOL));
+}
+
+/**
+  * @brief  Configure CRS for the synchronization
+  * @rmtoll CR           TRIM          LL_CRS_ConfigSynchronization\n
+  *         CFGR         RELOAD        LL_CRS_ConfigSynchronization\n
+  *         CFGR         FELIM         LL_CRS_ConfigSynchronization\n
+  *         CFGR         SYNCDIV       LL_CRS_ConfigSynchronization\n
+  *         CFGR         SYNCSRC       LL_CRS_ConfigSynchronization\n
+  *         CFGR         SYNCPOL       LL_CRS_ConfigSynchronization
+  * @param  HSI48CalibrationValue a number between Min_Data = 0 and Max_Data = 127
+  * @param  ErrorLimitValue a number between Min_Data = 0 and Max_Data = 0xFFFF
+  * @param  ReloadValue a number between Min_Data = 0 and Max_Data = 255
+  * @param  Settings This parameter can be a combination of the following values:
+  *         @arg @ref LL_CRS_SYNC_DIV_1 or @ref LL_CRS_SYNC_DIV_2 or @ref LL_CRS_SYNC_DIV_4 or @ref LL_CRS_SYNC_DIV_8
+  *              or @ref LL_CRS_SYNC_DIV_16 or @ref LL_CRS_SYNC_DIV_32 or @ref LL_CRS_SYNC_DIV_64 or @ref LL_CRS_SYNC_DIV_128
+  *         @arg @ref LL_CRS_SYNC_SOURCE_GPIO or @ref LL_CRS_SYNC_SOURCE_LSE or @ref LL_CRS_SYNC_SOURCE_USB
+  *         @arg @ref LL_CRS_SYNC_POLARITY_RISING or @ref LL_CRS_SYNC_POLARITY_FALLING
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_ConfigSynchronization(uint32_t HSI48CalibrationValue, uint32_t ErrorLimitValue, uint32_t ReloadValue, uint32_t Settings)
+{
+  MODIFY_REG(CRS->CR, CRS_CR_TRIM, HSI48CalibrationValue);
+  MODIFY_REG(CRS->CFGR,
+             CRS_CFGR_RELOAD | CRS_CFGR_FELIM | CRS_CFGR_SYNCDIV | CRS_CFGR_SYNCSRC | CRS_CFGR_SYNCPOL,
+             ReloadValue | (ErrorLimitValue << CRS_CFGR_FELIM_Pos) | Settings);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EF_CRS_Management CRS_Management
+  * @{
+  */
+
+/**
+  * @brief  Generate software SYNC event
+  * @rmtoll CR           SWSYNC        LL_CRS_GenerateEvent_SWSYNC
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_GenerateEvent_SWSYNC(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_SWSYNC);
+}
+
+/**
+  * @brief  Get the frequency error direction latched in the time of the last
+  * SYNC event
+  * @rmtoll ISR          FEDIR         LL_CRS_GetFreqErrorDirection
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_CRS_FREQ_ERROR_DIR_UP
+  *         @arg @ref LL_CRS_FREQ_ERROR_DIR_DOWN
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetFreqErrorDirection(void)
+{
+  return (uint32_t)(READ_BIT(CRS->ISR, CRS_ISR_FEDIR));
+}
+
+/**
+  * @brief  Get the frequency error counter value latched in the time of the last SYNC event
+  * @rmtoll ISR          FECAP         LL_CRS_GetFreqErrorCapture
+  * @retval A number between Min_Data = 0x0000 and Max_Data = 0xFFFF
+  */
+__STATIC_INLINE uint32_t LL_CRS_GetFreqErrorCapture(void)
+{
+  return (uint32_t)(READ_BIT(CRS->ISR, CRS_ISR_FECAP) >> CRS_ISR_FECAP_Pos);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EF_FLAG_Management FLAG_Management
+  * @{
+  */
+
+/**
+  * @brief  Check if SYNC event OK signal occurred or not
+  * @rmtoll ISR          SYNCOKF       LL_CRS_IsActiveFlag_SYNCOK
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_SYNCOK(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_SYNCOKF) == (CRS_ISR_SYNCOKF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if SYNC warning signal occurred or not
+  * @rmtoll ISR          SYNCWARNF     LL_CRS_IsActiveFlag_SYNCWARN
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_SYNCWARN(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_SYNCWARNF) == (CRS_ISR_SYNCWARNF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if Synchronization or trimming error signal occurred or not
+  * @rmtoll ISR          ERRF          LL_CRS_IsActiveFlag_ERR
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_ERR(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_ERRF) == (CRS_ISR_ERRF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if Expected SYNC signal occurred or not
+  * @rmtoll ISR          ESYNCF        LL_CRS_IsActiveFlag_ESYNC
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_ESYNC(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_ESYNCF) == (CRS_ISR_ESYNCF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if SYNC error signal occurred or not
+  * @rmtoll ISR          SYNCERR       LL_CRS_IsActiveFlag_SYNCERR
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_SYNCERR(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_SYNCERR) == (CRS_ISR_SYNCERR)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if SYNC missed error signal occurred or not
+  * @rmtoll ISR          SYNCMISS      LL_CRS_IsActiveFlag_SYNCMISS
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_SYNCMISS(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_SYNCMISS) == (CRS_ISR_SYNCMISS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if Trimming overflow or underflow occurred or not
+  * @rmtoll ISR          TRIMOVF       LL_CRS_IsActiveFlag_TRIMOVF
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsActiveFlag_TRIMOVF(void)
+{
+  return ((READ_BIT(CRS->ISR, CRS_ISR_TRIMOVF) == (CRS_ISR_TRIMOVF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Clear the SYNC event OK flag
+  * @rmtoll ICR          SYNCOKC       LL_CRS_ClearFlag_SYNCOK
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_ClearFlag_SYNCOK(void)
+{
+  WRITE_REG(CRS->ICR, CRS_ICR_SYNCOKC);
+}
+
+/**
+  * @brief  Clear the  SYNC warning flag
+  * @rmtoll ICR          SYNCWARNC     LL_CRS_ClearFlag_SYNCWARN
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_ClearFlag_SYNCWARN(void)
+{
+  WRITE_REG(CRS->ICR, CRS_ICR_SYNCWARNC);
+}
+
+/**
+  * @brief  Clear TRIMOVF, SYNCMISS and SYNCERR bits and consequently also
+  * the ERR flag
+  * @rmtoll ICR          ERRC          LL_CRS_ClearFlag_ERR
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_ClearFlag_ERR(void)
+{
+  WRITE_REG(CRS->ICR, CRS_ICR_ERRC);
+}
+
+/**
+  * @brief  Clear Expected SYNC flag
+  * @rmtoll ICR          ESYNCC        LL_CRS_ClearFlag_ESYNC
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_ClearFlag_ESYNC(void)
+{
+  WRITE_REG(CRS->ICR, CRS_ICR_ESYNCC);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CRS_LL_EF_IT_Management IT_Management
+  * @{
+  */
+
+/**
+  * @brief  Enable SYNC event OK interrupt
+  * @rmtoll CR           SYNCOKIE      LL_CRS_EnableIT_SYNCOK
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_EnableIT_SYNCOK(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_SYNCOKIE);
+}
+
+/**
+  * @brief  Disable SYNC event OK interrupt
+  * @rmtoll CR           SYNCOKIE      LL_CRS_DisableIT_SYNCOK
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_DisableIT_SYNCOK(void)
+{
+  CLEAR_BIT(CRS->CR, CRS_CR_SYNCOKIE);
+}
+
+/**
+  * @brief  Check if SYNC event OK interrupt is enabled or not
+  * @rmtoll CR           SYNCOKIE      LL_CRS_IsEnabledIT_SYNCOK
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsEnabledIT_SYNCOK(void)
+{
+  return ((READ_BIT(CRS->CR, CRS_CR_SYNCOKIE) == (CRS_CR_SYNCOKIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable SYNC warning interrupt
+  * @rmtoll CR           SYNCWARNIE    LL_CRS_EnableIT_SYNCWARN
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_EnableIT_SYNCWARN(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_SYNCWARNIE);
+}
+
+/**
+  * @brief  Disable SYNC warning interrupt
+  * @rmtoll CR           SYNCWARNIE    LL_CRS_DisableIT_SYNCWARN
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_DisableIT_SYNCWARN(void)
+{
+  CLEAR_BIT(CRS->CR, CRS_CR_SYNCWARNIE);
+}
+
+/**
+  * @brief  Check if SYNC warning interrupt is enabled or not
+  * @rmtoll CR           SYNCWARNIE    LL_CRS_IsEnabledIT_SYNCWARN
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsEnabledIT_SYNCWARN(void)
+{
+  return ((READ_BIT(CRS->CR, CRS_CR_SYNCWARNIE) == (CRS_CR_SYNCWARNIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable Synchronization or trimming error interrupt
+  * @rmtoll CR           ERRIE         LL_CRS_EnableIT_ERR
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_EnableIT_ERR(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_ERRIE);
+}
+
+/**
+  * @brief  Disable Synchronization or trimming error interrupt
+  * @rmtoll CR           ERRIE         LL_CRS_DisableIT_ERR
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_DisableIT_ERR(void)
+{
+  CLEAR_BIT(CRS->CR, CRS_CR_ERRIE);
+}
+
+/**
+  * @brief  Check if Synchronization or trimming error interrupt is enabled or not
+  * @rmtoll CR           ERRIE         LL_CRS_IsEnabledIT_ERR
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsEnabledIT_ERR(void)
+{
+  return ((READ_BIT(CRS->CR, CRS_CR_ERRIE) == (CRS_CR_ERRIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable Expected SYNC interrupt
+  * @rmtoll CR           ESYNCIE       LL_CRS_EnableIT_ESYNC
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_EnableIT_ESYNC(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_ESYNCIE);
+}
+
+/**
+  * @brief  Disable Expected SYNC interrupt
+  * @rmtoll CR           ESYNCIE       LL_CRS_DisableIT_ESYNC
+  * @retval None
+  */
+__STATIC_INLINE void LL_CRS_DisableIT_ESYNC(void)
+{
+  CLEAR_BIT(CRS->CR, CRS_CR_ESYNCIE);
+}
+
+/**
+  * @brief  Check if Expected SYNC interrupt is enabled or not
+  * @rmtoll CR           ESYNCIE       LL_CRS_IsEnabledIT_ESYNC
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_CRS_IsEnabledIT_ESYNC(void)
+{
+  return ((READ_BIT(CRS->CR, CRS_CR_ESYNCIE) == (CRS_CR_ESYNCIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup CRS_LL_EF_Init Initialization and de-initialization functions
+  * @{
+  */
+
+ErrorStatus LL_CRS_DeInit(void);
+
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* defined(CRS) */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32G0xx_LL_CRS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_dac.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_dac.h
@@ -312,7 +312,7 @@ typedef struct
   * @{
   */
 #define LL_DAC_OUTPUT_CONNECT_GPIO         0x00000000U             /*!< The selected DAC channel output is connected to external pin */
-#define LL_DAC_OUTPUT_CONNECT_INTERNAL     (DAC_MCR_MODE1_0)       /*!< The selected DAC channel output is connected to on-chip peripherals via internal paths. On this STM32 serie, output connection depends on output mode (normal or sample and hold) and output buffer state. Refer to comments of function @ref LL_DAC_SetOutputConnection(). */
+#define LL_DAC_OUTPUT_CONNECT_INTERNAL     (DAC_MCR_MODE1_0)       /*!< The selected DAC channel output is connected to on-chip peripherals via internal paths. On this STM32 series, output connection depends on output mode (normal or sample and hold) and output buffer state. Refer to comments of function @ref LL_DAC_SetOutputConnection(). */
 /**
   * @}
   */
@@ -850,7 +850,7 @@ __STATIC_INLINE uint32_t LL_DAC_GetWaveTriangleAmplitude(DAC_TypeDef *DACx, uint
   *         - @ref LL_DAC_SetOutputBuffer()
   *         - @ref LL_DAC_SetOutputMode()
   *         - @ref LL_DAC_SetOutputConnection()
-  * @note   On this STM32 serie, output connection depends on output mode
+  * @note   On this STM32 series, output connection depends on output mode
   *         (normal or sample and hold) and output buffer state.
   *         - if output connection is set to internal path and output buffer
   *           is enabled (whatever output mode):
@@ -939,7 +939,7 @@ __STATIC_INLINE uint32_t LL_DAC_GetOutputMode(DAC_TypeDef *DACx, uint32_t DAC_Ch
 
 /**
   * @brief  Set the output buffer for the selected DAC channel.
-  * @note   On this STM32 serie, when buffer is enabled, its offset can be
+  * @note   On this STM32 series, when buffer is enabled, its offset can be
   *         trimmed: factory calibration default values can be
   *         replaced by user trimming values, using function
   *         @ref LL_DAC_SetTrimmingValue().
@@ -982,7 +982,7 @@ __STATIC_INLINE uint32_t LL_DAC_GetOutputBuffer(DAC_TypeDef *DACx, uint32_t DAC_
 
 /**
   * @brief  Set the output connection for the selected DAC channel.
-  * @note   On this STM32 serie, output connection depends on output mode (normal or
+  * @note   On this STM32 series, output connection depends on output mode (normal or
   *         sample and hold) and output buffer state.
   *         - if output connection is set to internal path and output buffer
   *           is enabled (whatever output mode):
@@ -1012,7 +1012,7 @@ __STATIC_INLINE void LL_DAC_SetOutputConnection(DAC_TypeDef *DACx, uint32_t DAC_
 
 /**
   * @brief  Get the output connection for the selected DAC channel.
-  * @note   On this STM32 serie, output connection depends on output mode (normal or
+  * @note   On this STM32 series, output connection depends on output mode (normal or
   *         sample and hold) and output buffer state.
   *         - if output connection is set to internal path and output buffer
   *           is enabled (whatever output mode):

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_dma.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_dma.h
@@ -33,7 +33,7 @@ extern "C" {
   * @{
   */
 
-#if defined (DMA1)
+#if defined (DMA1) || defined (DMA2)
 
 /** @defgroup DMA_LL DMA
   * @{
@@ -56,7 +56,7 @@ static const uint8_t CHANNEL_OFFSET_TAB[] =
   (uint8_t)(DMA1_Channel6_BASE - DMA1_BASE),
 #endif
 #if defined(DMA1_Channel7_BASE)
-  (uint8_t)(DMA1_Channel7_BASE - DMA1_BASE)
+  (uint8_t)(DMA1_Channel7_BASE - DMA1_BASE),
 #endif
 };
 /**
@@ -65,13 +65,22 @@ static const uint8_t CHANNEL_OFFSET_TAB[] =
 
 /* Private constants ---------------------------------------------------------*/
 /* Private macros ------------------------------------------------------------*/
+
 /** @defgroup DMA_LL_Private_Macros DMA Private Macros
   * @{
   */
 /**
+  * @brief  Helper macro to convert DMA Instance DMAx into DMAMUX channel
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
+  * @param  __DMA_INSTANCE__ DMAx
+  * @retval Channel_Offset (LL_DMA_CHANNEL_7 or 0).
+  */
+#define __LL_DMA_INSTANCE_TO_DMAMUX_CHANNEL(__DMA_INSTANCE__)   \
+(((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) ? 0 : LL_DMA_CHANNEL_7)
+/**
   * @}
   */
-
 /* Exported types ------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup DMA_LL_ES_INIT DMA Exported Init structure
@@ -247,16 +256,16 @@ typedef struct
 /** @defgroup DMA_LL_EC_CHANNEL CHANNEL
   * @{
   */
-#define LL_DMA_CHANNEL_1                  0x00000001U /*!< DMA Channel 1 */
-#define LL_DMA_CHANNEL_2                  0x00000002U /*!< DMA Channel 2 */
-#define LL_DMA_CHANNEL_3                  0x00000003U /*!< DMA Channel 3 */
-#define LL_DMA_CHANNEL_4                  0x00000004U /*!< DMA Channel 4 */
-#define LL_DMA_CHANNEL_5                  0x00000005U /*!< DMA Channel 5 */
+#define LL_DMA_CHANNEL_1                  0x00000000U /*!< DMA Channel 1 */
+#define LL_DMA_CHANNEL_2                  0x00000001U /*!< DMA Channel 2 */
+#define LL_DMA_CHANNEL_3                  0x00000002U /*!< DMA Channel 3 */
+#define LL_DMA_CHANNEL_4                  0x00000003U /*!< DMA Channel 4 */
+#define LL_DMA_CHANNEL_5                  0x00000004U /*!< DMA Channel 5 */
 #if defined(DMA1_Channel6)
-#define LL_DMA_CHANNEL_6                  0x00000006U /*!< DMA Channel 6 */
+#define LL_DMA_CHANNEL_6                  0x00000005U /*!< DMA Channel 6 */
 #endif
 #if defined(DMA1_Channel7)
-#define LL_DMA_CHANNEL_7                  0x00000007U /*!< DMA Channel 7 */
+#define LL_DMA_CHANNEL_7                  0x00000006U /*!< DMA Channel 7 */
 #endif
 #if defined(USE_FULL_LL_DRIVER)
 #define LL_DMA_CHANNEL_ALL                0xFFFF0000U /*!< DMA Channel all (used only for function @ref LL_DMA_DeInit(). */
@@ -373,14 +382,34 @@ typedef struct
   * @param  __CHANNEL_INSTANCE__ DMAx_Channely
   * @retval DMAx
   */
+#if defined(DMA2)
+#define __LL_DMA_GET_INSTANCE(__CHANNEL_INSTANCE__)   \
+(((uint32_t)(__CHANNEL_INSTANCE__) > ((uint32_t)DMA1_Channel7)) ?  DMA2 : DMA1)
+#else /* DMA1 */
 #define __LL_DMA_GET_INSTANCE(__CHANNEL_INSTANCE__)  (DMA1)
+#endif
 
 /**
   * @brief  Convert DMAx_Channely into LL_DMA_CHANNEL_y
   * @param  __CHANNEL_INSTANCE__ DMAx_Channely
   * @retval LL_DMA_CHANNEL_y
   */
-#if defined(DMA1_Channel6) && defined(DMA1_Channel7)
+#if defined(DMA2)
+#define __LL_DMA_GET_CHANNEL(__CHANNEL_INSTANCE__)   \
+(((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel1)) ? LL_DMA_CHANNEL_1 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel2)) ? LL_DMA_CHANNEL_2 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel3)) ? LL_DMA_CHANNEL_3 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel4)) ? LL_DMA_CHANNEL_4 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel5)) ? LL_DMA_CHANNEL_5 : \
+ ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
+ LL_DMA_CHANNEL_7)
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
 #define __LL_DMA_GET_CHANNEL(__CHANNEL_INSTANCE__)   \
 (((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
  ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
@@ -397,6 +426,7 @@ typedef struct
  ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
  LL_DMA_CHANNEL_5)
 #endif
+#endif /* DMA2 */
 
 /**
   * @brief  Convert DMA Instance DMAx and LL_DMA_CHANNEL_y into DMAx_Channely
@@ -404,7 +434,22 @@ typedef struct
   * @param  __CHANNEL__ LL_DMA_CHANNEL_y
   * @retval DMAx_Channely
   */
-#if defined(DMA1_Channel6) && defined(DMA1_Channel7)
+#if defined(DMA2)
+#define __LL_DMA_GET_CHANNEL_INSTANCE(__DMA_INSTANCE__, __CHANNEL__)   \
+((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA2_Channel1 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA2_Channel2 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA2_Channel3 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA2_Channel4 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA2_Channel5 : \
+ (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
+ DMA1_Channel7)
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
 #define __LL_DMA_GET_CHANNEL_INSTANCE(__DMA_INSTANCE__, __CHANNEL__)   \
 ((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
  (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
@@ -421,6 +466,7 @@ typedef struct
  (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
  DMA1_Channel5)
 #endif
+#endif /* DMA2 */
 
 /**
   * @}
@@ -455,7 +501,7 @@ typedef struct
 __STATIC_INLINE void LL_DMA_EnableChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel-1U]))->CCR, DMA_CCR_EN);
+  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_EN);
 }
 
 /**
@@ -475,7 +521,7 @@ __STATIC_INLINE void LL_DMA_EnableChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE void LL_DMA_DisableChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel-1U]))->CCR, DMA_CCR_EN);
+  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_EN);
 }
 
 /**
@@ -495,8 +541,8 @@ __STATIC_INLINE void LL_DMA_DisableChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
-                  DMA_CCR_EN) == (DMA_CCR_EN)) ? 1UL : 0UL);
+  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
+                    DMA_CCR_EN) == (DMA_CCR_EN)) ? 1UL : 0UL);
 }
 
 /**
@@ -531,7 +577,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannel(DMA_TypeDef *DMAx, uint32_t Cha
 __STATIC_INLINE void LL_DMA_ConfigTransfer(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t Configuration)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
              DMA_CCR_DIR | DMA_CCR_MEM2MEM | DMA_CCR_CIRC | DMA_CCR_PINC | DMA_CCR_MINC | DMA_CCR_PSIZE | DMA_CCR_MSIZE | DMA_CCR_PL,
              Configuration);
 }
@@ -558,7 +604,7 @@ __STATIC_INLINE void LL_DMA_ConfigTransfer(DMA_TypeDef *DMAx, uint32_t Channel, 
 __STATIC_INLINE void LL_DMA_SetDataTransferDirection(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t Direction)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
              DMA_CCR_DIR | DMA_CCR_MEM2MEM, Direction);
 }
 
@@ -583,7 +629,7 @@ __STATIC_INLINE void LL_DMA_SetDataTransferDirection(DMA_TypeDef *DMAx, uint32_t
 __STATIC_INLINE uint32_t LL_DMA_GetDataTransferDirection(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_DIR | DMA_CCR_MEM2MEM));
 }
 
@@ -609,7 +655,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetDataTransferDirection(DMA_TypeDef *DMAx, uint
 __STATIC_INLINE void LL_DMA_SetMode(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t Mode)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_CIRC,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_CIRC,
              Mode);
 }
 
@@ -632,7 +678,7 @@ __STATIC_INLINE void LL_DMA_SetMode(DMA_TypeDef *DMAx, uint32_t Channel, uint32_
 __STATIC_INLINE uint32_t LL_DMA_GetMode(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_CIRC));
 }
 
@@ -655,8 +701,8 @@ __STATIC_INLINE uint32_t LL_DMA_GetMode(DMA_TypeDef *DMAx, uint32_t Channel)
   */
 __STATIC_INLINE void LL_DMA_SetPeriphIncMode(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t PeriphOrM2MSrcIncMode)
 {
-    uint32_t dma_base_addr = (uint32_t)DMAx;
-    MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_PINC,
+  uint32_t dma_base_addr = (uint32_t)DMAx;
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_PINC,
              PeriphOrM2MSrcIncMode);
 }
 
@@ -679,7 +725,7 @@ __STATIC_INLINE void LL_DMA_SetPeriphIncMode(DMA_TypeDef *DMAx, uint32_t Channel
 __STATIC_INLINE uint32_t LL_DMA_GetPeriphIncMode(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_PINC));
 }
 
@@ -703,7 +749,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetPeriphIncMode(DMA_TypeDef *DMAx, uint32_t Cha
 __STATIC_INLINE void LL_DMA_SetMemoryIncMode(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryOrM2MDstIncMode)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_MINC,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_MINC,
              MemoryOrM2MDstIncMode);
 }
 
@@ -726,7 +772,7 @@ __STATIC_INLINE void LL_DMA_SetMemoryIncMode(DMA_TypeDef *DMAx, uint32_t Channel
 __STATIC_INLINE uint32_t LL_DMA_GetMemoryIncMode(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_MINC));
 }
 
@@ -751,7 +797,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetMemoryIncMode(DMA_TypeDef *DMAx, uint32_t Cha
 __STATIC_INLINE void LL_DMA_SetPeriphSize(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t PeriphOrM2MSrcDataSize)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_PSIZE,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_PSIZE,
              PeriphOrM2MSrcDataSize);
 }
 
@@ -775,7 +821,7 @@ __STATIC_INLINE void LL_DMA_SetPeriphSize(DMA_TypeDef *DMAx, uint32_t Channel, u
 __STATIC_INLINE uint32_t LL_DMA_GetPeriphSize(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_PSIZE));
 }
 
@@ -800,7 +846,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetPeriphSize(DMA_TypeDef *DMAx, uint32_t Channe
 __STATIC_INLINE void LL_DMA_SetMemorySize(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryOrM2MDstDataSize)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_MSIZE,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_MSIZE,
              MemoryOrM2MDstDataSize);
 }
 
@@ -824,7 +870,7 @@ __STATIC_INLINE void LL_DMA_SetMemorySize(DMA_TypeDef *DMAx, uint32_t Channel, u
 __STATIC_INLINE uint32_t LL_DMA_GetMemorySize(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_MSIZE));
 }
 
@@ -850,7 +896,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetMemorySize(DMA_TypeDef *DMAx, uint32_t Channe
 __STATIC_INLINE void LL_DMA_SetChannelPriorityLevel(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t Priority)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_PL,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_PL,
              Priority);
 }
 
@@ -875,7 +921,7 @@ __STATIC_INLINE void LL_DMA_SetChannelPriorityLevel(DMA_TypeDef *DMAx, uint32_t 
 __STATIC_INLINE uint32_t LL_DMA_GetChannelPriorityLevel(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
                    DMA_CCR_PL));
 }
 
@@ -899,7 +945,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetChannelPriorityLevel(DMA_TypeDef *DMAx, uint3
 __STATIC_INLINE void LL_DMA_SetDataLength(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t NbData)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CNDTR,
+  MODIFY_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CNDTR,
              DMA_CNDTR_NDT, NbData);
 }
 
@@ -922,14 +968,14 @@ __STATIC_INLINE void LL_DMA_SetDataLength(DMA_TypeDef *DMAx, uint32_t Channel, u
 __STATIC_INLINE uint32_t LL_DMA_GetDataLength(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CNDTR,
+  return (READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CNDTR,
                    DMA_CNDTR_NDT));
 }
 
 /**
   * @brief  Configure the Source and Destination addresses.
   * @note   This API must not be called when the DMA channel is enabled.
-  * @note   Each peripheral using DMA provides an API to get directly the register adress (LL_PPP_DMA_GetRegAddr).
+  * @note   Each peripheral using DMA provides an API to get directly the register address (LL_PPP_DMA_GetRegAddr).
   * @rmtoll CPAR         PA            LL_DMA_ConfigAddresses\n
   *         CMAR         MA            LL_DMA_ConfigAddresses
   * @param  DMAx DMAx Instance
@@ -956,14 +1002,14 @@ __STATIC_INLINE void LL_DMA_ConfigAddresses(DMA_TypeDef *DMAx, uint32_t Channel,
   /* Direction Memory to Periph */
   if (Direction == LL_DMA_DIRECTION_MEMORY_TO_PERIPH)
   {
-    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CMAR, SrcAddress);
-    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CPAR, DstAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CMAR, SrcAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CPAR, DstAddress);
   }
   /* Direction Periph to Memory and Memory to Memory */
   else
   {
-    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CPAR, SrcAddress);
-    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CMAR, DstAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CPAR, SrcAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CMAR, DstAddress);
   }
 }
 
@@ -987,7 +1033,7 @@ __STATIC_INLINE void LL_DMA_ConfigAddresses(DMA_TypeDef *DMAx, uint32_t Channel,
 __STATIC_INLINE void LL_DMA_SetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryAddress)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CMAR, MemoryAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CMAR, MemoryAddress);
 }
 
 /**
@@ -1010,7 +1056,7 @@ __STATIC_INLINE void LL_DMA_SetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Channel
 __STATIC_INLINE void LL_DMA_SetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t PeriphAddress)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CPAR, PeriphAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CPAR, PeriphAddress);
 }
 
 /**
@@ -1031,7 +1077,7 @@ __STATIC_INLINE void LL_DMA_SetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Channel
 __STATIC_INLINE uint32_t LL_DMA_GetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CMAR));
+  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CMAR));
 }
 
 /**
@@ -1052,7 +1098,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Cha
 __STATIC_INLINE uint32_t LL_DMA_GetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CPAR));
+  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CPAR));
 }
 
 /**
@@ -1075,7 +1121,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Cha
 __STATIC_INLINE void LL_DMA_SetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryAddress)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CPAR, MemoryAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CPAR, MemoryAddress);
 }
 
 /**
@@ -1098,7 +1144,7 @@ __STATIC_INLINE void LL_DMA_SetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Channel
 __STATIC_INLINE void LL_DMA_SetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryAddress)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CMAR, MemoryAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CMAR, MemoryAddress);
 }
 
 /**
@@ -1119,7 +1165,7 @@ __STATIC_INLINE void LL_DMA_SetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Channel
 __STATIC_INLINE uint32_t LL_DMA_GetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CPAR));
+  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CPAR));
 }
 
 /**
@@ -1140,12 +1186,13 @@ __STATIC_INLINE uint32_t LL_DMA_GetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Cha
 __STATIC_INLINE uint32_t LL_DMA_GetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CMAR));
+  return (READ_REG(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CMAR));
 }
 
 /**
   * @brief  Set DMA request for DMA Channels on DMAMUX Channel x.
   * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         DMAREQ_ID     LL_DMA_SetPeriphRequest
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1202,10 +1249,10 @@ __STATIC_INLINE uint32_t LL_DMA_GetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Cha
   *         @arg @ref LL_DMAMUX_REQ_TIM15_TRIG_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM15_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM16_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM16_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM16_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM16_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM17_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM17_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM17_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM17_UP
   *         @arg @ref LL_DMAMUX_REQ_USART1_RX
   *         @arg @ref LL_DMAMUX_REQ_USART1_TX
@@ -1223,13 +1270,14 @@ __STATIC_INLINE uint32_t LL_DMA_GetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Cha
   */
 __STATIC_INLINE void LL_DMA_SetPeriphRequest(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t Request)
 {
-  (void)(DMAx);
-  MODIFY_REG(((DMAMUX_Channel_TypeDef *)((uint32_t)DMAMUX1_Channel0 + (DMAMUX_CCR_SIZE * (Channel - 1UL))))->CCR, DMAMUX_CxCR_DMAREQ_ID, Request);
+  uint32_t dmamux_ccr_offset = ((((uint32_t)DMAx ^ (uint32_t)DMA1) >> 10U) * 7U);
+  MODIFY_REG((DMAMUX1_Channel0 + Channel + dmamux_ccr_offset)->CCR, DMAMUX_CxCR_DMAREQ_ID, Request);
 }
 
 /**
   * @brief  Get DMA request for DMA Channels on DMAMUX Channel x.
   * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         DMAREQ_ID     LL_DMA_GetPeriphRequest
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1286,10 +1334,10 @@ __STATIC_INLINE void LL_DMA_SetPeriphRequest(DMA_TypeDef *DMAx, uint32_t Channel
   *         @arg @ref LL_DMAMUX_REQ_TIM15_TRIG_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM15_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM16_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM16_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM16_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM16_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM17_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM17_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM17_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM17_UP
   *         @arg @ref LL_DMAMUX_REQ_USART1_RX
   *         @arg @ref LL_DMAMUX_REQ_USART1_TX
@@ -1306,8 +1354,8 @@ __STATIC_INLINE void LL_DMA_SetPeriphRequest(DMA_TypeDef *DMAx, uint32_t Channel
   */
 __STATIC_INLINE uint32_t LL_DMA_GetPeriphRequest(DMA_TypeDef *DMAx, uint32_t Channel)
 {
-  (void)(DMAx);
-  return (READ_BIT(((DMAMUX_Channel_TypeDef *)(((uint32_t)DMAMUX1_Channel0 + (DMAMUX_CCR_SIZE * (Channel - 1UL)))))->CCR, DMAMUX_CxCR_DMAREQ_ID));
+  uint32_t dmamux_ccr_offset = ((((uint32_t)DMAx ^ (uint32_t)DMA1) >> 10U) * 7U);
+  return (READ_BIT((DMAMUX1_Channel0 + Channel + dmamux_ccr_offset)->CCR, DMAMUX_CxCR_DMAREQ_ID));
 }
 
 /**
@@ -1373,6 +1421,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_GI5(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_GIF5) == (DMA_ISR_GIF5)) ? 1UL : 0UL);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Get Channel 6 global interrupt flag.
   * @rmtoll ISR          GIF6          LL_DMA_IsActiveFlag_GI6
@@ -1384,6 +1433,8 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_GI6(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_GIF6) == (DMA_ISR_GIF6)) ? 1UL : 0UL);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Get Channel 7 global interrupt flag.
   * @rmtoll ISR          GIF7          LL_DMA_IsActiveFlag_GI7
@@ -1395,6 +1446,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_GI7(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_GIF7) == (DMA_ISR_GIF7)) ? 1UL : 0UL);
 }
 
+#endif
 /**
   * @brief  Get Channel 1 transfer complete flag.
   * @rmtoll ISR          TCIF1         LL_DMA_IsActiveFlag_TC1
@@ -1450,6 +1502,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TC5(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_TCIF5) == (DMA_ISR_TCIF5)) ? 1UL : 0UL);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Get Channel 6 transfer complete flag.
   * @rmtoll ISR          TCIF6         LL_DMA_IsActiveFlag_TC6
@@ -1461,6 +1514,8 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TC6(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_TCIF6) == (DMA_ISR_TCIF6)) ? 1UL : 0UL);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Get Channel 7 transfer complete flag.
   * @rmtoll ISR          TCIF7         LL_DMA_IsActiveFlag_TC7
@@ -1472,6 +1527,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TC7(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_TCIF7) == (DMA_ISR_TCIF7)) ? 1UL : 0UL);
 }
 
+#endif
 /**
   * @brief  Get Channel 1 half transfer flag.
   * @rmtoll ISR          HTIF1         LL_DMA_IsActiveFlag_HT1
@@ -1527,6 +1583,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_HT5(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_HTIF5) == (DMA_ISR_HTIF5)) ? 1UL : 0UL);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Get Channel 6 half transfer flag.
   * @rmtoll ISR          HTIF6         LL_DMA_IsActiveFlag_HT6
@@ -1538,6 +1595,8 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_HT6(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_HTIF6) == (DMA_ISR_HTIF6)) ? 1UL : 0UL);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Get Channel 7 half transfer flag.
   * @rmtoll ISR          HTIF7         LL_DMA_IsActiveFlag_HT7
@@ -1549,6 +1608,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_HT7(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_HTIF7) == (DMA_ISR_HTIF7)) ? 1UL : 0UL);
 }
 
+#endif
 /**
   * @brief  Get Channel 1 transfer error flag.
   * @rmtoll ISR          TEIF1         LL_DMA_IsActiveFlag_TE1
@@ -1604,6 +1664,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TE5(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_TEIF5) == (DMA_ISR_TEIF5)) ? 1UL : 0UL);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Get Channel 6 transfer error flag.
   * @rmtoll ISR          TEIF6         LL_DMA_IsActiveFlag_TE6
@@ -1615,6 +1676,8 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TE6(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_TEIF6) == (DMA_ISR_TEIF6)) ? 1UL : 0UL);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Get Channel 7 transfer error flag.
   * @rmtoll ISR          TEIF7         LL_DMA_IsActiveFlag_TE7
@@ -1626,8 +1689,13 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TE7(DMA_TypeDef *DMAx)
   return ((READ_BIT(DMAx->ISR, DMA_ISR_TEIF7) == (DMA_ISR_TEIF7)) ? 1UL : 0UL);
 }
 
+#endif
 /**
   * @brief  Clear Channel 1 global interrupt flag.
+  * @note Do not Clear Channel 1 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC1, LL_DMA_ClearFlag_HT1,
+    LL_DMA_ClearFlag_TE1. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF1         LL_DMA_ClearFlag_GI1
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1639,6 +1707,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI1(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 2 global interrupt flag.
+  * @note Do not Clear Channel 2 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC2, LL_DMA_ClearFlag_HT2,
+    LL_DMA_ClearFlag_TE2. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF2         LL_DMA_ClearFlag_GI2
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1650,6 +1722,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI2(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 3 global interrupt flag.
+  * @note Do not Clear Channel 3 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC3, LL_DMA_ClearFlag_HT3,
+    LL_DMA_ClearFlag_TE3. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF3         LL_DMA_ClearFlag_GI3
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1661,6 +1737,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI3(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 4 global interrupt flag.
+  * @note Do not Clear Channel 4 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC4, LL_DMA_ClearFlag_HT4,
+    LL_DMA_ClearFlag_TE4. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF4         LL_DMA_ClearFlag_GI4
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1672,6 +1752,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI4(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 5 global interrupt flag.
+  * @note Do not Clear Channel 5 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC5, LL_DMA_ClearFlag_HT5,
+    LL_DMA_ClearFlag_TE5. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF5         LL_DMA_ClearFlag_GI5
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1681,8 +1765,13 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI5(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CGIF5);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Clear Channel 6 global interrupt flag.
+  * @note Do not Clear Channel 6 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC6, LL_DMA_ClearFlag_HT6,
+    LL_DMA_ClearFlag_TE6. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF6         LL_DMA_ClearFlag_GI6
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1692,8 +1781,14 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI6(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CGIF6);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Clear Channel 7 global interrupt flag.
+  * @note Do not Clear Channel 7 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC7, LL_DMA_ClearFlag_HT7,
+    LL_DMA_ClearFlag_TE7. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF7         LL_DMA_ClearFlag_GI7
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1703,6 +1798,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI7(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CGIF7);
 }
 
+#endif
 /**
   * @brief  Clear Channel 1  transfer complete flag.
   * @rmtoll IFCR         CTCIF1        LL_DMA_ClearFlag_TC1
@@ -1758,6 +1854,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TC5(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CTCIF5);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Clear Channel 6  transfer complete flag.
   * @rmtoll IFCR         CTCIF6        LL_DMA_ClearFlag_TC6
@@ -1769,6 +1866,8 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TC6(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CTCIF6);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Clear Channel 7  transfer complete flag.
   * @rmtoll IFCR         CTCIF7        LL_DMA_ClearFlag_TC7
@@ -1780,6 +1879,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TC7(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CTCIF7);
 }
 
+#endif
 /**
   * @brief  Clear Channel 1  half transfer flag.
   * @rmtoll IFCR         CHTIF1        LL_DMA_ClearFlag_HT1
@@ -1835,6 +1935,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_HT5(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CHTIF5);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Clear Channel 6  half transfer flag.
   * @rmtoll IFCR         CHTIF6        LL_DMA_ClearFlag_HT6
@@ -1846,6 +1947,8 @@ __STATIC_INLINE void LL_DMA_ClearFlag_HT6(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CHTIF6);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Clear Channel 7  half transfer flag.
   * @rmtoll IFCR         CHTIF7        LL_DMA_ClearFlag_HT7
@@ -1857,6 +1960,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_HT7(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CHTIF7);
 }
 
+#endif
 /**
   * @brief  Clear Channel 1 transfer error flag.
   * @rmtoll IFCR         CTEIF1        LL_DMA_ClearFlag_TE1
@@ -1912,6 +2016,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TE5(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CTEIF5);
 }
 
+#if defined(DMA1_Channel6)
 /**
   * @brief  Clear Channel 6 transfer error flag.
   * @rmtoll IFCR         CTEIF6        LL_DMA_ClearFlag_TE6
@@ -1923,6 +2028,8 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TE6(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CTEIF6);
 }
 
+#endif
+#if defined(DMA1_Channel7)
 /**
   * @brief  Clear Channel 7 transfer error flag.
   * @rmtoll IFCR         CTEIF7        LL_DMA_ClearFlag_TE7
@@ -1934,6 +2041,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TE7(DMA_TypeDef *DMAx)
   WRITE_REG(DMAx->IFCR, DMA_IFCR_CTEIF7);
 }
 
+#endif
 /**
   * @}
   */
@@ -1958,7 +2066,7 @@ __STATIC_INLINE void LL_DMA_ClearFlag_TE7(DMA_TypeDef *DMAx)
 __STATIC_INLINE void LL_DMA_EnableIT_TC(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_TCIE);
+  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_TCIE);
 }
 
 /**
@@ -1978,7 +2086,7 @@ __STATIC_INLINE void LL_DMA_EnableIT_TC(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE void LL_DMA_EnableIT_HT(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_HTIE);
+  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_HTIE);
 }
 
 /**
@@ -1998,7 +2106,7 @@ __STATIC_INLINE void LL_DMA_EnableIT_HT(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE void LL_DMA_EnableIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_TEIE);
+  SET_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_TEIE);
 }
 
 /**
@@ -2018,7 +2126,7 @@ __STATIC_INLINE void LL_DMA_EnableIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE void LL_DMA_DisableIT_TC(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_TCIE);
+  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_TCIE);
 }
 
 /**
@@ -2038,7 +2146,7 @@ __STATIC_INLINE void LL_DMA_DisableIT_TC(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE void LL_DMA_DisableIT_HT(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_HTIE);
+  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_HTIE);
 }
 
 /**
@@ -2058,7 +2166,7 @@ __STATIC_INLINE void LL_DMA_DisableIT_HT(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE void LL_DMA_DisableIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR, DMA_CCR_TEIE);
+  CLEAR_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR, DMA_CCR_TEIE);
 }
 
 /**
@@ -2078,8 +2186,8 @@ __STATIC_INLINE void LL_DMA_DisableIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TC(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
-                   DMA_CCR_TCIE) == (DMA_CCR_TCIE)) ? 1UL : 0UL);
+  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
+                    DMA_CCR_TCIE) == (DMA_CCR_TCIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2099,8 +2207,8 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TC(DMA_TypeDef *DMAx, uint32_t Chann
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_HT(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
-                   DMA_CCR_HTIE) == (DMA_CCR_HTIE)) ? 1UL : 0UL);
+  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
+                    DMA_CCR_HTIE) == (DMA_CCR_HTIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2120,8 +2228,8 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_HT(DMA_TypeDef *DMAx, uint32_t Chann
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   uint32_t dma_base_addr = (uint32_t)DMAx;
-  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel - 1U]))->CCR,
-                   DMA_CCR_TEIE) == (DMA_CCR_TEIE)) ? 1UL : 0UL);
+  return ((READ_BIT(((DMA_Channel_TypeDef *)(dma_base_addr + CHANNEL_OFFSET_TAB[Channel]))->CCR,
+                    DMA_CCR_TEIE) == (DMA_CCR_TEIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2132,7 +2240,6 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TE(DMA_TypeDef *DMAx, uint32_t Chann
 /** @defgroup DMA_LL_EF_Init Initialization and de-initialization functions
   * @{
   */
-
 ErrorStatus LL_DMA_Init(DMA_TypeDef *DMAx, uint32_t Channel, LL_DMA_InitTypeDef *DMA_InitStruct);
 ErrorStatus LL_DMA_DeInit(DMA_TypeDef *DMAx, uint32_t Channel);
 void LL_DMA_StructInit(LL_DMA_InitTypeDef *DMA_InitStruct);
@@ -2150,7 +2257,7 @@ void LL_DMA_StructInit(LL_DMA_InitTypeDef *DMA_InitStruct);
   * @}
   */
 
-#endif /* DMA1 */
+#endif /* DMA1 || DMA2 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_dmamux.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_dmamux.h
@@ -74,6 +74,13 @@ extern "C" {
 #if defined(DMAMUX1_Channel6)
 #define LL_DMAMUX_CFR_CSOF6               DMAMUX_CFR_CSOF6       /*!< Synchronization Event Overrun Flag Channel 6  */
 #endif
+#if defined(DMA2)
+#define LL_DMAMUX_CFR_CSOF7               DMAMUX_CFR_CSOF7       /*!< Synchronization Event Overrun Flag Channel 7  */
+#define LL_DMAMUX_CFR_CSOF8               DMAMUX_CFR_CSOF8       /*!< Synchronization Event Overrun Flag Channel 8  */
+#define LL_DMAMUX_CFR_CSOF9               DMAMUX_CFR_CSOF9       /*!< Synchronization Event Overrun Flag Channel 9  */
+#define LL_DMAMUX_CFR_CSOF10              DMAMUX_CFR_CSOF10      /*!< Synchronization Event Overrun Flag Channel 10 */
+#define LL_DMAMUX_CFR_CSOF11              DMAMUX_CFR_CSOF11      /*!< Synchronization Event Overrun Flag Channel 11 */
+#endif /* DMA2 */
 #define LL_DMAMUX_RGCFR_RGCOF0            DMAMUX_RGCFR_COF0      /*!< Request Generator 0 Trigger Event Overrun Flag */
 #define LL_DMAMUX_RGCFR_RGCOF1            DMAMUX_RGCFR_COF1      /*!< Request Generator 1 Trigger Event Overrun Flag */
 #define LL_DMAMUX_RGCFR_RGCOF2            DMAMUX_RGCFR_COF2      /*!< Request Generator 2 Trigger Event Overrun Flag */
@@ -97,6 +104,13 @@ extern "C" {
 #if defined(DMAMUX1_Channel6)
 #define LL_DMAMUX_CSR_SOF6                DMAMUX_CSR_SOF6       /*!< Synchronization Event Overrun Flag Channel 6  */
 #endif
+#if defined(DMA2)
+#define LL_DMAMUX_CSR_SOF7                DMAMUX_CSR_SOF7       /*!< Synchronization Event Overrun Flag Channel 7  */
+#define LL_DMAMUX_CSR_SOF8                DMAMUX_CSR_SOF8       /*!< Synchronization Event Overrun Flag Channel 8  */
+#define LL_DMAMUX_CSR_SOF9                DMAMUX_CSR_SOF9       /*!< Synchronization Event Overrun Flag Channel 9  */
+#define LL_DMAMUX_CSR_SOF10               DMAMUX_CSR_SOF10      /*!< Synchronization Event Overrun Flag Channel 10 */
+#define LL_DMAMUX_CSR_SOF11               DMAMUX_CSR_SOF11      /*!< Synchronization Event Overrun Flag Channel 11 */
+#endif /* DMA2 */
 #define LL_DMAMUX_RGSR_RGOF0              DMAMUX_RGSR_OF0       /*!< Request Generator 0 Trigger Event Overrun Flag */
 #define LL_DMAMUX_RGSR_RGOF1              DMAMUX_RGSR_OF1       /*!< Request Generator 1 Trigger Event Overrun Flag */
 #define LL_DMAMUX_RGSR_RGOF2              DMAMUX_RGSR_OF2       /*!< Request Generator 2 Trigger Event Overrun Flag */
@@ -177,10 +191,10 @@ extern "C" {
 #define LL_DMAMUX_REQ_TIM15_UP            0x0000002BU  /*!< DMAMUX TIM15 UP request    */
 #endif
 #define LL_DMAMUX_REQ_TIM16_CH1           0x0000002CU  /*!< DMAMUX TIM16 CH1 request   */
-#define LL_DMAMUX_REQ_TIM16_TRIG_COM      0x0000002DU  /*!< DMAMUX TIM16 TRIG COM request */
+#define LL_DMAMUX_REQ_TIM16_COM           0x0000002DU  /*!< DMAMUX TIM16 COM request   */
 #define LL_DMAMUX_REQ_TIM16_UP            0x0000002EU  /*!< DMAMUX TIM16 UP request    */
-#define LL_DMAMUX_REQ_TIM17_CH1           0x0000002FU  /*!< DMAMUX TIM17 CH1 request    */
-#define LL_DMAMUX_REQ_TIM17_TRIG_COM      0x00000030U  /*!< DMAMUX TIM17 TRIG COM request */
+#define LL_DMAMUX_REQ_TIM17_CH1           0x0000002FU  /*!< DMAMUX TIM17 CH1 request   */
+#define LL_DMAMUX_REQ_TIM17_COM           0x00000030U  /*!< DMAMUX TIM17 COM request   */
 #define LL_DMAMUX_REQ_TIM17_UP            0x00000031U  /*!< DMAMUX TIM17 UP request    */
 #define LL_DMAMUX_REQ_USART1_RX           0x00000032U  /*!< DMAMUX USART1 RX request  */
 #define LL_DMAMUX_REQ_USART1_TX           0x00000033U  /*!< DMAMUX USART1 TX request  */
@@ -202,6 +216,52 @@ extern "C" {
 #define LL_DMAMUX_REQ_UCPD2_RX            0x0000003CU  /*!< DMAMUX UCPD2 RX request  */
 #define LL_DMAMUX_REQ_UCPD2_TX            0x0000003DU  /*!< DMAMUX UCPD2 TX request  */
 #endif
+
+#if defined(I2C3)
+#define LL_DMAMUX_REQ_I2C3_RX             0x0000003EU  /*!< DMAMUX I2C3 RX request  */
+#define LL_DMAMUX_REQ_I2C3_TX             0x0000003FU  /*!< DMAMUX I2C3 TX request  */
+#endif
+
+#if defined(LPUART2)
+#define LL_DMAMUX_REQ_LPUART2_RX          0x00000040U  /*!< DMAMUX LPUART2 RX request  */
+#define LL_DMAMUX_REQ_LPUART2_TX          0x00000041U  /*!< DMAMUX LPUART2 TX request  */
+#endif
+
+#if defined(SPI3)
+#define LL_DMAMUX_REQ_SPI3_RX             0x00000042U  /*!< DMAMUX SPI3 RX request     */
+#define LL_DMAMUX_REQ_SPI3_TX             0x00000043U  /*!< DMAMUX SPI3 TX request     */
+#endif
+
+#if defined(TIM4)
+#define LL_DMAMUX_REQ_TIM4_CH1            0x00000044U  /*!< DMAMUX TIM4 CH1 request    */
+#define LL_DMAMUX_REQ_TIM4_CH2            0x00000045U  /*!< DMAMUX TIM4 CH2 request    */
+#define LL_DMAMUX_REQ_TIM4_CH3            0x00000046U  /*!< DMAMUX TIM4 CH3 request    */
+#define LL_DMAMUX_REQ_TIM4_CH4            0x00000047U  /*!< DMAMUX TIM4 CH4 request    */
+#define LL_DMAMUX_REQ_TIM4_TRIG           0x00000048U  /*!< DMAMUX TIM4 TRIG request   */
+#define LL_DMAMUX_REQ_TIM4_UP             0x00000049U  /*!< DMAMUX TIM4 UP request     */
+#endif
+
+#if defined(USART5)
+#define LL_DMAMUX_REQ_USART5_RX           0x0000004AU  /*!< DMAMUX USART5 RX request  */
+#define LL_DMAMUX_REQ_USART5_TX           0x0000004BU  /*!< DMAMUX USART5 TX request  */
+#endif
+
+#if defined(USART6)
+#define LL_DMAMUX_REQ_USART6_RX           0x0000004CU  /*!< DMAMUX USART6 RX request  */
+#define LL_DMAMUX_REQ_USART6_TX           0x0000004DU  /*!< DMAMUX USART6 TX request  */
+#endif
+
+#if defined(STM32G0C1xx)||defined(STM32G0B1xx)
+#define LL_DMAMUX_MAX_REQ                 LL_DMAMUX_REQ_USART6_TX
+#elif defined(STM32G0B0xx)
+#define LL_DMAMUX_MAX_REQ                 LL_DMAMUX_REQ_USART4_TX
+#elif defined(STM32G081xx)||defined(STM32G071xx)
+#define LL_DMAMUX_MAX_REQ                 LL_DMAMUX_REQ_UCPD2_TX
+#elif defined(STM32G070xx)
+#define LL_DMAMUX_MAX_REQ                 LL_DMAMUX_REQ_USART4_TX
+#else
+#define LL_DMAMUX_MAX_REQ                 LL_DMAMUX_REQ_USART2_TX
+#endif
 /**
   * @}
   */
@@ -219,6 +279,13 @@ extern "C" {
 #endif
 #if defined(DMAMUX1_Channel6)
 #define LL_DMAMUX_CHANNEL_6               0x00000006U               /*!< DMAMUX Channel 6 connected to DMA1 Channel 7  */
+#endif
+#if defined(DMA2)
+#define LL_DMAMUX_CHANNEL_7               0x00000007U               /*!< DMAMUX Channel 7 connected to DMA2 Channel 1  */
+#define LL_DMAMUX_CHANNEL_8               0x00000008U               /*!< DMAMUX Channel 8 connected to DMA2 Channel 2  */
+#define LL_DMAMUX_CHANNEL_9               0x00000009U               /*!< DMAMUX Channel 9 connected to DMA2 Channel 3  */
+#define LL_DMAMUX_CHANNEL_10              0x0000000AU               /*!< DMAMUX Channel 10 connected to DMA2 Channel 4 */
+#define LL_DMAMUX_CHANNEL_11              0x0000000BU               /*!< DMAMUX Channel 11 connected to DMA2 Channel 5 */
 #endif
 /**
   * @}
@@ -259,10 +326,10 @@ extern "C" {
 #define LL_DMAMUX_SYNC_DMAMUX_CH2         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_1)                                                 /*!< Synchronization signal from DMAMUX channel2 Event */
 #define LL_DMAMUX_SYNC_DMAMUX_CH3         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_1 | DMAMUX_CxCR_SYNC_ID_0)                         /*!< Synchronization signal from DMAMUX channel3 Event */
 #if defined(LPTIM1)
-#define LL_DMAMUX_SYNC_LPTIM1_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_2)                                                 /*!< Synchronization signal from LPTIM1 Ouput */
+#define LL_DMAMUX_SYNC_LPTIM1_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_2)                                                 /*!< Synchronization signal from LPTIM1 Output */
 #endif
 #if defined(LPTIM2)
-#define LL_DMAMUX_SYNC_LPTIM2_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_2 | DMAMUX_CxCR_SYNC_ID_0)                         /*!< Synchronization signal from LPTIM2 Ouput */
+#define LL_DMAMUX_SYNC_LPTIM2_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_2 | DMAMUX_CxCR_SYNC_ID_0)                         /*!< Synchronization signal from LPTIM2 Output */
 #endif
 #define LL_DMAMUX_SYNC_TIM14_OC           (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_2 | DMAMUX_CxCR_SYNC_ID_1)                         /*!< Synchronization signal from TIM14 OC */
 /**
@@ -315,10 +382,10 @@ extern "C" {
 #define LL_DMAMUX_REQ_GEN_DMAMUX_CH2      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_1)                                                 /*!< Request signal generation from DMAMUX channel2 Event */
 #define LL_DMAMUX_REQ_GEN_DMAMUX_CH3      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_1 | DMAMUX_RGxCR_SIG_ID_0)                         /*!< Request signal generation from DMAMUX channel3 Event */
 #if defined(LPTIM1)
-#define LL_DMAMUX_REQ_GEN_LPTIM1_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_2)                                                 /*!< Request signal generation from LPTIM1 Ouput */
+#define LL_DMAMUX_REQ_GEN_LPTIM1_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_2)                                                 /*!< Request signal generation from LPTIM1 Output */
 #endif
 #if defined(LPTIM2)
-#define LL_DMAMUX_REQ_GEN_LPTIM2_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_2 | DMAMUX_RGxCR_SIG_ID_0)                         /*!< Request signal generation from LPTIM2 Ouput */
+#define LL_DMAMUX_REQ_GEN_LPTIM2_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_2 | DMAMUX_RGxCR_SIG_ID_0)                         /*!< Request signal generation from LPTIM2 Output */
 #endif
 #define LL_DMAMUX_REQ_GEN_TIM14_OC        (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_2 | DMAMUX_RGxCR_SIG_ID_1)                         /*!< Request signal generation from TIM14 OC */
 /**
@@ -372,6 +439,7 @@ extern "C" {
 /**
   * @brief  Set DMAMUX request ID for DMAMUX Channel x.
   * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         DMAREQ_ID     LL_DMAMUX_SetRequestID
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -380,8 +448,15 @@ extern "C" {
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @param  Request This parameter can be one of the following values:
   *         @arg @ref LL_DMAMUX_REQ_MEM2MEM
   *         @arg @ref LL_DMAMUX_REQ_GENERATOR0
@@ -428,10 +503,10 @@ extern "C" {
   *         @arg @ref LL_DMAMUX_REQ_TIM15_TRIG_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM15_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM16_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM16_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM16_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM16_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM17_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM17_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM17_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM17_UP
   *         @arg @ref LL_DMAMUX_REQ_USART1_RX
   *         @arg @ref LL_DMAMUX_REQ_USART1_TX
@@ -456,6 +531,7 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestID(DMAMUX_Channel_TypeDef *DMAMUXx, uin
 /**
   * @brief  Get DMAMUX request ID for DMAMUX Channel x.
   * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         DMAREQ_ID     LL_DMAMUX_GetRequestID
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -464,8 +540,15 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestID(DMAMUX_Channel_TypeDef *DMAMUXx, uin
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_DMAMUX_REQ_MEM2MEM
   *         @arg @ref LL_DMAMUX_REQ_GENERATOR0
@@ -512,10 +595,10 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestID(DMAMUX_Channel_TypeDef *DMAMUXx, uin
   *         @arg @ref LL_DMAMUX_REQ_TIM15_TRIG_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM15_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM16_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM16_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM16_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM16_UP
   *         @arg @ref LL_DMAMUX_REQ_TIM17_CH1
-  *         @arg @ref LL_DMAMUX_REQ_TIM17_TRIG_COM
+  *         @arg @ref LL_DMAMUX_REQ_TIM17_COM
   *         @arg @ref LL_DMAMUX_REQ_TIM17_UP
   *         @arg @ref LL_DMAMUX_REQ_USART1_RX
   *         @arg @ref LL_DMAMUX_REQ_USART1_TX
@@ -538,6 +621,8 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestID(DMAMUX_Channel_TypeDef *DMAMUXx,
 
 /**
   * @brief  Set the number of DMA request that will be autorized after a synchronization event and/or the number of DMA request needed to generate an event.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         NBREQ         LL_DMAMUX_SetSyncRequestNb
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -546,8 +631,15 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestID(DMAMUX_Channel_TypeDef *DMAMUXx,
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @param  RequestNb This parameter must be a value between Min_Data = 1 and Max_Data = 32.
   * @retval None
   */
@@ -559,6 +651,8 @@ __STATIC_INLINE void LL_DMAMUX_SetSyncRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx,
 
 /**
   * @brief  Get the number of DMA request that will be autorized after a synchronization event and/or the number of DMA request needed to generate an event.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         NBREQ         LL_DMAMUX_GetSyncRequestNb
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -567,8 +661,15 @@ __STATIC_INLINE void LL_DMAMUX_SetSyncRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx,
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval Between Min_Data = 1 and Max_Data = 32
   */
 __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -579,6 +680,8 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncRequestNb(DMAMUX_Channel_TypeDef *DMAM
 
 /**
   * @brief  Set the polarity of the signal on which the DMA request is synchronized.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SPOL          LL_DMAMUX_SetSyncPolarity
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -587,8 +690,15 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncRequestNb(DMAMUX_Channel_TypeDef *DMAM
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @param  Polarity This parameter can be one of the following values:
   *         @arg @ref LL_DMAMUX_SYNC_NO_EVENT
   *         @arg @ref LL_DMAMUX_SYNC_POL_RISING
@@ -604,6 +714,8 @@ __STATIC_INLINE void LL_DMAMUX_SetSyncPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, 
 
 /**
   * @brief  Get the polarity of the signal on which the DMA request is synchronized.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SPOL          LL_DMAMUX_GetSyncPolarity
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -612,8 +724,15 @@ __STATIC_INLINE void LL_DMAMUX_SetSyncPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, 
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_DMAMUX_SYNC_NO_EVENT
   *         @arg @ref LL_DMAMUX_SYNC_POL_RISING
@@ -628,6 +747,8 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncPolarity(DMAMUX_Channel_TypeDef *DMAMU
 
 /**
   * @brief  Enable the Event Generation on DMAMUX channel x.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         EGE           LL_DMAMUX_EnableEventGeneration
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -636,8 +757,15 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncPolarity(DMAMUX_Channel_TypeDef *DMAMU
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval None
   */
 __STATIC_INLINE void LL_DMAMUX_EnableEventGeneration(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -648,6 +776,8 @@ __STATIC_INLINE void LL_DMAMUX_EnableEventGeneration(DMAMUX_Channel_TypeDef *DMA
 
 /**
   * @brief  Disable the Event Generation on DMAMUX channel x.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         EGE           LL_DMAMUX_DisableEventGeneration
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -656,8 +786,15 @@ __STATIC_INLINE void LL_DMAMUX_EnableEventGeneration(DMAMUX_Channel_TypeDef *DMA
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval None
   */
 __STATIC_INLINE void LL_DMAMUX_DisableEventGeneration(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -668,6 +805,8 @@ __STATIC_INLINE void LL_DMAMUX_DisableEventGeneration(DMAMUX_Channel_TypeDef *DM
 
 /**
   * @brief  Check if the Event Generation on DMAMUX channel x is enabled or disabled.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         EGE           LL_DMAMUX_IsEnabledEventGeneration
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -676,18 +815,27 @@ __STATIC_INLINE void LL_DMAMUX_DisableEventGeneration(DMAMUX_Channel_TypeDef *DM
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledEventGeneration(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT((DMAMUX1_Channel0 + Channel)->CCR, DMAMUX_CxCR_EGE) == (DMAMUX_CxCR_EGE))? 1UL : 0UL);
+  return ((READ_BIT((DMAMUX1_Channel0 + Channel)->CCR, DMAMUX_CxCR_EGE) == (DMAMUX_CxCR_EGE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable the synchronization mode.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SE            LL_DMAMUX_EnableSync
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -696,8 +844,15 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledEventGeneration(DMAMUX_Channel_TypeD
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval None
   */
 __STATIC_INLINE void LL_DMAMUX_EnableSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -708,6 +863,8 @@ __STATIC_INLINE void LL_DMAMUX_EnableSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint3
 
 /**
   * @brief  Disable the synchronization mode.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SE            LL_DMAMUX_DisableSync
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -716,8 +873,15 @@ __STATIC_INLINE void LL_DMAMUX_EnableSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint3
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval None
   */
 __STATIC_INLINE void LL_DMAMUX_DisableSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -728,6 +892,8 @@ __STATIC_INLINE void LL_DMAMUX_DisableSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint
 
 /**
   * @brief  Check if the synchronization mode is enabled or disabled.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SE            LL_DMAMUX_IsEnabledSync
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -736,18 +902,27 @@ __STATIC_INLINE void LL_DMAMUX_DisableSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledSync(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT((DMAMUX1_Channel0 + Channel)->CCR, DMAMUX_CxCR_SE) == (DMAMUX_CxCR_SE))? 1UL : 0UL);
+  return ((READ_BIT((DMAMUX1_Channel0 + Channel)->CCR, DMAMUX_CxCR_SE) == (DMAMUX_CxCR_SE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Set DMAMUX synchronization ID  on DMAMUX Channel x.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SYNC_ID       LL_DMAMUX_SetSyncID
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -756,8 +931,15 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledSync(DMAMUX_Channel_TypeDef *DMAMUXx
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @param  SyncID This parameter can be one of the following values:
   *         @arg @ref LL_DMAMUX_SYNC_EXTI_LINE0
   *         @arg @ref LL_DMAMUX_SYNC_EXTI_LINE1
@@ -792,6 +974,8 @@ __STATIC_INLINE void LL_DMAMUX_SetSyncID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32
 
 /**
   * @brief  Get DMAMUX synchronization ID  on DMAMUX Channel x.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SYNC_ID       LL_DMAMUX_GetSyncID
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -800,8 +984,15 @@ __STATIC_INLINE void LL_DMAMUX_SetSyncID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_DMAMUX_SYNC_EXTI_LINE0
   *         @arg @ref LL_DMAMUX_SYNC_EXTI_LINE1
@@ -847,7 +1038,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncID(DMAMUX_Channel_TypeDef *DMAMUXx, ui
 __STATIC_INLINE void LL_DMAMUX_EnableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  SET_BIT(((DMAMUX_RequestGen_TypeDef*)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE*(RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
+  SET_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
 }
 
 /**
@@ -864,7 +1055,7 @@ __STATIC_INLINE void LL_DMAMUX_EnableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx,
 __STATIC_INLINE void LL_DMAMUX_DisableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  CLEAR_BIT(((DMAMUX_RequestGen_TypeDef*)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE*(RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
+  CLEAR_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
 }
 
 /**
@@ -881,7 +1072,7 @@ __STATIC_INLINE void LL_DMAMUX_DisableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx
 __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE) == (DMAMUX_RGxCR_GE))? 1UL : 0UL);
+  return ((READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE) == (DMAMUX_RGxCR_GE)) ? 1UL : 0UL);
 }
 
 /**
@@ -903,7 +1094,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledRequestGen(DMAMUX_Channel_TypeDef *D
 __STATIC_INLINE void LL_DMAMUX_SetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel, uint32_t Polarity)
 {
   (void)(DMAMUXx);
-  MODIFY_REG(((DMAMUX_RequestGen_TypeDef*)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE*(RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL, Polarity);
+  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL, Polarity);
 }
 
 /**
@@ -924,7 +1115,7 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMA
 __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef*)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE*(RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL));
+  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL));
 }
 
 /**
@@ -1001,7 +1192,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetGenRequestNb(DMAMUX_Channel_TypeDef *DMAMU
 __STATIC_INLINE void LL_DMAMUX_SetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel, uint32_t RequestSignalID)
 {
   (void)(DMAMUXx);
-  MODIFY_REG(((DMAMUX_RequestGen_TypeDef*)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE*(RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID, RequestSignalID);
+  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID, RequestSignalID);
 }
 
 /**
@@ -1041,7 +1232,7 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUX
 __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef*)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE*(RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID));
+  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID));
 }
 
 /**
@@ -1073,7 +1264,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO0(DMAMUX_Channel_TypeDef *DMAM
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO1(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF1) == (DMAMUX_CSR_SOF1)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF1) == (DMAMUX_CSR_SOF1)) ? 1UL : 0UL);
 }
 
 /**
@@ -1085,7 +1276,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO1(DMAMUX_Channel_TypeDef *DMAM
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO2(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF2) == (DMAMUX_CSR_SOF2)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF2) == (DMAMUX_CSR_SOF2)) ? 1UL : 0UL);
 }
 
 /**
@@ -1097,7 +1288,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO2(DMAMUX_Channel_TypeDef *DMAM
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO3(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF3) == (DMAMUX_CSR_SOF3)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF3) == (DMAMUX_CSR_SOF3)) ? 1UL : 0UL);
 }
 
 /**
@@ -1109,7 +1300,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO3(DMAMUX_Channel_TypeDef *DMAM
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO4(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF4) == (DMAMUX_CSR_SOF4)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF4) == (DMAMUX_CSR_SOF4)) ? 1UL : 0UL);
 }
 
 #if defined(DMAMUX1_Channel5)
@@ -1122,8 +1313,9 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO4(DMAMUX_Channel_TypeDef *DMAM
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO5(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF5) == (DMAMUX_CSR_SOF5)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF5) == (DMAMUX_CSR_SOF5)) ? 1UL : 0UL);
 }
+
 #endif
 #if defined(DMAMUX1_Channel6)
 /**
@@ -1137,8 +1329,78 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO6(DMAMUX_Channel_TypeDef *DMAM
   (void)(DMAMUXx);
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF6) == (DMAMUX_CSR_SOF6)) ? 1UL : 0UL);
 }
-#endif
 
+#endif
+#if defined(DMAMUX1_Channel7)
+/**
+  * @brief  Get Synchronization Event Overrun Flag Channel 7.
+  * @rmtoll CSR          SOF7          LL_DMAMUX_IsActiveFlag_SO7
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO7(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF7) == (DMAMUX_CSR_SOF7)) ? 1UL : 0UL);
+}
+
+#endif
+#if defined(DMAMUX1_Channel8)
+/**
+  * @brief  Get Synchronization Event Overrun Flag Channel 8.
+  * @rmtoll CSR          SOF8          LL_DMAMUX_IsActiveFlag_SO8
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO8(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF8) == (DMAMUX_CSR_SOF8)) ? 1UL : 0UL);
+}
+
+#endif
+#if defined(DMAMUX1_Channel9)
+/**
+  * @brief  Get Synchronization Event Overrun Flag Channel 9.
+  * @rmtoll CSR          SOF9          LL_DMAMUX_IsActiveFlag_SO9
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO9(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF9) == (DMAMUX_CSR_SOF9)) ? 1UL : 0UL);
+}
+
+#endif
+#if defined(DMAMUX1_Channel10)
+/**
+  * @brief  Get Synchronization Event Overrun Flag Channel 10.
+  * @rmtoll CSR          SOF10         LL_DMAMUX_IsActiveFlag_SO10
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO10(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF10) == (DMAMUX_CSR_SOF10)) ? 1UL : 0UL);
+}
+
+#endif
+#if defined(DMAMUX1_Channel11)
+/**
+  * @brief  Get Synchronization Event Overrun Flag Channel 11.
+  * @rmtoll CSR          SOF11         LL_DMAMUX_IsActiveFlag_SO11
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO11(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF11) == (DMAMUX_CSR_SOF11)) ? 1UL : 0UL);
+}
+
+#endif
 /**
   * @brief  Get Request Generator 0 Trigger Event Overrun Flag.
   * @rmtoll RGSR         OF0           LL_DMAMUX_IsActiveFlag_RGO0
@@ -1148,7 +1410,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO6(DMAMUX_Channel_TypeDef *DMAM
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO0(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF0) == (DMAMUX_RGSR_OF0)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF0) == (DMAMUX_RGSR_OF0)) ? 1UL : 0UL);
 }
 
 /**
@@ -1160,7 +1422,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO0(DMAMUX_Channel_TypeDef *DMA
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO1(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF1) == (DMAMUX_RGSR_OF1)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF1) == (DMAMUX_RGSR_OF1)) ? 1UL : 0UL);
 }
 
 /**
@@ -1172,7 +1434,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO1(DMAMUX_Channel_TypeDef *DMA
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO2(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF2) == (DMAMUX_RGSR_OF2)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF2) == (DMAMUX_RGSR_OF2)) ? 1UL : 0UL);
 }
 
 /**
@@ -1184,7 +1446,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO2(DMAMUX_Channel_TypeDef *DMA
 __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_RGO3(DMAMUX_Channel_TypeDef *DMAMUXx)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF3) == (DMAMUX_RGSR_OF3)) ? 1UL : 0UL);;
+  return ((READ_BIT(DMAMUX1_RequestGenStatus->RGSR, DMAMUX_RGSR_OF3) == (DMAMUX_RGSR_OF3)) ? 1UL : 0UL);
 }
 
 /**
@@ -1259,6 +1521,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO5(DMAMUX_Channel_TypeDef *DMAMUXx)
   (void)(DMAMUXx);
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF5);
 }
+
 #endif
 #if defined(DMAMUX1_Channel6)
 /**
@@ -1272,8 +1535,78 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO6(DMAMUX_Channel_TypeDef *DMAMUXx)
   (void)(DMAMUXx);
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF6);
 }
-#endif
 
+#endif
+#if defined(DMAMUX1_Channel7)
+/**
+  * @brief  Clear Synchronization Event Overrun Flag Channel 7.
+  * @rmtoll CFR          CSOF7         LL_DMAMUX_ClearFlag_SO7
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_DMAMUX_ClearFlag_SO7(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF7);
+}
+
+#endif
+#if defined(DMAMUX1_Channel8)
+/**
+  * @brief  Clear Synchronization Event Overrun Flag Channel 8.
+  * @rmtoll CFR          CSOF8         LL_DMAMUX_ClearFlag_SO8
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_DMAMUX_ClearFlag_SO8(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF8);
+}
+
+#endif
+#if defined(DMAMUX1_Channel9)
+/**
+  * @brief  Clear Synchronization Event Overrun Flag Channel 9.
+  * @rmtoll CFR          CSOF9         LL_DMAMUX_ClearFlag_SO9
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_DMAMUX_ClearFlag_SO9(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF9);
+}
+
+#endif
+#if defined(DMAMUX1_Channel10)
+/**
+  * @brief  Clear Synchronization Event Overrun Flag Channel 10.
+  * @rmtoll CFR          CSOF10        LL_DMAMUX_ClearFlag_SO10
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_DMAMUX_ClearFlag_SO10(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF10);
+}
+
+#endif
+#if defined(DMAMUX1_Channel11)
+/**
+  * @brief  Clear Synchronization Event Overrun Flag Channel 11.
+  * @rmtoll CFR          CSOF11        LL_DMAMUX_ClearFlag_SO11
+  * @param  DMAMUXx DMAMUXx DMAMUXx Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_DMAMUX_ClearFlag_SO11(DMAMUX_Channel_TypeDef *DMAMUXx)
+{
+  (void)(DMAMUXx);
+  SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF11);
+}
+
+#endif
 /**
   * @brief  Clear Request Generator 0 Trigger Event Overrun Flag.
   * @rmtoll RGCFR        COF0          LL_DMAMUX_ClearFlag_RGO0
@@ -1332,6 +1665,8 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_RGO3(DMAMUX_Channel_TypeDef *DMAMUXx)
 
 /**
   * @brief  Enable the Synchronization Event Overrun Interrupt on DMAMUX channel x.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SOIE          LL_DMAMUX_EnableIT_SO
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1340,8 +1675,15 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_RGO3(DMAMUX_Channel_TypeDef *DMAMUXx)
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval None
   */
 __STATIC_INLINE void LL_DMAMUX_EnableIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -1352,6 +1694,8 @@ __STATIC_INLINE void LL_DMAMUX_EnableIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uint
 
 /**
   * @brief  Disable the Synchronization Event Overrun Interrupt on DMAMUX channel x.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SOIE          LL_DMAMUX_DisableIT_SO
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1360,8 +1704,15 @@ __STATIC_INLINE void LL_DMAMUX_EnableIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uint
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval None
   */
 __STATIC_INLINE void LL_DMAMUX_DisableIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
@@ -1372,6 +1723,8 @@ __STATIC_INLINE void LL_DMAMUX_DisableIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uin
 
 /**
   * @brief  Check if the Synchronization Event Overrun Interrupt on DMAMUX channel x is enabled or disabled.
+  * @note   DMAMUX channel 0 to 6 are mapped to DMA1 channel 1 to 7.
+  *         DMAMUX channel 7 to 11 are mapped to DMA2 channel 1 to 5 (**** only available on chip which support DMA2 ****).
   * @rmtoll CxCR         SOIE          LL_DMAMUX_IsEnabledIT_SO
   * @param  DMAMUXx DMAMUXx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1380,14 +1733,21 @@ __STATIC_INLINE void LL_DMAMUX_DisableIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uin
   *         @arg @ref LL_DMAMUX_CHANNEL_2
   *         @arg @ref LL_DMAMUX_CHANNEL_3
   *         @arg @ref LL_DMAMUX_CHANNEL_4
-  *         @arg @ref LL_DMAMUX_CHANNEL_5
-  *         @arg @ref LL_DMAMUX_CHANNEL_6
+  *         @arg @ref LL_DMAMUX_CHANNEL_5 (**** only available on some devices ****)
+  *         @arg @ref LL_DMAMUX_CHANNEL_6 (**** only available on some devices ****)
+  *
+  *         @arg All the next values are only available on chip which support DMA2:
+  *         @arg @ref LL_DMAMUX_CHANNEL_7
+  *         @arg @ref LL_DMAMUX_CHANNEL_8
+  *         @arg @ref LL_DMAMUX_CHANNEL_9
+  *         @arg @ref LL_DMAMUX_CHANNEL_10
+  *         @arg @ref LL_DMAMUX_CHANNEL_11
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledIT_SO(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t Channel)
 {
   (void)(DMAMUXx);
-  return (((READ_BIT((DMAMUX1_Channel0 + Channel)->CCR, DMAMUX_CxCR_SOIE)) == (DMAMUX_CxCR_SOIE))? 1UL : 0UL);
+  return (((READ_BIT((DMAMUX1_Channel0 + Channel)->CCR, DMAMUX_CxCR_SOIE)) == (DMAMUX_CxCR_SOIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -1438,7 +1798,7 @@ __STATIC_INLINE void LL_DMAMUX_DisableIT_RGO(DMAMUX_Channel_TypeDef *DMAMUXx, ui
 __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledIT_RGO(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT((DMAMUX1_RequestGenerator0 + RequestGenChannel)->RGCR, DMAMUX_RGxCR_OIE) == (DMAMUX_RGxCR_OIE))? 1UL : 0UL);
+  return ((READ_BIT((DMAMUX1_RequestGenerator0 + RequestGenChannel)->RGCR, DMAMUX_RGxCR_OIE) == (DMAMUX_RGxCR_OIE)) ? 1UL : 0UL);
 }
 
 /**

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_exti.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_exti.h
@@ -62,7 +62,7 @@ typedef struct
 
   uint32_t Line_0_31;           /*!< Specifies the EXTI lines to be enabled or disabled for Lines in range 0 to 31
                                      This parameter can be any combination of @ref EXTI_LL_EC_LINE */
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
   uint32_t Line_32_63;          /*!< Specifies the EXTI lines to be enabled or disabled for Lines in range 32 to 63
                                      This parameter can be any combination of @ref EXTI_LL_EC_LINE */
 #endif
@@ -108,7 +108,9 @@ typedef struct
 #if defined(EXTI_IMR1_IM16)
 #define LL_EXTI_LINE_16                EXTI_IMR1_IM16          /*!< Extended line 16 */
 #endif
+#if defined(EXTI_IMR1_IM17)
 #define LL_EXTI_LINE_17                EXTI_IMR1_IM17          /*!< Extended line 17 */
+#endif
 #if defined(EXTI_IMR1_IM18)
 #define LL_EXTI_LINE_18                EXTI_IMR1_IM18          /*!< Extended line 18 */
 #endif
@@ -155,7 +157,16 @@ typedef struct
 #if defined(EXTI_IMR2_IM33)
 #define LL_EXTI_LINE_33                EXTI_IMR2_IM33          /*!< Extended line 33 */
 #endif
-#if defined(EXTI_IMR2_IM32) || defined(EXTI_IMR2_IM33)
+#if defined(EXTI_IMR2_IM34)
+#define LL_EXTI_LINE_34                EXTI_IMR2_IM34          /*!< Extended line 34 */
+#endif
+#if defined(EXTI_IMR2_IM35)
+#define LL_EXTI_LINE_35                EXTI_IMR2_IM35          /*!< Extended line 35 */
+#endif
+#if defined(EXTI_IMR2_IM36)
+#define LL_EXTI_LINE_36                EXTI_IMR2_IM36          /*!< Extended line 36 */
+#endif
+#if defined(EXTI_IMR2_IM32) || defined(EXTI_IMR2_IM33) || defined(EXTI_IMR2_IM34) || defined(EXTI_IMR2_IM35) || defined(EXTI_IMR2_IM36)
 #define LL_EXTI_LINE_ALL_32_63         EXTI_IMR2_IM            /*!< All Extended line not reserved*/
 #endif
 
@@ -325,7 +336,8 @@ __STATIC_INLINE void LL_EXTI_EnableIT_0_31(uint32_t ExtiLine)
 {
   SET_BIT(EXTI->IMR1, ExtiLine);
 }
-#if defined(STM32G081xx) || defined(STM32G071xx)
+
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Enable ExtiLine Interrupt request for Lines in range 32 to 63
   * @note The reset value for the direct lines (lines 32 & 33)
@@ -335,7 +347,11 @@ __STATIC_INLINE void LL_EXTI_EnableIT_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be one of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableIT_32_63(uint32_t ExtiLine)
@@ -343,6 +359,7 @@ __STATIC_INLINE void LL_EXTI_EnableIT_32_63(uint32_t ExtiLine)
   SET_BIT(EXTI->IMR2, ExtiLine);
 }
 #endif
+
 /**
   * @brief  Disable ExtiLine Interrupt request for Lines in range 0 to 31
   * @note The reset value for the direct or internal lines (see RM)
@@ -388,7 +405,7 @@ __STATIC_INLINE void LL_EXTI_DisableIT_0_31(uint32_t ExtiLine)
   CLEAR_BIT(EXTI->IMR1, ExtiLine);
 }
 
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Disable ExtiLine Interrupt request for Lines in range 32 to 63
   * @note The reset value for the direct lines (lines 32 & 33)
@@ -398,7 +415,11 @@ __STATIC_INLINE void LL_EXTI_DisableIT_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be one of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableIT_32_63(uint32_t ExtiLine)
@@ -452,7 +473,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_0_31(uint32_t ExtiLine)
   return ((READ_BIT(EXTI->IMR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
 
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Indicate if ExtiLine Interrupt request is enabled for Lines in range 32 to 63
   * @note The reset value for the direct lines (lines 32 & 33)
@@ -461,7 +482,11 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_0_31(uint32_t ExtiLine)
   * @param  ExtiLine This parameter can be one of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_32_63(uint32_t ExtiLine)
@@ -521,14 +546,18 @@ __STATIC_INLINE void LL_EXTI_EnableEvent_0_31(uint32_t ExtiLine)
 
 }
 
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Enable ExtiLine Event request for Lines in range 32 to 63
   * @rmtoll EMR2         EMx           LL_EXTI_EnableEvent_32_63
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_EnableEvent_32_63(uint32_t ExtiLine)
@@ -578,14 +607,18 @@ __STATIC_INLINE void LL_EXTI_DisableEvent_0_31(uint32_t ExtiLine)
   CLEAR_BIT(EXTI->EMR1, ExtiLine);
 }
 
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Disable ExtiLine Event request for Lines in range 32 to 63
   * @rmtoll EMR2         EMx           LL_EXTI_DisableEvent_32_63
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
 __STATIC_INLINE void LL_EXTI_DisableEvent_32_63(uint32_t ExtiLine)
@@ -635,14 +668,18 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_0_31(uint32_t ExtiLine)
   return ((READ_BIT(EXTI->EMR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
 
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Indicate if ExtiLine Event request is enabled for Lines in range 32 to 63
   * @rmtoll EMR2         EMx           LL_EXTI_IsEnabledEvent_32_63
   * @param  ExtiLine This parameter can be a combination of the following values:
   *         @arg @ref LL_EXTI_LINE_32
   *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
   *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_32_63(uint32_t ExtiLine)
@@ -689,6 +726,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_32_63(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -697,6 +735,28 @@ __STATIC_INLINE void LL_EXTI_EnableRisingTrig_0_31(uint32_t ExtiLine)
   SET_BIT(EXTI->RTSR1, ExtiLine);
 
 }
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Enable ExtiLine Rising Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a rising edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_RTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll RTSR2        RTx           LL_EXTI_EnableRisingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableRisingTrig_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->RTSR2, ExtiLine);
+
+}
+#endif
 
 /**
   * @brief  Disable ExtiLine Rising Edge Trigger for Lines in range 0 to 31
@@ -728,6 +788,7 @@ __STATIC_INLINE void LL_EXTI_EnableRisingTrig_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -736,6 +797,29 @@ __STATIC_INLINE void LL_EXTI_DisableRisingTrig_0_31(uint32_t ExtiLine)
   CLEAR_BIT(EXTI->RTSR1, ExtiLine);
 
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Disable ExtiLine Rising Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a rising edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_RTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll RTSR2        RTx           LL_EXTI_DisableRisingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableRisingTrig_32_63(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->RTSR2, ExtiLine);
+
+}
+#endif
 
 /**
   * @brief  Check if rising edge trigger is enabled for Lines in range 0 to 31
@@ -759,7 +843,7 @@ __STATIC_INLINE void LL_EXTI_DisableRisingTrig_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_15
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
-  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
@@ -767,6 +851,21 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_0_31(uint32_t ExtiLine)
 {
   return ((READ_BIT(EXTI->RTSR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Check if rising edge trigger is enabled for Lines in range 32 to 63
+  * @rmtoll RTSR2        RTx           LL_EXTI_IsEnabledRisingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->RTSR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+#endif
 
 /**
   * @}
@@ -806,6 +905,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -813,6 +913,28 @@ __STATIC_INLINE void LL_EXTI_EnableFallingTrig_0_31(uint32_t ExtiLine)
 {
   SET_BIT(EXTI->FTSR1, ExtiLine);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Enable ExtiLine Falling Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a falling edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_FTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll FTSR2        FTx           LL_EXTI_EnableFallingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableFallingTrig_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->FTSR2, ExtiLine);
+}
+#endif
 
 /**
   * @brief  Disable ExtiLine Falling Edge Trigger for Lines in range 0 to 31
@@ -843,6 +965,7 @@ __STATIC_INLINE void LL_EXTI_EnableFallingTrig_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -850,6 +973,27 @@ __STATIC_INLINE void LL_EXTI_DisableFallingTrig_0_31(uint32_t ExtiLine)
 {
   CLEAR_BIT(EXTI->FTSR1, ExtiLine);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Disable ExtiLine Falling Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a Falling edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_FTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for the same interrupt line.
+  *       In this case, both generate a trigger condition.
+  * @rmtoll FTSR2        FTx           LL_EXTI_DisableFallingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableFallingTrig_32_63(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->FTSR2, ExtiLine);
+}
+#endif
 
 /**
   * @brief  Check if falling edge trigger is enabled for Lines in range 0 to 31
@@ -874,6 +1018,7 @@ __STATIC_INLINE void LL_EXTI_DisableFallingTrig_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
@@ -882,6 +1027,20 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_0_31(uint32_t ExtiLine)
   return ((READ_BIT(EXTI->FTSR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Check if falling edge trigger is enabled for Lines in range 32 to 63
+  * @rmtoll FTSR2        FTx           LL_EXTI_IsEnabledFallingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->FTSR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+#endif
 /**
   * @}
   */
@@ -918,6 +1077,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -925,6 +1085,26 @@ __STATIC_INLINE void LL_EXTI_GenerateSWI_0_31(uint32_t ExtiLine)
 {
   SET_BIT(EXTI->SWIER1, ExtiLine);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Generate a software Interrupt Event for Lines in range 32 to 63
+  * @note If the interrupt is enabled on this line in the EXTI_IMR, writing a 1 to
+  *       this bit when it is at '0' sets the corresponding pending bit in EXTI_PR
+  *       resulting in an interrupt request generation.
+  *       This bit is cleared by clearing the corresponding bit in the EXTI_PR
+  *       register (by writing a 1 into the bit)
+  * @rmtoll SWIER2       SWIx          LL_EXTI_GenerateSWI_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_GenerateSWI_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->SWIER2, ExtiLine);
+}
+#endif
 
 /**
   * @}
@@ -959,6 +1139,7 @@ __STATIC_INLINE void LL_EXTI_GenerateSWI_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
@@ -966,6 +1147,23 @@ __STATIC_INLINE uint32_t LL_EXTI_IsActiveFallingFlag_0_31(uint32_t ExtiLine)
 {
   return ((READ_BIT(EXTI->FPR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Check if the ExtLine Falling Flag is set or not for Lines in range 32 to 63
+  * @note This bit is set when the falling edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll FPR2          FPIFx           LL_EXTI_IsActiveFallingFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsActiveFallingFlag_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->FPR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+#endif
 
 /**
   * @brief  Read ExtLine Combination Falling Flag for Lines in range 0 to 31
@@ -992,6 +1190,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsActiveFallingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval @note This bit is set when the selected edge event arrives on the interrupt
   */
@@ -999,6 +1198,23 @@ __STATIC_INLINE uint32_t LL_EXTI_ReadFallingFlag_0_31(uint32_t ExtiLine)
 {
   return (READ_BIT(EXTI->FPR1, ExtiLine));
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Read ExtLine Combination Falling Flag for Lines in range 32 to 63
+  * @note This bit is set when the falling edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll FPR2          FPIFx           LL_EXTI_ReadFallingFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval @note This bit is set when the selected edge event arrives on the interrupt
+  */
+__STATIC_INLINE uint32_t LL_EXTI_ReadFallingFlag_32_63(uint32_t ExtiLine)
+{
+  return (READ_BIT(EXTI->FPR2, ExtiLine));
+}
+#endif
 
 /**
   * @brief  Clear ExtLine Falling Flags  for Lines in range 0 to 31
@@ -1025,6 +1241,7 @@ __STATIC_INLINE uint32_t LL_EXTI_ReadFallingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -1032,6 +1249,23 @@ __STATIC_INLINE void LL_EXTI_ClearFallingFlag_0_31(uint32_t ExtiLine)
 {
   WRITE_REG(EXTI->FPR1, ExtiLine);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Clear ExtLine Falling Flags  for Lines in range 32 to 63
+  * @note This bit is set when the falling edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll FPR2          FPIFx           LL_EXTI_ClearFallingFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_ClearFallingFlag_32_63(uint32_t ExtiLine)
+{
+  WRITE_REG(EXTI->FPR2, ExtiLine);
+}
+#endif
 
 /**
   * @brief  Check if the ExtLine Rising Flag is set or not for Lines in range 0 to 31
@@ -1058,6 +1292,7 @@ __STATIC_INLINE void LL_EXTI_ClearFallingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval State of bit (1 or 0).
   */
@@ -1065,6 +1300,23 @@ __STATIC_INLINE uint32_t LL_EXTI_IsActiveRisingFlag_0_31(uint32_t ExtiLine)
 {
   return ((READ_BIT(EXTI->RPR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Check if the ExtLine Rising Flag is set or not for Lines in range 32 to 63
+  * @note This bit is set when the Rising edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll RPR2          RPIFx           LL_EXTI_IsActiveRisingFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsActiveRisingFlag_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->RPR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+#endif
 
 /**
   * @brief  Read ExtLine Combination Rising Flag for Lines in range 0 to 31
@@ -1091,6 +1343,7 @@ __STATIC_INLINE uint32_t LL_EXTI_IsActiveRisingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval @note This bit is set when the selected edge event arrives on the interrupt
   */
@@ -1098,6 +1351,23 @@ __STATIC_INLINE uint32_t LL_EXTI_ReadRisingFlag_0_31(uint32_t ExtiLine)
 {
   return (READ_BIT(EXTI->RPR1, ExtiLine));
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Read ExtLine Combination Rising Flag for Lines in range 32 to 63
+  * @note This bit is set when the Rising edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll RPR2          RPIFx           LL_EXTI_ReadRisingFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval @note This bit is set when the selected edge event arrives on the interrupt
+  */
+__STATIC_INLINE uint32_t LL_EXTI_ReadRisingFlag_32_63(uint32_t ExtiLine)
+{
+  return (READ_BIT(EXTI->RPR2, ExtiLine));
+}
+#endif
 
 /**
   * @brief  Clear ExtLine Rising Flags  for Lines in range 0 to 31
@@ -1124,6 +1394,7 @@ __STATIC_INLINE uint32_t LL_EXTI_ReadRisingFlag_0_31(uint32_t ExtiLine)
   *         @arg @ref LL_EXTI_LINE_16
   *         @arg @ref LL_EXTI_LINE_17
   *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_20
   * @note   Please check each device line mapping for EXTI Line availability
   * @retval None
   */
@@ -1131,6 +1402,23 @@ __STATIC_INLINE void LL_EXTI_ClearRisingFlag_0_31(uint32_t ExtiLine)
 {
   WRITE_REG(EXTI->RPR1, ExtiLine);
 }
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Clear ExtLine Rising Flags  for Lines in range 32 to 63
+  * @note This bit is set when the Rising edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll RPR2          RPIFx           LL_EXTI_ClearRisingFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_34
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_ClearRisingFlag_32_63(uint32_t ExtiLine)
+{
+  WRITE_REG(EXTI->RPR2, ExtiLine);
+}
+#endif
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_gpio.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_gpio.h
@@ -196,6 +196,11 @@ typedef struct
 #define LL_GPIO_AF_5                       (0x0000005U) /*!< Select alternate function 5 */
 #define LL_GPIO_AF_6                       (0x0000006U) /*!< Select alternate function 6 */
 #define LL_GPIO_AF_7                       (0x0000007U) /*!< Select alternate function 7 */
+#if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined (STM32G0C1xx)
+#define LL_GPIO_AF_8                       (0x0000008U) /*!< Select alternate function 8 */
+#define LL_GPIO_AF_9                       (0x0000009U) /*!< Select alternate function 9 */
+#define LL_GPIO_AF_10                      (0x000000AU) /*!< Select alternate function 10 */
+#endif
 /**
   * @}
   */
@@ -910,8 +915,10 @@ __STATIC_INLINE void LL_GPIO_ResetOutputPin(GPIO_TypeDef *GPIOx, uint32_t PinMas
   */
 __STATIC_INLINE void LL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint32_t PinMask)
 {
-  WRITE_REG(GPIOx->ODR, READ_REG(GPIOx->ODR) ^ PinMask);
+  uint32_t odr = READ_REG(GPIOx->ODR);
+  WRITE_REG(GPIOx->BSRR, ((odr & PinMask) << 16u) | (~odr & PinMask));
 }
+
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_i2c.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_i2c.h
@@ -32,7 +32,7 @@ extern "C" {
   * @{
   */
 
-#if defined (I2C1) || defined (I2C2)
+#if defined (I2C1) || defined (I2C2) || defined (I2C3)
 
 /** @defgroup I2C_LL I2C
   * @{
@@ -67,38 +67,38 @@ extern "C" {
 typedef struct
 {
   uint32_t PeripheralMode;      /*!< Specifies the peripheral mode.
-                                     This parameter can be a value of @ref I2C_LL_EC_PERIPHERAL_MODE
+                                     This parameter can be a value of @ref I2C_LL_EC_PERIPHERAL_MODE.
 
                                      This feature can be modified afterwards using unitary function @ref LL_I2C_SetMode(). */
 
   uint32_t Timing;              /*!< Specifies the SDA setup, hold time and the SCL high, low period values.
                                      This parameter must be set by referring to the STM32CubeMX Tool and
-                                     the helper macro @ref __LL_I2C_CONVERT_TIMINGS()
+                                     the helper macro @ref __LL_I2C_CONVERT_TIMINGS().
 
                                      This feature can be modified afterwards using unitary function @ref LL_I2C_SetTiming(). */
 
   uint32_t AnalogFilter;        /*!< Enables or disables analog noise filter.
-                                     This parameter can be a value of @ref I2C_LL_EC_ANALOGFILTER_SELECTION
+                                     This parameter can be a value of @ref I2C_LL_EC_ANALOGFILTER_SELECTION.
 
                                      This feature can be modified afterwards using unitary functions @ref LL_I2C_EnableAnalogFilter() or LL_I2C_DisableAnalogFilter(). */
 
   uint32_t DigitalFilter;       /*!< Configures the digital noise filter.
-                                     This parameter can be a number between Min_Data = 0x00 and Max_Data = 0x0F
+                                     This parameter can be a number between Min_Data = 0x00 and Max_Data = 0x0F.
 
                                      This feature can be modified afterwards using unitary function @ref LL_I2C_SetDigitalFilter(). */
 
   uint32_t OwnAddress1;         /*!< Specifies the device own address 1.
-                                     This parameter must be a value between Min_Data = 0x00 and Max_Data = 0x3FF
+                                     This parameter must be a value between Min_Data = 0x00 and Max_Data = 0x3FF.
 
                                      This feature can be modified afterwards using unitary function @ref LL_I2C_SetOwnAddress1(). */
 
   uint32_t TypeAcknowledge;     /*!< Specifies the ACKnowledge or Non ACKnowledge condition after the address receive match code or next received byte.
-                                     This parameter can be a value of @ref I2C_LL_EC_I2C_ACKNOWLEDGE
+                                     This parameter can be a value of @ref I2C_LL_EC_I2C_ACKNOWLEDGE.
 
                                      This feature can be modified afterwards using unitary function @ref LL_I2C_AcknowledgeNextData(). */
 
   uint32_t OwnAddrSize;         /*!< Specifies the device own address 1 size (7-bit or 10-bit).
-                                     This parameter can be a value of @ref I2C_LL_EC_OWNADDRESS1
+                                     This parameter can be a value of @ref I2C_LL_EC_OWNADDRESS1.
 
                                      This feature can be modified afterwards using unitary function @ref LL_I2C_SetOwnAddress1(). */
 } LL_I2C_InitTypeDef;
@@ -578,7 +578,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledDMAReq_RX(I2C_TypeDef *I2Cx)
   */
 __STATIC_INLINE uint32_t LL_I2C_DMA_GetRegAddr(I2C_TypeDef *I2Cx, uint32_t Direction)
 {
-  register uint32_t data_reg_addr;
+  uint32_t data_reg_addr;
 
   if (Direction == LL_I2C_DMA_REG_DATA_TRANSMIT)
   {
@@ -664,7 +664,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledSlaveByteControl(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Enable Wakeup from STOP.
-  * @note   Macro @ref IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
   *         WakeUpFromStop feature is supported by the I2Cx Instance.
   * @note   This bit can only be programmed when Digital Filter is disabled.
   * @rmtoll CR1          WUPEN         LL_I2C_EnableWakeUpFromStop
@@ -678,7 +678,7 @@ __STATIC_INLINE void LL_I2C_EnableWakeUpFromStop(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable Wakeup from STOP.
-  * @note   Macro @ref IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
   *         WakeUpFromStop feature is supported by the I2Cx Instance.
   * @rmtoll CR1          WUPEN         LL_I2C_DisableWakeUpFromStop
   * @param  I2Cx I2C Instance.
@@ -691,7 +691,7 @@ __STATIC_INLINE void LL_I2C_DisableWakeUpFromStop(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if Wakeup from STOP is enabled or disabled.
-  * @note   Macro @ref IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
   *         WakeUpFromStop feature is supported by the I2Cx Instance.
   * @rmtoll CR1          WUPEN         LL_I2C_IsEnabledWakeUpFromStop
   * @param  I2Cx I2C Instance.
@@ -941,7 +941,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetDataSetupTime(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Configure peripheral mode.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          SMBHEN        LL_I2C_SetMode\n
   *         CR1          SMBDEN        LL_I2C_SetMode
@@ -960,7 +960,7 @@ __STATIC_INLINE void LL_I2C_SetMode(I2C_TypeDef *I2Cx, uint32_t PeripheralMode)
 
 /**
   * @brief  Get peripheral mode.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          SMBHEN        LL_I2C_GetMode\n
   *         CR1          SMBDEN        LL_I2C_GetMode
@@ -978,7 +978,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetMode(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Enable SMBus alert (Host or Device mode)
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   SMBus Device mode:
   *         - SMBus Alert pin is drived low and
@@ -996,7 +996,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusAlert(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable SMBus alert (Host or Device mode)
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   SMBus Device mode:
   *         - SMBus Alert pin is not drived (can be used as a standard GPIO) and
@@ -1014,7 +1014,7 @@ __STATIC_INLINE void LL_I2C_DisableSMBusAlert(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if SMBus alert (Host or Device mode) is enabled or disabled.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          ALERTEN       LL_I2C_IsEnabledSMBusAlert
   * @param  I2Cx I2C Instance.
@@ -1027,7 +1027,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusAlert(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Enable SMBus Packet Error Calculation (PEC).
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          PECEN         LL_I2C_EnableSMBusPEC
   * @param  I2Cx I2C Instance.
@@ -1040,7 +1040,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusPEC(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable SMBus Packet Error Calculation (PEC).
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          PECEN         LL_I2C_DisableSMBusPEC
   * @param  I2Cx I2C Instance.
@@ -1053,7 +1053,7 @@ __STATIC_INLINE void LL_I2C_DisableSMBusPEC(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if SMBus Packet Error Calculation (PEC) is enabled or disabled.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          PECEN         LL_I2C_IsEnabledSMBusPEC
   * @param  I2Cx I2C Instance.
@@ -1066,7 +1066,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPEC(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Configure the SMBus Clock Timeout.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   This configuration can only be programmed when associated Timeout is disabled (TimeoutA and/orTimeoutB).
   * @rmtoll TIMEOUTR     TIMEOUTA      LL_I2C_ConfigSMBusTimeout\n
@@ -1089,7 +1089,7 @@ __STATIC_INLINE void LL_I2C_ConfigSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Timeo
 
 /**
   * @brief  Configure the SMBus Clock TimeoutA (SCL low timeout or SCL and SDA high timeout depends on TimeoutA mode).
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   These bits can only be programmed when TimeoutA is disabled.
   * @rmtoll TIMEOUTR     TIMEOUTA      LL_I2C_SetSMBusTimeoutA
@@ -1104,7 +1104,7 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutA(I2C_TypeDef *I2Cx, uint32_t Timeout
 
 /**
   * @brief  Get the SMBus Clock TimeoutA setting.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMEOUTA      LL_I2C_GetSMBusTimeoutA
   * @param  I2Cx I2C Instance.
@@ -1117,7 +1117,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutA(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Set the SMBus Clock TimeoutA mode.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   This bit can only be programmed when TimeoutA is disabled.
   * @rmtoll TIMEOUTR     TIDLE         LL_I2C_SetSMBusTimeoutAMode
@@ -1134,7 +1134,7 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutAMode(I2C_TypeDef *I2Cx, uint32_t Tim
 
 /**
   * @brief  Get the SMBus Clock TimeoutA mode.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIDLE         LL_I2C_GetSMBusTimeoutAMode
   * @param  I2Cx I2C Instance.
@@ -1149,7 +1149,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutAMode(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Configure the SMBus Extended Cumulative Clock TimeoutB (Master or Slave mode).
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   These bits can only be programmed when TimeoutB is disabled.
   * @rmtoll TIMEOUTR     TIMEOUTB      LL_I2C_SetSMBusTimeoutB
@@ -1163,8 +1163,8 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutB(I2C_TypeDef *I2Cx, uint32_t Timeout
 }
 
 /**
-  * @brief  Get the SMBus Extented Cumulative Clock TimeoutB setting.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @brief  Get the SMBus Extended Cumulative Clock TimeoutB setting.
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMEOUTB      LL_I2C_GetSMBusTimeoutB
   * @param  I2Cx I2C Instance.
@@ -1177,7 +1177,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutB(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Enable the SMBus Clock Timeout.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMOUTEN      LL_I2C_EnableSMBusTimeout\n
   *         TIMEOUTR     TEXTEN        LL_I2C_EnableSMBusTimeout
@@ -1195,7 +1195,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Clock
 
 /**
   * @brief  Disable the SMBus Clock Timeout.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMOUTEN      LL_I2C_DisableSMBusTimeout\n
   *         TIMEOUTR     TEXTEN        LL_I2C_DisableSMBusTimeout
@@ -1213,7 +1213,7 @@ __STATIC_INLINE void LL_I2C_DisableSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Cloc
 
 /**
   * @brief  Check if the SMBus Clock Timeout is enabled or disabled.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMOUTEN      LL_I2C_IsEnabledSMBusTimeout\n
   *         TIMEOUTR     TEXTEN        LL_I2C_IsEnabledSMBusTimeout
@@ -1443,7 +1443,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_TC(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Enable Error interrupts.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   Any of these errors will generate interrupt :
   *         Arbitration Loss (ARLO)
@@ -1463,7 +1463,7 @@ __STATIC_INLINE void LL_I2C_EnableIT_ERR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable Error interrupts.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   Any of these errors will generate interrupt :
   *         Arbitration Loss (ARLO)
@@ -1645,7 +1645,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_OVR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Indicate the status of SMBus PEC error flag in reception.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   RESET: Clear default value.
   *         SET: When the received PEC does not match with the PEC register content.
@@ -1660,7 +1660,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_PECERR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Indicate the status of SMBus Timeout detection flag.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   RESET: Clear default value.
   *         SET: When a timeout or extended clock timeout occurs.
@@ -1675,7 +1675,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_TIMEOUT(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Indicate the status of SMBus alert flag.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   RESET: Clear default value.
   *         SET: When SMBus host configuration, SMBus alert enabled and
@@ -1782,7 +1782,7 @@ __STATIC_INLINE void LL_I2C_ClearFlag_OVR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Clear SMBus PEC error flag.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll ICR          PECCF         LL_I2C_ClearSMBusFlag_PECERR
   * @param  I2Cx I2C Instance.
@@ -1795,7 +1795,7 @@ __STATIC_INLINE void LL_I2C_ClearSMBusFlag_PECERR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Clear SMBus Timeout detection flag.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll ICR          TIMOUTCF      LL_I2C_ClearSMBusFlag_TIMEOUT
   * @param  I2Cx I2C Instance.
@@ -1808,7 +1808,7 @@ __STATIC_INLINE void LL_I2C_ClearSMBusFlag_TIMEOUT(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Clear SMBus Alert flag.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll ICR          ALERTCF       LL_I2C_ClearSMBusFlag_ALERT
   * @param  I2Cx I2C Instance.
@@ -2123,7 +2123,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetAddressMatchCode(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Enable internal comparison of the SMBus Packet Error byte (transmission or reception mode).
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   This feature is cleared by hardware when the PEC byte is transferred, or when a STOP condition or an Address Matched is received.
   *         This bit has no effect when RELOAD bit is set.
@@ -2139,7 +2139,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusPECCompare(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if the SMBus Packet Error byte internal comparison is requested or not.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR2          PECBYTE       LL_I2C_IsEnabledSMBusPECCompare
   * @param  I2Cx I2C Instance.
@@ -2152,7 +2152,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPECCompare(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Get the SMBus Packet Error byte calculated.
-  * @note   Macro @ref IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll PECR         PEC           LL_I2C_GetSMBusPEC
   * @param  I2Cx I2C Instance.
@@ -2213,7 +2213,7 @@ void LL_I2C_StructInit(LL_I2C_InitTypeDef *I2C_InitStruct);
   * @}
   */
 
-#endif /* I2C1 || I2C2 */
+#endif /* I2C1 || I2C2 || I2C3 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_lptim.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_lptim.h
@@ -128,8 +128,8 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_OPERATING_MODE Operating Mode
   * @{
   */
-#define LL_LPTIM_OPERATING_MODE_CONTINUOUS    LPTIM_CR_CNTSTRT       /*!<LP Timer starts in continuous mode*/
-#define LL_LPTIM_OPERATING_MODE_ONESHOT       LPTIM_CR_SNGSTRT       /*!<LP Tilmer starts in single mode*/
+#define LL_LPTIM_OPERATING_MODE_CONTINUOUS    LPTIM_CR_CNTSTRT /*!<LP Timer starts in continuous mode*/
+#define LL_LPTIM_OPERATING_MODE_ONESHOT       LPTIM_CR_SNGSTRT /*!<LP Tilmer starts in single mode*/
 /**
   * @}
   */
@@ -137,8 +137,8 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_UPDATE_MODE Update Mode
   * @{
   */
-#define LL_LPTIM_UPDATE_MODE_IMMEDIATE        0x00000000U             /*!<Preload is disabled: registers are updated after each APB bus write access*/
-#define LL_LPTIM_UPDATE_MODE_ENDOFPERIOD      LPTIM_CFGR_PRELOAD      /*!<preload is enabled: registers are updated at the end of the current LPTIM period*/
+#define LL_LPTIM_UPDATE_MODE_IMMEDIATE        0x00000000U        /*!<Preload is disabled: registers are updated after each APB bus write access*/
+#define LL_LPTIM_UPDATE_MODE_ENDOFPERIOD      LPTIM_CFGR_PRELOAD /*!<preload is enabled: registers are updated at the end of the current LPTIM period*/
 /**
   * @}
   */
@@ -146,8 +146,8 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_COUNTER_MODE Counter Mode
   * @{
   */
-#define LL_LPTIM_COUNTER_MODE_INTERNAL        0x00000000U             /*!<The counter is incremented following each internal clock pulse*/
-#define LL_LPTIM_COUNTER_MODE_EXTERNAL        LPTIM_CFGR_COUNTMODE    /*!<The counter is incremented following each valid clock pulse on the LPTIM external Input1*/
+#define LL_LPTIM_COUNTER_MODE_INTERNAL        0x00000000U          /*!<The counter is incremented following each internal clock pulse*/
+#define LL_LPTIM_COUNTER_MODE_EXTERNAL        LPTIM_CFGR_COUNTMODE /*!<The counter is incremented following each valid clock pulse on the LPTIM external Input1*/
 /**
   * @}
   */
@@ -155,8 +155,8 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_OUTPUT_WAVEFORM Output Waveform Type
   * @{
   */
-#define LL_LPTIM_OUTPUT_WAVEFORM_PWM          0x00000000U             /*!<LPTIM  generates either a PWM waveform or a One pulse waveform depending on chosen operating mode CONTINOUS or SINGLE*/
-#define LL_LPTIM_OUTPUT_WAVEFORM_SETONCE      LPTIM_CFGR_WAVE         /*!<LPTIM  generates a Set Once waveform*/
+#define LL_LPTIM_OUTPUT_WAVEFORM_PWM          0x00000000U     /*!<LPTIM  generates either a PWM waveform or a One pulse waveform depending on chosen operating mode CONTINUOUS or SINGLE*/
+#define LL_LPTIM_OUTPUT_WAVEFORM_SETONCE      LPTIM_CFGR_WAVE /*!<LPTIM  generates a Set Once waveform*/
 /**
   * @}
   */
@@ -164,8 +164,8 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_OUTPUT_POLARITY Output Polarity
   * @{
   */
-#define LL_LPTIM_OUTPUT_POLARITY_REGULAR      0x00000000U              /*!<The LPTIM output reflects the compare results between LPTIMx_ARR and LPTIMx_CMP registers*/
-#define LL_LPTIM_OUTPUT_POLARITY_INVERSE      LPTIM_CFGR_WAVPOL        /*!<The LPTIM output reflects the inverse of the compare results between LPTIMx_ARR and LPTIMx_CMP registers*/
+#define LL_LPTIM_OUTPUT_POLARITY_REGULAR      0x00000000U             /*!<The LPTIM output reflects the compare results between LPTIMx_ARR and LPTIMx_CMP registers*/
+#define LL_LPTIM_OUTPUT_POLARITY_INVERSE      LPTIM_CFGR_WAVPOL       /*!<The LPTIM output reflects the inverse of the compare results between LPTIMx_ARR and LPTIMx_CMP registers*/
 /**
   * @}
   */
@@ -188,13 +188,19 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_TRIG_SOURCE Trigger Source
   * @{
   */
-#define LL_LPTIM_TRIG_SOURCE_GPIO             0x00000000U                                   /*!<External input trigger is connected to TIMx_ETR input*/
-#define LL_LPTIM_TRIG_SOURCE_RTCALARMA        LPTIM_CFGR_TRIGSEL_0                          /*!<External input trigger is connected to RTC Alarm A*/
-#define LL_LPTIM_TRIG_SOURCE_RTCALARMB        LPTIM_CFGR_TRIGSEL_1                          /*!<External input trigger is connected to RTC Alarm B*/
-#define LL_LPTIM_TRIG_SOURCE_RTCTAMP1         (LPTIM_CFGR_TRIGSEL_1 | LPTIM_CFGR_TRIGSEL_0) /*!<External input trigger is connected to RTC Tamper 1*/
-#define LL_LPTIM_TRIG_SOURCE_RTCTAMP2         LPTIM_CFGR_TRIGSEL_2                          /*!<External input trigger is connected to RTC Tamper 2*/
-#define LL_LPTIM_TRIG_SOURCE_COMP1            (LPTIM_CFGR_TRIGSEL_2 | LPTIM_CFGR_TRIGSEL_1) /*!<External input trigger is connected to COMP1 output*/
-#define LL_LPTIM_TRIG_SOURCE_COMP2            LPTIM_CFGR_TRIGSEL                            /*!<External input trigger is connected to COMP2 output*/
+#define LL_LPTIM_TRIG_SOURCE_GPIO             0x00000000U                                                          /*!<External input trigger is connected to TIMx_ETR input*/
+#define LL_LPTIM_TRIG_SOURCE_RTCALARMA        LPTIM_CFGR_TRIGSEL_0                                                 /*!<External input trigger is connected to RTC Alarm A*/
+#define LL_LPTIM_TRIG_SOURCE_RTCALARMB        LPTIM_CFGR_TRIGSEL_1                                                 /*!<External input trigger is connected to RTC Alarm B*/
+#define LL_LPTIM_TRIG_SOURCE_RTCTAMP1         (LPTIM_CFGR_TRIGSEL_1 | LPTIM_CFGR_TRIGSEL_0)                        /*!<External input trigger is connected to RTC Tamper 1*/
+#define LL_LPTIM_TRIG_SOURCE_RTCTAMP2         LPTIM_CFGR_TRIGSEL_2                                                 /*!<External input trigger is connected to RTC Tamper 2*/
+#if defined(RTC_TAMPER3_SUPPORT)
+#define LL_LPTIM_TRIG_SOURCE_RTCTAMP3         (LPTIM_CFGR_TRIGSEL_2 | LPTIM_CFGR_TRIGSEL_0)                        /*!<External input trigger is connected to RTC Tamper 3*/
+#endif /* RTC_TAMPER3_SUPPORT */
+#define LL_LPTIM_TRIG_SOURCE_COMP1            (LPTIM_CFGR_TRIGSEL_2 | LPTIM_CFGR_TRIGSEL_1)                        /*!<External input trigger is connected to COMP1 output*/
+#define LL_LPTIM_TRIG_SOURCE_COMP2            LPTIM_CFGR_TRIGSEL                                                   /*!<External input trigger is connected to COMP2 output*/
+#if defined(COMP3)
+#define LL_LPTIM_TRIG_SOURCE_COMP3            (LPTIM_CFGR_TRIGSEL_2 | LPTIM_CFGR_TRIGSEL_0)                        /*!<External input trigger is connected to COMP3 output*/
+#endif /* COMP3 */
 /**
   * @}
   */
@@ -202,10 +208,10 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_TRIG_FILTER Trigger Filter
   * @{
   */
-#define LL_LPTIM_TRIG_FILTER_NONE             0x00000000U             /*!<Any trigger active level change is considered as a valid trigger*/
-#define LL_LPTIM_TRIG_FILTER_2                LPTIM_CFGR_TRGFLT_0     /*!<Trigger active level change must be stable for at least 2 clock periods before it is considered as valid trigger*/
-#define LL_LPTIM_TRIG_FILTER_4                LPTIM_CFGR_TRGFLT_1     /*!<Trigger active level change must be stable for at least 4 clock periods before it is considered as valid trigger*/
-#define LL_LPTIM_TRIG_FILTER_8                LPTIM_CFGR_TRGFLT       /*!<Trigger active level change must be stable for at least 8 clock periods before it is considered as valid trigger*/
+#define LL_LPTIM_TRIG_FILTER_NONE             0x00000000U         /*!<Any trigger active level change is considered as a valid trigger*/
+#define LL_LPTIM_TRIG_FILTER_2                LPTIM_CFGR_TRGFLT_0 /*!<Trigger active level change must be stable for at least 2 clock periods before it is considered as valid trigger*/
+#define LL_LPTIM_TRIG_FILTER_4                LPTIM_CFGR_TRGFLT_1 /*!<Trigger active level change must be stable for at least 4 clock periods before it is considered as valid trigger*/
+#define LL_LPTIM_TRIG_FILTER_8                LPTIM_CFGR_TRGFLT   /*!<Trigger active level change must be stable for at least 8 clock periods before it is considered as valid trigger*/
 /**
   * @}
   */
@@ -213,9 +219,9 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_TRIG_POLARITY Trigger Polarity
   * @{
   */
-#define LL_LPTIM_TRIG_POLARITY_RISING         LPTIM_CFGR_TRIGEN_0    /*!<LPTIM counter starts when a rising edge is detected*/
-#define LL_LPTIM_TRIG_POLARITY_FALLING        LPTIM_CFGR_TRIGEN_1    /*!<LPTIM counter starts when a falling edge is detected*/
-#define LL_LPTIM_TRIG_POLARITY_RISING_FALLING LPTIM_CFGR_TRIGEN      /*!<LPTIM counter starts when a rising or a falling edge is detected*/
+#define LL_LPTIM_TRIG_POLARITY_RISING         LPTIM_CFGR_TRIGEN_0 /*!<LPTIM counter starts when a rising edge is detected*/
+#define LL_LPTIM_TRIG_POLARITY_FALLING        LPTIM_CFGR_TRIGEN_1 /*!<LPTIM counter starts when a falling edge is detected*/
+#define LL_LPTIM_TRIG_POLARITY_RISING_FALLING LPTIM_CFGR_TRIGEN   /*!<LPTIM counter starts when a rising or a falling edge is detected*/
 /**
   * @}
   */
@@ -223,8 +229,8 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_CLK_SOURCE Clock Source
   * @{
   */
-#define LL_LPTIM_CLK_SOURCE_INTERNAL          0x00000000U             /*!<LPTIM is clocked by internal clock source (APB clock or any of the embedded oscillators)*/
-#define LL_LPTIM_CLK_SOURCE_EXTERNAL          LPTIM_CFGR_CKSEL        /*!<LPTIM is clocked by an external clock source through the LPTIM external Input1*/
+#define LL_LPTIM_CLK_SOURCE_INTERNAL          0x00000000U      /*!<LPTIM is clocked by internal clock source (APB clock or any of the embedded oscillators)*/
+#define LL_LPTIM_CLK_SOURCE_EXTERNAL          LPTIM_CFGR_CKSEL /*!<LPTIM is clocked by an external clock source through the LPTIM external Input1*/
 /**
   * @}
   */
@@ -232,10 +238,10 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_CLK_FILTER Clock Filter
   * @{
   */
-#define LL_LPTIM_CLK_FILTER_NONE              0x00000000U             /*!<Any external clock signal level change is considered as a valid transition*/
-#define LL_LPTIM_CLK_FILTER_2                 LPTIM_CFGR_CKFLT_0      /*!<External clock signal level change must be stable for at least 2 clock periods before it is considered as valid transition*/
-#define LL_LPTIM_CLK_FILTER_4                 LPTIM_CFGR_CKFLT_1      /*!<External clock signal level change must be stable for at least 4 clock periods before it is considered as valid transition*/
-#define LL_LPTIM_CLK_FILTER_8                 LPTIM_CFGR_CKFLT        /*!<External clock signal level change must be stable for at least 8 clock periods before it is considered as valid transition*/
+#define LL_LPTIM_CLK_FILTER_NONE              0x00000000U        /*!<Any external clock signal level change is considered as a valid transition*/
+#define LL_LPTIM_CLK_FILTER_2                 LPTIM_CFGR_CKFLT_0 /*!<External clock signal level change must be stable for at least 2 clock periods before it is considered as valid transition*/
+#define LL_LPTIM_CLK_FILTER_4                 LPTIM_CFGR_CKFLT_1 /*!<External clock signal level change must be stable for at least 4 clock periods before it is considered as valid transition*/
+#define LL_LPTIM_CLK_FILTER_8                 LPTIM_CFGR_CKFLT   /*!<External clock signal level change must be stable for at least 8 clock periods before it is considered as valid transition*/
 /**
   * @}
   */
@@ -243,9 +249,9 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_CLK_POLARITY Clock Polarity
   * @{
   */
-#define LL_LPTIM_CLK_POLARITY_RISING          0x00000000U             /*!< The rising edge is the active edge used for counting*/
-#define LL_LPTIM_CLK_POLARITY_FALLING         LPTIM_CFGR_CKPOL_0      /*!< The falling edge is the active edge used for counting*/
-#define LL_LPTIM_CLK_POLARITY_RISING_FALLING  LPTIM_CFGR_CKPOL_1      /*!< Both edges are active edges*/
+#define LL_LPTIM_CLK_POLARITY_RISING          0x00000000U        /*!< The rising edge is the active edge used for counting*/
+#define LL_LPTIM_CLK_POLARITY_FALLING         LPTIM_CFGR_CKPOL_0 /*!< The falling edge is the active edge used for counting*/
+#define LL_LPTIM_CLK_POLARITY_RISING_FALLING  LPTIM_CFGR_CKPOL_1 /*!< Both edges are active edges*/
 /**
   * @}
   */
@@ -253,9 +259,9 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_ENCODER_MODE Encoder Mode
   * @{
   */
-#define LL_LPTIM_ENCODER_MODE_RISING          0x00000000U             /*!< The rising edge is the active edge used for counting*/
-#define LL_LPTIM_ENCODER_MODE_FALLING         LPTIM_CFGR_CKPOL_0      /*!< The falling edge is the active edge used for counting*/
-#define LL_LPTIM_ENCODER_MODE_RISING_FALLING  LPTIM_CFGR_CKPOL_1      /*!< Both edges are active edges*/
+#define LL_LPTIM_ENCODER_MODE_RISING          0x00000000U        /*!< The rising edge is the active edge used for counting*/
+#define LL_LPTIM_ENCODER_MODE_FALLING         LPTIM_CFGR_CKPOL_0 /*!< The falling edge is the active edge used for counting*/
+#define LL_LPTIM_ENCODER_MODE_RISING_FALLING  LPTIM_CFGR_CKPOL_1 /*!< Both edges are active edges*/
 /**
   * @}
   */
@@ -263,10 +269,10 @@ typedef struct
 /** @defgroup LPTIM_EC_INPUT1_SRC Input1 Source
   * @{
   */
-#define LL_LPTIM_INPUT1_SRC_GPIO         0x00000000U                                   /*!< For LPTIM1 and LPTIM2 */
-#define LL_LPTIM_INPUT1_SRC_COMP1        LPTIM_CFGR2_IN1SEL_0                          /*!< For LPTIM1 and LPTIM2 */
-#define LL_LPTIM_INPUT1_SRC_COMP2        LPTIM_CFGR2_IN1SEL_1                          /*!< For LPTIM2 */
-#define LL_LPTIM_INPUT1_SRC_COMP1_COMP2  (LPTIM_CFGR2_IN1SEL_1 | LPTIM_CFGR2_IN1SEL_0) /*!< For LPTIM2 */
+#define LL_LPTIM_INPUT1_SRC_GPIO         0x00000000U                                            /*!< For LPTIM1 and LPTIM2 */
+#define LL_LPTIM_INPUT1_SRC_COMP1        LPTIM_CFGR2_IN1SEL_0                                   /*!< For LPTIM1 and LPTIM2 */
+#define LL_LPTIM_INPUT1_SRC_COMP2        LPTIM_CFGR2_IN1SEL_1                                   /*!< For LPTIM2 */
+#define LL_LPTIM_INPUT1_SRC_COMP1_COMP2  (LPTIM_CFGR2_IN1SEL_1 | LPTIM_CFGR2_IN1SEL_0)          /*!< For LPTIM2 */
 /**
   * @}
   */
@@ -274,12 +280,11 @@ typedef struct
 /** @defgroup LPTIM_EC_INPUT2_SRC Input2 Source
   * @{
   */
-#define LL_LPTIM_INPUT2_SRC_GPIO         0x00000000U             /*!< For LPTIM1 */
-#define LL_LPTIM_INPUT2_SRC_COMP2        LPTIM_CFGR2_IN2SEL_0    /*!< For LPTIM1 */
+#define LL_LPTIM_INPUT2_SRC_GPIO         0x00000000U                   /*!< For LPTIM1 */
+#define LL_LPTIM_INPUT2_SRC_COMP2        LPTIM_CFGR2_IN2SEL_0          /*!< For LPTIM1 */
 /**
   * @}
   */
-
 
 /**
   * @}
@@ -301,7 +306,7 @@ typedef struct
   * @param  __VALUE__ Value to be written in the register
   * @retval None
   */
-#define LL_LPTIM_WriteReg(__INSTANCE__, __REG__, __VALUE__) WRITE_REG(__INSTANCE__->__REG__, (__VALUE__))
+#define LL_LPTIM_WriteReg(__INSTANCE__, __REG__, __VALUE__) WRITE_REG((__INSTANCE__)->__REG__, (__VALUE__))
 
 /**
   * @brief  Read a value in LPTIM register
@@ -309,7 +314,7 @@ typedef struct
   * @param  __REG__ Register to be read
   * @retval Register value
   */
-#define LL_LPTIM_ReadReg(__INSTANCE__, __REG__) READ_REG(__INSTANCE__->__REG__)
+#define LL_LPTIM_ReadReg(__INSTANCE__, __REG__) READ_REG((__INSTANCE__)->__REG__)
 /**
   * @}
   */
@@ -317,12 +322,25 @@ typedef struct
 /**
   * @}
   */
-
 
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup LPTIM_LL_Exported_Functions LPTIM Exported Functions
   * @{
   */
+
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup LPTIM_LL_EF_Init Initialisation and deinitialisation functions
+  * @{
+  */
+
+ErrorStatus LL_LPTIM_DeInit(LPTIM_TypeDef *LPTIMx);
+void LL_LPTIM_StructInit(LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
+ErrorStatus LL_LPTIM_Init(LPTIM_TypeDef *LPTIMx, LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
+void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx);
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
 
 /** @defgroup LPTIM_LL_EF_LPTIM_Configuration LPTIM Configuration
   * @{
@@ -342,17 +360,6 @@ __STATIC_INLINE void LL_LPTIM_Enable(LPTIM_TypeDef *LPTIMx)
 }
 
 /**
-  * @brief  Disable the LPTIM instance
-  * @rmtoll CR           ENABLE        LL_LPTIM_Disable
-  * @param  LPTIMx Low-Power Timer instance
-  * @retval None
-  */
-__STATIC_INLINE void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
-{
-  CLEAR_BIT(LPTIMx->CR, LPTIM_CR_ENABLE);
-}
-
-/**
   * @brief  Indicates whether the LPTIM instance is enabled.
   * @rmtoll CR           ENABLE        LL_LPTIM_IsEnabled
   * @param  LPTIMx Low-Power Timer instance
@@ -360,7 +367,7 @@ __STATIC_INLINE void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabled(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->CR, LPTIM_CR_ENABLE) == LPTIM_CR_ENABLE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->CR, LPTIM_CR_ENABLE) == LPTIM_CR_ENABLE) ? 1UL : 0UL));
 }
 
 /**
@@ -413,7 +420,7 @@ __STATIC_INLINE void LL_LPTIM_DisableResetAfterRead(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledResetAfterRead(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->CR, LPTIM_CR_RSTARE) == LPTIM_CR_RSTARE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->CR, LPTIM_CR_RSTARE) == LPTIM_CR_RSTARE) ? 1UL : 0UL));
 }
 
 /**
@@ -464,7 +471,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetUpdateMode(LPTIM_TypeDef *LPTIMx)
   * @note The LPTIMx_ARR register content must only be modified when the LPTIM is enabled
   * @note After a write to the LPTIMx_ARR register a new write operation to the
   *       same register can only be performed when the previous write operation
-  *       is completed. Any successive write before  the ARROK flag be set, will
+  *       is completed. Any successive write before  the ARROK flag is set, will
   *       lead to unpredictable results.
   * @note autoreload value be strictly greater than the compare value.
   * @rmtoll ARR          ARR           LL_LPTIM_SetAutoReload
@@ -492,7 +499,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetAutoReload(LPTIM_TypeDef *LPTIMx)
   * @brief  Set the compare value
   * @note After a write to the LPTIMx_CMP register a new write operation to the
   *       same register can only be performed when the previous write operation
-  *       is completed. Any successive write before the CMPOK flag be set, will
+  *       is completed. Any successive write before the CMPOK flag is set, will
   *       lead to unpredictable results.
   * @rmtoll CMP          CMP           LL_LPTIM_SetCompare
   * @param  LPTIMx Low-Power Timer instance
@@ -691,7 +698,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetPrescaler(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE void LL_LPTIM_SetInput1Src(LPTIM_TypeDef *LPTIMx, uint32_t Src)
 {
-  WRITE_REG(LPTIMx->CFGR2, Src);
+  MODIFY_REG(LPTIMx->CFGR2, LPTIM_CFGR2_IN1SEL, Src);
 }
 
 /**
@@ -705,7 +712,7 @@ __STATIC_INLINE void LL_LPTIM_SetInput1Src(LPTIM_TypeDef *LPTIMx, uint32_t Src)
   */
 __STATIC_INLINE void LL_LPTIM_SetInput2Src(LPTIM_TypeDef *LPTIMx, uint32_t Src)
 {
-  WRITE_REG(LPTIMx->CFGR2, Src);
+  MODIFY_REG(LPTIMx->CFGR2, LPTIM_CFGR2_IN2SEL, Src);
 }
 
 /**
@@ -755,7 +762,7 @@ __STATIC_INLINE void LL_LPTIM_DisableTimeout(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledTimeout(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_TIMOUT) == LPTIM_CFGR_TIMOUT)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_TIMOUT) == LPTIM_CFGR_TIMOUT) ? 1UL : 0UL));
 }
 
 /**
@@ -785,8 +792,13 @@ __STATIC_INLINE void LL_LPTIM_TrigSw(LPTIM_TypeDef *LPTIMx)
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCALARMB
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCTAMP1
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCTAMP2
+  *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCTAMP3 (*)
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_COMP1
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_COMP2
+  *         @arg @ref LL_LPTIM_TRIG_SOURCE_COMP3 (*)
+  *
+  *         (*)  Value not defined in all devices. \n
+  *
   * @param  Filter This parameter can be one of the following values:
   *         @arg @ref LL_LPTIM_TRIG_FILTER_NONE
   *         @arg @ref LL_LPTIM_TRIG_FILTER_2
@@ -813,8 +825,13 @@ __STATIC_INLINE void LL_LPTIM_ConfigTrigger(LPTIM_TypeDef *LPTIMx, uint32_t Sour
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCALARMB
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCTAMP1
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCTAMP2
+  *         @arg @ref LL_LPTIM_TRIG_SOURCE_RTCTAMP3 (*)
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_COMP1
   *         @arg @ref LL_LPTIM_TRIG_SOURCE_COMP2
+  *         @arg @ref LL_LPTIM_TRIG_SOURCE_COMP3 (*)
+  *
+  *         (*)  Value not defined in all devices. \n
+  *
   */
 __STATIC_INLINE uint32_t LL_LPTIM_GetTriggerSource(LPTIM_TypeDef *LPTIMx)
 {
@@ -1016,7 +1033,7 @@ __STATIC_INLINE void LL_LPTIM_DisableEncoderMode(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledEncoderMode(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_ENC) == LPTIM_CFGR_ENC)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_ENC) == LPTIM_CFGR_ENC) ? 1UL : 0UL));
 }
 
 /**
@@ -1046,7 +1063,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFLAG_CMPM(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_CMPM(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_CMPM) == LPTIM_ISR_CMPM)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_CMPM) == LPTIM_ISR_CMPM) ? 1UL : 0UL));
 }
 
 /**
@@ -1068,7 +1085,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFLAG_ARRM(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_ARRM(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_ARRM) == LPTIM_ISR_ARRM)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_ARRM) == LPTIM_ISR_ARRM) ? 1UL : 0UL));
 }
 
 /**
@@ -1090,7 +1107,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_EXTTRIG(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_EXTTRIG(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_EXTTRIG) == LPTIM_ISR_EXTTRIG)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_EXTTRIG) == LPTIM_ISR_EXTTRIG) ? 1UL : 0UL));
 }
 
 /**
@@ -1112,7 +1129,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_CMPOK(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_CMPOK(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_CMPOK) == LPTIM_ISR_CMPOK)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_CMPOK) == LPTIM_ISR_CMPOK) ? 1UL : 0UL));
 }
 
 /**
@@ -1134,7 +1151,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_ARROK(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_ARROK(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_ARROK) == LPTIM_ISR_ARROK)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_ARROK) == LPTIM_ISR_ARROK) ? 1UL : 0UL));
 }
 
 /**
@@ -1156,7 +1173,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_UP(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_UP(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_UP) == LPTIM_ISR_UP)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_UP) == LPTIM_ISR_UP) ? 1UL : 0UL));
 }
 
 /**
@@ -1178,7 +1195,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_DOWN(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_DOWN(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_DOWN) == LPTIM_ISR_DOWN)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_DOWN) == LPTIM_ISR_DOWN) ? 1UL : 0UL));
 }
 
 /**
@@ -1219,7 +1236,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_CMPM(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_CMPM(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_CMPMIE) == LPTIM_IER_CMPMIE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_CMPMIE) == LPTIM_IER_CMPMIE) ? 1UL : 0UL));
 }
 
 /**
@@ -1252,7 +1269,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_ARRM(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_ARRM(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_ARRMIE) == LPTIM_IER_ARRMIE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_ARRMIE) == LPTIM_IER_ARRMIE) ? 1UL : 0UL));
 }
 
 /**
@@ -1285,7 +1302,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_EXTTRIG(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_EXTTRIG(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_EXTTRIGIE) == LPTIM_IER_EXTTRIGIE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_EXTTRIGIE) == LPTIM_IER_EXTTRIGIE) ? 1UL : 0UL));
 }
 
 /**
@@ -1318,7 +1335,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_CMPOK(LPTIM_TypeDef *LPTIMx)
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_CMPOK(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_CMPOKIE) == LPTIM_IER_CMPOKIE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_CMPOKIE) == LPTIM_IER_CMPOKIE) ? 1UL : 0UL));
 }
 
 /**
@@ -1347,11 +1364,11 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_ARROK(LPTIM_TypeDef *LPTIMx)
   * @brief  Indicates whether the autoreload register write completed interrupt (ARROKIE) is enabled.
   * @rmtoll IER          ARROKIE       LL_LPTIM_IsEnabledIT_ARROK
   * @param  LPTIMx Low-Power Timer instance
-  * @retval State of bit (1 or 0).
+  * @retval State of bit(1 or 0).
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_ARROK(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_ARROKIE) == LPTIM_IER_ARROKIE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_ARROKIE) == LPTIM_IER_ARROKIE) ? 1UL : 0UL));
 }
 
 /**
@@ -1380,11 +1397,11 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_UP(LPTIM_TypeDef *LPTIMx)
   * @brief  Indicates whether the direction change to up interrupt (UPIE) is enabled.
   * @rmtoll IER          UPIE          LL_LPTIM_IsEnabledIT_UP
   * @param  LPTIMx Low-Power Timer instance
-  * @retval State of bit (1 or 0).
+  * @retval State of bit(1 or 0).
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_UP(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_UPIE) == LPTIM_IER_UPIE)? 1UL : 0UL));
+  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_UPIE) == LPTIM_IER_UPIE) ? 1UL : 0UL));
 }
 
 /**
@@ -1413,29 +1430,16 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_DOWN(LPTIM_TypeDef *LPTIMx)
   * @brief  Indicates whether the direction change to down interrupt (DOWNIE) is enabled.
   * @rmtoll IER          DOWNIE        LL_LPTIM_IsEnabledIT_DOWN
   * @param  LPTIMx Low-Power Timer instance
-  * @retval State of bit (1 or 0).
+  * @retval State of bit(1 or 0).
   */
 __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_DOWN(LPTIM_TypeDef *LPTIMx)
 {
-  return (((READ_BIT(LPTIMx->IER, LPTIM_IER_DOWNIE) == LPTIM_IER_DOWNIE)? 1UL : 0UL));
+  return ((READ_BIT(LPTIMx->IER, LPTIM_IER_DOWNIE) == LPTIM_IER_DOWNIE) ? 1UL : 0UL);
 }
 
 /**
   * @}
   */
-
-#if defined(USE_FULL_LL_DRIVER)
-/** @defgroup LPTIM_LL_EF_Init Initialisation and deinitialisation functions
-  * @{
-  */
-
-ErrorStatus LL_LPTIM_DeInit(LPTIM_TypeDef *LPTIMx);
-void LL_LPTIM_StructInit(LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
-ErrorStatus LL_LPTIM_Init(LPTIM_TypeDef *LPTIMx, LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
-/**
-  * @}
-  */
-#endif /* USE_FULL_LL_DRIVER */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_lpuart.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_lpuart.h
@@ -32,7 +32,7 @@ extern "C" {
   * @{
   */
 
-#if defined (LPUART1)
+#if defined (LPUART1) || defined (LPUART2)
 
 /** @defgroup LPUART_LL LPUART
   * @{
@@ -100,36 +100,43 @@ typedef struct
   uint32_t PrescalerValue;            /*!< Specifies the Prescaler to compute the communication baud rate.
                                            This parameter can be a value of @ref LPUART_LL_EC_PRESCALER.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetPrescaler().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetPrescaler().*/
 
   uint32_t BaudRate;                  /*!< This field defines expected LPUART communication baud rate.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetBaudRate().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetBaudRate().*/
 
   uint32_t DataWidth;                 /*!< Specifies the number of data bits transmitted or received in a frame.
                                            This parameter can be a value of @ref LPUART_LL_EC_DATAWIDTH.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetDataWidth().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetDataWidth().*/
 
   uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
                                            This parameter can be a value of @ref LPUART_LL_EC_STOPBITS.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetStopBitsLength().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetStopBitsLength().*/
 
   uint32_t Parity;                    /*!< Specifies the parity mode.
                                            This parameter can be a value of @ref LPUART_LL_EC_PARITY.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetParity().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetParity().*/
 
   uint32_t TransferDirection;         /*!< Specifies whether the Receive and/or Transmit mode is enabled or disabled.
                                            This parameter can be a value of @ref LPUART_LL_EC_DIRECTION.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetTransferDirection().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetTransferDirection().*/
 
   uint32_t HardwareFlowControl;       /*!< Specifies whether the hardware flow control mode is enabled or disabled.
                                            This parameter can be a value of @ref LPUART_LL_EC_HWCONTROL.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetHWFlowCtrl().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetHWFlowCtrl().*/
 
 } LL_LPUART_InitTypeDef;
 
@@ -267,18 +274,18 @@ typedef struct
 /** @defgroup LPUART_LL_EC_PRESCALER Clock Source Prescaler
   * @{
   */
-#define LL_LPUART_PRESCALER_DIV1           0x00000000U                                                                   /*!< Input clock not devided   */
-#define LL_LPUART_PRESCALER_DIV2           (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock devided by 2  */
-#define LL_LPUART_PRESCALER_DIV4           (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock devided by 4  */
-#define LL_LPUART_PRESCALER_DIV6           (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 6  */
-#define LL_LPUART_PRESCALER_DIV8           (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock devided by 8  */
-#define LL_LPUART_PRESCALER_DIV10          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 10 */
-#define LL_LPUART_PRESCALER_DIV12          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 12 */
-#define LL_LPUART_PRESCALER_DIV16          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 16 */
-#define LL_LPUART_PRESCALER_DIV32          (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock devided by 32 */
-#define LL_LPUART_PRESCALER_DIV64          (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 64 */
-#define LL_LPUART_PRESCALER_DIV128         (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 128 */
-#define LL_LPUART_PRESCALER_DIV256         (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 256 */
+#define LL_LPUART_PRESCALER_DIV1           0x00000000U                                                                   /*!< Input clock not divided   */
+#define LL_LPUART_PRESCALER_DIV2           (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock divided by 2  */
+#define LL_LPUART_PRESCALER_DIV4           (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock divided by 4  */
+#define LL_LPUART_PRESCALER_DIV6           (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 6  */
+#define LL_LPUART_PRESCALER_DIV8           (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock divided by 8  */
+#define LL_LPUART_PRESCALER_DIV10          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 10 */
+#define LL_LPUART_PRESCALER_DIV12          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock divided by 12 */
+#define LL_LPUART_PRESCALER_DIV16          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock divided by 16 */
+#define LL_LPUART_PRESCALER_DIV32          (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock divided by 32 */
+#define LL_LPUART_PRESCALER_DIV64          (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 64 */
+#define LL_LPUART_PRESCALER_DIV128         (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock divided by 128 */
+#define LL_LPUART_PRESCALER_DIV256         (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock divided by 256 */
 /**
   * @}
   */
@@ -442,8 +449,9 @@ typedef struct
   * @param  __BAUDRATE__ Baud Rate value to achieve
   * @retval LPUARTDIV value to be used for BRR register filling
   */
-#define __LL_LPUART_DIV(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) (uint32_t)((((((uint64_t)(__PERIPHCLK__)/(uint64_t)(LPUART_PRESCALER_TAB[(uint16_t)(__PRESCALER__)])) * LPUART_LPUARTDIV_FREQ_MUL)\
-                                                                                + (uint32_t)((__BAUDRATE__)/2U))/(__BAUDRATE__)) & LPUART_BRR_MASK)
+#define __LL_LPUART_DIV(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) (uint32_t)\
+  ((((((uint64_t)(__PERIPHCLK__)/(uint64_t)(LPUART_PRESCALER_TAB[(uint16_t)(__PRESCALER__)]))\
+      * LPUART_LPUARTDIV_FREQ_MUL) + (uint32_t)((__BAUDRATE__)/2U))/(__BAUDRATE__)) & LPUART_BRR_MASK)
 
 /**
   * @}
@@ -629,7 +637,8 @@ __STATIC_INLINE uint32_t LL_LPUART_GetRXFIFOThreshold(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_ConfigFIFOsThreshold(USART_TypeDef *LPUARTx, uint32_t TXThreshold, uint32_t RXThreshold)
 {
-  MODIFY_REG(LPUARTx->CR3, USART_CR3_TXFTCFG | USART_CR3_RXFTCFG, (TXThreshold << USART_CR3_TXFTCFG_Pos) | (RXThreshold << USART_CR3_RXFTCFG_Pos));
+  MODIFY_REG(LPUARTx->CR3, USART_CR3_TXFTCFG | USART_CR3_RXFTCFG, (TXThreshold << USART_CR3_TXFTCFG_Pos) | \
+             (RXThreshold << USART_CR3_RXFTCFG_Pos));
 }
 
 /**
@@ -1345,7 +1354,10 @@ __STATIC_INLINE uint32_t LL_LPUART_GetWKUPType(USART_TypeDef *LPUARTx)
 __STATIC_INLINE void LL_LPUART_SetBaudRate(USART_TypeDef *LPUARTx, uint32_t PeriphClk, uint32_t PrescalerValue,
                                            uint32_t BaudRate)
 {
-  LPUARTx->BRR = __LL_LPUART_DIV(PeriphClk, PrescalerValue, BaudRate);
+  if (BaudRate != 0U)
+  {
+    LPUARTx->BRR = __LL_LPUART_DIV(PeriphClk, PrescalerValue, BaudRate);
+  }
 }
 
 /**
@@ -1372,9 +1384,9 @@ __STATIC_INLINE void LL_LPUART_SetBaudRate(USART_TypeDef *LPUARTx, uint32_t Peri
   */
 __STATIC_INLINE uint32_t LL_LPUART_GetBaudRate(USART_TypeDef *LPUARTx, uint32_t PeriphClk, uint32_t PrescalerValue)
 {
-  register uint32_t lpuartdiv;
-  register uint32_t brrresult;
-  register uint32_t periphclkpresc = (uint32_t)(PeriphClk / (LPUART_PRESCALER_TAB[(uint16_t)PrescalerValue]));
+  uint32_t lpuartdiv;
+  uint32_t brrresult;
+  uint32_t periphclkpresc = (uint32_t)(PeriphClk / (LPUART_PRESCALER_TAB[(uint16_t)PrescalerValue]));
 
   lpuartdiv = LPUARTx->BRR & LPUART_BRR_MASK;
 
@@ -2482,7 +2494,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMADeactOnRxErr(USART_TypeDef *LPUAR
   */
 __STATIC_INLINE uint32_t LL_LPUART_DMA_GetRegAddr(USART_TypeDef *LPUARTx, uint32_t Direction)
 {
-  register uint32_t data_reg_addr;
+  uint32_t data_reg_addr;
 
   if (Direction == LL_LPUART_DMA_REG_DATA_TRANSMIT)
   {
@@ -2619,7 +2631,7 @@ void        LL_LPUART_StructInit(LL_LPUART_InitTypeDef *LPUART_InitStruct);
   * @}
   */
 
-#endif /* LPUART1 */
+#endif /* LPUART1 || LPUART2 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_pwr.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_pwr.h
@@ -60,6 +60,9 @@ extern "C" {
 #define LL_PWR_SCR_CWUF6                   PWR_SCR_CWUF6
 #define LL_PWR_SCR_CWUF5                   PWR_SCR_CWUF5
 #define LL_PWR_SCR_CWUF4                   PWR_SCR_CWUF4
+#if defined(PWR_CR3_EWUP3)
+#define LL_PWR_SCR_CWUF3                   PWR_SCR_CWUF3
+#endif
 #define LL_PWR_SCR_CWUF2                   PWR_SCR_CWUF2
 #define LL_PWR_SCR_CWUF1                   PWR_SCR_CWUF1
 /**
@@ -75,6 +78,9 @@ extern "C" {
 #define LL_PWR_SR1_WUF6                    PWR_SR1_WUF6
 #define LL_PWR_SR1_WUF5                    PWR_SR1_WUF5
 #define LL_PWR_SR1_WUF4                    PWR_SR1_WUF4
+#if defined(PWR_CR3_EWUP3)
+#define LL_PWR_SR1_WUF3                    PWR_SR1_WUF3
+#endif
 #define LL_PWR_SR1_WUF2                    PWR_SR1_WUF2
 #define LL_PWR_SR1_WUF1                    PWR_SR1_WUF1
 #if defined(PWR_SR2_PVDO)
@@ -134,11 +140,24 @@ extern "C" {
   */
 #endif
 
+#if defined(PWR_PVM_SUPPORT)
+/** @defgroup PWR_LL_EC_PVM_IP PVM_IP
+  * @{
+  */
+#define LL_PWR_PVM_USB                  PWR_CR2_PVMEN_USB                           /*!< Peripheral Voltage Monitoring enable for USB peripheral: Enable to keep the USB peripheral voltage monitoring under control (power domain Vddio2) */
+/**
+  * @}
+  */
+#endif
+
 /** @defgroup PWR_LL_EC_WAKEUP WAKEUP
   * @{
   */
 #define LL_PWR_WAKEUP_PIN1                 (PWR_CR3_EWUP1)
 #define LL_PWR_WAKEUP_PIN2                 (PWR_CR3_EWUP2)
+#if defined(PWR_CR3_EWUP3)
+#define LL_PWR_WAKEUP_PIN3                 (PWR_CR3_EWUP3)
+#endif
 #define LL_PWR_WAKEUP_PIN4                 (PWR_CR3_EWUP4)
 #if defined(PWR_CR3_EWUP5)
 #define LL_PWR_WAKEUP_PIN5                 (PWR_CR3_EWUP5)
@@ -434,6 +453,114 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnableFlashPowerDownInStop(void)
   return ((READ_BIT(PWR->CR1, PWR_CR1_FPD_STOP) == (PWR_CR1_FPD_STOP)) ? 1UL : 0UL);
 }
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Enable VDDIO2 supply
+  * @rmtoll CR2          IOSV          LL_PWR_EnableVddIO2
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_EnableVddIO2(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_IOSV);
+}
+
+/**
+  * @brief  Disable VDDIO2 supply
+  * @rmtoll CR2          IOSV          LL_PWR_DisableVddIO2
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_DisableVddIO2(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_IOSV);
+}
+
+/**
+  * @brief  Check if VDDIO2 supply is enabled
+  * @rmtoll CR2          IOSV          LL_PWR_IsEnabledVddIO2
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsEnabledVddIO2(void)
+{
+  return ((READ_BIT(PWR->CR2, PWR_CR2_IOSV) == (PWR_CR2_IOSV)) ? 1UL : 0UL);
+}
+#endif
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+/**
+  * @brief  Enable VDDUSB supply
+  * @rmtoll CR2          USV           LL_PWR_EnableVddUSB
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_EnableVddUSB(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_USV);
+}
+
+/**
+  * @brief  Disable VDDUSB supply
+  * @rmtoll CR2          USV           LL_PWR_DisableVddUSB
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_DisableVddUSB(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_USV);
+}
+
+/**
+  * @brief  Check if VDDUSB supply is enabled
+  * @rmtoll CR2          USV           LL_PWR_IsEnabledVddUSB
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsEnabledVddUSB(void)
+{
+  return ((READ_BIT(PWR->CR2, PWR_CR2_USV) == (PWR_CR2_USV)) ? 1UL : 0UL);
+}
+#endif
+
+#if defined (PWR_PVM_SUPPORT)
+/**
+  * @brief  Enable the Power Voltage Monitoring on a peripheral
+  * @rmtoll CR2          PVMUSB         LL_PWR_EnablePVM
+  * @param  PeriphVoltage This parameter can be one of the following values:
+  *         @arg @ref LL_PWR_PVM_USB (*)
+  *
+  *         (*) value not defined in all devices
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_EnablePVM(uint32_t PeriphVoltage)
+{
+  SET_BIT(PWR->CR2, PeriphVoltage);
+}
+
+/**
+  * @brief  Disable the Power Voltage Monitoring on a peripheral
+  * @rmtoll CR2          PVMUSB         LL_PWR_DisablePVM
+  * @param  PeriphVoltage This parameter can be one of the following values:
+  *         @arg @ref LL_PWR_PVM_USB (*)
+  *
+  *         (*) value not defined in all devices
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_DisablePVM(uint32_t PeriphVoltage)
+{
+  CLEAR_BIT(PWR->CR2, PeriphVoltage);
+}
+
+/**
+  * @brief  Check if Power Voltage Monitoring is enabled on a peripheral
+  * @rmtoll CR2          PVMUSB         LL_PWR_IsEnabledPVM
+  * @param  PeriphVoltage This parameter can be one of the following values:
+  *         @arg @ref LL_PWR_PVM_USB (*)
+  *
+  *         (*) value not defined in all devices
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsEnabledPVM(uint32_t PeriphVoltage)
+{
+  return ((READ_BIT(PWR->CR2, PeriphVoltage) == (PeriphVoltage)) ? 1UL : 0UL);
+}
+#endif
+
 /**
   * @brief  Set Low-Power mode
   * @rmtoll CR1          LPMS          LL_PWR_SetPowerMode
@@ -694,16 +821,19 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnableLPMUResetSamplingMode(void)
   * @brief  Enable the WakeUp PINx functionality
   * @rmtoll CR3          EWUP1         LL_PWR_EnableWakeUpPin\n
   *         CR3          EWUP2         LL_PWR_EnableWakeUpPin\n
+  *         CR3          EWUP3         LL_PWR_EnableWakeUpPin\n
   *         CR3          EWUP4         LL_PWR_EnableWakeUpPin\n
   *         CR3          EWUP5         LL_PWR_EnableWakeUpPin\n
   *         CR3          EWUP6         LL_PWR_EnableWakeUpPin
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
+  *         @arg @ref LL_PWR_WAKEUP_PIN3 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
-  *         @arg @ref LL_PWR_WAKEUP_PIN5
+  *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN6
   * @retval None
+  * @note (*) availability depends on devices
   */
 __STATIC_INLINE void LL_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
 {
@@ -714,16 +844,19 @@ __STATIC_INLINE void LL_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
   * @brief  Disable the WakeUp PINx functionality
   * @rmtoll CR3          EWUP1         LL_PWR_DisableWakeUpPin\n
   *         CR3          EWUP2         LL_PWR_DisableWakeUpPin\n
+  *         CR3          EWUP3         LL_PWR_DisableWakeUpPin\n
   *         CR3          EWUP4         LL_PWR_DisableWakeUpPin\n
   *         CR3          EWUP5         LL_PWR_DisableWakeUpPin\n
   *         CR3          EWUP6         LL_PWR_DisableWakeUpPin
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
+  *         @arg @ref LL_PWR_WAKEUP_PIN3 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
-  *         @arg @ref LL_PWR_WAKEUP_PIN5
+  *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN6
   * @retval None
+  * @note (*) availability depends on devices
   */
 __STATIC_INLINE void LL_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
 {
@@ -734,16 +867,19 @@ __STATIC_INLINE void LL_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
   * @brief  Check if the WakeUp PINx functionality is enabled
   * @rmtoll CR3          EWUP1         LL_PWR_IsEnabledWakeUpPin\n
   *         CR3          EWUP2         LL_PWR_IsEnabledWakeUpPin\n
+  *         CR3          EWUP3         LL_PWR_IsEnabledWakeUpPin\n
   *         CR3          EWUP4         LL_PWR_IsEnabledWakeUpPin\n
   *         CR3          EWUP5         LL_PWR_IsEnabledWakeUpPin\n
   *         CR3          EWUP6         LL_PWR_IsEnabledWakeUpPin
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
+  *         @arg @ref LL_PWR_WAKEUP_PIN3 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
-  *         @arg @ref LL_PWR_WAKEUP_PIN5
+  *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN6
   * @retval State of bit (1 or 0).
+  * @note (*) availability depends on devices
   */
 __STATIC_INLINE uint32_t LL_PWR_IsEnabledWakeUpPin(uint32_t WakeUpPin)
 {
@@ -809,16 +945,19 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledBatteryCharging(void)
   * @brief  Set the Wake-Up pin polarity low for the event detection
   * @rmtoll CR4          WP1           LL_PWR_SetWakeUpPinPolarityLow\n
   *         CR4          WP2           LL_PWR_SetWakeUpPinPolarityLow\n
+  *         CR4          WP3           LL_PWR_SetWakeUpPinPolarityLow\n
   *         CR4          WP4           LL_PWR_SetWakeUpPinPolarityLow\n
   *         CR4          WP5           LL_PWR_SetWakeUpPinPolarityLow\n
-  *         CR4          WP6           LL_PWR_SetWakeUpPinPolarityLow\n
+  *         CR4          WP6           LL_PWR_SetWakeUpPinPolarityLow
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
+  *         @arg @ref LL_PWR_WAKEUP_PIN3 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
-  *         @arg @ref LL_PWR_WAKEUP_PIN5
+  *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN6
   * @retval None
+  * @note (*) availability depends on devices
   */
 __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityLow(uint32_t WakeUpPin)
 {
@@ -829,15 +968,18 @@ __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityLow(uint32_t WakeUpPin)
   * @brief  Set the Wake-Up pin polarity high for the event detection
   * @rmtoll CR4          WP1           LL_PWR_SetWakeUpPinPolarityHigh\n
   *         CR4          WP2           LL_PWR_SetWakeUpPinPolarityHigh\n
+  *         CR4          WP3           LL_PWR_SetWakeUpPinPolarityHigh\n
   *         CR4          WP4           LL_PWR_SetWakeUpPinPolarityHigh\n
   *         CR4          WP5           LL_PWR_SetWakeUpPinPolarityHigh\n
   *         CR4          WP6           LL_PWR_SetWakeUpPinPolarityHigh
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
+  *         @arg @ref LL_PWR_WAKEUP_PIN3 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
-  *         @arg @ref LL_PWR_WAKEUP_PIN5
+  *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN6
+  * @note (*) availability depends on devices
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityHigh(uint32_t WakeUpPin)
@@ -849,15 +991,18 @@ __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityHigh(uint32_t WakeUpPin)
   * @brief  Get the Wake-Up pin polarity for the event detection
   * @rmtoll CR4          WP1           LL_PWR_IsWakeUpPinPolarityLow\n
   *         CR4          WP2           LL_PWR_IsWakeUpPinPolarityLow\n
+  *         CR4          WP3           LL_PWR_IsWakeUpPinPolarityLow\n
   *         CR4          WP4           LL_PWR_IsWakeUpPinPolarityLow\n
   *         CR4          WP5           LL_PWR_IsWakeUpPinPolarityLow\n
   *         CR4          WP6           LL_PWR_IsWakeUpPinPolarityLow
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
+  *         @arg @ref LL_PWR_WAKEUP_PIN3 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
-  *         @arg @ref LL_PWR_WAKEUP_PIN5
+  *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *         @arg @ref LL_PWR_WAKEUP_PIN6
+  * @note (*) availability depends on devices
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_PWR_IsWakeUpPinPolarityLow(uint32_t WakeUpPin)
@@ -871,12 +1016,14 @@ __STATIC_INLINE uint32_t LL_PWR_IsWakeUpPinPolarityLow(uint32_t WakeUpPin)
   *         PUCRB        PU0-15        LL_PWR_EnableGPIOPullUp\n
   *         PUCRC        PU0-15        LL_PWR_EnableGPIOPullUp\n
   *         PUCRD        PU0-15        LL_PWR_EnableGPIOPullUp\n
-  *         PUCRF        PU0-15        LL_PWR_EnableGPIOPullUp
+  *         PUCRE        PU0-15        LL_PWR_EnableGPIOPullUp\n
+  *         PUCRF        PU0-13        LL_PWR_EnableGPIOPullUp
   * @param  GPIO This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_A
   *         @arg @ref LL_PWR_GPIO_B
   *         @arg @ref LL_PWR_GPIO_C
   *         @arg @ref LL_PWR_GPIO_D
+  *         @arg @ref LL_PWR_GPIO_E (*)
   *         @arg @ref LL_PWR_GPIO_F
   * @param  GPIONumber This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_BIT_0
@@ -908,12 +1055,14 @@ __STATIC_INLINE void LL_PWR_EnableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber)
   *         PUCRB        PU0-15        LL_PWR_DisableGPIOPullUp\n
   *         PUCRC        PU0-15        LL_PWR_DisableGPIOPullUp\n
   *         PUCRD        PU0-15        LL_PWR_DisableGPIOPullUp\n
-  *         PUCRF        PU0-15        LL_PWR_DisableGPIOPullUp
+  *         PUCRE        PU0-15        LL_PWR_DisableGPIOPullUp\n
+  *         PUCRF        PU0-13        LL_PWR_DisableGPIOPullUp
   * @param  GPIO This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_A
   *         @arg @ref LL_PWR_GPIO_B
   *         @arg @ref LL_PWR_GPIO_C
   *         @arg @ref LL_PWR_GPIO_D
+  *         @arg @ref LL_PWR_GPIO_E (*)
   *         @arg @ref LL_PWR_GPIO_F
   * @param  GPIONumber This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_BIT_0
@@ -945,12 +1094,14 @@ __STATIC_INLINE void LL_PWR_DisableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber
   *         PUCRB        PU0-15        LL_PWR_IsEnabledGPIOPullUp\n
   *         PUCRC        PU0-15        LL_PWR_IsEnabledGPIOPullUp\n
   *         PUCRD        PU0-15        LL_PWR_IsEnabledGPIOPullUp\n
-  *         PUCRF        PU0-15        LL_PWR_IsEnabledGPIOPullUp
+  *         PUCRE        PU0-15        LL_PWR_IsEnabledGPIOPullUp\n
+  *         PUCRF        PU0-13        LL_PWR_IsEnabledGPIOPullUp
   * @param  GPIO This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_A
   *         @arg @ref LL_PWR_GPIO_B
   *         @arg @ref LL_PWR_GPIO_C
   *         @arg @ref LL_PWR_GPIO_D
+  *         @arg @ref LL_PWR_GPIO_E (*)
   *         @arg @ref LL_PWR_GPIO_F
   * @param  GPIONumber This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_BIT_0
@@ -982,12 +1133,14 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledGPIOPullUp(uint32_t GPIO, uint32_t GPIO
   *         PDCRB        PD0-15        LL_PWR_EnableGPIOPullDown\n
   *         PDCRC        PD0-15        LL_PWR_EnableGPIOPullDown\n
   *         PDCRD        PD0-15        LL_PWR_EnableGPIOPullDown\n
-  *         PDCRF        PD0-15        LL_PWR_EnableGPIOPullDown
+  *         PDCRE        PD0-15        LL_PWR_EnableGPIOPullDown\n
+  *         PDCRF        PD0-13        LL_PWR_EnableGPIOPullDown
   * @param  GPIO This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_A
   *         @arg @ref LL_PWR_GPIO_B
   *         @arg @ref LL_PWR_GPIO_C
   *         @arg @ref LL_PWR_GPIO_D
+  *         @arg @ref LL_PWR_GPIO_E (*)
   *         @arg @ref LL_PWR_GPIO_F
   * @param  GPIONumber This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_BIT_0
@@ -1019,12 +1172,14 @@ __STATIC_INLINE void LL_PWR_EnableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumbe
   *         PDCRB        PD0-15        LL_PWR_DisableGPIOPullDown\n
   *         PDCRC        PD0-15        LL_PWR_DisableGPIOPullDown\n
   *         PDCRD        PD0-15        LL_PWR_DisableGPIOPullDown\n
-  *         PDCRF        PD0-15        LL_PWR_DisableGPIOPullDown
+  *         PDCRE        PD0-15        LL_PWR_DisableGPIOPullDown\n
+  *         PDCRF        PD0-13        LL_PWR_DisableGPIOPullDown
   * @param  GPIO This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_A
   *         @arg @ref LL_PWR_GPIO_B
   *         @arg @ref LL_PWR_GPIO_C
   *         @arg @ref LL_PWR_GPIO_D
+  *         @arg @ref LL_PWR_GPIO_E (*)
   *         @arg @ref LL_PWR_GPIO_F
   * @param  GPIONumber This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_BIT_0
@@ -1056,12 +1211,14 @@ __STATIC_INLINE void LL_PWR_DisableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumb
   *         PDCRB        PD0-15        LL_PWR_IsEnabledGPIOPullDown\n
   *         PDCRC        PD0-15        LL_PWR_IsEnabledGPIOPullDown\n
   *         PDCRD        PD0-15        LL_PWR_IsEnabledGPIOPullDown\n
-  *         PDCRF        PD0-15        LL_PWR_IsEnabledGPIOPullDown
+  *         PDCRE        PD0-15        LL_PWR_IsEnabledGPIOPullDown\n
+  *         PDCRF        PD0-13        LL_PWR_IsEnabledGPIOPullDown
   * @param  GPIO This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_A
   *         @arg @ref LL_PWR_GPIO_B
   *         @arg @ref LL_PWR_GPIO_C
   *         @arg @ref LL_PWR_GPIO_D
+  *         @arg @ref LL_PWR_GPIO_E (*)
   *         @arg @ref LL_PWR_GPIO_F
   * @param  GPIONumber This parameter can be one of the following values:
   *         @arg @ref LL_PWR_GPIO_BIT_0
@@ -1147,6 +1304,17 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_WU4(void)
   return ((READ_BIT(PWR->SR1, PWR_SR1_WUF4) == (PWR_SR1_WUF4)) ? 1UL : 0UL);
 }
 
+#if defined(PWR_CR3_EWUP3)
+/**
+  * @brief  Get Wake-up Flag 3
+  * @rmtoll SR1          WUF3          LL_PWR_IsActiveFlag_WU3
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_WU3(void)
+{
+  return ((READ_BIT(PWR->SR1, PWR_SR1_WUF3) == (PWR_SR1_WUF3)) ? 1UL : 0UL);
+}
+#endif
 
 /**
   * @brief  Get Wake-up Flag 2
@@ -1220,6 +1388,17 @@ __STATIC_INLINE void LL_PWR_ClearFlag_WU4(void)
   WRITE_REG(PWR->SCR, PWR_SCR_CWUF4);
 }
 
+#if defined(PWR_CR3_EWUP3)
+/**
+  * @brief  Clear Wake-up Flag 3
+  * @rmtoll SCR          CWUF3         LL_PWR_ClearFlag_WU3
+  * @retval None
+  */
+__STATIC_INLINE void LL_PWR_ClearFlag_WU3(void)
+{
+  WRITE_REG(PWR->SCR, PWR_SCR_CWUF3);
+}
+#endif
 
 /**
   * @brief  Clear Wake-up Flag 2
@@ -1240,6 +1419,19 @@ __STATIC_INLINE void LL_PWR_ClearFlag_WU1(void)
 {
   WRITE_REG(PWR->SCR, PWR_SCR_CWUF1);
 }
+
+#if defined (PWR_PVM_SUPPORT)
+/**
+  * @brief  Indicate whether VDD voltage is below or above the selected PVD
+  *         threshold
+  * @rmtoll SR2          PVDMO_USB          LL_PWR_IsActiveFlag_PVMOUSB
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_PVMOUSB(void)
+{
+  return ((READ_BIT(PWR->SR2, PWR_SR2_PVMO_USB) == (PWR_SR2_PVMO_USB)) ? 1UL : 0UL);
+}
+#endif
 
 #if defined(PWR_SR2_PVDO)
 /**

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_rcc.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_rcc.h
@@ -118,6 +118,12 @@ typedef struct
 #if !defined  (EXTERNAL_CLOCK_VALUE)
 #define EXTERNAL_CLOCK_VALUE    48000000U /*!< Value of the I2S_CKIN external oscillator in Hz */
 #endif /* EXTERNAL_CLOCK_VALUE */
+
+#if defined(RCC_HSI48_SUPPORT)
+#if !defined  (HSI48_VALUE)
+#define HSI48_VALUE  48000000U  /*!< Value of the HSI48 oscillator in Hz */
+#endif /* HSI48_VALUE */
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -133,6 +139,9 @@ typedef struct
 #define LL_RCC_CICR_PLLRDYC                RCC_CICR_PLLRDYC     /*!< PLL Ready Interrupt Clear */
 #define LL_RCC_CICR_LSECSSC                RCC_CICR_LSECSSC     /*!< LSE Clock Security System Interrupt Clear */
 #define LL_RCC_CICR_CSSC                   RCC_CICR_CSSC        /*!< Clock Security System Interrupt Clear */
+#if defined(RCC_HSI48_SUPPORT)
+#define LL_RCC_CICR_HSI48RDYC              RCC_CICR_HSI48RDYC   /*!< HSI48 Ready Interrupt Clear */
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -144,6 +153,9 @@ typedef struct
 #define LL_RCC_CIFR_LSIRDYF                RCC_CIFR_LSIRDYF     /*!< LSI Ready Interrupt flag */
 #define LL_RCC_CIFR_LSERDYF                RCC_CIFR_LSERDYF     /*!< LSE Ready Interrupt flag */
 #define LL_RCC_CIFR_HSIRDYF                RCC_CIFR_HSIRDYF     /*!< HSI Ready Interrupt flag */
+#if defined(RCC_HSI48_SUPPORT)
+#define LL_RCC_CIFR_HSI48RDYF              RCC_CIFR_HSI48RDYF   /*!< HSI48 Ready Interrupt flag */
+#endif /* RCC_HSI48_SUPPORT */
 #define LL_RCC_CIFR_HSERDYF                RCC_CIFR_HSERDYF     /*!< HSE Ready Interrupt flag */
 #define LL_RCC_CIFR_PLLRDYF                RCC_CIFR_PLLRDYF     /*!< PLL Ready Interrupt flag */
 #define LL_RCC_CIFR_LSECSSF                RCC_CIFR_LSECSSF     /*!< LSE Clock Security System Interrupt flag */
@@ -168,6 +180,9 @@ typedef struct
 #define LL_RCC_CIER_HSIRDYIE               RCC_CIER_HSIRDYIE      /*!< HSI Ready Interrupt Enable */
 #define LL_RCC_CIER_HSERDYIE               RCC_CIER_HSERDYIE      /*!< HSE Ready Interrupt Enable */
 #define LL_RCC_CIER_PLLRDYIE               RCC_CIER_PLLRDYIE      /*!< PLL Ready Interrupt Enable */
+#if defined(RCC_HSI48_SUPPORT)
+#define LL_RCC_CIER_HSI48RDYIE             RCC_CIER_HSI48RDYIE    /*!< HSI48 Ready Interrupt Enable */
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -264,11 +279,20 @@ typedef struct
   */
 #define LL_RCC_MCO1SOURCE_NOCLOCK          0x00000000U                            /*!< MCO output disabled, no clock on MCO */
 #define LL_RCC_MCO1SOURCE_SYSCLK           RCC_CFGR_MCOSEL_0                      /*!< SYSCLK selection as MCO1 source */
+#if defined(RCC_HSI48_SUPPORT)
+#define LL_RCC_MCO1SOURCE_HSI48            RCC_CFGR_MCOSEL_1                      /*!< HSI48 selection as MCO1 source */
+#endif /* RCC_HSI48_SUPPORT */
 #define LL_RCC_MCO1SOURCE_HSI              (RCC_CFGR_MCOSEL_0| RCC_CFGR_MCOSEL_1) /*!< HSI16 selection as MCO1 source */
 #define LL_RCC_MCO1SOURCE_HSE              RCC_CFGR_MCOSEL_2                      /*!< HSE selection as MCO1 source */
 #define LL_RCC_MCO1SOURCE_PLLCLK           (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_2)  /*!< Main PLL selection as MCO1 source */
 #define LL_RCC_MCO1SOURCE_LSI              (RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_2)  /*!< LSI selection as MCO1 source */
 #define LL_RCC_MCO1SOURCE_LSE              (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_2) /*!< LSE selection as MCO1 source */
+#if defined(RCC_CFGR_MCOSEL_3)
+#define LL_RCC_MCO1SOURCE_PLLPCLK         RCC_CFGR_MCOSEL_3                       /*!< PLLPCLK selection as MCO1 source */
+#define LL_RCC_MCO1SOURCE_PLLQCLK         (RCC_CFGR_MCOSEL_3|RCC_CFGR_MCOSEL_0)   /*!< PLLQCLK selection as MCO1 source */
+#define LL_RCC_MCO1SOURCE_RTCCLK          (RCC_CFGR_MCOSEL_3|RCC_CFGR_MCOSEL_1)   /*!< RTCCLK selection as MCO1 source */
+#define LL_RCC_MCO1SOURCE_RTC_WKUP        (RCC_CFGR_MCOSEL_3|RCC_CFGR_MCOSEL_1|RCC_CFGR_MCOSEL_0) /*!< RTC_Wakeup selection as MCO1 source */
+#endif /* RCC_CFGR_MCOSEL_3 */
 /**
   * @}
   */
@@ -284,9 +308,55 @@ typedef struct
 #define LL_RCC_MCO1_DIV_32                 (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_0)                     /*!< MCO1 divided by 32 */
 #define LL_RCC_MCO1_DIV_64                 (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_1)                     /*!< MCO1 divided by 64 */
 #define LL_RCC_MCO1_DIV_128                (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_1 | RCC_CFGR_MCOPRE_0) /*!< MCO1 divided by 128 */
+#if defined(RCC_CFGR_MCOPRE_3)
+#define LL_RCC_MCO1_DIV_256                 RCC_CFGR_MCOPRE_3                                           /*!< MCO divided by 256 */
+#define LL_RCC_MCO1_DIV_512                (RCC_CFGR_MCOPRE_3 | RCC_CFGR_MCOPRE_0)                      /*!< MCO divided by 512 */
+#define LL_RCC_MCO1_DIV_1024               (RCC_CFGR_MCOPRE_3 | RCC_CFGR_MCOPRE_1)                      /*!< MCO divided by 1024 */
+#endif /* RCC_CFGR_MCOPRE_3 */
 /**
   * @}
   */
+
+#if defined(RCC_MCO2_SUPPORT)
+/** @defgroup RCC_LL_EC_MCO2SOURCE  MCO2 SOURCE selection
+  * @{
+  */
+#define LL_RCC_MCO2SOURCE_NOCLOCK          0x00000000U                                                    /*!< MCO output disabled, no clock on MCO */
+#define LL_RCC_MCO2SOURCE_SYSCLK           RCC_CFGR_MCO2SEL_0                                             /*!< SYSCLK selection as MCO2 source */
+#if defined(RCC_HSI48_SUPPORT)
+#define LL_RCC_MCO2SOURCE_HSI48            RCC_CFGR_MCO2SEL_1                                             /*!< HSI48 selection as MCO2 source */
+#endif /* RCC_HSI48_SUPPORT */
+#define LL_RCC_MCO2SOURCE_HSI              (RCC_CFGR_MCO2SEL_1 | RCC_CFGR_MCO2SEL_0)                      /*!< HSI16 selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_HSE              RCC_CFGR_MCO2SEL_2                                             /*!< HSE selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_PLLCLK           (RCC_CFGR_MCO2SEL_2 | RCC_CFGR_MCO2SEL_0)                      /*!< Main PLL "R" clock selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_LSI              (RCC_CFGR_MCO2SEL_2 | RCC_CFGR_MCO2SEL_1)                      /*!< LSI selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_LSE              (RCC_CFGR_MCO2SEL_2 | RCC_CFGR_MCO2SEL_1 | RCC_CFGR_MCO2SEL_0) /*!< LSE selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_PLLPCLK          RCC_CFGR_MCO2SEL_3                                             /*!< PLL "P" clock selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_PLLQCLK          (RCC_CFGR_MCO2SEL_3 | RCC_CFGR_MCO2SEL_0)                      /*!< PLL "Q" clock  selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_RTCCLK           (RCC_CFGR_MCO2SEL_3 | RCC_CFGR_MCO2SEL_1)                      /*!< RTC Clock selection as MCO2 source */
+#define LL_RCC_MCO2SOURCE_RTC_WKUP         (RCC_CFGR_MCO2SEL_3 | RCC_CFGR_MCO2SEL_1 | RCC_CFGR_MCO2SEL_0) /*!< RTC Wakeup timer selection as MCO2 source */
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LL_EC_MCO2_DIV  MCO2 prescaler
+  * @{
+  */
+#define LL_RCC_MCO2_DIV_1                  0x00000000U                                                    /*!< MCO2 not divided */
+#define LL_RCC_MCO2_DIV_2                  RCC_CFGR_MCO2PRE_0                                             /*!< MCO2 divided by 2 */
+#define LL_RCC_MCO2_DIV_4                  RCC_CFGR_MCO2PRE_1                                             /*!< MCO2 divided by 4 */
+#define LL_RCC_MCO2_DIV_8                  (RCC_CFGR_MCO2PRE_1 | RCC_CFGR_MCO2PRE_0)                      /*!< MCO2 divided by 8 */
+#define LL_RCC_MCO2_DIV_16                 RCC_CFGR_MCO2PRE_2                                             /*!< MCO2 divided by 16 */
+#define LL_RCC_MCO2_DIV_32                 (RCC_CFGR_MCO2PRE_2 | RCC_CFGR_MCO2PRE_0)                      /*!< MCO2 divided by 32 */
+#define LL_RCC_MCO2_DIV_64                 (RCC_CFGR_MCO2PRE_2 | RCC_CFGR_MCO2PRE_1)                      /*!< MCO2 divided by 64 */
+#define LL_RCC_MCO2_DIV_128                (RCC_CFGR_MCO2PRE_2 | RCC_CFGR_MCO2PRE_1 | RCC_CFGR_MCO2PRE_0) /*!< MCO2 divided by 128 */
+#define LL_RCC_MCO2_DIV_256                RCC_CFGR_MCO2PRE_3                                             /*!< MCO2 divided by 256 */
+#define LL_RCC_MCO2_DIV_512                (RCC_CFGR_MCO2PRE_3 | RCC_CFGR_MCO2PRE_0)                      /*!< MCO2 divided by 512 */
+#define LL_RCC_MCO2_DIV_1024               (RCC_CFGR_MCO2PRE_3 | RCC_CFGR_MCO2PRE_1)                      /*!< MCO2 divided by 1024 */
+/**
+  * @}
+  */
+#endif /* RCC_MCO2_SUPPORT */
 
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup RCC_LL_EC_PERIPH_FREQUENCY Peripheral clock frequency
@@ -310,41 +380,68 @@ typedef struct
 #define LL_RCC_USART2_CLKSOURCE_SYSCLK     ((RCC_CCIPR_USART2SEL << 16U) | RCC_CCIPR_USART2SEL_0)  /*!< SYSCLK clock used as USART2 clock source */
 #define LL_RCC_USART2_CLKSOURCE_HSI        ((RCC_CCIPR_USART2SEL << 16U) | RCC_CCIPR_USART2SEL_1)  /*!< HSI clock used as USART2 clock source */
 #define LL_RCC_USART2_CLKSOURCE_LSE        ((RCC_CCIPR_USART2SEL << 16U) | RCC_CCIPR_USART2SEL)    /*!< LSE clock used as USART2 clock source */
+#if defined(RCC_CCIPR_USART3SEL)
+#define LL_RCC_USART3_CLKSOURCE_PCLK1      ((RCC_CCIPR_USART3SEL << 16U) | 0x00000000U)           /*!< PCLK1 clock used as USART3 clock source */
+#define LL_RCC_USART3_CLKSOURCE_SYSCLK     ((RCC_CCIPR_USART3SEL << 16U) | RCC_CCIPR_USART3SEL_0) /*!< SYSCLK clock used as USART3 clock source */
+#define LL_RCC_USART3_CLKSOURCE_HSI        ((RCC_CCIPR_USART3SEL << 16U) | RCC_CCIPR_USART3SEL_1) /*!< HSI clock used as USART3 clock source */
+#define LL_RCC_USART3_CLKSOURCE_LSE        ((RCC_CCIPR_USART3SEL << 16U) | RCC_CCIPR_USART3SEL)   /*!< LSE clock used as USART3 clock source */
+#endif /* RCC_CCIPR_USART3SEL */
 /**
   * @}
   */
 
-#if defined(LPUART1)
-/** @defgroup RCC_LL_EC_LPUART1_CLKSOURCE Peripheral LPUART clock source selection
+#if defined(LPUART1) || defined(LPUART2)
+/** @defgroup RCC_LL_EC_LPUARTx_CLKSOURCE Peripheral LPUART clock source selection
   * @{
   */
-#define LL_RCC_LPUART1_CLKSOURCE_PCLK1     0x00000000U                     /*!< PCLK1 clock used as LPUART1 clock source */
-#define LL_RCC_LPUART1_CLKSOURCE_SYSCLK    RCC_CCIPR_LPUART1SEL_0          /*!< SYSCLK clock used as LPUART1 clock source */
-#define LL_RCC_LPUART1_CLKSOURCE_HSI       RCC_CCIPR_LPUART1SEL_1          /*!< HSI clock used as LPUART1 clock source */
-#define LL_RCC_LPUART1_CLKSOURCE_LSE       RCC_CCIPR_LPUART1SEL            /*!< LSE clock used as LPUART1 clock source */
+#if defined(LPUART2)
+#define LL_RCC_LPUART2_CLKSOURCE_PCLK1     ((RCC_CCIPR_LPUART2SEL << 16U) | 0x00000000U)              /*!< PCLK1 clock used as LPUART2 clock source */
+#define LL_RCC_LPUART2_CLKSOURCE_SYSCLK    ((RCC_CCIPR_LPUART2SEL << 16U) | RCC_CCIPR_LPUART2SEL_0)  /*!< SYSCLK clock used as LPUART2 clock source */
+#define LL_RCC_LPUART2_CLKSOURCE_HSI       ((RCC_CCIPR_LPUART2SEL << 16U) | RCC_CCIPR_LPUART2SEL_1)  /*!< HSI clock used as LPUART2 clock source */
+#define LL_RCC_LPUART2_CLKSOURCE_LSE       ((RCC_CCIPR_LPUART2SEL << 16U) | RCC_CCIPR_LPUART2SEL)    /*!< LSE clock used as LPUART2 clock source */
+#endif /* LPUART2 */
+#define LL_RCC_LPUART1_CLKSOURCE_PCLK1     ((RCC_CCIPR_LPUART1SEL << 16U) | 0x00000000U)              /*!< PCLK1 clock used as LPUART1 clock source */
+#define LL_RCC_LPUART1_CLKSOURCE_SYSCLK    ((RCC_CCIPR_LPUART1SEL << 16U) | RCC_CCIPR_LPUART1SEL_0)   /*!< SYSCLK clock used as LPUART1 clock source */
+#define LL_RCC_LPUART1_CLKSOURCE_HSI       ((RCC_CCIPR_LPUART1SEL << 16U) | RCC_CCIPR_LPUART1SEL_1)   /*!< HSI clock used as LPUART1 clock source */
+#define LL_RCC_LPUART1_CLKSOURCE_LSE       ((RCC_CCIPR_LPUART1SEL << 16U) | RCC_CCIPR_LPUART1SEL)     /*!< LSE clock used as LPUART1 clock source */
 /**
   * @}
   */
-#endif /* LPUART1 */
+#endif /* LPUART1 || LPUART2 */
 
-/** @defgroup RCC_LL_EC_I2C1_CLKSOURCE Peripheral I2C clock source selection
+/** @defgroup RCC_LL_EC_I2Cx_CLKSOURCE Peripheral I2C clock source selection
   * @{
   */
-#define LL_RCC_I2C1_CLKSOURCE_PCLK1        0x00000000U                  /*!< PCLK1 clock used as I2C1 clock source */
-#define LL_RCC_I2C1_CLKSOURCE_SYSCLK       RCC_CCIPR_I2C1SEL_0          /*!< SYSCLK clock used as I2C1 clock source */
-#define LL_RCC_I2C1_CLKSOURCE_HSI          RCC_CCIPR_I2C1SEL_1          /*!< HSI clock used as I2C1 clock source */
+#define LL_RCC_I2C1_CLKSOURCE_PCLK1        ((RCC_CCIPR_I2C1SEL << 16U) | 0x00000000U)          /*!< PCLK1 clock used as I2C1 clock source */
+#define LL_RCC_I2C1_CLKSOURCE_SYSCLK       ((RCC_CCIPR_I2C1SEL << 16U) | RCC_CCIPR_I2C1SEL_0)  /*!< SYSCLK clock used as I2C1 clock source */
+#define LL_RCC_I2C1_CLKSOURCE_HSI          ((RCC_CCIPR_I2C1SEL << 16U) | RCC_CCIPR_I2C1SEL_1)  /*!< HSI clock used as I2C1 clock source */
+#if defined(RCC_CCIPR_I2C2SEL)
+#define LL_RCC_I2C2_CLKSOURCE_PCLK1        ((RCC_CCIPR_I2C2SEL << 16U) | 0x00000000U)          /*!< PCLK1 clock used as I2C2 clock source */
+#define LL_RCC_I2C2_CLKSOURCE_SYSCLK       ((RCC_CCIPR_I2C2SEL << 16U) | RCC_CCIPR_I2C2SEL_0)  /*!< SYSCLK clock used as I2C2 clock source */
+#define LL_RCC_I2C2_CLKSOURCE_HSI          ((RCC_CCIPR_I2C2SEL << 16U) | RCC_CCIPR_I2C2SEL_1)  /*!< HSI clock used as I2C2 clock source */
+#endif /* RCC_CCIPR_I2C2SEL */
 /**
   * @}
   */
 
-/** @defgroup RCC_LL_EC_I2S1_CLKSOURCE Peripheral I2S clock source selection
+/** @defgroup RCC_LL_EC_I2Sx_CLKSOURCE Peripheral I2S clock source selection
   * @{
   */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define LL_RCC_I2S1_CLKSOURCE_SYSCLK      ((RCC_CCIPR2_I2S1SEL << 16U) | 0x00000000U)          /*!< SYSCLK clock used as I2S1 clock source */
+#define LL_RCC_I2S1_CLKSOURCE_PLL         ((RCC_CCIPR2_I2S1SEL << 16U) | RCC_CCIPR2_I2S1SEL_0)  /*!< PLL clock used as I2S1 clock source */
+#define LL_RCC_I2S1_CLKSOURCE_HSI         ((RCC_CCIPR2_I2S1SEL << 16U) | RCC_CCIPR2_I2S1SEL_1)  /*!< HSI clock used as I2S1 clock source */
+#define LL_RCC_I2S1_CLKSOURCE_PIN         ((RCC_CCIPR2_I2S1SEL << 16U) | RCC_CCIPR2_I2S1SEL)    /*!< External clock used as I2S1 clock source */
+#define LL_RCC_I2S2_CLKSOURCE_SYSCLK      ((RCC_CCIPR2_I2S2SEL << 16U) | 0x00000000U)          /*!< SYSCLK clock used as I2S2 clock source */
+#define LL_RCC_I2S2_CLKSOURCE_PLL         ((RCC_CCIPR2_I2S2SEL << 16U) | RCC_CCIPR2_I2S2SEL_0)  /*!< PLL clock used as I2S2 clock source */
+#define LL_RCC_I2S2_CLKSOURCE_HSI         ((RCC_CCIPR2_I2S2SEL << 16U) | RCC_CCIPR2_I2S2SEL_1)  /*!< HSI clock used as I2S2 clock source */
+#define LL_RCC_I2S2_CLKSOURCE_PIN         ((RCC_CCIPR2_I2S2SEL << 16U) | RCC_CCIPR2_I2S2SEL)    /*!< External clock used as I2S2 clock source */
+#else
 #define LL_RCC_I2S1_CLKSOURCE_SYSCLK      0x00000000U                  /*!< SYSCLK clock used as I2S1 clock source */
 #define LL_RCC_I2S1_CLKSOURCE_PLL         RCC_CCIPR_I2S1SEL_0          /*!< PLL clock used as I2S1 clock source */
 #define LL_RCC_I2S1_CLKSOURCE_HSI         RCC_CCIPR_I2S1SEL_1          /*!< HSI clock used as I2S1 clock source */
 #define LL_RCC_I2S1_CLKSOURCE_PIN         RCC_CCIPR_I2S1SEL            /*!< External clock used as I2S1 clock source */
-
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 /**
   * @}
@@ -401,6 +498,19 @@ typedef struct
 */
 #endif /* CEC */
 
+#if defined(FDCAN1) || defined(FDCAN2)
+/** @defgroup RCC_LL_EC_FDCAN_CLKSOURCE_HSI Peripheral FDCAN clock source selection
+  * @{
+  */
+#define LL_RCC_FDCAN_CLKSOURCE_PCLK1         0x00000000U                   /*!< PCLK1 oscillator clock used as FDCAN clock */
+#define LL_RCC_FDCAN_CLKSOURCE_PLL           RCC_CCIPR2_FDCANSEL_0          /*!< PLL "Q"  oscillator clock used as FDCAN clock */
+#define LL_RCC_FDCAN_CLKSOURCE_HSE           RCC_CCIPR2_FDCANSEL_1          /*!< HSE oscillator clock used as FDCAN clock */
+
+/**
+  * @}
+*/
+#endif /* FDCAN1 || FDCAN2 */
+
 #if defined(RNG)
 /** @defgroup RCC_LL_EC_RNG_CLKSOURCE Peripheral RNG clock source selection
   * @{
@@ -427,12 +537,26 @@ typedef struct
   */
 #endif /* RNG */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/** @defgroup RCC_LL_EC_USB_CLKSOURCE  Peripheral USB clock source selection
+  * @{
+  */
+#if defined(RCC_HSI48_SUPPORT)
+#define LL_RCC_USB_CLKSOURCE_HSI48         0x00000000U            /*!< HSI48 clock used as USB clock source */
+#endif /* RCC_HSI48_SUPPORT */
+#define LL_RCC_USB_CLKSOURCE_HSE           RCC_CCIPR2_USBSEL_0  /*!< PLL clock used as USB clock source */
+#define LL_RCC_USB_CLKSOURCE_PLL           RCC_CCIPR2_USBSEL_1  /*!< PLL clock used as USB clock source */
+/**
+  * @}
+  */
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
 /** @defgroup RCC_LL_EC_ADC_CLKSOURCE Peripheral ADC clock source selection
   * @{
   */
 #define LL_RCC_ADC_CLKSOURCE_SYSCLK        0x00000000U                   /*!< SYSCLK used as ADC clock */
-#define LL_RCC_ADC_CLKSOURCE_PLL          RCC_CCIPR_ADCSEL_0             /*!< PLL used as ADC clock */
-#define LL_RCC_ADC_CLKSOURCE_HSI           RCC_CCIPR_ADCSEL              /*!< HSI used as ADC clock */
+#define LL_RCC_ADC_CLKSOURCE_PLL           RCC_CCIPR_ADCSEL_0            /*!< PLL used as ADC clock */
+#define LL_RCC_ADC_CLKSOURCE_HSI           RCC_CCIPR_ADCSEL_1            /*!< HSI used as ADC clock */
 /**
   * @}
   */
@@ -442,6 +566,9 @@ typedef struct
   */
 #define LL_RCC_USART1_CLKSOURCE            RCC_CCIPR_USART1SEL /*!< USART1 Clock source selection */
 #define LL_RCC_USART2_CLKSOURCE            RCC_CCIPR_USART2SEL /*!< USART2 Clock source selection */
+#if defined(RCC_CCIPR_USART3SEL)
+#define LL_RCC_USART3_CLKSOURCE            RCC_CCIPR_USART3SEL /*!< USART3 Clock source selection */
+#endif /* RCC_CCIPR_USART3SEL */
 /**
   * @}
   */
@@ -451,6 +578,9 @@ typedef struct
   * @{
   */
 #define LL_RCC_LPUART1_CLKSOURCE           RCC_CCIPR_LPUART1SEL /*!< LPUART1 Clock source selection */
+#if defined(LPUART2)
+#define LL_RCC_LPUART2_CLKSOURCE           RCC_CCIPR_LPUART2SEL /*!< LPUART2 Clock source selection */
+#endif /* LPUART2 */
 /**
   * @}
   */
@@ -460,6 +590,9 @@ typedef struct
   * @{
   */
 #define LL_RCC_I2C1_CLKSOURCE              RCC_CCIPR_I2C1SEL /*!< I2C1 Clock source selection */
+#if defined(RCC_CCIPR_I2C2SEL)
+#define LL_RCC_I2C2_CLKSOURCE              RCC_CCIPR_I2C2SEL /*!< I2C2 Clock source selection */
+#endif /* RCC_CCIPR_I2C2SEL */
 /**
   * @}
   */
@@ -467,7 +600,12 @@ typedef struct
 /** @defgroup RCC_LL_EC_I2S1 Peripheral I2S get clock source
   * @{
   */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define LL_RCC_I2S1_CLKSOURCE              RCC_CCIPR2_I2S1SEL /*!< I2S1 Clock source selection */
+#define LL_RCC_I2S2_CLKSOURCE              RCC_CCIPR2_I2S2SEL /*!< I2S2 Clock source selection */
+#else
 #define LL_RCC_I2S1_CLKSOURCE              RCC_CCIPR_I2S1SEL /*!< I2S1 Clock source selection */
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 /**
   * @}
   */
@@ -505,6 +643,26 @@ typedef struct
   * @}
   */
 #endif /* CEC */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+/** @defgroup RCC_LL_EC_FDCAN Peripheral FDCAN get clock source
+  * @{
+  */
+#define LL_RCC_FDCAN_CLKSOURCE               RCC_CCIPR2_FDCANSEL        /*!< FDCAN Clock source selection */
+/**
+  * @}
+  */
+#endif /* FDCAN1 */
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/** @defgroup RCC_LL_EC_USB  Peripheral USB get clock source
+  * @{
+  */
+#define LL_RCC_USB_CLKSOURCE               RCC_CCIPR2_USBSEL /*!< USB Clock source selection */
+/**
+  * @}
+  */
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 #if defined(RNG)
 /** @defgroup RCC_LL_EC_RNG Peripheral RNG get clock source
@@ -635,7 +793,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
 
 /**
   * @}
@@ -697,7 +855,8 @@ typedef struct
   *         @arg @ref LL_RCC_PLLR_DIV_8
   * @retval PLL clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PLLCLK_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLR__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+#define __LL_RCC_CALC_PLLCLK_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLR__)   \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
                    (((__PLLR__) >> RCC_PLLCFGR_PLLR_Pos) + 1U))
 
 /**
@@ -749,8 +908,64 @@ typedef struct
   *         @arg @ref LL_RCC_PLLP_DIV_32
   * @retval PLL clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PLLCLK_I2S1_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__) ((__INPUTFREQ__)  * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+#define __LL_RCC_CALC_PLLCLK_I2S1_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__)  \
+  ((__INPUTFREQ__)  * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /    \
                    (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
+
+#if defined(RCC_CCIPR2_I2S2SEL)
+/**
+  * @brief  Helper macro to calculate the PLLPCLK frequency used on I2S2 domain
+  * @note ex: @ref __LL_RCC_CALC_PLLCLK_I2S2_FREQ (HSE_VALUE,@ref LL_RCC_PLL_GetDivider (),
+  *             @ref LL_RCC_PLL_GetN (), @ref LL_RCC_PLL_GetP ());
+  * @param  __INPUTFREQ__ PLL Input frequency (based on HSE/HSI)
+  * @param  __PLLM__ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLM_DIV_1
+  *         @arg @ref LL_RCC_PLLM_DIV_2
+  *         @arg @ref LL_RCC_PLLM_DIV_3
+  *         @arg @ref LL_RCC_PLLM_DIV_4
+  *         @arg @ref LL_RCC_PLLM_DIV_5
+  *         @arg @ref LL_RCC_PLLM_DIV_6
+  *         @arg @ref LL_RCC_PLLM_DIV_7
+  *         @arg @ref LL_RCC_PLLM_DIV_8
+  * @param  __PLLN__ Between Min_Data = 8 and Max_Data = 86
+  * @param  __PLLP__ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLP_DIV_2
+  *         @arg @ref LL_RCC_PLLP_DIV_3
+  *         @arg @ref LL_RCC_PLLP_DIV_4
+  *         @arg @ref LL_RCC_PLLP_DIV_5
+  *         @arg @ref LL_RCC_PLLP_DIV_6
+  *         @arg @ref LL_RCC_PLLP_DIV_7
+  *         @arg @ref LL_RCC_PLLP_DIV_8
+  *         @arg @ref LL_RCC_PLLP_DIV_9
+  *         @arg @ref LL_RCC_PLLP_DIV_10
+  *         @arg @ref LL_RCC_PLLP_DIV_11
+  *         @arg @ref LL_RCC_PLLP_DIV_12
+  *         @arg @ref LL_RCC_PLLP_DIV_13
+  *         @arg @ref LL_RCC_PLLP_DIV_14
+  *         @arg @ref LL_RCC_PLLP_DIV_15
+  *         @arg @ref LL_RCC_PLLP_DIV_16
+  *         @arg @ref LL_RCC_PLLP_DIV_17
+  *         @arg @ref LL_RCC_PLLP_DIV_18
+  *         @arg @ref LL_RCC_PLLP_DIV_19
+  *         @arg @ref LL_RCC_PLLP_DIV_20
+  *         @arg @ref LL_RCC_PLLP_DIV_21
+  *         @arg @ref LL_RCC_PLLP_DIV_22
+  *         @arg @ref LL_RCC_PLLP_DIV_23
+  *         @arg @ref LL_RCC_PLLP_DIV_24
+  *         @arg @ref LL_RCC_PLLP_DIV_25
+  *         @arg @ref LL_RCC_PLLP_DIV_26
+  *         @arg @ref LL_RCC_PLLP_DIV_27
+  *         @arg @ref LL_RCC_PLLP_DIV_28
+  *         @arg @ref LL_RCC_PLLP_DIV_29
+  *         @arg @ref LL_RCC_PLLP_DIV_30
+  *         @arg @ref LL_RCC_PLLP_DIV_31
+  *         @arg @ref LL_RCC_PLLP_DIV_32
+  * @retval PLL clock frequency (in Hz)
+  */
+#define __LL_RCC_CALC_PLLCLK_I2S2_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__)  \
+  ((__INPUTFREQ__)  * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /    \
+                   (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
+#endif /* RCC_CCIPR2_I2S2SEL */
 
 /**
   * @brief  Helper macro to calculate the PLLPCLK frequency used on ADC domain
@@ -801,7 +1016,8 @@ typedef struct
   *         @arg @ref LL_RCC_PLLP_DIV_32
   * @retval PLL clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PLLCLK_ADC_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+#define __LL_RCC_CALC_PLLCLK_ADC_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__)  \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /    \
                    (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
 
 #if defined(RNG)
@@ -830,7 +1046,8 @@ typedef struct
   *         @arg @ref LL_RCC_PLLQ_DIV_8
   * @retval PLL clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PLLCLK_RNG_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+#define __LL_RCC_CALC_PLLCLK_RNG_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__)   \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /     \
                    (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
 #endif /* RNG */
 
@@ -860,7 +1077,8 @@ typedef struct
   *         @arg @ref LL_RCC_PLLQ_DIV_8
   * @retval PLL clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PLLCLK_TIM1_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+#define __LL_RCC_CALC_PLLCLK_TIM1_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /    \
                    (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
 #if defined(TIM15)
 /**
@@ -888,10 +1106,73 @@ typedef struct
   *         @arg @ref LL_RCC_PLLQ_DIV_8
   * @retval PLL clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PLLCLK_TIM15_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+#define __LL_RCC_CALC_PLLCLK_TIM15_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__)  \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /      \
                    (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
 #endif /* TIM15 */
 #endif /* RCC_PLLQ_SUPPORT */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+/**
+  * @brief  Helper macro to calculate the PLLQCLK frequency used on FDCAN domain
+  * @note ex: @ref __LL_RCC_CALC_PLLCLK_FDCAN_FREQ (HSE_VALUE,@ref LL_RCC_PLL_GetDivider (),
+  *             @ref LL_RCC_PLL_GetN (), @ref LL_RCC_PLL_GetQ ());
+  * @param  __INPUTFREQ__ PLL Input frequency (based on HSE/HSI)
+  * @param  __PLLM__ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLM_DIV_1
+  *         @arg @ref LL_RCC_PLLM_DIV_2
+  *         @arg @ref LL_RCC_PLLM_DIV_3
+  *         @arg @ref LL_RCC_PLLM_DIV_4
+  *         @arg @ref LL_RCC_PLLM_DIV_5
+  *         @arg @ref LL_RCC_PLLM_DIV_6
+  *         @arg @ref LL_RCC_PLLM_DIV_7
+  *         @arg @ref LL_RCC_PLLM_DIV_8
+  * @param  __PLLN__ Between Min_Data = 8 and Max_Data = 86
+  * @param  __PLLQ__ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLQ_DIV_2
+  *         @arg @ref LL_RCC_PLLQ_DIV_3
+  *         @arg @ref LL_RCC_PLLQ_DIV_4
+  *         @arg @ref LL_RCC_PLLQ_DIV_5
+  *         @arg @ref LL_RCC_PLLQ_DIV_6
+  *         @arg @ref LL_RCC_PLLQ_DIV_7
+  *         @arg @ref LL_RCC_PLLQ_DIV_8
+  * @retval PLL clock frequency (in Hz)
+  */
+#define __LL_RCC_CALC_PLLCLK_FDCAN_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /     \
+                   (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
+#endif /* FDCAN1 || FDCAN2 */
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Helper macro to calculate the PLLQCLK frequency used on USB domain
+  * @note ex: @ref __LL_RCC_CALC_PLLCLK_USB_FREQ (HSE_VALUE,@ref LL_RCC_PLL_GetDivider (),
+  *             @ref LL_RCC_PLL_GetN (), @ref LL_RCC_PLL_GetQ ());
+  * @param  __INPUTFREQ__ PLL Input frequency (based on HSE/HSI)
+  * @param  __PLLM__ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLM_DIV_1
+  *         @arg @ref LL_RCC_PLLM_DIV_2
+  *         @arg @ref LL_RCC_PLLM_DIV_3
+  *         @arg @ref LL_RCC_PLLM_DIV_4
+  *         @arg @ref LL_RCC_PLLM_DIV_5
+  *         @arg @ref LL_RCC_PLLM_DIV_6
+  *         @arg @ref LL_RCC_PLLM_DIV_7
+  *         @arg @ref LL_RCC_PLLM_DIV_8
+  * @param  __PLLN__ Between Min_Data = 8 and Max_Data = 86
+  * @param  __PLLQ__ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLQ_DIV_2
+  *         @arg @ref LL_RCC_PLLQ_DIV_3
+  *         @arg @ref LL_RCC_PLLQ_DIV_4
+  *         @arg @ref LL_RCC_PLLQ_DIV_5
+  *         @arg @ref LL_RCC_PLLQ_DIV_6
+  *         @arg @ref LL_RCC_PLLQ_DIV_7
+  *         @arg @ref LL_RCC_PLLQ_DIV_8
+  * @retval PLL clock frequency (in Hz)
+  */
+#define __LL_RCC_CALC_PLLCLK_USB_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) \
+  ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) /   \
+                   (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 /**
   * @brief  Helper macro to calculate the HCLK frequency
@@ -908,7 +1189,8 @@ typedef struct
   *         @arg @ref LL_RCC_SYSCLK_DIV_512
   * @retval HCLK clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_HCLK_FREQ(__SYSCLKFREQ__,__AHBPRESCALER__) ((__SYSCLKFREQ__) >> (AHBPrescTable[((__AHBPRESCALER__) & RCC_CFGR_HPRE) >>  RCC_CFGR_HPRE_Pos] & 0x1FU))
+#define __LL_RCC_CALC_HCLK_FREQ(__SYSCLKFREQ__,__AHBPRESCALER__)  \
+  ((__SYSCLKFREQ__) >> (AHBPrescTable[((__AHBPRESCALER__) & RCC_CFGR_HPRE) >>  RCC_CFGR_HPRE_Pos] & 0x1FU))
 
 /**
   * @brief  Helper macro to calculate the PCLK1 frequency (ABP1)
@@ -921,7 +1203,8 @@ typedef struct
   *         @arg @ref LL_RCC_APB1_DIV_16
   * @retval PCLK1 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PCLK1_FREQ(__HCLKFREQ__, __APB1PRESCALER__) ((__HCLKFREQ__) >> (APBPrescTable[(__APB1PRESCALER__) >>  RCC_CFGR_PPRE_Pos] & 0x1FU))
+#define __LL_RCC_CALC_PCLK1_FREQ(__HCLKFREQ__, __APB1PRESCALER__)  \
+  ((__HCLKFREQ__) >> (APBPrescTable[(__APB1PRESCALER__) >>  RCC_CFGR_PPRE_Pos] & 0x1FU))
 
 /**
   * @brief  Helper macro to calculate the HSISYS frequency
@@ -1123,6 +1406,56 @@ __STATIC_INLINE uint32_t LL_RCC_HSI_GetCalibTrimming(void)
 /**
   * @}
   */
+
+#if defined(RCC_HSI48_SUPPORT)
+/** @defgroup RCC_LL_EF_HSI48 HSI48
+  * @{
+  */
+
+/**
+  * @brief  Enable HSI48
+  * @rmtoll CR         HSI48ON       LL_RCC_HSI48_Enable
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_HSI48_Enable(void)
+{
+  SET_BIT(RCC->CR, RCC_CR_HSI48ON);
+}
+
+/**
+  * @brief  Disable HSI48
+  * @rmtoll CR          HSI48ON       LL_RCC_HSI48_Disable
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_HSI48_Disable(void)
+{
+  CLEAR_BIT(RCC->CR, RCC_CR_HSI48ON);
+}
+
+/**
+  * @brief  Check if HSI48 oscillator Ready
+  * @rmtoll CR          HSI48RDY      LL_RCC_HSI48_IsReady
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_HSI48_IsReady(void)
+{
+  return ((READ_BIT(RCC->CR, RCC_CR_HSI48RDY) == RCC_CR_HSI48RDY) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get HSI48 Calibration value
+  * @rmtoll CRRCR          HSI48CAL      LL_RCC_HSI48_GetCalibration
+  * @retval Between Min_Data = 0x00 and Max_Data = 0x1FF
+  */
+__STATIC_INLINE uint32_t LL_RCC_HSI48_GetCalibration(void)
+{
+  return (uint32_t)(READ_BIT(RCC->CRRCR, RCC_CRRCR_HSI48CAL) >> RCC_CRRCR_HSI48CAL_Pos);
+}
+
+/**
+  * @}
+  */
+#endif /* RCC_HSI48_SUPPORT */
 
 /** @defgroup RCC_LL_EF_LSE LSE
   * @{
@@ -1483,7 +1816,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetHSIDiv(void)
   * @}
   */
 
-/** @defgroup RCC_LL_EF_MCO MCO
+/** @defgroup RCC_LL_EF_MCO1 MCO1
   * @{
   */
 
@@ -1495,16 +1828,25 @@ __STATIC_INLINE uint32_t LL_RCC_GetHSIDiv(void)
   *         @arg @ref LL_RCC_MCO1SOURCE_NOCLOCK
   *         @arg @ref LL_RCC_MCO1SOURCE_SYSCLK
   *         @arg @ref LL_RCC_MCO1SOURCE_HSI
+  *         @arg @ref LL_RCC_MCO1SOURCE_HSI48 (*)
   *         @arg @ref LL_RCC_MCO1SOURCE_HSE
   *         @arg @ref LL_RCC_MCO1SOURCE_PLLCLK
   *         @arg @ref LL_RCC_MCO1SOURCE_LSI
   *         @arg @ref LL_RCC_MCO1SOURCE_LSE
+  *         @arg @ref LL_RCC_MCO1SOURCE_PLLPCLK (*)
+  *         @arg @ref LL_RCC_MCO1SOURCE_PLLQCLK (*)
+  *         @arg @ref LL_RCC_MCO1SOURCE_RTCCLK (*)
+  *         @arg @ref LL_RCC_MCO1SOURCE_RTC_WKUP (*)
+  *
+  *         (*) value not defined in all devices.
   * @param  MCOxPrescaler This parameter can be one of the following values:
   *         @arg @ref LL_RCC_MCO1_DIV_1
   *         @arg @ref LL_RCC_MCO1_DIV_2
   *         @arg @ref LL_RCC_MCO1_DIV_4
   *         @arg @ref LL_RCC_MCO1_DIV_8
-  *         @arg @ref LL_RCC_MCO1_DIV_16
+  *         @arg @ref LL_RCC_MCO1_DIV_32
+  *         @arg @ref LL_RCC_MCO1_DIV_64
+  *         @arg @ref LL_RCC_MCO1_DIV_128
   * @retval None
   */
 __STATIC_INLINE void LL_RCC_ConfigMCO(uint32_t MCOxSource, uint32_t MCOxPrescaler)
@@ -1515,6 +1857,54 @@ __STATIC_INLINE void LL_RCC_ConfigMCO(uint32_t MCOxSource, uint32_t MCOxPrescale
 /**
   * @}
   */
+
+#if defined(RCC_MCO2_SUPPORT)
+/** @defgroup RCC_LL_EF_MCO2 MCO2
+  * @{
+  */
+
+/**
+  * @brief  Configure MCO2
+  * @rmtoll CFGR         MCO2SEL        LL_RCC_ConfigMCO2\n
+  *         CFGR         MCO2PRE        LL_RCC_ConfigMCO2
+  * @note  feature not available in all devices.
+  * @param  MCOxSource This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_MCO2SOURCE_NOCLOCK
+  *         @arg @ref LL_RCC_MCO2SOURCE_SYSCLK
+  *         @arg @ref LL_RCC_MCO2SOURCE_HSI
+  *         @arg @ref LL_RCC_MCO2SOURCE_HSI48
+  *         @arg @ref LL_RCC_MCO2SOURCE_HSE
+  *         @arg @ref LL_RCC_MCO2SOURCE_PLLCLK
+  *         @arg @ref LL_RCC_MCO2SOURCE_LSI
+  *         @arg @ref LL_RCC_MCO2SOURCE_LSE
+  *         @arg @ref LL_RCC_MCO2SOURCE_PLLPCLK
+  *         @arg @ref LL_RCC_MCO2SOURCE_PLLQCLK
+  *         @arg @ref LL_RCC_MCO2SOURCE_RTCCLK
+  *         @arg @ref LL_RCC_MCO2SOURCE_RTC_WKUP
+  *
+  * @param  MCOxPrescaler This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_MCO2_DIV_1
+  *         @arg @ref LL_RCC_MCO2_DIV_2
+  *         @arg @ref LL_RCC_MCO2_DIV_4
+  *         @arg @ref LL_RCC_MCO2_DIV_8
+  *         @arg @ref LL_RCC_MCO2_DIV_16
+  *         @arg @ref LL_RCC_MCO2_DIV_32
+  *         @arg @ref LL_RCC_MCO2_DIV_64
+  *         @arg @ref LL_RCC_MCO2_DIV_128
+  *         @arg @ref LL_RCC_MCO2_DIV_256
+  *         @arg @ref LL_RCC_MCO2_DIV_512
+  *         @arg @ref LL_RCC_MCO2_DIV_1024
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_ConfigMCO2(uint32_t MCOxSource, uint32_t MCOxPrescaler)
+{
+  MODIFY_REG(RCC->CFGR, RCC_CFGR_MCO2SEL | RCC_CFGR_MCO2PRE, MCOxSource | MCOxPrescaler);
+}
+
+/**
+  * @}
+  */
+#endif /* RCC_MCO2_SUPPORT */
 
 /** @defgroup RCC_LL_EF_Peripheral_Clock_Source Peripheral Clock Source
   * @{
@@ -1532,6 +1922,12 @@ __STATIC_INLINE void LL_RCC_ConfigMCO(uint32_t MCOxSource, uint32_t MCOxPrescale
   *         @arg @ref LL_RCC_USART2_CLKSOURCE_SYSCLK
   *         @arg @ref LL_RCC_USART2_CLKSOURCE_HSI
   *         @arg @ref LL_RCC_USART2_CLKSOURCE_LSE
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_PCLK1 (*)
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_SYSCLK (*)
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_HSI (*)
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_LSE (*)
+  *
+  *         (*) value not defined in all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RCC_SetUSARTClockSource(uint32_t USARTxSource)
@@ -1541,18 +1937,24 @@ __STATIC_INLINE void LL_RCC_SetUSARTClockSource(uint32_t USARTxSource)
 
 #if defined(LPUART1)
 /**
-  * @brief  Configure LPUART1x clock source
+  * @brief  Configure LPUARTx clock source
   * @rmtoll CCIPR        LPUART1SEL    LL_RCC_SetLPUARTClockSource
+  * @rmtoll CCIPR        LPUART2SEL    LL_RCC_SetLPUARTClockSource
   * @param  LPUARTxSource This parameter can be one of the following values:
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_PCLK1
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_SYSCLK
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_HSI
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_LSE
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_PCLK1 (*)
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_SYSCLK (*)
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_HSI (*)
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_LSE (*)
+  * (*) feature not available on all devices
   * @retval None
   */
 __STATIC_INLINE void LL_RCC_SetLPUARTClockSource(uint32_t LPUARTxSource)
 {
-  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPUART1SEL, LPUARTxSource);
+  MODIFY_REG(RCC->CCIPR, (LPUARTxSource >> 16U), (LPUARTxSource & 0x0000FFFFU));
 }
 #endif /* LPUART1 */
 
@@ -1563,11 +1965,15 @@ __STATIC_INLINE void LL_RCC_SetLPUARTClockSource(uint32_t LPUARTxSource)
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE_PCLK1
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE_SYSCLK
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE_HSI
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE_PCLK1 (*)
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE_SYSCLK (*)
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE_HSI (*)
+  *         (*) value not defined in all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RCC_SetI2CClockSource(uint32_t I2CxSource)
 {
-  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2C1SEL, I2CxSource);
+  MODIFY_REG(RCC->CCIPR, (I2CxSource >> 16U), (I2CxSource & 0x0000FFFFU));
 }
 
 #if defined(RCC_CCIPR_TIM1SEL) || defined(RCC_CCIPR_TIM15SEL)
@@ -1659,6 +2065,40 @@ __STATIC_INLINE void LL_RCC_SetRNGClockSource(uint32_t RNGxSource)
 }
 #endif /* RNG */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Configure USB clock source
+  * @rmtoll CCIPR2        CK48MSEL      LL_RCC_SetUSBClockSource
+  * @param  USBxSource This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_USB_CLKSOURCE_HSI48
+  *         @arg @ref LL_RCC_USB_CLKSOURCE_HSE
+  *         @arg @ref LL_RCC_USB_CLKSOURCE_PLL
+  *
+  *         (*) value not defined in all devices.
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_SetUSBClockSource(uint32_t USBxSource)
+{
+  MODIFY_REG(RCC->CCIPR2, RCC_CCIPR2_USBSEL, USBxSource);
+}
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
+#if defined (FDCAN1) || defined (FDCAN2)
+/**
+  * @brief  Configure FDCAN clock source
+  * @rmtoll CCIPR2        FDCANSEL        LL_RCC_SetFDCANClockSource
+  * @param  FDCANxSource This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE_HSE
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE_PCLK1
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE_PLL
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_SetFDCANClockSource(uint32_t FDCANxSource)
+{
+  MODIFY_REG(RCC->CCIPR2, RCC_CCIPR2_FDCANSEL, FDCANxSource);
+}
+#endif /* FDCAN1 || FDCAN2 */
+
 /**
   * @brief  Configure ADC clock source
   * @rmtoll CCIPR        ADCSEL        LL_RCC_SetADCClockSource
@@ -1673,6 +2113,27 @@ __STATIC_INLINE void LL_RCC_SetADCClockSource(uint32_t ADCxSource)
   MODIFY_REG(RCC->CCIPR, RCC_CCIPR_ADCSEL, ADCxSource);
 }
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Configure I2Sx clock source
+  * @rmtoll CCIPR2        I2SxSEL       LL_RCC_SetI2SClockSource
+  * @param  I2SxSource This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_SYSCLK
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_PIN
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_PLL
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_HSI
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_SYSCLK
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_PIN
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_PLL
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_HSI
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_SetI2SClockSource(uint32_t I2SxSource)
+{
+  MODIFY_REG(RCC->CCIPR2, (I2SxSource >> 16U), (I2SxSource & 0x0000FFFFU));
+}
+
+#else
 /**
   * @brief  Configure I2Sx clock source
   * @rmtoll CCIPR        I2S1SEL       LL_RCC_SetI2SClockSource
@@ -1687,13 +2148,15 @@ __STATIC_INLINE void LL_RCC_SetI2SClockSource(uint32_t I2SxSource)
 {
   MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2S1SEL, I2SxSource);
 }
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 /**
   * @brief  Get USARTx clock source
-  * @rmtoll CCIPR        USART1SEL     LL_RCC_GetUSARTClockSource
+  * @rmtoll CCIPR        USARTxSEL     LL_RCC_GetUSARTClockSource
   * @param  USARTx This parameter can be one of the following values:
   *         @arg @ref LL_RCC_USART1_CLKSOURCE
   *         @arg @ref LL_RCC_USART2_CLKSOURCE
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE (*)
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_RCC_USART1_CLKSOURCE_PCLK1
   *         @arg @ref LL_RCC_USART1_CLKSOURCE_SYSCLK
@@ -1703,43 +2166,60 @@ __STATIC_INLINE void LL_RCC_SetI2SClockSource(uint32_t I2SxSource)
   *         @arg @ref LL_RCC_USART2_CLKSOURCE_SYSCLK
   *         @arg @ref LL_RCC_USART2_CLKSOURCE_HSI
   *         @arg @ref LL_RCC_USART2_CLKSOURCE_LSE
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_PCLK1 (*)
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_SYSCLK (*)
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_HSI (*)
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE_LSE (*)
+  * (*) feature not available on all devices
   */
 __STATIC_INLINE uint32_t LL_RCC_GetUSARTClockSource(uint32_t USARTx)
 {
   return (uint32_t)(READ_BIT(RCC->CCIPR, USARTx) | (USARTx << 16U));
 }
 
-#if defined (RCC_CCIPR_LPUART1SEL)
+#if defined (LPUART2) || defined (LPUART1)
 /**
   * @brief  Get LPUARTx clock source
-  * @rmtoll CCIPR        LPUART1SEL    LL_RCC_GetLPUARTClockSource
+  * @rmtoll CCIPR        LPUART1SEL    LL_RCC_GetLPUARTClockSource\n
+  *         CCIPR        LPUART2SEL    LL_RCC_GetLPUARTClockSource
   * @param  LPUARTx This parameter can be one of the following values:
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE (*)
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_PCLK1
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_SYSCLK
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_HSI
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE_LSE
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_PCLK1 (*)
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_SYSCLK (*)
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_HSI (*)
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE_LSE (*)
+  * (*) feature not available on all devices
   */
 __STATIC_INLINE uint32_t LL_RCC_GetLPUARTClockSource(uint32_t LPUARTx)
 {
-  return (uint32_t)(READ_BIT(RCC->CCIPR, LPUARTx));
+  return (uint32_t)(READ_BIT(RCC->CCIPR, LPUARTx) | (LPUARTx << 16U));
 }
-#endif /* LPUART1 */
+#endif /* LPUART2 || LPUART1 */
 
 /**
   * @brief  Get I2Cx clock source
-  * @rmtoll CCIPR        I2C1SEL       LL_RCC_GetI2CClockSource
+  * @rmtoll CCIPR        I2C1SEL       LL_RCC_GetI2CClockSource\n
+  *         CCIPR        I2C2SEL       LL_RCC_GetI2CClockSource
   * @param  I2Cx This parameter can be one of the following values:
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE_PCLK1
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE_SYSCLK
   *         @arg @ref LL_RCC_I2C1_CLKSOURCE_HSI
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE_PCLK1
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE_SYSCLK
+  *         @arg @ref LL_RCC_I2C2_CLKSOURCE_HSI
   */
 __STATIC_INLINE uint32_t LL_RCC_GetI2CClockSource(uint32_t I2Cx)
 {
-  return (uint32_t)(READ_BIT(RCC->CCIPR, I2Cx));
+  return (uint32_t)(READ_BIT(RCC->CCIPR, I2Cx) | (I2Cx << 16U));
 }
 
 #if defined(RCC_CCIPR_TIM1SEL) || defined(RCC_CCIPR_TIM15SEL)
@@ -1766,7 +2246,8 @@ __STATIC_INLINE uint32_t LL_RCC_GetTIMClockSource(uint32_t TIMx)
 #if defined(LPTIM1) && defined(LPTIM2)
 /**
   * @brief  Get LPTIMx clock source
-  * @rmtoll CCIPR        LPTIMxSEL     LL_RCC_GetLPTIMClockSource
+  * @rmtoll CCIPR        LPTIM1SEL     LL_RCC_GetLPTIMClockSource\n
+            CCIPR        LPTIM2SEL     LL_RCC_GetLPTIMClockSource
   * @param  LPTIMx This parameter can be one of the following values:
   *         @arg @ref LL_RCC_LPTIM1_CLKSOURCE
   *         @arg @ref LL_RCC_LPTIM2_CLKSOURCE
@@ -1802,6 +2283,22 @@ __STATIC_INLINE uint32_t LL_RCC_GetCECClockSource(uint32_t CECx)
 }
 #endif /* CEC */
 
+#if defined(RCC_CCIPR2_FDCANSEL)
+/**
+  * @brief  Get FDCAN clock source
+  * @rmtoll CCIPR2        FDCANSEL        LL_RCC_GetFDCANClockSource
+  * @param  FDCANx This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE_PCLK1
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE_HSE
+  */
+__STATIC_INLINE uint32_t LL_RCC_GetFDCANClockSource(uint32_t FDCANx)
+{
+  return (uint32_t)(READ_BIT(RCC->CCIPR2, FDCANx));
+}
+#endif /* RCC_CCIPR2_FDCANSEL */
+
 #if defined(RNG)
 /**
   * @brief  Get RNGx clock source
@@ -1836,6 +2333,22 @@ __STATIC_INLINE uint32_t LL_RCC_GetRNGClockDiv(void)
 }
 #endif /* RNG */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Get USBx clock source
+  * @rmtoll CCIPR2        CK48MSEL        LL_RCC_GetUSBClockSource
+  * @param  USBx This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_USB_CLKSOURCE
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RCC_USB_CLKSOURCE_HSI48
+  *         @arg @ref LL_RCC_USB_CLKSOURCE_PLL
+  */
+__STATIC_INLINE uint32_t LL_RCC_GetUSBClockSource(uint32_t USBx)
+{
+  return (uint32_t)(READ_BIT(RCC->CCIPR2, USBx));
+}
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
 /**
   * @brief  Get ADCx clock source
   * @rmtoll CCIPR        ADCSEL        LL_RCC_GetADCClockSource
@@ -1851,9 +2364,32 @@ __STATIC_INLINE uint32_t LL_RCC_GetADCClockSource(uint32_t ADCx)
   return (uint32_t)(READ_BIT(RCC->CCIPR, ADCx));
 }
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 /**
   * @brief  Get I2Sx clock source
-  * @rmtoll CCIPR        I2S        LL_RCC_GetI2SClockSource
+  * @rmtoll CCIPR2        I2S1SEL     LL_RCC_GetI2SClockSource\n
+  *         CCIPR2        I2S2SEL     LL_RCC_GetI2SClockSource
+  * @param  I2Sx This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_PIN
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_SYSCLK
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_HSI
+  *         @arg @ref LL_RCC_I2S1_CLKSOURCE_PLL
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_PIN
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_SYSCLK
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_HSI
+  *         @arg @ref LL_RCC_I2S2_CLKSOURCE_PLL
+  */
+__STATIC_INLINE uint32_t LL_RCC_GetI2SClockSource(uint32_t I2Sx)
+{
+  return (uint32_t)(READ_BIT(RCC->CCIPR2, I2Sx) | (I2Sx << 16U));
+}
+#else
+/**
+  * @brief  Get I2Sx clock source
+  * @rmtoll CCIPR        I2S1SEL        LL_RCC_GetI2SClockSource
   * @param  I2Sx This parameter can be one of the following values:
   *         @arg @ref LL_RCC_I2S1_CLKSOURCE
   * @retval Returned value can be one of the following values:
@@ -1866,6 +2402,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetI2SClockSource(uint32_t I2Sx)
 {
   return (uint32_t)(READ_BIT(RCC->CCIPR, I2Sx));
 }
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 /**
   * @}
   */
@@ -2100,7 +2637,7 @@ __STATIC_INLINE void LL_RCC_PLL_ConfigDomain_ADC(uint32_t Source, uint32_t PLLM,
 }
 
 /**
-  * @brief  Configure PLL used for I2S domain clock
+  * @brief  Configure PLL used for I2S1 domain clock
   * @note   PLL Source and PLLM Divider can be written only when PLL is disabled
   * @note   PLLN/PLLP can be written only when PLL is disabled
   * @note   User shall verify whether the PLL configuration is not done through
@@ -2164,6 +2701,73 @@ __STATIC_INLINE void LL_RCC_PLL_ConfigDomain_I2S1(uint32_t Source, uint32_t PLLM
              Source | PLLM | (PLLN << RCC_PLLCFGR_PLLN_Pos) | PLLP);
 }
 
+#if defined(RCC_CCIPR2_I2S2SEL)
+/**
+  * @brief  Configure PLL used for I2S2 domain clock
+  * @note   PLL Source and PLLM Divider can be written only when PLL is disabled
+  * @note   PLLN/PLLP can be written only when PLL is disabled
+  * @note   User shall verify whether the PLL configuration is not done through
+  *         other functions (ex: ADC)
+  * @note   This can be selected for I2S2
+  * @rmtoll PLLCFGR      PLLSRC        LL_RCC_PLL_ConfigDomain_I2S2\n
+  *         PLLCFGR      PLLM          LL_RCC_PLL_ConfigDomain_I2S2\n
+  *         PLLCFGR      PLLN          LL_RCC_PLL_ConfigDomain_I2S2\n
+  *         PLLCFGR      PLLP          LL_RCC_PLL_ConfigDomain_I2S2
+  * @param  Source This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLSOURCE_NONE
+  *         @arg @ref LL_RCC_PLLSOURCE_HSI
+  *         @arg @ref LL_RCC_PLLSOURCE_HSE
+  * @param  PLLM This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLM_DIV_1
+  *         @arg @ref LL_RCC_PLLM_DIV_2
+  *         @arg @ref LL_RCC_PLLM_DIV_3
+  *         @arg @ref LL_RCC_PLLM_DIV_4
+  *         @arg @ref LL_RCC_PLLM_DIV_5
+  *         @arg @ref LL_RCC_PLLM_DIV_6
+  *         @arg @ref LL_RCC_PLLM_DIV_7
+  *         @arg @ref LL_RCC_PLLM_DIV_8
+  * @param  PLLN Between 8 and 86
+  * @param  PLLP This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLP_DIV_2
+  *         @arg @ref LL_RCC_PLLP_DIV_3
+  *         @arg @ref LL_RCC_PLLP_DIV_4
+  *         @arg @ref LL_RCC_PLLP_DIV_5
+  *         @arg @ref LL_RCC_PLLP_DIV_6
+  *         @arg @ref LL_RCC_PLLP_DIV_7
+  *         @arg @ref LL_RCC_PLLP_DIV_8
+  *         @arg @ref LL_RCC_PLLP_DIV_9
+  *         @arg @ref LL_RCC_PLLP_DIV_10
+  *         @arg @ref LL_RCC_PLLP_DIV_11
+  *         @arg @ref LL_RCC_PLLP_DIV_12
+  *         @arg @ref LL_RCC_PLLP_DIV_13
+  *         @arg @ref LL_RCC_PLLP_DIV_14
+  *         @arg @ref LL_RCC_PLLP_DIV_15
+  *         @arg @ref LL_RCC_PLLP_DIV_16
+  *         @arg @ref LL_RCC_PLLP_DIV_17
+  *         @arg @ref LL_RCC_PLLP_DIV_18
+  *         @arg @ref LL_RCC_PLLP_DIV_19
+  *         @arg @ref LL_RCC_PLLP_DIV_20
+  *         @arg @ref LL_RCC_PLLP_DIV_21
+  *         @arg @ref LL_RCC_PLLP_DIV_22
+  *         @arg @ref LL_RCC_PLLP_DIV_23
+  *         @arg @ref LL_RCC_PLLP_DIV_24
+  *         @arg @ref LL_RCC_PLLP_DIV_25
+  *         @arg @ref LL_RCC_PLLP_DIV_26
+  *         @arg @ref LL_RCC_PLLP_DIV_27
+  *         @arg @ref LL_RCC_PLLP_DIV_28
+  *         @arg @ref LL_RCC_PLLP_DIV_29
+  *         @arg @ref LL_RCC_PLLP_DIV_30
+  *         @arg @ref LL_RCC_PLLP_DIV_31
+  *         @arg @ref LL_RCC_PLLP_DIV_32
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_ConfigDomain_I2S2(uint32_t Source, uint32_t PLLM, uint32_t PLLN, uint32_t PLLP)
+{
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN | RCC_PLLCFGR_PLLP,
+             Source | PLLM | (PLLN << RCC_PLLCFGR_PLLN_Pos) | PLLP);
+}
+#endif /* RCC_CCIPR2_I2S2SEL */
+
 #if defined(RNG)
 /**
   * @brief  Configure PLL used for RNG domain clock
@@ -2206,6 +2810,92 @@ __STATIC_INLINE void LL_RCC_PLL_ConfigDomain_RNG(uint32_t Source, uint32_t PLLM,
              Source | PLLM | (PLLN << RCC_PLLCFGR_PLLN_Pos) | PLLQ);
 }
 #endif /* RNG */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+/**
+  * @brief  Configure PLL used for FDCAN domain clock
+  * @note PLL Source and PLLM Divider can be written only when PLL is disabled
+  * @note PLLN/PLLQ can be written only when PLL is disabled
+  * @note   User shall verify whether the PLL configuration is not done through
+  *         other functions (ex: TIM1, TIM15)
+  * @note This  can be selected for FDCAN
+  * @rmtoll PLLCFGR      PLLSRC        LL_RCC_PLL_ConfigDomain_FDCAN\n
+  *         PLLCFGR      PLLM          LL_RCC_PLL_ConfigDomain_FDCAN\n
+  *         PLLCFGR      PLLN          LL_RCC_PLL_ConfigDomain_FDCAN\n
+  *         PLLCFGR      PLLQ          LL_RCC_PLL_ConfigDomain_FDCAN
+  * @param  Source This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLSOURCE_NONE
+  *         @arg @ref LL_RCC_PLLSOURCE_HSI
+  *         @arg @ref LL_RCC_PLLSOURCE_HSE
+  * @param  PLLM This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLM_DIV_1
+  *         @arg @ref LL_RCC_PLLM_DIV_2
+  *         @arg @ref LL_RCC_PLLM_DIV_3
+  *         @arg @ref LL_RCC_PLLM_DIV_4
+  *         @arg @ref LL_RCC_PLLM_DIV_5
+  *         @arg @ref LL_RCC_PLLM_DIV_6
+  *         @arg @ref LL_RCC_PLLM_DIV_7
+  *         @arg @ref LL_RCC_PLLM_DIV_8
+  * @param  PLLN Between 8 and 86
+  * @param  PLLQ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLQ_DIV_2
+  *         @arg @ref LL_RCC_PLLQ_DIV_3
+  *         @arg @ref LL_RCC_PLLQ_DIV_4
+  *         @arg @ref LL_RCC_PLLQ_DIV_5
+  *         @arg @ref LL_RCC_PLLQ_DIV_6
+  *         @arg @ref LL_RCC_PLLQ_DIV_7
+  *         @arg @ref LL_RCC_PLLQ_DIV_8
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_ConfigDomain_FDCAN(uint32_t Source, uint32_t PLLM, uint32_t PLLN, uint32_t PLLQ)
+{
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN | RCC_PLLCFGR_PLLQ,
+             Source | PLLM | (PLLN << RCC_PLLCFGR_PLLN_Pos) | PLLQ);
+}
+#endif /* FDCAN1 || FDCAN2 */
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Configure PLL used for USB domain clock
+  * @note PLL Source and PLLM Divider can be written only when PLL is disabled
+  * @note PLLN/PLLQ can be written only when PLL is disabled
+  * @note   User shall verify whether the PLL configuration is not done through
+  *         other functions (ex: TIM1, TIM15)
+  * @note This  can be selected for USB
+  * @rmtoll PLLCFGR      PLLSRC        LL_RCC_PLL_ConfigDomain_USB\n
+  *         PLLCFGR      PLLM          LL_RCC_PLL_ConfigDomain_USB\n
+  *         PLLCFGR      PLLN          LL_RCC_PLL_ConfigDomain_USB\n
+  *         PLLCFGR      PLLQ          LL_RCC_PLL_ConfigDomain_USB
+  * @param  Source This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLSOURCE_NONE
+  *         @arg @ref LL_RCC_PLLSOURCE_HSI
+  *         @arg @ref LL_RCC_PLLSOURCE_HSE
+  * @param  PLLM This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLM_DIV_1
+  *         @arg @ref LL_RCC_PLLM_DIV_2
+  *         @arg @ref LL_RCC_PLLM_DIV_3
+  *         @arg @ref LL_RCC_PLLM_DIV_4
+  *         @arg @ref LL_RCC_PLLM_DIV_5
+  *         @arg @ref LL_RCC_PLLM_DIV_6
+  *         @arg @ref LL_RCC_PLLM_DIV_7
+  *         @arg @ref LL_RCC_PLLM_DIV_8
+  * @param  PLLN Between 8 and 86
+  * @param  PLLQ This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_PLLQ_DIV_2
+  *         @arg @ref LL_RCC_PLLQ_DIV_3
+  *         @arg @ref LL_RCC_PLLQ_DIV_4
+  *         @arg @ref LL_RCC_PLLQ_DIV_5
+  *         @arg @ref LL_RCC_PLLQ_DIV_6
+  *         @arg @ref LL_RCC_PLLQ_DIV_7
+  *         @arg @ref LL_RCC_PLLQ_DIV_8
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_ConfigDomain_USB(uint32_t Source, uint32_t PLLM, uint32_t PLLN, uint32_t PLLQ)
+{
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN | RCC_PLLCFGR_PLLQ,
+             Source | PLLM | (PLLN << RCC_PLLCFGR_PLLN_Pos) | PLLQ);
+}
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 #if defined(RCC_PLLQ_SUPPORT)
 /**
@@ -2466,6 +3156,20 @@ __STATIC_INLINE void LL_RCC_PLL_EnableDomain_I2S1(void)
   SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN);
 }
 
+#if defined(RCC_CCIPR2_I2S2SEL)
+/**
+  * @brief  Enable PLL output mapped on I2S2 domain clock
+  * @rmtoll PLLCFGR      PLLPEN        LL_RCC_PLL_EnableDomain_I2S2
+  * @note   User shall check that PLL enable is not done through
+  *         other functions (ex: ADC)
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_EnableDomain_I2S2(void)
+{
+  SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN);
+}
+#endif /* RCC_CCIPR2_I2S2SEL */
+
 /**
   * @brief  Disable PLL output mapped on I2S1 domain clock
   * @note Cannot be disabled if the PLL clock is used as the system clock
@@ -2480,6 +3184,23 @@ __STATIC_INLINE void LL_RCC_PLL_DisableDomain_I2S1(void)
 {
   CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN);
 }
+
+#if defined(RCC_CCIPR2_I2S2SEL)
+/**
+  * @brief  Disable PLL output mapped on I2S2 domain clock
+  * @note Cannot be disabled if the PLL clock is used as the system clock
+  * @note   User shall check that PLL is not used by any other peripheral
+  *         (ex: RNG)
+  * @note In order to save power, when the PLLCLK  of the PLL is
+  *       not used,  should be 0
+  * @rmtoll PLLCFGR      PLLPEN        LL_RCC_PLL_DisableDomain_I2S2
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_DisableDomain_I2S2(void)
+{
+  CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN);
+}
+#endif /* RCC_CCIPR2_I2S2SEL */
 
 #if defined(RNG)
 /**
@@ -2509,6 +3230,64 @@ __STATIC_INLINE void LL_RCC_PLL_DisableDomain_RNG(void)
   CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN);
 }
 #endif /* RNG */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+/**
+  * @brief  Enable PLL output mapped on FDCAN domain clock
+  * @rmtoll PLLCFGR      PLLQEN        LL_RCC_PLL_EnableDomain_FDCAN
+  * @note   User shall check that PLL enable is not done through
+  *         other functions (ex: TIM1, TIM15)
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_EnableDomain_FDCAN(void)
+{
+  SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN);
+}
+
+/**
+  * @brief  Disable PLL output mapped on FDCAN domain clock
+  * @note Cannot be disabled if the PLL clock is used as the system clock
+  * @note   User shall check that PLL is not used by any other peripheral
+  *         (ex: TIM, TIM15)
+  * @note In order to save power, when the PLLCLK  of the PLL is
+  *       not used,  should be 0
+  * @rmtoll PLLCFGR      PLLQEN        LL_RCC_PLL_DisableDomain_FDCAN
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_DisableDomain_FDCAN(void)
+{
+  CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN);
+}
+#endif /* FDCAN1 || FDCAN2 */
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Enable PLL output mapped on USB domain clock
+  * @rmtoll PLLCFGR      PLLQEN        LL_RCC_PLL_EnableDomain_USB
+  * @note   User shall check that PLL enable is not done through
+  *         other functions (ex: TIM1, TIM15)
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_EnableDomain_USB(void)
+{
+  SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN);
+}
+
+/**
+  * @brief  Disable PLL output mapped on USB domain clock
+  * @note Cannot be disabled if the PLL clock is used as the system clock
+  * @note   User shall check that PLL is not used by any other peripheral
+  *         (ex: TIM, TIM15)
+  * @note In order to save power, when the PLLCLK  of the PLL is
+  *       not used,  should be 0
+  * @rmtoll PLLCFGR      PLLQEN        LL_RCC_PLL_DisableDomain_USB
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_PLL_DisableDomain_USB(void)
+{
+  CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN);
+}
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 #if defined(RCC_PLLQ_SUPPORT)
 /**
@@ -2651,6 +3430,17 @@ __STATIC_INLINE void LL_RCC_ClearFlag_PLLRDY(void)
   SET_BIT(RCC->CICR, RCC_CICR_PLLRDYC);
 }
 
+#if defined(RCC_HSI48_SUPPORT)
+/**
+  * @brief  Clear HSI48 ready interrupt flag
+  * @rmtoll CICR          HSI48RDYC     LL_RCC_ClearFlag_HSI48RDY
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_ClearFlag_HSI48RDY(void)
+{
+  SET_BIT(RCC->CICR, RCC_CICR_HSI48RDYC);
+}
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @brief  Clear Clock security system interrupt flag
   * @rmtoll CICR         CSSC          LL_RCC_ClearFlag_HSECSS
@@ -2720,6 +3510,18 @@ __STATIC_INLINE uint32_t LL_RCC_IsActiveFlag_PLLRDY(void)
 {
   return ((READ_BIT(RCC->CIFR, RCC_CIFR_PLLRDYF) == (RCC_CIFR_PLLRDYF)) ? 1UL : 0UL);
 }
+
+#if defined(RCC_HSI48_SUPPORT)
+/**
+  * @brief  Check if HSI48 ready interrupt occurred or not
+  * @rmtoll CIR          HSI48RDYF     LL_RCC_IsActiveFlag_HSI48RDY
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_IsActiveFlag_HSI48RDY(void)
+{
+  return ((READ_BIT(RCC->CIFR, RCC_CIFR_HSI48RDYF) == (RCC_CIFR_HSI48RDYF)) ? 1UL : 0UL);
+}
+#endif /* RCC_HSI48_SUPPORT */
 
 /**
   * @brief  Check if Clock security system interrupt occurred or not
@@ -2879,6 +3681,18 @@ __STATIC_INLINE void LL_RCC_EnableIT_PLLRDY(void)
   SET_BIT(RCC->CIER, RCC_CIER_PLLRDYIE);
 }
 
+#if defined(RCC_HSI48_SUPPORT)
+/**
+  * @brief  Enable HSI48 ready interrupt
+  * @rmtoll CIER          HSI48RDYIE    LL_RCC_EnableIT_HSI48RDY
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_EnableIT_HSI48RDY(void)
+{
+  SET_BIT(RCC->CIER, RCC_CIER_HSI48RDYIE);
+}
+#endif /* RCC_HSI48_SUPPORT */
+
 /**
   * @brief  Disable LSI ready interrupt
   * @rmtoll CIER         LSIRDYIE      LL_RCC_DisableIT_LSIRDY
@@ -2929,6 +3743,18 @@ __STATIC_INLINE void LL_RCC_DisableIT_PLLRDY(void)
   CLEAR_BIT(RCC->CIER, RCC_CIER_PLLRDYIE);
 }
 
+#if defined(RCC_HSI48_SUPPORT)
+/**
+  * @brief  Disable HSI48 ready interrupt
+  * @rmtoll CIER          HSI48RDYIE    LL_RCC_DisableIT_HSI48RDY
+  * @retval None
+  */
+__STATIC_INLINE void LL_RCC_DisableIT_HSI48RDY(void)
+{
+  CLEAR_BIT(RCC->CIER, RCC_CIER_HSI48RDYIE);
+}
+#endif /* RCC_HSI48_SUPPORT */
+
 /**
   * @brief  Checks if LSI ready interrupt source is enabled or disabled.
   * @rmtoll CIER         LSIRDYIE      LL_RCC_IsEnabledIT_LSIRDY
@@ -2958,6 +3784,18 @@ __STATIC_INLINE uint32_t LL_RCC_IsEnabledIT_HSIRDY(void)
 {
   return ((READ_BIT(RCC->CIER, RCC_CIER_HSIRDYIE) == (RCC_CIER_HSIRDYIE)) ? 1UL : 0UL);
 }
+
+#if defined(RCC_HSI48_SUPPORT)
+/**
+  * @brief  Checks if HSI48 ready interrupt source is enabled or disabled.
+  * @rmtoll CIER         HSI48RDYIE      LL_RCC_IsEnabledIT_HSI48RDY
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_IsEnabledIT_HSI48RDY(void)
+{
+  return ((READ_BIT(RCC->CIER, RCC_CIER_HSI48RDYIE) == (RCC_CIER_HSI48RDYIE)) ? 1UL : 0UL);
+}
+#endif /* RCC_HSI48_SUPPORT */
 
 /**
   * @brief  Checks if HSE ready interrupt source is enabled or disabled.
@@ -2998,7 +3836,7 @@ ErrorStatus LL_RCC_DeInit(void);
 void        LL_RCC_GetSystemClocksFreq(LL_RCC_ClocksTypeDef *RCC_Clocks);
 uint32_t    LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource);
 uint32_t    LL_RCC_GetI2CClockFreq(uint32_t I2CxSource);
-#if defined(LPUART1)
+#if defined(LPUART1) || defined(LPUART2)
 uint32_t    LL_RCC_GetLPUARTClockFreq(uint32_t LPUARTxSource);
 #endif /* LPUART1 */
 #if defined(LPTIM1) && defined(LPTIM2)
@@ -3012,8 +3850,14 @@ uint32_t    LL_RCC_GetI2SClockFreq(uint32_t I2SxSource);
 #if defined(CEC)
 uint32_t    LL_RCC_GetCECClockFreq(uint32_t CECxSource);
 #endif /* CEC */
+#if defined(FDCAN1) || defined(FDCAN2)
+uint32_t    LL_RCC_GetFDCANClockFreq(uint32_t FDCANxSource);
+#endif /* FDCAN1 */
 uint32_t    LL_RCC_GetTIMClockFreq(uint32_t TIMxSource);
 uint32_t    LL_RCC_GetRTCClockFreq(void);
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+uint32_t    LL_RCC_GetUSBClockFreq(uint32_t USBxSource);
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 /**
   * @}
   */
@@ -3027,7 +3871,7 @@ uint32_t    LL_RCC_GetRTCClockFreq(void);
   * @}
   */
 
-#endif /* defined(RCC) */
+#endif /* RCC */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_rtc.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_rtc.h
@@ -205,8 +205,8 @@ typedef struct
 /** @defgroup RTC_LL_EC_FORMAT FORMAT
   * @{
   */
-#define LL_RTC_FORMAT_BIN                  0x000000000U /*!< Binary data format */
-#define LL_RTC_FORMAT_BCD                  0x000000001U /*!< BCD data format */
+#define LL_RTC_FORMAT_BIN                  0x00000000U /*!< Binary data format */
+#define LL_RTC_FORMAT_BCD                  0x00000001U /*!< BCD data format */
 /**
   * @}
   */
@@ -272,7 +272,7 @@ typedef struct
 #define LL_RTC_WEEKDAY_MONDAY              ((uint8_t)0x01U) /*!< Monday    */
 #define LL_RTC_WEEKDAY_TUESDAY             ((uint8_t)0x02U) /*!< Tuesday   */
 #define LL_RTC_WEEKDAY_WEDNESDAY           ((uint8_t)0x03U) /*!< Wednesday */
-#define LL_RTC_WEEKDAY_THURSDAY            ((uint8_t)0x04U) /*!< Thrusday  */
+#define LL_RTC_WEEKDAY_THURSDAY            ((uint8_t)0x04U) /*!< Thursday  */
 #define LL_RTC_WEEKDAY_FRIDAY              ((uint8_t)0x05U) /*!< Friday    */
 #define LL_RTC_WEEKDAY_SATURDAY            ((uint8_t)0x06U) /*!< Saturday  */
 #define LL_RTC_WEEKDAY_SUNDAY              ((uint8_t)0x07U) /*!< Sunday    */
@@ -422,6 +422,9 @@ typedef struct
   */
 #define LL_RTC_TAMPER_1                    TAMP_CR1_TAMP1E /*!< Tamper 1 input detection */
 #define LL_RTC_TAMPER_2                    TAMP_CR1_TAMP2E /*!< Tamper 2 input detection */
+#if defined (TAMP_CR1_TAMP3E)
+#define LL_RTC_TAMPER_3                    TAMP_CR1_TAMP3E /*!< Tamper 3 input detection */
+#endif
 /**
   * @}
   */
@@ -431,6 +434,9 @@ typedef struct
   */
 #define LL_RTC_TAMPER_MASK_TAMPER1         TAMP_CR2_TAMP1MSK /*!< Tamper 1 event generates a trigger event. TAMP1F is masked and internally cleared by hardware.The backup registers are not erased */
 #define LL_RTC_TAMPER_MASK_TAMPER2         TAMP_CR2_TAMP2MSK /*!< Tamper 2 event generates a trigger event. TAMP2F is masked and internally cleared by hardware. The backup registers are not erased. */
+#if defined (TAMP_CR1_TAMP3E)
+#define LL_RTC_TAMPER_MASK_TAMPER3         TAMP_CR2_TAMP3MSK /*!< Tamper 3 event generates a trigger event. TAMP3F is masked and internally cleared by hardware. The backup registers are not erased. */
+#endif
 /**
   * @}
   */
@@ -440,6 +446,9 @@ typedef struct
   */
 #define LL_RTC_TAMPER_NOERASE_TAMPER1      TAMP_CR2_TAMP1NOERASE /*!< Tamper 1 event does not erase the backup registers. */
 #define LL_RTC_TAMPER_NOERASE_TAMPER2      TAMP_CR2_TAMP2NOERASE /*!< Tamper 2 event does not erase the backup registers. */
+#if defined (TAMP_CR1_TAMP3E)
+#define LL_RTC_TAMPER_NOERASE_TAMPER3      TAMP_CR2_TAMP3NOERASE /*!< Tamper 3 event does not erase the backup registers. */
+#endif
 /**
   * @}
   */
@@ -486,6 +495,9 @@ typedef struct
   */
 #define LL_RTC_TAMPER_ACTIVELEVEL_TAMP1    TAMP_CR2_TAMP1TRG /*!< Tamper 1 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
 #define LL_RTC_TAMPER_ACTIVELEVEL_TAMP2    TAMP_CR2_TAMP2TRG /*!< Tamper 2 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
+#if defined (TAMP_CR1_TAMP3E)
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP3    TAMP_CR2_TAMP3TRG /*!< Tamper 3 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
+#endif
 /**
   * @}
   */
@@ -1253,7 +1265,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetSecond(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx, uint32_t Format12_24, uint32_t Hours, uint32_t Minutes, uint32_t Seconds)
 {
-  register uint32_t temp;
+  uint32_t temp;
 
   temp = Format12_24                                                                            | \
          (((Hours & 0xF0U) << (RTC_TR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos))       | \
@@ -1281,7 +1293,7 @@ __STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx, uint32_t Format12_24,
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_Get(RTC_TypeDef *RTCx)
 {
-  register uint32_t temp;
+  uint32_t temp;
 
   temp = READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU));
   return (uint32_t)((((((temp & RTC_TR_HT) >> RTC_TR_HT_Pos) << 4U) | ((temp & RTC_TR_HU) >> RTC_TR_HU_Pos)) << RTC_OFFSET_HOUR) |  \
@@ -1583,7 +1595,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetDay(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx, uint32_t WeekDay, uint32_t Day, uint32_t Month, uint32_t Year)
 {
-  register uint32_t temp;
+  uint32_t temp;
 
   temp = (WeekDay << RTC_DR_WDU_Pos)                                                        | \
          (((Year & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year & 0x0FU) << RTC_DR_YU_Pos))   | \
@@ -1611,7 +1623,7 @@ __STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx, uint32_t WeekDay, uin
   */
 __STATIC_INLINE uint32_t LL_RTC_DATE_Get(RTC_TypeDef *RTCx)
 {
-  register uint32_t temp;
+  uint32_t temp;
 
   temp = READ_BIT(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU));
   return (uint32_t)((((temp & RTC_DR_WDU) >> RTC_DR_WDU_Pos) << RTC_OFFSET_WEEKDAY) | \
@@ -1911,7 +1923,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetSecond(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_ALMA_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12_24, uint32_t Hours, uint32_t Minutes, uint32_t Seconds)
 {
-  register uint32_t temp;
+  uint32_t temp;
 
   temp = Format12_24 | (((Hours & 0xF0U) << (RTC_ALRMAR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMAR_HU_Pos))    | \
          (((Minutes & 0xF0U) << (RTC_ALRMAR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMAR_MNU_Pos)) | \
@@ -2277,7 +2289,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetSecond(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_ALMB_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12_24, uint32_t Hours, uint32_t Minutes, uint32_t Seconds)
 {
-  register uint32_t temp;
+  uint32_t temp;
 
   temp = Format12_24 | (((Hours & 0xF0U) << (RTC_ALRMBR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMBR_HU_Pos))    | \
          (((Minutes & 0xF0U) << (RTC_ALRMBR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMBR_MNU_Pos)) | \
@@ -2387,7 +2399,7 @@ __STATIC_INLINE void LL_RTC_TS_DisableInternalEvent(RTC_TypeDef *RTCx)
 /**
   * @brief  Enable Timestamp
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
-  * @rmtoll RTC_CR           ITSE           LL_RTC_TS_Enable
+  * @rmtoll RTC_CR           TSE           LL_RTC_TS_Enable
   * @param  RTCx RTC Instance
   * @retval None
   */
@@ -2399,7 +2411,7 @@ __STATIC_INLINE void LL_RTC_TS_Enable(RTC_TypeDef *RTCx)
 /**
   * @brief  Disable Timestamp
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
-  * @rmtoll RTC_CR           ITSE           LL_RTC_TS_Disable
+  * @rmtoll RTC_CR           TSE           LL_RTC_TS_Disable
   * @param  RTCx RTC Instance
   * @retval None
   */
@@ -2584,7 +2596,7 @@ __STATIC_INLINE uint32_t LL_RTC_TS_GetDate(RTC_TypeDef *RTCx)
 
 /**
   * @brief  Get time-stamp sub second value
-  * @rmtoll RTC_TSDR         SS            LL_RTC_TS_GetSubSecond
+  * @rmtoll RTC_TSSSR         SS            LL_RTC_TS_GetSubSecond
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xFFFF
   */
@@ -2627,11 +2639,13 @@ __STATIC_INLINE void LL_RTC_TS_DisableOnTamper(RTC_TypeDef *RTCx)
 /**
   * @brief  Enable TAMPx input detection
   * @rmtoll TAMP_CR1       TAMP1E        LL_RTC_TAMPER_Enable\n
-  *         TAMP_CR1       TAMP2E        LL_RTC_TAMPER_Enable
+  *         TAMP_CR1       TAMP2E        LL_RTC_TAMPER_Enable\n
+  *         TAMP_CR1       TAMP3E        LL_RTC_TAMPER_Enable
   * @param  TAMPx TAMP Instance
   * @param  Tamper This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_1
   *         @arg @ref LL_RTC_TAMPER_2
+  *         @arg @ref LL_RTC_TAMPER_3 (*)
   *
   * @retval None
   */
@@ -2643,11 +2657,13 @@ __STATIC_INLINE void LL_RTC_TAMPER_Enable(TAMP_TypeDef *TAMPx, uint32_t Tamper)
 /**
   * @brief  Clear TAMPx input detection
   * @rmtoll TAMP_CR1       TAMP1E        LL_RTC_TAMPER_Disable\n
-  *         TAMP_CR1       TAMP2E        LL_RTC_TAMPER_Disable
+  *         TAMP_CR1       TAMP2E        LL_RTC_TAMPER_Disable\n
+  *         TAMP_CR1       TAMP3E        LL_RTC_TAMPER_Disable
   * @param  TAMPx TAMP Instance
   * @param  Tamper This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_1
   *         @arg @ref LL_RTC_TAMPER_2
+  *         @arg @ref LL_RTC_TAMPER_2 (*)
   *
   * @retval None
   */
@@ -2660,11 +2676,13 @@ __STATIC_INLINE void LL_RTC_TAMPER_Disable(TAMP_TypeDef *TAMPx, uint32_t Tamper)
   * @brief  Enable Tamper mask flag
   * @note Associated Tamper IT must not enabled when tamper mask is set.
   * @rmtoll TAMP_CR2       TAMP1MF       LL_RTC_TAMPER_EnableMask\n
-  *         TAMP_CR2       TAMP2MF       LL_RTC_TAMPER_EnableMask
+  *         TAMP_CR2       TAMP2MF       LL_RTC_TAMPER_EnableMask\n
+  *         TAMP_CR2       TAMP3MF       LL_RTC_TAMPER_EnableMask
   * @param  TAMPx TAMP Instance
   * @param  Mask This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER1
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER3 (*)
   *
   * @retval None
   */
@@ -2676,11 +2694,13 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnableMask(TAMP_TypeDef *TAMPx, uint32_t Mask
 /**
   * @brief  Disable Tamper mask flag
   * @rmtoll TAMP_CR2       TAMP1MF       LL_RTC_TAMPER_DisableMask\n
-  *         TAMP_CR2       TAMP2MF       LL_RTC_TAMPER_DisableMask
+  *         TAMP_CR2       TAMP2MF       LL_RTC_TAMPER_DisableMask\n
+  *         TAMP_CR2       TAMP3MF       LL_RTC_TAMPER_DisableMask
   * @param  TAMPx TAMP Instance
   * @param  Mask This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER1
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER3 (*)
   *
   * @retval None
   */
@@ -2692,11 +2712,13 @@ __STATIC_INLINE void LL_RTC_TAMPER_DisableMask(TAMP_TypeDef *TAMPx, uint32_t Mas
 /**
   * @brief  Enable backup register erase after Tamper event detection
   * @rmtoll TAMP_CR2       TAMP1NOERASE  LL_RTC_TAMPER_EnableEraseBKP\n
-  *         TAMP_CR2       TAMP2NOERASE  LL_RTC_TAMPER_EnableEraseBKP
+  *         TAMP_CR2       TAMP2NOERASE  LL_RTC_TAMPER_EnableEraseBKP\n
+  *         TAMP_CR2       TAMP3NOERASE  LL_RTC_TAMPER_EnableEraseBKP
   * @param  TAMPx TAMP Instance
   * @param  Tamper This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER1
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER3 (*)
   *
   * @retval None
   */
@@ -2708,11 +2730,13 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnableEraseBKP(TAMP_TypeDef *TAMPx, uint32_t 
 /**
   * @brief  Disable backup register erase after Tamper event detection
   * @rmtoll TAMP_CR2       TAMP1NOERASE  LL_RTC_TAMPER_DisableEraseBKP\n
-  *         TAMP_CR2       TAMP2NOERASE  LL_RTC_TAMPER_DisableEraseBKP
+  *         TAMP_CR2       TAMP2NOERASE  LL_RTC_TAMPER_DisableEraseBKP\n
+  *         TAMP_CR2       TAMP3NOERASE  LL_RTC_TAMPER_DisableEraseBKP
   * @param  TAMPx TAMP Instance
   * @param  Tamper This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER1
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER3 (*)
   *
   * @retval None
   */
@@ -2847,11 +2871,13 @@ __STATIC_INLINE uint32_t LL_RTC_TAMPER_GetSamplingFreq(TAMP_TypeDef *TAMPx)
 /**
   * @brief  Enable Active level for Tamper input
   * @rmtoll TAMP_CR2       TAMP1TRG      LL_RTC_TAMPER_EnableActiveLevel\n
-  *         TAMP_CR2       TAMP2TRG      LL_RTC_TAMPER_EnableActiveLevel
+  *         TAMP_CR2       TAMP2TRG      LL_RTC_TAMPER_EnableActiveLevel\n
+  *         TAMP_CR2       TAMP3TRG      LL_RTC_TAMPER_EnableActiveLevel
   * @param  TAMPx TAMP Instance
   * @param  Tamper This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1
   *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP2
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3 (*)
   *
   * @retval None
   */
@@ -2863,11 +2889,13 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnableActiveLevel(TAMP_TypeDef *TAMPx, uint32
 /**
   * @brief  Disable Active level for Tamper input
   * @rmtoll TAMP_CR2       TAMP1TRG      LL_RTC_TAMPER_DisableActiveLevel\n
-  *         TAMP_CR2       TAMP2TRG      LL_RTC_TAMPER_DisableActiveLevel
+  *         TAMP_CR2       TAMP2TRG      LL_RTC_TAMPER_DisableActiveLevel\n
+  *         TAMP_CR2       TAMP3TRG      LL_RTC_TAMPER_DisableActiveLevel
   * @param  TAMPx TAMP Instance
   * @param  Tamper This parameter can be a combination of the following values:
   *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1
   *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP2
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3 (*)
   *
   * @retval None
   */
@@ -3052,7 +3080,7 @@ __STATIC_INLINE uint32_t LL_RTC_WAKEUP_GetAutoReload(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_BKP_SetRegister(TAMP_TypeDef *TAMPx, uint32_t BackupRegister, uint32_t Data)
 {
-  register __IO uint32_t *tmp;
+  __IO uint32_t *tmp;
 
   tmp = &(TAMPx->BKP0R) + BackupRegister;
 
@@ -3074,7 +3102,7 @@ __STATIC_INLINE void LL_RTC_BKP_SetRegister(TAMP_TypeDef *TAMPx, uint32_t Backup
   */
 __STATIC_INLINE uint32_t LL_RTC_BKP_GetRegister(TAMP_TypeDef *TAMPx, uint32_t BackupRegister)
 {
-  const register __IO uint32_t *tmp;
+  const __IO uint32_t *tmp;
 
   tmp = &(TAMPx->BKP0R) + BackupRegister;
 
@@ -3534,7 +3562,18 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP2(TAMP_TypeDef *TAMPx)
   return ((READ_BIT(TAMPx->SR, TAMP_SR_TAMP2F) == (TAMP_SR_TAMP2F)) ? 1UL : 0UL);
 }
 
-
+#if defined (TAMP_CR1_TAMP3E)
+/**
+  * @brief  Get tamper 3 detection flag.
+  * @rmtoll TAMP_SR          TAMP3F        LL_RTC_IsActiveFlag_TAMP3
+  * @param  TAMPx TAMP Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP3(TAMP_TypeDef *TAMPx)
+{
+  return ((READ_BIT(TAMPx->SR, TAMP_SR_TAMP3F) == (TAMP_SR_TAMP3F)) ? 1UL : 0UL);
+}
+#endif
 /**
   * @brief  Get internal tamper 3 detection flag.
   * @rmtoll TAMP_SR          ITAMP3F        LL_RTC_IsActiveFlag_ITAMP3
@@ -3602,6 +3641,18 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP2M(TAMP_TypeDef *TAMPx)
   return ((READ_BIT(TAMPx->MISR, TAMP_MISR_TAMP2MF) == (TAMP_MISR_TAMP2MF)) ? 1UL : 0UL);
 }
 
+#if defined (TAMP_CR1_TAMP3E)
+/**
+  * @brief  Get tamper 3 interrupt masked flag.
+  * @rmtoll TAMP_MISR          TAMP3MF        LL_RTC_IsActiveFlag_TAMP3M
+  * @param  TAMPx TAMP Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP3M(TAMP_TypeDef *TAMPx)
+{
+  return ((READ_BIT(TAMPx->MISR, TAMP_MISR_TAMP3MF) == (TAMP_MISR_TAMP3MF)) ? 1UL : 0UL);
+}
+#endif
 
 /**
   * @brief  Get internal tamper 3 interrupt masked flag.
@@ -3616,7 +3667,7 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_ITAMP3M(TAMP_TypeDef *TAMPx)
 
 /**
   * @brief  Get internal tamper 4 interrupt masked flag.
-  * @rmtoll TAMP_MISR          ITAMP3MF        LL_RTC_IsActiveFlag_ITAMP4M
+  * @rmtoll TAMP_MISR          ITAMP4MF        LL_RTC_IsActiveFlag_ITAMP4M
   * @param  TAMPx TAMP Instance
   * @retval State of bit (1 or 0).
   */
@@ -3670,10 +3721,22 @@ __STATIC_INLINE void LL_RTC_ClearFlag_TAMP2(TAMP_TypeDef *TAMPx)
   SET_BIT(TAMPx->SCR, TAMP_SCR_CTAMP2F);
 }
 
+#if defined (TAMP_CR1_TAMP3E)
+/**
+  * @brief  Clear tamper 3 detection flag.
+  * @rmtoll TAMP_SCR          CTAMP3F         LL_RTC_ClearFlag_TAMP3
+  * @param  TAMPx TAMP Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_TAMP3(TAMP_TypeDef *TAMPx)
+{
+  SET_BIT(TAMPx->SCR, TAMP_SCR_CTAMP3F);
+}
+#endif
 
 /**
   * @brief  Clear internal tamper 3 detection flag.
-  * @rmtoll TAMP_SCR          CTAMP3F         LL_RTC_ClearFlag_ITAMP3
+  * @rmtoll TAMP_SCR          CITAMP3F         LL_RTC_ClearFlag_ITAMP3
   * @param  TAMPx TAMP Instance
   * @retval None
   */
@@ -3684,7 +3747,7 @@ __STATIC_INLINE void LL_RTC_ClearFlag_ITAMP3(TAMP_TypeDef *TAMPx)
 
 /**
   * @brief  Clear internal tamper 4 detection flag.
-  * @rmtoll TAMP_SCR          CTAMP4F         LL_RTC_ClearFlag_ITAMP4
+  * @rmtoll TAMP_SCR          CITAMP4F         LL_RTC_ClearFlag_ITAMP4
   * @param  TAMPx TAMP Instance
   * @retval None
   */
@@ -3695,7 +3758,7 @@ __STATIC_INLINE void LL_RTC_ClearFlag_ITAMP4(TAMP_TypeDef *TAMPx)
 
 /**
   * @brief  Clear internal tamper 5 detection flag.
-  * @rmtoll TAMP_SCR          CTAMP5F         LL_RTC_ClearFlag_ITAMP5
+  * @rmtoll TAMP_SCR          CITAMP5F         LL_RTC_ClearFlag_ITAMP5
   * @param  TAMPx TAMP Instance
   * @retval None
   */
@@ -3706,7 +3769,7 @@ __STATIC_INLINE void LL_RTC_ClearFlag_ITAMP5(TAMP_TypeDef *TAMPx)
 
 /**
   * @brief  Clear internal tamper 6 detection flag.
-  * @rmtoll TAMP_SCR          CTAMP6F         LL_RTC_ClearFlag_ITAMP6
+  * @rmtoll TAMP_SCR          CITAMP6F         LL_RTC_ClearFlag_ITAMP6
   * @param  TAMPx TAMP Instance
   * @retval None
   */
@@ -3908,6 +3971,29 @@ __STATIC_INLINE void LL_RTC_DisableIT_TAMP2(TAMP_TypeDef *TAMPx)
   CLEAR_BIT(TAMPx->IER, TAMP_IER_TAMP2IE);
 }
 
+#if defined (TAMP_CR1_TAMP3E)
+/**
+  * @brief  Enable tamper 3 interrupt.
+  * @rmtoll TAMP_IER           TAMP3IE          LL_RTC_EnableIT_TAMP3
+  * @param  TAMPx TAMP Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_TAMP3(TAMP_TypeDef *TAMPx)
+{
+  SET_BIT(TAMPx->IER, TAMP_IER_TAMP3IE);
+}
+
+/**
+  * @brief  Disable tamper 3 interrupt.
+  * @rmtoll TAMP_IER           TAMP3IE          LL_RTC_DisableIT_TAMP3
+  * @param  TAMPx TAMP Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_TAMP3(TAMP_TypeDef *TAMPx)
+{
+  CLEAR_BIT(TAMPx->IER, TAMP_IER_TAMP3IE);
+}
+#endif
 
 /**
   * @brief  Enable internal tamper 3 interrupt.
@@ -4020,6 +4106,18 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP2(TAMP_TypeDef *TAMPx)
   return ((READ_BIT(TAMPx->IER, TAMP_IER_TAMP2IE) == (TAMP_IER_TAMP2IE)) ? 1UL : 0UL);
 }
 
+#if defined (TAMP_CR1_TAMP3E)
+/**
+  * @brief  Check if tamper 3 interrupt is enabled or not.
+  * @rmtoll TAMP_IER           TAMP3IE        LL_RTC_IsEnabledIT_TAMP3
+  * @param  TAMPx TAMP Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP3(TAMP_TypeDef *TAMPx)
+{
+  return ((READ_BIT(TAMPx->IER, TAMP_IER_TAMP3IE) == (TAMP_IER_TAMP3IE)) ? 1UL : 0UL);
+}
+#endif
 
 /**
   * @brief  Check if internal tamper 3 interrupt is enabled or not.

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_spi.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_spi.h
@@ -32,7 +32,7 @@ extern "C" {
   * @{
   */
 
-#if defined (SPI1) || defined (SPI2)
+#if defined (SPI1) || defined (SPI2) || defined (SPI3)
 
 /** @defgroup SPI_LL SPI
   * @{
@@ -266,8 +266,8 @@ typedef struct
 /** @defgroup SPI_LL_EC_RX_FIFO_TH RX FIFO Threshold
   * @{
   */
-#define LL_SPI_RX_FIFO_TH_HALF             0x00000000U               /*!< RXNE event is generated if FIFO level is greater than or equel to 1/2 (16-bit) */
-#define LL_SPI_RX_FIFO_TH_QUARTER          (SPI_CR2_FRXTH)           /*!< RXNE event is generated if FIFO level is greater than or equel to 1/4 (8-bit)  */
+#define LL_SPI_RX_FIFO_TH_HALF             0x00000000U               /*!< RXNE event is generated if FIFO level is greater than or equal to 1/2 (16-bit) */
+#define LL_SPI_RX_FIFO_TH_QUARTER          (SPI_CR2_FRXTH)           /*!< RXNE event is generated if FIFO level is greater than or equal to 1/4 (8-bit)  */
 /**
   * @}
   */
@@ -848,8 +848,8 @@ __STATIC_INLINE void LL_SPI_SetNSSMode(SPI_TypeDef *SPIx, uint32_t NSS)
   */
 __STATIC_INLINE uint32_t LL_SPI_GetNSSMode(SPI_TypeDef *SPIx)
 {
-  register uint32_t Ssm  = (READ_BIT(SPIx->CR1, SPI_CR1_SSM));
-  register uint32_t Ssoe = (READ_BIT(SPIx->CR2,  SPI_CR2_SSOE) << 16U);
+  uint32_t Ssm  = (READ_BIT(SPIx->CR1, SPI_CR1_SSM));
+  uint32_t Ssoe = (READ_BIT(SPIx->CR2,  SPI_CR2_SSOE) << 16U);
   return (Ssm | Ssoe);
 }
 
@@ -1314,7 +1314,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetDMAParity_TX(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE uint32_t LL_SPI_DMA_GetRegAddr(SPI_TypeDef *SPIx)
 {
-  return (uint32_t) & (SPIx->DR);
+  return (uint32_t) &(SPIx->DR);
 }
 
 /**
@@ -1361,7 +1361,7 @@ __STATIC_INLINE void LL_SPI_TransmitData8(SPI_TypeDef *SPIx, uint8_t TxData)
   *spidr = TxData;
 #else
   *((__IO uint8_t *)&SPIx->DR) = TxData;
-#endif
+#endif /* __GNUC__ */
 }
 
 /**
@@ -1378,7 +1378,7 @@ __STATIC_INLINE void LL_SPI_TransmitData16(SPI_TypeDef *SPIx, uint16_t TxData)
   *spidr = TxData;
 #else
   SPIx->DR = TxData;
-#endif
+#endif /* __GNUC__ */
 }
 
 /**
@@ -1501,10 +1501,10 @@ typedef struct
 /** @defgroup I2S_LL_EC_DATA_FORMAT Data format
   * @{
   */
-#define LL_I2S_DATAFORMAT_16B              0x00000000U                                   /*!< Data length 16 bits, Channel lenght 16bit */
-#define LL_I2S_DATAFORMAT_16B_EXTENDED     (SPI_I2SCFGR_CHLEN)                           /*!< Data length 16 bits, Channel lenght 32bit */
-#define LL_I2S_DATAFORMAT_24B              (SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_0)    /*!< Data length 24 bits, Channel lenght 32bit */
-#define LL_I2S_DATAFORMAT_32B              (SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_1)    /*!< Data length 16 bits, Channel lenght 32bit */
+#define LL_I2S_DATAFORMAT_16B              0x00000000U                                   /*!< Data length 16 bits, Channel length 16bit */
+#define LL_I2S_DATAFORMAT_16B_EXTENDED     (SPI_I2SCFGR_CHLEN)                           /*!< Data length 16 bits, Channel length 32bit */
+#define LL_I2S_DATAFORMAT_24B              (SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_0)    /*!< Data length 24 bits, Channel length 32bit */
+#define LL_I2S_DATAFORMAT_32B              (SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_1)    /*!< Data length 16 bits, Channel length 32bit */
 /**
   * @}
   */
@@ -1839,7 +1839,7 @@ __STATIC_INLINE uint32_t LL_I2S_GetPrescalerParity(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Enable the master clock ouput (Pin MCK)
+  * @brief  Enable the master clock output (Pin MCK)
   * @rmtoll I2SPR        MCKOE         LL_I2S_EnableMasterClock
   * @param  SPIx SPI Instance
   * @retval None
@@ -1850,7 +1850,7 @@ __STATIC_INLINE void LL_I2S_EnableMasterClock(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Disable the master clock ouput (Pin MCK)
+  * @brief  Disable the master clock output (Pin MCK)
   * @rmtoll I2SPR        MCKOE         LL_I2S_DisableMasterClock
   * @param  SPIx SPI Instance
   * @retval None
@@ -1861,7 +1861,7 @@ __STATIC_INLINE void LL_I2S_DisableMasterClock(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Check if the master clock ouput (Pin MCK) is enabled
+  * @brief  Check if the master clock output (Pin MCK) is enabled
   * @rmtoll I2SPR        MCKOE         LL_I2S_IsEnabledMasterClock
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
@@ -2271,7 +2271,7 @@ void        LL_I2S_ConfigPrescaler(SPI_TypeDef *SPIx, uint32_t PrescalerLinear, 
   */
 #endif /* SPI_I2S_SUPPORT */
 
-#endif /* defined (SPI1) || defined (SPI2) */
+#endif /* defined (SPI1) || defined (SPI2) || defined (SPI3) */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_system.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_system.h
@@ -72,8 +72,8 @@ extern "C" {
   */
 
 /** @defgroup SYSTEM_LL_EC_REMAP SYSCFG REMAP
-* @{
-*/
+  * @{
+  */
 #define LL_SYSCFG_REMAP_FLASH               0x00000000U                                           /*!< Main Flash memory mapped at 0x00000000 */
 #define LL_SYSCFG_REMAP_SYSTEMFLASH         SYSCFG_CFGR1_MEM_MODE_0                               /*!< System Flash memory mapped at 0x00000000 */
 #define LL_SYSCFG_REMAP_SRAM                (SYSCFG_CFGR1_MEM_MODE_1 | SYSCFG_CFGR1_MEM_MODE_0)   /*!< Embedded SRAM mapped at 0x00000000 */
@@ -82,8 +82,8 @@ extern "C" {
   */
 
 /** @defgroup SYSTEM_LL_EC_PIN_RMP SYSCFG PIN RMP
-* @{
-*/
+  * @{
+  */
 #define LL_SYSCFG_PIN_RMP_PA11              SYSCFG_CFGR1_PA11_RMP                           /*!< PA11 pad behaves as PA9 pin */
 #define LL_SYSCFG_PIN_RMP_PA12              SYSCFG_CFGR1_PA12_RMP                           /*!< PA12 pad behaves as PA10 pin */
 /**
@@ -101,7 +101,7 @@ extern "C" {
 #define LL_SYSCFG_IR_MOD_USART4      (SYSCFG_CFGR1_IR_MOD_1)                            /*!< 10: USART4 is selected as IRDA Modulation enveloppe source */
 #else
 #define LL_SYSCFG_IR_MOD_USART2      (SYSCFG_CFGR1_IR_MOD_1)                            /*!< 10: USART2 is selected as IRDA Modulation enveloppe source */
-#endif
+#endif /* USART4 */
 /**
   * @}
   */
@@ -113,7 +113,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* SYSCFG_CFGR1_IR_MOD */
 
 #if defined(SYSCFG_CFGR1_BOOSTEN)
 /** @defgroup SYSTEM_LL_EC_BOOSTEN SYSCFG I/O analog switch voltage booster enable
@@ -123,9 +123,9 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* SYSCFG_CFGR1_BOOSTEN */
 
-#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(SYSCFG_CFGR1_UCPD1_STROBE) ||  defined(SYSCFG_CFGR1_UCPD2_STROBE)
 /** @defgroup SYSTEM_LL_EC_UCPD_DBATTDIS SYSCFG UCPD Dead Battery feature Disable
   * @{
   */
@@ -134,7 +134,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE) || SYSCFG_CFGR1_UCPD2_STROBE */
 
 /** @defgroup SYSTEM_LL_EC_I2C_FASTMODEPLUS SYSCFG I2C FASTMODEPLUS
   * @{
@@ -155,6 +155,11 @@ extern "C" {
 #if defined(SYSCFG_CFGR1_I2C_PA10_FMP)
 #define LL_SYSCFG_I2C_FASTMODEPLUS_PA10    SYSCFG_CFGR1_I2C_PA10_FMP /*!< Enable Fast Mode Plus on PA10 */
 #endif /*SYSCFG_CFGR1_I2C_PA10_FMP*/
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#if defined(SYSCFG_CFGR1_I2C3_FMP)
+#define LL_SYSCFG_I2C_FASTMODEPLUS_I2C3    SYSCFG_CFGR1_I2C3_FMP /*!< Enable I2C3 Fast mode plus  */
+#endif /*SYSCFG_CFGR1_I2C3_FMP*/
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 /**
   * @}
   */
@@ -168,7 +173,7 @@ extern "C" {
 #define LL_SYSCFG_TIMBREAK_PVD             SYSCFG_CFGR2_PVDL           /*!< Enables and locks the PVD connection
                                                                        with TIM1/15/16/17 Break Input and also
                                                                        the PVDE and PLS bits of the Power Control Interface */
-#endif
+#endif /* PWR_PVD_SUPPORT */
 #define LL_SYSCFG_TIMBREAK_SRAM_PARITY     SYSCFG_CFGR2_SPL            /*!< Enables and locks the SRAM_PARITY error signal
                                                                                 with Break Input of TIM1/15/16/17 */
 #define LL_SYSCFG_TIMBREAK_LOCKUP          SYSCFG_CFGR2_CLL            /*!< Enables and locks the LOCKUP (Hardfault) output of
@@ -177,7 +182,7 @@ extern "C" {
   * @}
   */
 
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 /** @defgroup SYSTEM_LL_EC_CLAMPING_DIODE SYSCFG CLAMPING DIODE
   * @{
   */
@@ -192,7 +197,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 
 /** @defgroup SYSTEM_LL_EC_APB1_GRP1_STOP_IP  DBGMCU APB1 GRP1 STOP IP
   * @{
@@ -201,6 +206,9 @@ extern "C" {
 #define LL_DBGMCU_APB1_GRP1_TIM2_STOP      DBG_APB_FZ1_DBG_TIM2_STOP        /*!< TIM2 counter stopped when core is halted */
 #endif /*DBG_APB_FZ1_DBG_TIM2_STOP*/
 #define LL_DBGMCU_APB1_GRP1_TIM3_STOP      DBG_APB_FZ1_DBG_TIM3_STOP        /*!< TIM3 counter stopped when core is halted */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define LL_DBGMCU_APB1_GRP1_TIM4_STOP      DBG_APB_FZ1_DBG_TIM4_STOP        /*!< TIM4 counter stopped when core is halted */
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 #if defined(DBG_APB_FZ1_DBG_TIM6_STOP)
 #define LL_DBGMCU_APB1_GRP1_TIM6_STOP      DBG_APB_FZ1_DBG_TIM6_STOP        /*!< TIM6 counter stopped when core is halted */
 #endif /*DBG_APB_FZ1_DBG_TIM6_STOP*/
@@ -211,6 +219,9 @@ extern "C" {
 #define LL_DBGMCU_APB1_GRP1_WWDG_STOP      DBG_APB_FZ1_DBG_WWDG_STOP        /*!< Debug Window Watchdog stopped when Core is halted */
 #define LL_DBGMCU_APB1_GRP1_IWDG_STOP      DBG_APB_FZ1_DBG_IWDG_STOP        /*!< Debug Independent Watchdog stopped when Core is halted */
 #define LL_DBGMCU_APB1_GRP1_I2C1_STOP      DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP /*!< I2C1 SMBUS timeout mode stopped when Core is halted */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define LL_DBGMCU_APB1_GRP1_I2C2_STOP      DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP /*!< I2C2 SMBUS timeout mode stopped when Core is halted */
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 #if defined(DBG_APB_FZ1_DBG_LPTIM2_STOP)
 #define LL_DBGMCU_APB1_GRP1_LPTIM2_STOP    DBG_APB_FZ1_DBG_LPTIM2_STOP      /*!< LPTIM2 counter stopped when Core is halted */
 #endif /* DBG_APB_FZ1_DBG_LPTIM2_STOP */
@@ -422,7 +433,7 @@ __STATIC_INLINE void LL_SYSCFG_DisableAnalogBooster(void)
 {
   CLEAR_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_BOOSTEN);
 }
-#endif
+#endif /* SYSCFG_CFGR1_BOOSTEN */
 
 /**
   * @brief  Enable the I2C fast mode plus driving capability.
@@ -432,6 +443,7 @@ __STATIC_INLINE void LL_SYSCFG_DisableAnalogBooster(void)
   *         SYSCFG_CFGR1 I2C_FMP_PB9   LL_SYSCFG_EnableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_I2C1  LL_SYSCFG_EnableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_I2C2  LL_SYSCFG_EnableFastModePlus\n
+  *         SYSCFG_CFGR1 I2C_FMP_I2C3  LL_SYSCFG_EnableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_PA9   LL_SYSCFG_EnableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_PA10  LL_SYSCFG_EnableFastModePlus
   * @param  ConfigFastModePlus This parameter can be a combination of the following values:
@@ -441,6 +453,7 @@ __STATIC_INLINE void LL_SYSCFG_DisableAnalogBooster(void)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_PB9
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_I2C1 (*)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_I2C2 (*)
+  *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_I2C3 (*)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_PA9 (*)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_PA10 (*)
   *
@@ -460,6 +473,7 @@ __STATIC_INLINE void LL_SYSCFG_EnableFastModePlus(uint32_t ConfigFastModePlus)
   *         SYSCFG_CFGR1 I2C_FMP_PB9   LL_SYSCFG_DisableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_I2C1  LL_SYSCFG_DisableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_I2C2  LL_SYSCFG_DisableFastModePlus\n
+  *         SYSCFG_CFGR1 I2C_FMP_I2C3  LL_SYSCFG_DisableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_PA9   LL_SYSCFG_DisableFastModePlus\n
   *         SYSCFG_CFGR1 I2C_FMP_PA10  LL_SYSCFG_DisableFastModePlus
   * @param  ConfigFastModePlus This parameter can be a combination of the following values:
@@ -469,6 +483,7 @@ __STATIC_INLINE void LL_SYSCFG_EnableFastModePlus(uint32_t ConfigFastModePlus)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_PB9
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_I2C1 (*)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_I2C2 (*)
+  *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_I2C3 (*)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_PA9 (*)
   *         @arg @ref LL_SYSCFG_I2C_FASTMODEPLUS_PA10 (*)
   *
@@ -480,7 +495,7 @@ __STATIC_INLINE void LL_SYSCFG_DisableFastModePlus(uint32_t ConfigFastModePlus)
   CLEAR_BIT(SYSCFG->CFGR1, ConfigFastModePlus);
 }
 
-#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(SYSCFG_CFGR1_UCPD1_STROBE) || defined(SYSCFG_CFGR1_UCPD2_STROBE)
 /**
   * @brief  Disable dead battery behavior
   * @rmtoll SYSCFG_CFGR1 UCPD1_STROBE   LL_SYSCFG_DisableDBATT\n
@@ -495,22 +510,7 @@ __STATIC_INLINE void LL_SYSCFG_DisableDBATT(uint32_t ConfigDeadBattery)
 {
   SET_BIT(SYSCFG->CFGR1, ConfigDeadBattery);
 }
-
-/**
-  * @brief  Enable dead battery behavior
-  * @rmtoll SYSCFG_CFGR1 UCPD1_STROBE   LL_SYSCFG_EnableDBATT\n
-  *         SYSCFG_CFGR1 UCPD2_STROBE   LL_SYSCFG_EnableDBATT
-  * @param  ConfigDeadBattery This parameter can be a combination of the following values:
-  *         @arg @ref LL_SYSCFG_UCPD1_STROBE\n
-  *         @arg @ref LL_SYSCFG_UCPD2_STROBE
-  *         (*) value not defined in all devices
-  * @retval None
-  */
-__STATIC_INLINE void LL_SYSCFG_EnableDBATT(uint32_t ConfigDeadBattery)
-{
-  CLEAR_BIT(SYSCFG->CFGR1, ConfigDeadBattery);
-}
-#endif
+#endif /* SYSCFG_CFGR1_UCPD1_STROBE || SYSCFG_CFGR1_UCPD2_STROBE */
 
 #if defined(SYSCFG_ITLINE0_SR_EWDG)
 /**
@@ -524,7 +524,7 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_WWDG(void)
 }
 #endif /* SYSCFG_ITLINE0_SR_EWDG */
 
-#if defined(SYSCFG_ITLINE1_SR_PVDOUT)
+#if defined (PWR_PVD_SUPPORT)
 /**
   * @brief  Check if PVD supply monitoring interrupt occurred or not (EXTI line 16).
   * @rmtoll SYSCFG_ITLINE1 SR_PVDOUT     LL_SYSCFG_IsActiveFlag_PVDOUT
@@ -534,9 +534,21 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_PVDOUT(void)
 {
   return ((READ_BIT(SYSCFG->IT_LINE_SR[1], SYSCFG_ITLINE1_SR_PVDOUT) == (SYSCFG_ITLINE1_SR_PVDOUT)) ? 1UL : 0UL);
 }
-#endif /* SYSCFG_ITLINE1_SR_PVDOUT */
+#endif /* PWR_PVD_SUPPORT */
 
-#if defined(SYSCFG_ITLINE2_SR_RTC_WAKEUP)
+#if defined (PWR_PVM_SUPPORT)
+/**
+  * @brief  Check if VDDUSB supply monitoring interrupt occurred or not (EXTI line 34).
+  * @rmtoll SYSCFG_ITLINE1 SR_PVMOUT     LL_SYSCFG_IsActiveFlag_PVMOUT
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_PVMOUT(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[1], SYSCFG_ITLINE1_SR_PVMOUT) == (SYSCFG_ITLINE1_SR_PVMOUT)) ? 1UL : 0UL);
+}
+#endif /* PWR_PVM_SUPPORT */
+
+#if defined(SYSCFG_ITLINE2_SR_RTC)
 /**
   * @brief  Check if RTC Wake Up interrupt occurred or not (EXTI line 19).
   * @rmtoll SYSCFG_ITLINE2 SR_RTC_WAKEUP  LL_SYSCFG_IsActiveFlag_RTC_WAKEUP
@@ -544,9 +556,9 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_PVDOUT(void)
   */
 __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_RTC_WAKEUP(void)
 {
-  return ((READ_BIT(SYSCFG->IT_LINE_SR[2], SYSCFG_ITLINE2_SR_RTC_WAKEUP) == (SYSCFG_ITLINE2_SR_RTC_WAKEUP)) ? 1UL : 0UL);
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[2], SYSCFG_ITLINE2_SR_RTC) == (SYSCFG_ITLINE2_SR_RTC)) ? 1UL : 0UL);
 }
-#endif /* SYSCFG_ITLINE2_SR_RTC_WAKEUP */
+#endif /* SYSCFG_ITLINE2_SR_RTC */
 
 #if defined(SYSCFG_ITLINE2_SR_TAMPER)
 /**
@@ -596,6 +608,17 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_CLK_CTRL(void)
 }
 #endif /* SYSCFG_ITLINE4_SR_CLK_CTRL */
 
+#if defined(CRS)
+/**
+  * @brief  Check if Reset and clock control interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE4 SR_CRS   LL_SYSCFG_IsActiveFlag_CRS
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_CRS(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[4], SYSCFG_ITLINE4_SR_CRS) == (SYSCFG_ITLINE4_SR_CRS)) ? 1UL : 0UL);
+}
+#endif /* CRS */
 #if defined(SYSCFG_ITLINE5_SR_EXTI0)
 /**
   * @brief  Check if EXTI line 0 interrupt occurred or not.
@@ -812,6 +835,18 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_UCPD2(void)
 }
 #endif /* SYSCFG_ITLINE8_SR_UCPD2 */
 
+#if defined(SYSCFG_ITLINE8_SR_USB)
+/**
+  * @brief  Check if USB interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE8 SR_USB    LL_SYSCFG_IsActiveFlag_USB
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_USB(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[8], SYSCFG_ITLINE8_SR_USB) == (SYSCFG_ITLINE8_SR_USB)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE8_SR_USB */
+
 #if defined(SYSCFG_ITLINE9_SR_DMA1_CH1)
 /**
   * @brief  Check if DMA1 channel 1 interrupt occurred or not.
@@ -908,6 +943,66 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_DMAMUX(void)
 }
 #endif /* SYSCFG_ITLINE11_SR_DMAMUX */
 
+#if defined(SYSCFG_ITLINE11_SR_DMA2_CH1)
+/**
+  * @brief  Check if DMA2_CH1 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE11 SR_DMA2_CH1   LL_SYSCFG_IsActiveFlag_DMA2_CH1
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_DMA2_CH1(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[11], SYSCFG_ITLINE11_SR_DMA2_CH1) == (SYSCFG_ITLINE11_SR_DMA2_CH1)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE11_SR_DMA2_CH1 */
+
+#if defined(SYSCFG_ITLINE11_SR_DMA2_CH2)
+/**
+  * @brief  Check if DMA2_CH2 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE11 SR_DMA2_CH2   LL_SYSCFG_IsActiveFlag_DMA2_CH2
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_DMA2_CH2(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[11], SYSCFG_ITLINE11_SR_DMA2_CH2) == (SYSCFG_ITLINE11_SR_DMA2_CH2)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE11_SR_DMA2_CH2 */
+
+#if defined(SYSCFG_ITLINE11_SR_DMA2_CH3)
+/**
+  * @brief  Check if DMA2_CH3 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE11 SR_DMA2_CH3   LL_SYSCFG_IsActiveFlag_DMA2_CH3
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_DMA2_CH3(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[11], SYSCFG_ITLINE11_SR_DMA2_CH3) == (SYSCFG_ITLINE11_SR_DMA2_CH3)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE11_SR_DMA2_CH3 */
+
+#if defined(SYSCFG_ITLINE11_SR_DMA2_CH4)
+/**
+  * @brief  Check if DMA2_CH4 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE11 SR_DMA2_CH4   LL_SYSCFG_IsActiveFlag_DMA2_CH4
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_DMA2_CH4(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[11], SYSCFG_ITLINE11_SR_DMA2_CH4) == (SYSCFG_ITLINE11_SR_DMA2_CH4)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE11_SR_DMA2_CH4 */
+
+#if defined(SYSCFG_ITLINE11_SR_DMA2_CH5)
+/**
+  * @brief  Check if DMA2_CH5 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE11 SR_DMA2_CH5   LL_SYSCFG_IsActiveFlag_DMA2_CH5
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_DMA2_CH5(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[11], SYSCFG_ITLINE11_SR_DMA2_CH5) == (SYSCFG_ITLINE11_SR_DMA2_CH5)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE11_SR_DMA2_CH5 */
+
 #if defined(SYSCFG_ITLINE12_SR_ADC)
 /**
   * @brief  Check if ADC interrupt occurred or not.
@@ -943,6 +1038,18 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_COMP2(void)
   return ((READ_BIT(SYSCFG->IT_LINE_SR[12], SYSCFG_ITLINE12_SR_COMP2) == (SYSCFG_ITLINE12_SR_COMP2)) ? 1UL : 0UL);
 }
 #endif /* SYSCFG_ITLINE12_SR_COMP2 */
+
+#if defined(SYSCFG_ITLINE12_SR_COMP3)
+/**
+  * @brief  Check if Comparator 3 interrupt occurred or not (EXTI line 20).
+  * @rmtoll SYSCFG_ITLINE12 SR_COMP3      LL_SYSCFG_IsActiveFlag_COMP3
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_COMP3(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[12], SYSCFG_ITLINE12_SR_COMP3) == (SYSCFG_ITLINE12_SR_COMP3)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE12_SR_COMP3 */
 
 #if defined(SYSCFG_ITLINE13_SR_TIM1_BRK)
 /**
@@ -1027,6 +1134,18 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_TIM3(void)
   return ((READ_BIT(SYSCFG->IT_LINE_SR[16], SYSCFG_ITLINE16_SR_TIM3_GLB) == (SYSCFG_ITLINE16_SR_TIM3_GLB)) ? 1UL : 0UL);
 }
 #endif /* SYSCFG_ITLINE16_SR_TIM3_GLB */
+
+#if defined(SYSCFG_ITLINE16_SR_TIM4_GLB)
+/**
+  * @brief  Check if Timer 3 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE16 SR_TIM4_GLB   LL_SYSCFG_IsActiveFlag_TIM4
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_TIM4(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[16], SYSCFG_ITLINE16_SR_TIM4_GLB) == (SYSCFG_ITLINE16_SR_TIM4_GLB)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE16_SR_TIM4_GLB */
 
 #if defined(SYSCFG_ITLINE17_SR_DAC)
 /**
@@ -1124,6 +1243,29 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_TIM16(void)
 }
 #endif /* SYSCFG_ITLINE21_SR_TIM16_GLB */
 
+#if defined(SYSCFG_ITLINE21_SR_FDCAN1_IT0)
+/**
+  * @brief  Check if FDCAN1_IT0 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE21 SR_FDCAN1_IT0  LL_SYSCFG_IsActiveFlag_FDCAN1_IT0
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_FDCAN1_IT0(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[21], SYSCFG_ITLINE21_SR_FDCAN1_IT0) == (SYSCFG_ITLINE21_SR_FDCAN1_IT0)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE21_SR_FDCAN1_IT0 */
+#if defined(SYSCFG_ITLINE21_SR_FDCAN2_IT0)
+/**
+  * @brief  Check if FDCAN2_IT0 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE21 SR_FDCAN2_IT0  LL_SYSCFG_IsActiveFlag_FDCAN2_IT0
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_FDCAN2_IT0(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[21], SYSCFG_ITLINE21_SR_FDCAN2_IT0) == (SYSCFG_ITLINE21_SR_FDCAN2_IT0)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE21_SR_FDCAN2_IT0 */
+
 #if defined(SYSCFG_ITLINE22_SR_TIM17_GLB)
 /**
   * @brief  Check if Timer 17 interrupt occurred or not.
@@ -1135,6 +1277,29 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_TIM17(void)
   return ((READ_BIT(SYSCFG->IT_LINE_SR[22], SYSCFG_ITLINE22_SR_TIM17_GLB) == (SYSCFG_ITLINE22_SR_TIM17_GLB)) ? 1UL : 0UL);
 }
 #endif /* SYSCFG_ITLINE22_SR_TIM17_GLB */
+
+#if defined(SYSCFG_ITLINE22_SR_FDCAN1_IT1)
+/**
+  * @brief  Check if FDCAN1_IT1 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE22 SR_FDCAN1_IT1  LL_SYSCFG_IsActiveFlag_FDCAN1_IT1
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_FDCAN1_IT1(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[22], SYSCFG_ITLINE22_SR_FDCAN1_IT1) == (SYSCFG_ITLINE22_SR_FDCAN1_IT1)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE22_SR_FDCAN1_IT1 */
+#if defined(SYSCFG_ITLINE22_SR_FDCAN2_IT1)
+/**
+  * @brief  Check if FDCAN2_IT1 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE22 SR_FDCAN2_IT1  LL_SYSCFG_IsActiveFlag_FDCAN2_IT1
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_FDCAN2_IT1(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[22], SYSCFG_ITLINE22_SR_FDCAN2_IT1) == (SYSCFG_ITLINE22_SR_FDCAN2_IT1)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE22_SR_FDCAN2_IT1 */
 
 #if defined(SYSCFG_ITLINE23_SR_I2C1_GLB)
 /**
@@ -1160,6 +1325,18 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_I2C2(void)
 }
 #endif /* SYSCFG_ITLINE24_SR_I2C2_GLB */
 
+#if defined(SYSCFG_ITLINE24_SR_I2C3_GLB)
+/**
+  * @brief  Check if I2C3 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE24 SR_I2C3_GLB   LL_SYSCFG_IsActiveFlag_I2C3
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_I2C3(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[24], SYSCFG_ITLINE24_SR_I2C3_GLB) == (SYSCFG_ITLINE24_SR_I2C3_GLB)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE24_SR_I2C3_GLB */
+
 #if defined(SYSCFG_ITLINE25_SR_SPI1)
 /**
   * @brief  Check if SPI1 interrupt occurred or not.
@@ -1184,6 +1361,18 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_SPI2(void)
 }
 #endif /* SYSCFG_ITLINE26_SR_SPI2 */
 
+#if defined(SYSCFG_ITLINE26_SR_SPI3)
+/**
+  * @brief  Check if SPI3 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE26 SR_SPI3       LL_SYSCFG_IsActiveFlag_SPI3
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_SPI3(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[26], SYSCFG_ITLINE26_SR_SPI3) == (SYSCFG_ITLINE26_SR_SPI3)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE26_SR_SPI3 */
+
 #if defined(SYSCFG_ITLINE27_SR_USART1_GLB)
 /**
   * @brief  Check if USART1 interrupt occurred or not, combined with EXTI line 25.
@@ -1207,6 +1396,18 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_USART2(void)
   return ((READ_BIT(SYSCFG->IT_LINE_SR[28], SYSCFG_ITLINE28_SR_USART2_GLB) == (SYSCFG_ITLINE28_SR_USART2_GLB)) ? 1UL : 0UL);
 }
 #endif /* SYSCFG_ITLINE28_SR_USART2_GLB */
+
+#if defined(SYSCFG_ITLINE28_SR_LPUART2_GLB)
+/**
+  * @brief  Check if LPUART2 interrupt occurred or not, combined with EXTI line 26.
+  * @rmtoll SYSCFG_ITLINE28 SR_LPUART2_GLB  LL_SYSCFG_IsActiveFlag_LPUART2
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_LPUART2(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[28], SYSCFG_ITLINE28_SR_LPUART2_GLB) == (SYSCFG_ITLINE28_SR_LPUART2_GLB)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE28_SR_LPUART2_GLB */
 
 #if defined(SYSCFG_ITLINE29_SR_USART3_GLB)
 /**
@@ -1243,6 +1444,30 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_LPUART1(void)
   return ((READ_BIT(SYSCFG->IT_LINE_SR[29], SYSCFG_ITLINE29_SR_LPUART1_GLB) == (SYSCFG_ITLINE29_SR_LPUART1_GLB)) ? 1UL : 0UL);
 }
 #endif /* SYSCFG_ITLINE29_SR_LPUART1_GLB */
+
+#if defined(SYSCFG_ITLINE29_SR_USART5_GLB)
+/**
+  * @brief  Check if USART5 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE29 SR_USART5_GLB  LL_SYSCFG_IsActiveFlag_USART5
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_USART5(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[29], SYSCFG_ITLINE29_SR_USART5_GLB) == (SYSCFG_ITLINE29_SR_USART5_GLB)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE29_SR_USART5_GLB */
+
+#if defined(SYSCFG_ITLINE29_SR_USART6_GLB)
+/**
+  * @brief  Check if USART6 interrupt occurred or not.
+  * @rmtoll SYSCFG_ITLINE29 SR_USART6_GLB  LL_SYSCFG_IsActiveFlag_USART6
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_USART6(void)
+{
+  return ((READ_BIT(SYSCFG->IT_LINE_SR[29], SYSCFG_ITLINE29_SR_USART6_GLB) == (SYSCFG_ITLINE29_SR_USART6_GLB)) ? 1UL : 0UL);
+}
+#endif /* SYSCFG_ITLINE29_SR_USART6_GLB */
 
 #if defined(SYSCFG_ITLINE30_SR_CEC)
 /**
@@ -1284,7 +1509,7 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsActiveFlag_RNG(void)
   * @brief  Set connections to TIM1/15/16/17 Break inputs
   * @rmtoll SYSCFG_CFGR2 CLL   LL_SYSCFG_SetTIMBreakInputs\n
   *         SYSCFG_CFGR2 SPL   LL_SYSCFG_SetTIMBreakInputs\n
-  *         SYSCFG_CFGR2 PVDL  LL_SYSCFG_SetTIMBreakInputs (*)\n
+  *         SYSCFG_CFGR2 PVDL  LL_SYSCFG_SetTIMBreakInputs\n
   *         SYSCFG_CFGR2 ECCL  LL_SYSCFG_GetTIMBreakInputs
   * @param  Break This parameter can be a combination of the following values:
   * @ifnot STM32G070xx
@@ -1310,7 +1535,7 @@ __STATIC_INLINE void LL_SYSCFG_SetTIMBreakInputs(uint32_t Break)
   * @brief  Get connections to TIM1/15/16/17 Break inputs
   * @rmtoll SYSCFG_CFGR2 CLL   LL_SYSCFG_GetTIMBreakInputs\n
   *         SYSCFG_CFGR2 SPL   LL_SYSCFG_GetTIMBreakInputs\n
-  *         SYSCFG_CFGR2 PVDL  LL_SYSCFG_GetTIMBreakInputs (*)\n
+  *         SYSCFG_CFGR2 PVDL  LL_SYSCFG_GetTIMBreakInputs\n
   *         SYSCFG_CFGR2 ECCL  LL_SYSCFG_GetTIMBreakInputs
   * @retval Returned value can be can be a combination of the following values:
   * @ifnot STM32G070xx
@@ -1351,7 +1576,7 @@ __STATIC_INLINE void LL_SYSCFG_ClearFlag_SP(void)
   SET_BIT(SYSCFG->CFGR2, SYSCFG_CFGR2_SPF);
 }
 
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 /**
   * @brief  Enable Clamping Diode on specific pin
   * @rmtoll SYSCFG_CFGR2 PA1_CDEN   LL_SYSCFG_EnableClampingDiode\n
@@ -1428,7 +1653,7 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsEnabledClampingDiode(uint32_t ConfigClampin
 {
   return ((READ_BIT(SYSCFG->CFGR2, ConfigClampingDiode) == (ConfigClampingDiode)) ? 1UL : 0UL);
 }
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 
 /**
   * @}
@@ -1504,23 +1729,29 @@ __STATIC_INLINE void LL_DBGMCU_DisableDBGStandbyMode(void)
   * @brief  Freeze APB1 peripherals (group1 peripherals)
   * @rmtoll DBG_APB_FZ1 DBG_TIM2_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
   *         DBG_APB_FZ1 DBG_TIM3_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
+  *         DBG_APB_FZ1 DBG_TIM4_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
   *         DBG_APB_FZ1 DBG_TIM6_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
   *         DBG_APB_FZ1 DBG_TIM7_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
   *         DBG_APB_FZ1 DBG_RTC_STOP            LL_DBGMCU_APB1_GRP1_FreezePeriph\n
   *         DBG_APB_FZ1 DBG_WWDG_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
   *         DBG_APB_FZ1 DBG_IWDG_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
-  *         DBG_APB_FZ1 DBG_CAN_STOP  LL_DBGMCU_APB1_GRP1_FreezePeriph
+  *         DBG_APB_FZ1 DBG_I2C1_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
+  *         DBG_APB_FZ1 DBG_I2C2_STOP           LL_DBGMCU_APB1_GRP1_FreezePeriph\n
+  *         DBG_APB_FZ1 DBG_LPTIM2_STOP         LL_DBGMCU_APB1_GRP1_FreezePeriph\n
+  *         DBG_APB_FZ1 DBG_LPTIM1_STOP         LL_DBGMCU_APB1_GRP1_FreezePeriph
   * @param  Periphs This parameter can be a combination of the following values:
-  * @ifnot STM32G070xx
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM2_STOP (*)
-  * @endif
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM3_STOP
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM4_STOP (*)
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM6_STOP (*)
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM7_STOP (*)
   *         @arg @ref LL_DBGMCU_APB1_GRP1_RTC_STOP
   *         @arg @ref LL_DBGMCU_APB1_GRP1_WWDG_STOP
   *         @arg @ref LL_DBGMCU_APB1_GRP1_IWDG_STOP
   *         @arg @ref LL_DBGMCU_APB1_GRP1_I2C1_STOP
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_I2C2_STOP (*)
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_LPTIM2_STOP (*)
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_LPTIM1_STOP (*)
   *
   *         (*) value not defined in all devices
   * @retval None
@@ -1534,24 +1765,29 @@ __STATIC_INLINE void LL_DBGMCU_APB1_GRP1_FreezePeriph(uint32_t Periphs)
   * @brief  Unfreeze APB1 peripherals (group1 peripherals)
   * @rmtoll DBG_APB_FZ1 DBG_TIM2_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_TIM3_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
+  *         DBG_APB_FZ1 DBG_TIM4_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_TIM6_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_TIM7_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
-  *         DBG_APB_FZ1 DBG_TIM14_STOP          LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_RTC_STOP            LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_WWDG_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_IWDG_STOP           LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
   *         DBG_APB_FZ1 DBG_I2C1_SMBUS_TIMEOUT  LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
+  *         DBG_APB_FZ1 DBG_I2C2_SMBUS_TIMEOUT  LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
+  *         DBG_APB_FZ1 DBG_LPTIM2_SMBUS_TIMEOUT  LL_DBGMCU_APB1_GRP1_UnFreezePeriph\n
+  *         DBG_APB_FZ1 DBG_LPTIM1_SMBUS_TIMEOUT  LL_DBGMCU_APB1_GRP1_UnFreezePeriph
   * @param  Periphs This parameter can be a combination of the following values:
-  * @ifnot STM32G070xx
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM2_STOP (*)
-  * @endif
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM3_STOP
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM4_STOP (*)
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM6_STOP (*)
   *         @arg @ref LL_DBGMCU_APB1_GRP1_TIM7_STOP (*)
   *         @arg @ref LL_DBGMCU_APB1_GRP1_RTC_STOP
   *         @arg @ref LL_DBGMCU_APB1_GRP1_WWDG_STOP
   *         @arg @ref LL_DBGMCU_APB1_GRP1_IWDG_STOP
   *         @arg @ref LL_DBGMCU_APB1_GRP1_I2C1_STOP
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_I2C2_STOP (*)
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_LPTIM2_STOP (*)
+  *         @arg @ref LL_DBGMCU_APB1_GRP1_LPTIM1_STOP (*)
   *
   *         (*) value not defined in all devices
   * @retval None
@@ -1700,6 +1936,11 @@ __STATIC_INLINE uint32_t LL_VREFBUF_GetTrimming(void)
 
 /**
   * @brief  Set the trimming code for VREFBUF calibration (Tune the internal reference buffer voltage)
+  * @note   VrefBuf voltage scale is calibrated in production for each device,
+  *         using voltage scale 1. This calibration value is loaded
+  *         as default trimming value at device power up.
+  *         This trimming value can be fine tuned for voltage scales 0 and 1
+  *         using this function.
   * @rmtoll VREFBUF_CCR  VREFBUF_CCR_TRIM          LL_VREFBUF_SetTrimming
   * @param  Value Between 0 and 0x3F
   * @retval None

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_tim.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_tim.h
@@ -32,7 +32,7 @@ extern "C" {
   * @{
   */
 
-#if defined (TIM1) || defined (TIM2) || defined (TIM3) ||  defined (TIM14) ||  defined (TIM15) || defined (TIM16) || defined (TIM17) || defined (TIM6) || defined (TIM7)
+#if defined (TIM1) || defined (TIM2) || defined (TIM3) || defined (TIM4) ||  defined (TIM14) ||  defined (TIM15) || defined (TIM16) || defined (TIM17) || defined (TIM6) || defined (TIM7)
 
 /** @defgroup TIM_LL TIM
   * @{
@@ -117,33 +117,18 @@ static const uint8_t SHIFT_TAB_OISx[] =
   */
 
 /* Defines used for the bit position in the register and perform offsets */
+#if defined(COMP3)
+#define TIM_POSITION_BRK_SOURCE \
+  ((Source == LL_TIM_BKIN_SOURCE_BKIN)    ? 0U :\
+   (Source == LL_TIM_BKIN_SOURCE_BKCOMP1) ? 1U :\
+   (Source == LL_TIM_BKIN_SOURCE_BKCOMP2) ? 2U :3U)
+#else
 #define TIM_POSITION_BRK_SOURCE            ((Source >> 1U) & 0x1FUL)
+#endif
 
 /* Generic bit definitions for TIMx_AF1 register */
-#define TIMx_AF1_BKINE     TIM1_AF1_BKINE     /*!< BRK BKIN input enable */
-#if defined(COMP1) && defined(COMP2)
-#define TIMx_AF1_BKCOMP1E  TIM1_AF1_BKCMP1E   /*!< BRK COMP1 enable */
-#define TIMx_AF1_BKCOMP2E  TIM1_AF1_BKCMP2E   /*!< BRK COMP2 enable */
-#endif /* COMP1 && COMP2 */
 #define TIMx_AF1_BKINP     TIM1_AF1_BKINP     /*!< BRK BKIN input polarity */
-#if defined(COMP1) && defined(COMP2)
-#define TIMx_AF1_BKCOMP1P  TIM1_AF1_BKCMP1P   /*!< BRK COMP1 input polarity */
-#define TIMx_AF1_BKCOMP2P  TIM1_AF1_BKCMP2P   /*!< BRK COMP2 input polarity */
-#endif /* COMP1 && COMP2 */
 #define TIMx_AF1_ETRSEL    TIM1_AF1_ETRSEL    /*!< TIMx ETR source selection */
-
-/* Generic bit definitions for TIMx_AF2 register */
-#define TIMx_AF2_BK2INE    TIM1_AF2_BK2INE      /*!< BRK2 BKIN2 input enable */
-#if defined(COMP1) && defined(COMP2)
-#define TIMx_AF2_BK2COMP1E TIM1_AF2_BK2CMP1E    /*!< BRK2 COMP1 enable */
-#define TIMx_AF2_BK2COMP2E TIM1_AF2_BK2CMP2E    /*!< BRK2 COMP2 enable */
-#endif /* COMP1 && COMP2 */
-#define TIMx_AF2_BK2INP    TIM1_AF2_BK2INP      /*!< BRK2 BKIN2 input polarity */
-#if defined(COMP1) && defined(COMP2)
-#define TIMx_AF2_BK2COMP1P TIM1_AF2_BK2CMP1P    /*!< BRK2 COMP1 input polarity */
-#define TIMx_AF2_BK2COMP2P TIM1_AF2_BK2CMP2P    /*!< BRK2 COMP2 input polarity */
-
-#endif /* COMP1 && COMP2 */
 
 
 /* Mask used to set the TDG[x:0] of the DTG bits of the TIMx_BDTR register */
@@ -248,13 +233,14 @@ typedef struct
 
                                    This feature can be modified afterwards using unitary function @ref LL_TIM_SetClockDivision().*/
 
-  uint8_t RepetitionCounter;  /*!< Specifies the repetition counter value. Each time the RCR downcounter
+  uint32_t RepetitionCounter;  /*!< Specifies the repetition counter value. Each time the RCR downcounter
                                    reaches zero, an update event is generated and counting restarts
                                    from the RCR value (N).
                                    This means in PWM mode that (N+1) corresponds to:
                                       - the number of PWM periods in edge-aligned mode
                                       - the number of half PWM period in center-aligned mode
-                                   This parameter must be a number between 0x00 and 0xFF.
+                                   GP timers: this parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF.
+                                   Advanced timers: this parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF.
 
                                    This feature can be modified afterwards using unitary function @ref LL_TIM_SetRepetitionCounter().*/
 } LL_TIM_InitTypeDef;
@@ -621,8 +607,8 @@ typedef struct
   */
 #define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!<Counter used as upcounter */
 #define LL_TIM_COUNTERMODE_DOWN                TIM_CR1_DIR          /*!< Counter used as downcounter */
-#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
-#define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_1        /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
+#define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
+#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_1        /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
 #define LL_TIM_COUNTERMODE_CENTER_UP_DOWN      TIM_CR1_CMS          /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up or down. */
 /**
   * @}
@@ -888,6 +874,9 @@ typedef struct
 #define LL_TIM_TS_TI1FP1                       (TIM_SMCR_TS_2 | TIM_SMCR_TS_0)                                 /*!< Filtered Timer Input 1 (TI1FP1) is used as trigger input */
 #define LL_TIM_TS_TI2FP2                       (TIM_SMCR_TS_2 | TIM_SMCR_TS_1)                                 /*!< Filtered Timer Input 2 (TI12P2) is used as trigger input */
 #define LL_TIM_TS_ETRF                         (TIM_SMCR_TS_2 | TIM_SMCR_TS_1 | TIM_SMCR_TS_0)                 /*!< Filtered external Trigger (ETRF) is used as trigger input */
+#if defined(USB_BASE)
+#define LL_TIM_TS_ITR7                         (TIM_SMCR_TS_3 | TIM_SMCR_TS_1 | TIM_SMCR_TS_0)                 /*!< Internal Trigger 7 (ITR7) is used as trigger input */
+#endif /* USB_BASE */
 /**
   * @}
   */
@@ -943,10 +932,15 @@ typedef struct
 #define LL_TIM_ETRSOURCE_COMP1                 TIM1_AF1_ETRSEL_0                                 /*!< ETR input is connected to COMP1_OUT */
 #define LL_TIM_ETRSOURCE_COMP2                 TIM1_AF1_ETRSEL_1                                 /*!< ETR input is connected to COMP2_OUT */
 #endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+#define LL_TIM_ETRSOURCE_COMP3                 (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_1) /*!< ETR input is connected to COMP3_OUT */
+#endif /* COMP3 */
 #define LL_TIM_ETRSOURCE_ADC1_AWD1             (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to ADC1 analog watchdog 1 */
 #define LL_TIM_ETRSOURCE_ADC1_AWD2             TIM1_AF1_ETRSEL_2                                 /*!< ETR input is connected to ADC1 analog watchdog 2 */
 #define LL_TIM_ETRSOURCE_ADC1_AWD3             (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to ADC1 analog watchdog 3 */
 #define LL_TIM_ETRSOURCE_LSE                   (TIM1_AF1_ETRSEL_1 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to LSE */
+#define LL_TIM_ETRSOURCE_MCO                   TIM1_AF1_ETRSEL_2                                 /*!< ETR input is connected to MCO */
+#define LL_TIM_ETRSOURCE_MCO2                  (TIM1_AF1_ETRSEL_2 | TIM1_AF1_ETRSEL_0) /*!< ETR input is connected to MCO2 */
 /**
   * @}
   */
@@ -1050,6 +1044,9 @@ typedef struct
 #define LL_TIM_BKIN_SOURCE_BKCOMP1             TIM1_AF1_BKCMP1E    /*!< internal signal: COMP1 output */
 #define LL_TIM_BKIN_SOURCE_BKCOMP2             TIM1_AF1_BKCMP2E    /*!< internal signal: COMP2 output */
 #endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+#define LL_TIM_BKIN_SOURCE_BKCOMP3             TIM1_AF1_BKCMP3E    /*!< internal signal: COMP3 output */
+#endif /* COMP3 */
 /**
   * @}
   */
@@ -1102,7 +1099,7 @@ typedef struct
 #define LL_TIM_DMABURST_BASEADDR_CCR3          (TIM_DCR_DBA_3 | TIM_DCR_DBA_2 | TIM_DCR_DBA_1 | TIM_DCR_DBA_0)  /*!< TIMx_CCR3 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_CCR4          TIM_DCR_DBA_4                                                    /*!< TIMx_CCR4 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_BDTR          (TIM_DCR_DBA_4 | TIM_DCR_DBA_0)                                  /*!< TIMx_BDTR register is the DMA base address for DMA burst */
-#define LL_TIM_DMABURST_BASEADDR_OR1            (TIM_DCR_DBA_4 | TIM_DCR_DBA_2)                                  /*!< TIMx_OR1 register is the DMA base address for DMA burst */
+#define LL_TIM_DMABURST_BASEADDR_OR1           (TIM_DCR_DBA_4 | TIM_DCR_DBA_2)                                  /*!< TIMx_OR1 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_CCMR3         (TIM_DCR_DBA_4 | TIM_DCR_DBA_2 | TIM_DCR_DBA_0)                  /*!< TIMx_CCMR3 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_CCR5          (TIM_DCR_DBA_4 | TIM_DCR_DBA_2 | TIM_DCR_DBA_1)                  /*!< TIMx_CCR5 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_CCR6          (TIM_DCR_DBA_4 | TIM_DCR_DBA_2 | TIM_DCR_DBA_1 | TIM_DCR_DBA_0)  /*!< TIMx_CCR6 register is the DMA base address for DMA burst */
@@ -1160,6 +1157,17 @@ typedef struct
   * @}
   */
 
+/** @defgroup TIM_LL_EC_TIM1_TI3_RMP  TIM1 Timer Input Ch3 Remap
+  * @{
+  */
+#define LL_TIM_TIM1_TI3_RMP_GPIO   0x00000000U                                       /*!< TIM1 input 3 is connected to GPIO */
+#if defined(COMP3)
+#define LL_TIM_TIM1_TI3_RMP_COMP3  TIM_TISEL_TI3SEL_0                                /*!< TIM1 input 3 is connected to COMP3_OUT */
+#endif
+/**
+  * @}
+  */
+
 #if defined(TIM2)
 /** @defgroup TIM_LL_EC_TIM2_TI1_RMP  TIM2 Timer Input Ch1 Remap
   * @{
@@ -1175,6 +1183,17 @@ typedef struct
   */
 #define LL_TIM_TIM2_TI2_RMP_GPIO   0x00000000U                                       /*!< TIM2 input 2 is connected to GPIO */
 #define LL_TIM_TIM2_TI2_RMP_COMP2  TIM_TISEL_TI2SEL_0                                /*!< TIM2 input 2 is connected to COMP2_OUT */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_LL_EC_TIM2_TI3_RMP  TIM2 Timer Input Ch3 Remap
+  * @{
+  */
+#define LL_TIM_TIM2_TI3_RMP_GPIO   0x00000000U                                       /*!< TIM2 input 3 is connected to GPIO */
+#if defined(COMP3)
+#define LL_TIM_TIM2_TI3_RMP_COMP3  TIM_TISEL_TI3SEL_0                                /*!< TIM2 input 3 is connected to COMP3_OUT */
+#endif
 /**
   * @}
   */
@@ -1202,13 +1221,60 @@ typedef struct
   * @}
   */
 
+/** @defgroup TIM_LL_EC_TIM3_TI3_RMP  TIM3 Timer Input Ch3 Remap
+  * @{
+  */
+#define LL_TIM_TIM3_TI3_RMP_GPIO   0x00000000U                                       /*!< TIM3 input 3 is connected to GPIO */
+#if defined(COMP3)
+#define LL_TIM_TIM3_TI3_RMP_COMP3  TIM_TISEL_TI3SEL_0                                /*!< TIM3 input 3 is connected to COMP3_OUT */
+#endif
+/**
+  * @}
+  */
+
+#if defined(TIM4)
+/** @defgroup TIM_LL_EC_TIM4_TI1_RMP  TIM4 Timer Input Ch1 Remap
+  * @{
+  */
+#define LL_TIM_TIM4_TI1_RMP_GPIO   0x00000000U                                       /*!< TIM4 input 1 is connected to GPIO */
+#if defined(COMP1)
+#define LL_TIM_TIM4_TI1_RMP_COMP1  TIM_TISEL_TI1SEL_0                                /*!< TIM4 input 1 is connected to COMP1_OUT */
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup TIM_LL_EC_TIM4_TI2_RMP  TIM4 Timer Input Ch2 Remap
+  * @{
+  */
+#define LL_TIM_TIM4_TI2_RMP_GPIO   0x00000000U                                       /*!< TIM4 input 2 is connected to GPIO */
+#if defined(COMP2)
+#define LL_TIM_TIM4_TI2_RMP_COMP2  TIM_TISEL_TI2SEL_0                                /*!< TIM4 input 2 is connected to COMP2_OUT */
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup TIM_LL_EC_TIM4_TI3_RMP  TIM4 Timer Input Ch3 Remap
+  * @{
+  */
+#define LL_TIM_TIM4_TI3_RMP_GPIO   0x00000000U                                       /*!< TIM4 input 3 is connected to GPIO */
+#if defined(COMP3)
+#define LL_TIM_TIM4_TI3_RMP_COMP3  TIM_TISEL_TI3SEL_0                                /*!< TIM4 input 3 is connected to COMP3_OUT */
+#endif
+/**
+  * @}
+  */
+#endif
+
 /** @defgroup TIM_LL_EC_TIM14_TI1_RMP  TIM14 Timer Input Ch1 Remap
   * @{
   */
 #define LL_TIM_TIM14_TI1_RMP_GPIO     0x00000000U                                    /*!< TIM14 input 1 is connected to GPIO */
 #define LL_TIM_TIM14_TI1_RMP_RTC_CLK  TIM_TISEL_TI1SEL_0                             /*!< TIM14 input 1 is connected to RTC clock */
-#define LL_TIM_TIM14_TI1_RMP_HSE_32   TIM_TISEL_TI1SEL_1                             /*!< TIM14_TI1 is connected to HSE/32 clock */
-#define LL_TIM_TIM14_TI1_RMP_MCO      (TIM_TISEL_TI1SEL_0  | TIM_TISEL_TI1SEL_1)     /*!< TIM14 input 1 is connected to MCO */
+#define LL_TIM_TIM14_TI1_RMP_HSE_32   TIM_TISEL_TI1SEL_1                             /*!< TIM14 input 1 is connected to HSE/32 clock */
+#define LL_TIM_TIM14_TI1_RMP_MCO     (TIM_TISEL_TI1SEL_0  | TIM_TISEL_TI1SEL_1)     /*!< TIM14 input 1 is connected to MCO */
+#define LL_TIM_TIM14_TI1_RMP_MCO2    TIM_TISEL_TI1SEL_2                             /*!< TIM14 input 1 is connected to MCO2 */
 /**
   * @}
   */
@@ -1252,6 +1318,7 @@ typedef struct
 #define LL_TIM_TIM16_TI1_RMP_LSI     TIM_TISEL_TI1SEL_0                              /*!< TIM16 input 1 is connected to LSI */
 #define LL_TIM_TIM16_TI1_RMP_LSE     TIM_TISEL_TI1SEL_1                              /*!< TIM16 input 1 is connected to LSE */
 #define LL_TIM_TIM16_TI1_RMP_RTC_WK  (TIM_TISEL_TI1SEL_0 | TIM_TISEL_TI1SEL_1)       /*!< TIM16 input 1 is connected to RTC_WAKEUP */
+#define LL_TIM_TIM16_TI1_RMP_MCO2    TIM_TISEL_TI1SEL_2                              /*!< TIM16 input 1 is connected to MCO2 */
 /**
   * @}
   */
@@ -1260,8 +1327,10 @@ typedef struct
   * @{
   */
 #define LL_TIM_TIM17_TI1_RMP_GPIO    0x00000000U                                     /*!< TIM17 input 1 is connected to GPIO */
+#define LL_TIM_TIM17_TI1_RMP_HSI48   TIM_TISEL_TI1SEL_0                              /*!< TIM17 input 1 is connected to HSI48/256 */
 #define LL_TIM_TIM17_TI1_RMP_HSE_32  TIM_TISEL_TI1SEL_1                              /*!< TIM17 input 1 is connected to HSE/32 clock */
 #define LL_TIM_TIM17_TI1_RMP_MCO    (TIM_TISEL_TI1SEL_0 | TIM_TISEL_TI1SEL_1)        /*!< TIM17 input 1 is connected to MCO */
+#define LL_TIM_TIM17_TI1_RMP_MCO2    TIM_TISEL_TI1SEL_2                              /*!< TIM17 input 1 is connected to MCO2 */
 /**
   * @}
   */
@@ -1272,7 +1341,12 @@ typedef struct
 #define LL_TIM_OCREF_CLR_INT_ETR         OCREF_CLEAR_SELECT_Msk       /*!< OCREF_CLR_INT is connected to ETRF */
 #if defined(COMP1) && defined(COMP2)
 #define LL_TIM_OCREF_CLR_INT_COMP1       0x00000000U                  /*!< OCREF clear input is connected to COMP1_OUT */
+#if defined(COMP3)
+#define LL_TIM_OCREF_CLR_INT_COMP2       TIM1_OR1_OCREF_CLR_0         /*!< OCREF clear input is connected to COMP2_OUT */
+#define LL_TIM_OCREF_CLR_INT_COMP3       TIM1_OR1_OCREF_CLR_1         /*!< OCREF clear input is connected to COMP3_OUT */
+#else
 #define LL_TIM_OCREF_CLR_INT_COMP2       TIM1_OR1_OCREF_CLR           /*!< OCREF clear input is connected to COMP2_OUT */
+#endif /* COMP3 */
 #endif /* COMP1 & COMP2 */
 /**
   * @}
@@ -1769,7 +1843,7 @@ __STATIC_INLINE uint32_t LL_TIM_GetAutoReload(TIM_TypeDef *TIMx)
   *       whether or not a timer instance supports a repetition counter.
   * @rmtoll RCR          REP           LL_TIM_SetRepetitionCounter
   * @param  TIMx Timer instance
-  * @param  RepetitionCounter between Min_Data=0 and Max_Data=255
+  * @param  RepetitionCounter between Min_Data=0 and Max_Data=255 or 65535 for advanced timer.
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_SetRepetitionCounter(TIM_TypeDef *TIMx, uint32_t RepetitionCounter)
@@ -1811,6 +1885,16 @@ __STATIC_INLINE void LL_TIM_EnableUIFRemap(TIM_TypeDef *TIMx)
 __STATIC_INLINE void LL_TIM_DisableUIFRemap(TIM_TypeDef *TIMx)
 {
   CLEAR_BIT(TIMx->CR1, TIM_CR1_UIFREMAP);
+}
+
+/**
+  * @brief  Indicate whether update interrupt flag (UIF) copy is set.
+  * @param  Counter Counter value
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_TIM_IsActiveUIFCPY(uint32_t Counter)
+{
+  return (((Counter & TIM_CNT_UIFCPY) == (TIM_CNT_UIFCPY)) ? 1UL : 0UL);
 }
 
 /**
@@ -2040,8 +2124,8 @@ __STATIC_INLINE uint32_t LL_TIM_CC_IsEnabledChannel(TIM_TypeDef *TIMx, uint32_t 
   */
 __STATIC_INLINE void LL_TIM_OC_ConfigOutput(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Configuration)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   CLEAR_BIT(*pReg, (TIM_CCMR1_CC1S << SHIFT_TAB_OCxx[iChannel]));
   MODIFY_REG(TIMx->CCER, (TIM_CCER_CC1P << SHIFT_TAB_CCxP[iChannel]),
              (Configuration & TIM_CCER_CC1P) << SHIFT_TAB_CCxP[iChannel]);
@@ -2085,8 +2169,8 @@ __STATIC_INLINE void LL_TIM_OC_ConfigOutput(TIM_TypeDef *TIMx, uint32_t Channel,
   */
 __STATIC_INLINE void LL_TIM_OC_SetMode(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Mode)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   MODIFY_REG(*pReg, ((TIM_CCMR1_OC1M  | TIM_CCMR1_CC1S) << SHIFT_TAB_OCxx[iChannel]),  Mode << SHIFT_TAB_OCxx[iChannel]);
 }
 
@@ -2124,8 +2208,8 @@ __STATIC_INLINE void LL_TIM_OC_SetMode(TIM_TypeDef *TIMx, uint32_t Channel, uint
   */
 __STATIC_INLINE uint32_t LL_TIM_OC_GetMode(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   return (READ_BIT(*pReg, ((TIM_CCMR1_OC1M  | TIM_CCMR1_CC1S) << SHIFT_TAB_OCxx[iChannel])) >> SHIFT_TAB_OCxx[iChannel]);
 }
 
@@ -2158,7 +2242,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetMode(TIM_TypeDef *TIMx, uint32_t Channel)
   */
 __STATIC_INLINE void LL_TIM_OC_SetPolarity(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Polarity)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   MODIFY_REG(TIMx->CCER, (TIM_CCER_CC1P << SHIFT_TAB_CCxP[iChannel]),  Polarity << SHIFT_TAB_CCxP[iChannel]);
 }
 
@@ -2190,7 +2274,7 @@ __STATIC_INLINE void LL_TIM_OC_SetPolarity(TIM_TypeDef *TIMx, uint32_t Channel, 
   */
 __STATIC_INLINE uint32_t LL_TIM_OC_GetPolarity(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   return (READ_BIT(TIMx->CCER, (TIM_CCER_CC1P << SHIFT_TAB_CCxP[iChannel])) >> SHIFT_TAB_CCxP[iChannel]);
 }
 
@@ -2227,7 +2311,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetPolarity(TIM_TypeDef *TIMx, uint32_t Chann
   */
 __STATIC_INLINE void LL_TIM_OC_SetIdleState(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t IdleState)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   MODIFY_REG(TIMx->CR2, (TIM_CR2_OIS1 << SHIFT_TAB_OISx[iChannel]),  IdleState << SHIFT_TAB_OISx[iChannel]);
 }
 
@@ -2259,7 +2343,7 @@ __STATIC_INLINE void LL_TIM_OC_SetIdleState(TIM_TypeDef *TIMx, uint32_t Channel,
   */
 __STATIC_INLINE uint32_t LL_TIM_OC_GetIdleState(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   return (READ_BIT(TIMx->CR2, (TIM_CR2_OIS1 << SHIFT_TAB_OISx[iChannel])) >> SHIFT_TAB_OISx[iChannel]);
 }
 
@@ -2284,8 +2368,8 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetIdleState(TIM_TypeDef *TIMx, uint32_t Chan
   */
 __STATIC_INLINE void LL_TIM_OC_EnableFast(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   SET_BIT(*pReg, (TIM_CCMR1_OC1FE << SHIFT_TAB_OCxx[iChannel]));
 
 }
@@ -2310,8 +2394,8 @@ __STATIC_INLINE void LL_TIM_OC_EnableFast(TIM_TypeDef *TIMx, uint32_t Channel)
   */
 __STATIC_INLINE void LL_TIM_OC_DisableFast(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   CLEAR_BIT(*pReg, (TIM_CCMR1_OC1FE << SHIFT_TAB_OCxx[iChannel]));
 
 }
@@ -2336,9 +2420,9 @@ __STATIC_INLINE void LL_TIM_OC_DisableFast(TIM_TypeDef *TIMx, uint32_t Channel)
   */
 __STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledFast(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
-  register uint32_t bitfield = TIM_CCMR1_OC1FE << SHIFT_TAB_OCxx[iChannel];
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint32_t bitfield = TIM_CCMR1_OC1FE << SHIFT_TAB_OCxx[iChannel];
   return ((READ_BIT(*pReg, bitfield) == bitfield) ? 1UL : 0UL);
 }
 
@@ -2362,8 +2446,8 @@ __STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledFast(TIM_TypeDef *TIMx, uint32_t Cha
   */
 __STATIC_INLINE void LL_TIM_OC_EnablePreload(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   SET_BIT(*pReg, (TIM_CCMR1_OC1PE << SHIFT_TAB_OCxx[iChannel]));
 }
 
@@ -2387,8 +2471,8 @@ __STATIC_INLINE void LL_TIM_OC_EnablePreload(TIM_TypeDef *TIMx, uint32_t Channel
   */
 __STATIC_INLINE void LL_TIM_OC_DisablePreload(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   CLEAR_BIT(*pReg, (TIM_CCMR1_OC1PE << SHIFT_TAB_OCxx[iChannel]));
 }
 
@@ -2412,9 +2496,9 @@ __STATIC_INLINE void LL_TIM_OC_DisablePreload(TIM_TypeDef *TIMx, uint32_t Channe
   */
 __STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledPreload(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
-  register uint32_t bitfield = TIM_CCMR1_OC1PE << SHIFT_TAB_OCxx[iChannel];
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint32_t bitfield = TIM_CCMR1_OC1PE << SHIFT_TAB_OCxx[iChannel];
   return ((READ_BIT(*pReg, bitfield) == bitfield) ? 1UL : 0UL);
 }
 
@@ -2441,8 +2525,8 @@ __STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledPreload(TIM_TypeDef *TIMx, uint32_t 
   */
 __STATIC_INLINE void LL_TIM_OC_EnableClear(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   SET_BIT(*pReg, (TIM_CCMR1_OC1CE << SHIFT_TAB_OCxx[iChannel]));
 }
 
@@ -2468,8 +2552,8 @@ __STATIC_INLINE void LL_TIM_OC_EnableClear(TIM_TypeDef *TIMx, uint32_t Channel)
   */
 __STATIC_INLINE void LL_TIM_OC_DisableClear(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   CLEAR_BIT(*pReg, (TIM_CCMR1_OC1CE << SHIFT_TAB_OCxx[iChannel]));
 }
 
@@ -2497,9 +2581,9 @@ __STATIC_INLINE void LL_TIM_OC_DisableClear(TIM_TypeDef *TIMx, uint32_t Channel)
   */
 __STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledClear(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
-  register uint32_t bitfield = TIM_CCMR1_OC1CE << SHIFT_TAB_OCxx[iChannel];
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint32_t bitfield = TIM_CCMR1_OC1CE << SHIFT_TAB_OCxx[iChannel];
   return ((READ_BIT(*pReg, bitfield) == bitfield) ? 1UL : 0UL);
 }
 
@@ -2768,8 +2852,8 @@ __STATIC_INLINE void LL_TIM_SetCH5CombinedChannels(TIM_TypeDef *TIMx, uint32_t G
   */
 __STATIC_INLINE void LL_TIM_IC_Config(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Configuration)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   MODIFY_REG(*pReg, ((TIM_CCMR1_IC1F | TIM_CCMR1_IC1PSC | TIM_CCMR1_CC1S) << SHIFT_TAB_ICxx[iChannel]),
              ((Configuration >> 16U) & (TIM_CCMR1_IC1F | TIM_CCMR1_IC1PSC | TIM_CCMR1_CC1S))  << SHIFT_TAB_ICxx[iChannel]);
   MODIFY_REG(TIMx->CCER, ((TIM_CCER_CC1NP | TIM_CCER_CC1P) << SHIFT_TAB_CCxP[iChannel]),
@@ -2796,8 +2880,8 @@ __STATIC_INLINE void LL_TIM_IC_Config(TIM_TypeDef *TIMx, uint32_t Channel, uint3
   */
 __STATIC_INLINE void LL_TIM_IC_SetActiveInput(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t ICActiveInput)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   MODIFY_REG(*pReg, ((TIM_CCMR1_CC1S) << SHIFT_TAB_ICxx[iChannel]), (ICActiveInput >> 16U) << SHIFT_TAB_ICxx[iChannel]);
 }
 
@@ -2820,8 +2904,8 @@ __STATIC_INLINE void LL_TIM_IC_SetActiveInput(TIM_TypeDef *TIMx, uint32_t Channe
   */
 __STATIC_INLINE uint32_t LL_TIM_IC_GetActiveInput(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   return ((READ_BIT(*pReg, ((TIM_CCMR1_CC1S) << SHIFT_TAB_ICxx[iChannel])) >> SHIFT_TAB_ICxx[iChannel]) << 16U);
 }
 
@@ -2846,8 +2930,8 @@ __STATIC_INLINE uint32_t LL_TIM_IC_GetActiveInput(TIM_TypeDef *TIMx, uint32_t Ch
   */
 __STATIC_INLINE void LL_TIM_IC_SetPrescaler(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t ICPrescaler)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   MODIFY_REG(*pReg, ((TIM_CCMR1_IC1PSC) << SHIFT_TAB_ICxx[iChannel]), (ICPrescaler >> 16U) << SHIFT_TAB_ICxx[iChannel]);
 }
 
@@ -2871,8 +2955,8 @@ __STATIC_INLINE void LL_TIM_IC_SetPrescaler(TIM_TypeDef *TIMx, uint32_t Channel,
   */
 __STATIC_INLINE uint32_t LL_TIM_IC_GetPrescaler(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   return ((READ_BIT(*pReg, ((TIM_CCMR1_IC1PSC) << SHIFT_TAB_ICxx[iChannel])) >> SHIFT_TAB_ICxx[iChannel]) << 16U);
 }
 
@@ -2909,8 +2993,8 @@ __STATIC_INLINE uint32_t LL_TIM_IC_GetPrescaler(TIM_TypeDef *TIMx, uint32_t Chan
   */
 __STATIC_INLINE void LL_TIM_IC_SetFilter(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t ICFilter)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   MODIFY_REG(*pReg, ((TIM_CCMR1_IC1F) << SHIFT_TAB_ICxx[iChannel]), (ICFilter >> 16U) << SHIFT_TAB_ICxx[iChannel]);
 }
 
@@ -2946,8 +3030,8 @@ __STATIC_INLINE void LL_TIM_IC_SetFilter(TIM_TypeDef *TIMx, uint32_t Channel, ui
   */
 __STATIC_INLINE uint32_t LL_TIM_IC_GetFilter(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
-  register const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   return ((READ_BIT(*pReg, ((TIM_CCMR1_IC1F) << SHIFT_TAB_ICxx[iChannel])) >> SHIFT_TAB_ICxx[iChannel]) << 16U);
 }
 
@@ -2975,7 +3059,7 @@ __STATIC_INLINE uint32_t LL_TIM_IC_GetFilter(TIM_TypeDef *TIMx, uint32_t Channel
   */
 __STATIC_INLINE void LL_TIM_IC_SetPolarity(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t ICPolarity)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   MODIFY_REG(TIMx->CCER, ((TIM_CCER_CC1NP | TIM_CCER_CC1P) << SHIFT_TAB_CCxP[iChannel]),
              ICPolarity << SHIFT_TAB_CCxP[iChannel]);
 }
@@ -3003,7 +3087,7 @@ __STATIC_INLINE void LL_TIM_IC_SetPolarity(TIM_TypeDef *TIMx, uint32_t Channel, 
   */
 __STATIC_INLINE uint32_t LL_TIM_IC_GetPolarity(TIM_TypeDef *TIMx, uint32_t Channel)
 {
-  register uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
+  uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   return (READ_BIT(TIMx->CCER, ((TIM_CCER_CC1NP | TIM_CCER_CC1P) << SHIFT_TAB_CCxP[iChannel])) >>
           SHIFT_TAB_CCxP[iChannel]);
 }
@@ -3292,6 +3376,9 @@ __STATIC_INLINE void LL_TIM_SetSlaveMode(TIM_TypeDef *TIMx, uint32_t SlaveMode)
   *         @arg @ref LL_TIM_TS_TI1FP1
   *         @arg @ref LL_TIM_TS_TI2FP2
   *         @arg @ref LL_TIM_TS_ETRF
+  *         @arg @ref LL_TIM_TS_ITR7 (*)
+  *
+  *      (*)  Value not defined in all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_SetTriggerInput(TIM_TypeDef *TIMx, uint32_t TriggerInput)
@@ -3389,36 +3476,57 @@ __STATIC_INLINE void LL_TIM_ConfigETR(TIM_TypeDef *TIMx, uint32_t ETRPolarity, u
   *         TIM1
   *
   *         @arg @ref LL_TIM_ETRSOURCE_GPIO
-  * @if STM32G081xx
-  *         @arg @ref LL_TIM_ETRSOURCE_COMP1
-  *         @arg @ref LL_TIM_ETRSOURCE_COMP2
-  * @endif
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP1 (**)
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP2 (**)
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP3 (**)
   *         @arg @ref LL_TIM_ETRSOURCE_ADC1_AWD1
   *         @arg @ref LL_TIM_ETRSOURCE_ADC1_AWD2
   *         @arg @ref LL_TIM_ETRSOURCE_ADC1_AWD3
   *
-  *         TIM2
+  *         TIM2 (*)
   *
   *         @arg @ref LL_TIM_ETRSOURCE_GPIO
-  * @if STM32G081xx
   *         @arg @ref LL_TIM_ETRSOURCE_COMP1
   *         @arg @ref LL_TIM_ETRSOURCE_COMP2
-  * @endif
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP3 (**)
   *         @arg @ref LL_TIM_ETRSOURCE_LSE
+  *         @arg @ref LL_TIM_ETRSOURCE_MCO (**)
+  *         @arg @ref LL_TIM_ETRSOURCE_MCO2 (**)
   *
   *         TIM3
   *
   *         @arg @ref LL_TIM_ETRSOURCE_GPIO
-  * @if STM32G081xx
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP1 (**)
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP2 (**)
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP3 (**)
+  *
+  *         TIM4 (*)
+  *
+  *         @arg @ref LL_TIM_ETRSOURCE_GPIO
   *         @arg @ref LL_TIM_ETRSOURCE_COMP1
   *         @arg @ref LL_TIM_ETRSOURCE_COMP2
-  * @endif
+  *         @arg @ref LL_TIM_ETRSOURCE_COMP3 (**)
+  *
+  *  (*) Timer instance not available on all devices \n
+  *  (**) Value not defined in all devices. \n
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_SetETRSource(TIM_TypeDef *TIMx, uint32_t ETRSource)
 {
-
+#if defined(COMP3)
+  uint32_t etrsel_shift = ((ETRSource == LL_TIM_ETRSOURCE_COMP3) ? 1u : 0u);
+  if ((TIMx == TIM1) || (TIMx == TIM2))
+  {
+    MODIFY_REG(TIMx->AF1, TIMx_AF1_ETRSEL, ETRSource);
+  }
+  else
+  {
+    MODIFY_REG(TIMx->AF1, TIMx_AF1_ETRSEL, ETRSource >> etrsel_shift);
+  }
+#else
   MODIFY_REG(TIMx->AF1, TIMx_AF1_ETRSEL, ETRSource);
+#endif
 }
 
 /**
@@ -3737,30 +3845,30 @@ __STATIC_INLINE uint32_t LL_TIM_IsEnabledAllOutputs(TIM_TypeDef *TIMx)
   * @note Macro IS_TIM_BREAKSOURCE_INSTANCE(TIMx) can be used to check whether
   *       or not a timer instance allows for break input selection.
   * @rmtoll AF1          BKINE         LL_TIM_EnableBreakInputSource\n
-  * @if STM32G081xx
   *         AF1          BKCMP1E       LL_TIM_EnableBreakInputSource\n
   *         AF1          BKCMP2E       LL_TIM_EnableBreakInputSource\n
-  * @endif
+  *         AF1          BKCMP3E       LL_TIM_EnableBreakInputSource\n
   *         AF2          BK2INE        LL_TIM_EnableBreakInputSource\n
-  * @if STM32G081xx
   *         AF2          BK2CMP1E      LL_TIM_EnableBreakInputSource\n
-  *         AF2          BK2CMP2E      LL_TIM_EnableBreakInputSource
-  * @endif
+  *         AF2          BK2CMP2E      LL_TIM_EnableBreakInputSource\n
+  *         AF2          BK2CMP3E      LL_TIM_EnableBreakInputSource
   * @param  TIMx Timer instance
   * @param  BreakInput This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN2
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKIN
-  * @if STM32G081xx
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP2
-  * @endif
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP3 (*)
+  *
+  *         (*)  Value not defined in all devices. \n
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_EnableBreakInputSource(TIM_TypeDef *TIMx, uint32_t BreakInput, uint32_t Source)
 {
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->AF1) + BreakInput));
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->AF1) + BreakInput));
   SET_BIT(*pReg, Source);
 }
 
@@ -3769,30 +3877,30 @@ __STATIC_INLINE void LL_TIM_EnableBreakInputSource(TIM_TypeDef *TIMx, uint32_t B
   * @note Macro IS_TIM_BREAKSOURCE_INSTANCE(TIMx) can be used to check whether
   *       or not a timer instance allows for break input selection.
   * @rmtoll AF1          BKINE         LL_TIM_DisableBreakInputSource\n
-  * @if STM32G081xx
   *         AF1          BKCMP1E       LL_TIM_DisableBreakInputSource\n
   *         AF1          BKCMP2E       LL_TIM_DisableBreakInputSource\n
-  * @endif
+  *         AF1          BKCMP3E       LL_TIM_DisableBreakInputSource\n
   *         AF2          BK2INE        LL_TIM_DisableBreakInputSource\n
-  * @if STM32G081xx
   *         AF2          BK2CMP1E      LL_TIM_DisableBreakInputSource\n
-  *         AF2          BK2CMP2E      LL_TIM_DisableBreakInputSource
-  * @endif
+  *         AF2          BK2CMP2E      LL_TIM_DisableBreakInputSource\n
+  *         AF2          BK2CMP3E      LL_TIM_DisableBreakInputSource
   * @param  TIMx Timer instance
   * @param  BreakInput This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN2
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKIN
-  * @if STM32G081xx
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP2
-  * @endif
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP3 (*)
+  *
+  *         (*)  Value not defined in all devices. \n
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_DisableBreakInputSource(TIM_TypeDef *TIMx, uint32_t BreakInput, uint32_t Source)
 {
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->AF1) + BreakInput));
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->AF1) + BreakInput));
   CLEAR_BIT(*pReg, Source);
 }
 
@@ -3801,34 +3909,34 @@ __STATIC_INLINE void LL_TIM_DisableBreakInputSource(TIM_TypeDef *TIMx, uint32_t 
   * @note Macro IS_TIM_BREAKSOURCE_INSTANCE(TIMx) can be used to check whether
   *       or not a timer instance allows for break input selection.
   * @rmtoll AF1          BKINP         LL_TIM_SetBreakInputSourcePolarity\n
-  * @if STM32G081xx
   *         AF1          BKCMP1P       LL_TIM_SetBreakInputSourcePolarity\n
   *         AF1          BKCMP2P       LL_TIM_SetBreakInputSourcePolarity\n
-  * @endif
+  *         AF1          BKCMP3P       LL_TIM_SetBreakInputSourcePolarity\n
   *         AF2          BK2INP        LL_TIM_SetBreakInputSourcePolarity\n
-  * @if STM32G081xx
   *         AF2          BK2CMP1P      LL_TIM_SetBreakInputSourcePolarity\n
-  *         AF2          BK2CMP2P      LL_TIM_SetBreakInputSourcePolarity
-  * @endif
+  *         AF2          BK2CMP2P      LL_TIM_SetBreakInputSourcePolarity\n
+  *         AF2          BK2CMP3P      LL_TIM_SetBreakInputSourcePolarity
   * @param  TIMx Timer instance
   * @param  BreakInput This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN
   *         @arg @ref LL_TIM_BREAK_INPUT_BKIN2
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKIN
-  * @if STM32G081xx
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP1
   *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP2
-  * @endif
+  *         @arg @ref LL_TIM_BKIN_SOURCE_BKCOMP3 (*)
   * @param  Polarity This parameter can be one of the following values:
   *         @arg @ref LL_TIM_BKIN_POLARITY_LOW
   *         @arg @ref LL_TIM_BKIN_POLARITY_HIGH
+  *
+  *         (*)  Value not defined in all devices. \n
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_SetBreakInputSourcePolarity(TIM_TypeDef *TIMx, uint32_t BreakInput, uint32_t Source,
                                                         uint32_t Polarity)
 {
-  register __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->AF1) + BreakInput));
+  __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->AF1) + BreakInput));
   MODIFY_REG(*pReg, (TIMx_AF1_BKINP << TIM_POSITION_BRK_SOURCE), (Polarity << TIM_POSITION_BRK_SOURCE));
 }
 /**
@@ -3914,6 +4022,9 @@ __STATIC_INLINE void LL_TIM_ConfigDMABurst(TIM_TypeDef *TIMx, uint32_t DMABurstB
   *         TIM2_TISEL    TI2SEL      LL_TIM_SetRemap\n
   *         TIM3_TISEL    TI1SEL      LL_TIM_SetRemap\n
   *         TIM3_TISEL    TI2SEL      LL_TIM_SetRemap\n
+  *         TIM4_TISEL    TI1SEL      LL_TIM_SetRemap\n
+  *         TIM4_TISEL    TI2SEL      LL_TIM_SetRemap\n
+  *         TIM4_TISEL    TI3SEL      LL_TIM_SetRemap\n
   *         TIM14_TISEL   TI1SEL      LL_TIM_SetRemap\n
   *         TIM15_TISEL   TI1SEL      LL_TIM_SetRemap\n
   *         TIM15_TISEL   TI2SEL      LL_TIM_SetRemap\n
@@ -3930,31 +4041,57 @@ __STATIC_INLINE void LL_TIM_ConfigDMABurst(TIM_TypeDef *TIMx, uint32_t DMABurstB
   *
   *            . . TI1_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM1_TI1_RMP_GPIO
-  *            @arg @ref LL_TIM_TIM1_TI1_RMP_COMP1
+  *            @arg @ref LL_TIM_TIM1_TI1_RMP_COMP1 (**)
   *
   *            . . TI2_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM1_TI2_RMP_GPIO
-  *            @arg @ref LL_TIM_TIM1_TI2_RMP_COMP2
+  *            @arg @ref LL_TIM_TIM1_TI2_RMP_COMP2 (**)
+  *
+  *            . . TI3_RMP can be one of the following values
+  *            @arg @ref LL_TIM_TIM1_TI3_RMP_GPIO
+  *            @arg @ref LL_TIM_TIM1_TI3_RMP_COMP3 (**)
   *
   *         TIM2: any combination of TI1_RMP and TI2_RMP where
   *
   *            . . TI1_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM2_TI1_RMP_GPIO
-  *            @arg @ref LL_TIM_TIM2_TI1_RMP_COMP1
+  *            @arg @ref LL_TIM_TIM2_TI1_RMP_COMP1 (**)
   *
   *            . . TI2_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM2_TI2_RMP_GPIO
-  *            @arg @ref LL_TIM_TIM2_TI2_RMP_COMP2
+  *            @arg @ref LL_TIM_TIM2_TI2_RMP_COMP2 (**)
+  *
+  *            . . TI3_RMP can be one of the following values
+  *            @arg @ref LL_TIM_TIM2_TI3_RMP_GPIO
+  *            @arg @ref LL_TIM_TIM2_TI3_RMP_COMP3 (**)
   *
   *         TIM3: any combination of TI1_RMP and TI2_RMP where
   *
   *            . . TI1_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM3_TI1_RMP_GPIO
-  *            @arg @ref LL_TIM_TIM3_TI1_RMP_COMP1
+  *            @arg @ref LL_TIM_TIM3_TI1_RMP_COMP1 (**)
   *
   *            . . TI2_RMP can be one of the following values
   *            @arg @ref LL_TIM_TIM3_TI2_RMP_GPIO
-  *            @arg @ref LL_TIM_TIM3_TI2_RMP_COMP2
+  *            @arg @ref LL_TIM_TIM3_TI2_RMP_COMP2 (**)
+  *
+  *            . . TI3_RMP can be one of the following values
+  *            @arg @ref LL_TIM_TIM3_TI3_RMP_GPIO
+  *            @arg @ref LL_TIM_TIM3_TI3_RMP_COMP3 (**)
+  *
+  *         TIM4: any combination of TI1_RMP, TI2_RMP and TI3_RMP where  (*)
+  *
+  *            . . TI1_RMP can be one of the following values
+  *            @arg @ref LL_TIM_TIM4_TI1_RMP_GPIO
+  *            @arg @ref LL_TIM_TIM4_TI1_RMP_COMP1 (**)
+  *
+  *            . . TI2_RMP can be one of the following values
+  *            @arg @ref LL_TIM_TIM4_TI2_RMP_GPIO
+  *            @arg @ref LL_TIM_TIM4_TI2_RMP_COMP2 (**)
+  *
+  *            . . TI3_RMP can be one of the following values
+  *            @arg @ref LL_TIM_TIM4_TI3_RMP_GPIO
+  *            @arg @ref LL_TIM_TIM4_TI3_RMP_COMP3 (**)
   *
   *         TIM14: one of the following values
   *
@@ -3962,6 +4099,7 @@ __STATIC_INLINE void LL_TIM_ConfigDMABurst(TIM_TypeDef *TIMx, uint32_t DMABurstB
   *            @arg @ref LL_TIM_TIM14_TI1_RMP_RTC_CLK
   *            @arg @ref LL_TIM_TIM14_TI1_RMP_HSE_32
   *            @arg @ref LL_TIM_TIM14_TI1_RMP_MCO
+  *            @arg @ref LL_TIM_TIM14_TI1_RMP_MCO2 (**)
   *
   *         TIM15: any combination of TI1_RMP and TI2_RMP where
   *
@@ -3981,12 +4119,18 @@ __STATIC_INLINE void LL_TIM_ConfigDMABurst(TIM_TypeDef *TIMx, uint32_t DMABurstB
   *            @arg @ref LL_TIM_TIM16_TI1_RMP_LSI
   *            @arg @ref LL_TIM_TIM16_TI1_RMP_LSE
   *            @arg @ref LL_TIM_TIM16_TI1_RMP_RTC_WK
+  *            @arg @ref LL_TIM_TIM16_TI1_RMP_MCO2(**)
   *
   *         TIM17: one of the following values
   *
   *            @arg @ref LL_TIM_TIM17_TI1_RMP_GPIO
   *            @arg @ref LL_TIM_TIM17_TI1_RMP_HSE_32
   *            @arg @ref LL_TIM_TIM17_TI1_RMP_MCO
+  *            @arg @ref LL_TIM_TIM17_TI1_RMP_HSI48 (**)
+  *            @arg @ref LL_TIM_TIM17_TI1_RMP_MCO2(**)
+  *
+  *  (*) Timer instance not available on all devices \n
+  *  (**) Value not defined in all devices. \n
   *
   * @retval None
   */
@@ -4011,8 +4155,12 @@ __STATIC_INLINE void LL_TIM_SetRemap(TIM_TypeDef *TIMx, uint32_t Remap)
   * @param  TIMx Timer instance
   * @param  OCRefClearInputSource This parameter can be one of the following values:
   *         @arg @ref LL_TIM_OCREF_CLR_INT_ETR
-  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP1
-  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP2
+  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP1 (*)
+  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP2 (*)
+  *         @arg @ref LL_TIM_OCREF_CLR_INT_COMP3 (*)
+  *
+  *         (*)  Value not defined in all devices. \n
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_SetOCRefClearInputSource(TIM_TypeDef *TIMx, uint32_t OCRefClearInputSource)
@@ -5030,7 +5178,7 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDT
   * @}
   */
 
-#endif /* TIM1 || TIM2 || TIM3 ||  TIM14 || TIM15 || TIM16 || TIM17 || TIM6 || TIM7 */
+#endif /* TIM1 || TIM2 || TIM3 || TIM4 || TIM14 || TIM15 || TIM16 || TIM17 || TIM6 || TIM7 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_ucpd.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_ucpd.h
@@ -53,24 +53,24 @@ extern "C" {
   */
 typedef struct
 {
-  uint32_t psc_ucpdclk;         /*!< Specifies the prescaler for the ucpd clock.
+  uint32_t psc_ucpdclk;         /*!< Specify the prescaler for the UCPD clock.
                                      This parameter can be a value of @ref UCPD_LL_EC_PSC.
-                                     This feature can be modified afterwards using unitary function @ref LL_UCPD_SetPSCClk().*/
+                                     This feature can be modified afterwards using unitary function @ref LL_UCPD_SetPSCClk().         */
 
-  uint32_t transwin;            /*!< Specifies the number of cycles (minus 1) of the half bit clock (see HBITCLKDIV) to achieve a legal
-                                    tTransitionWindow (set according to peripheral clock to define an interval of between 12 and 20 us).
+  uint32_t transwin;            /*!< Specify the number of cycles (minus 1) of the half bit clock (see HBITCLKDIV) to achieve a legal
+                                    tTransitionWindow (set according to peripheral clock to define an interval of between 12 and 20 us)
                                     This parameter can be a value between Min_Data=0x1 and Max_Data=0x1F
-                                    This value can be modified afterwards using unitary function @ref LL_UCPD_SetTransWin().*/
+                                    This value can be modified afterwards using unitary function @ref LL_UCPD_SetTransWin().          */
 
-  uint32_t IfrGap;              /*!< Specifies the definition of the clock divider (minus 1) in order to generate tInterframeGap
+  uint32_t IfrGap;              /*!< Specify the definition of the clock divider (minus 1) in order to generate tInterframeGap
                                     from the peripheral clock.
                                     This parameter can be a value between Min_Data=0x1 and Max_Data=0x1F
-                                    This feature can be modified afterwards using unitary function @ref LL_UCPD_SetIfrGap().*/
+                                    This feature can be modified afterwards using unitary function @ref LL_UCPD_SetIfrGap().          */
 
-  uint32_t HbitClockDiv;        /*!< Specifies  the number of cycles (minus one) at UCPD peripheral for a half bit clock e.g. program 3
+  uint32_t HbitClockDiv;        /*!< Specify the number of cycles (minus one) at UCPD peripheral for a half bit clock e.g. program 3
                                      for a bit clock that takes 8 cycles of the peripheral clock "UCPD1_CLK"..
                                      This parameter can be a value between Min_Data=0x0 and Max_Data=0x3F.
-                                     This feature can be modified afterwards using unitary function @ref LL_UCPD_SetHbitClockDiv().*/
+                                     This feature can be modified afterwards using unitary function @ref LL_UCPD_SetHbitClockDiv().   */
 
 } LL_UCPD_InitTypeDef;
 
@@ -88,24 +88,24 @@ typedef struct
   * @brief    Flags defines which can be used with LL_ucpd_ReadReg function
   * @{
   */
-#define LL_UCPD_SR_TXIS             UCPD_SR_TXIS               /*!< Transmit interrupt status            */
-#define LL_UCPD_SR_TXMSGDISC        UCPD_SR_TXMSGDISC          /*!< Transmit message discarded interrupt */
-#define LL_UCPD_SR_TXMSGSENT        UCPD_SR_TXMSGSENT          /*!< Transmit message sent interrupt      */
-#define LL_UCPD_SR_TXMSGABT         UCPD_SR_TXMSGABT           /*!< Transmit message abort interrupt     */
-#define LL_UCPD_SR_HRSTDISC         UCPD_SR_HRSTDISC           /*!< HRST discarded interrupt             */
-#define LL_UCPD_SR_HRSTSENT         UCPD_SR_HRSTSENT           /*!< HRST sent interrupt                  */
-#define LL_UCPD_SR_TXUND            UCPD_SR_TXUND              /*!< Tx data underrun condition interrupt */
-#define LL_UCPD_SR_RXNE             UCPD_SR_RXNE               /*!< Receive data register not empty interrupt  */
-#define LL_UCPD_SR_RXORDDET         UCPD_SR_RXORDDET           /*!< Rx ordered set (4 K-codes) detected interrupt  */
-#define LL_UCPD_SR_RXHRSTDET        UCPD_SR_RXHRSTDET          /*!< Rx Hard Reset detect interrupt  */
-#define LL_UCPD_SR_RXOVR            UCPD_SR_RXOVR              /*!< Rx data overflow interrupt  */
-#define LL_UCPD_SR_RXMSGEND         UCPD_SR_RXMSGEND           /*!< Rx message received  */
-#define LL_UCPD_SR_RXERR            UCPD_SR_RXERR              /*!< Rx error  */
-#define LL_UCPD_SR_TYPECEVT1        UCPD_SR_TYPECEVT1          /*!< Type C voltage level event on CC1  */
-#define LL_UCPD_SR_TYPECEVT2        UCPD_SR_TYPECEVT2          /*!< Type C voltage level event on CC2  */
-#define LL_UCPD_SR_TYPEC_VSTATE_CC1 UCPD_SR_TYPEC_VSTATE_CC1   /*!<Status of DC level on CC1 pin  */
-#define LL_UCPD_SR_TYPEC_VSTATE_CC2 UCPD_SR_TYPEC_VSTATE_CC2   /*!<Status of DC level on CC2 pin  */
-#define LL_UCPD_SR_FRSEVT           UCPD_SR_FRSEVT             /*!<Fast Role Swap detection event  */
+#define LL_UCPD_SR_TXIS             UCPD_SR_TXIS                  /*!< Transmit interrupt status                      */
+#define LL_UCPD_SR_TXMSGDISC        UCPD_SR_TXMSGDISC             /*!< Transmit message discarded interrupt           */
+#define LL_UCPD_SR_TXMSGSENT        UCPD_SR_TXMSGSENT             /*!< Transmit message sent interrupt                */
+#define LL_UCPD_SR_TXMSGABT         UCPD_SR_TXMSGABT              /*!< Transmit message abort interrupt               */
+#define LL_UCPD_SR_HRSTDISC         UCPD_SR_HRSTDISC              /*!< HRST discarded interrupt                       */
+#define LL_UCPD_SR_HRSTSENT         UCPD_SR_HRSTSENT              /*!< HRST sent interrupt                            */
+#define LL_UCPD_SR_TXUND            UCPD_SR_TXUND                 /*!< Tx data underrun condition interrupt           */
+#define LL_UCPD_SR_RXNE             UCPD_SR_RXNE                  /*!< Receive data register not empty interrupt      */
+#define LL_UCPD_SR_RXORDDET         UCPD_SR_RXORDDET              /*!< Rx ordered set (4 K-codes) detected interrupt  */
+#define LL_UCPD_SR_RXHRSTDET        UCPD_SR_RXHRSTDET             /*!< Rx Hard Reset detect interrupt                 */
+#define LL_UCPD_SR_RXOVR            UCPD_SR_RXOVR                 /*!< Rx data overflow interrupt                     */
+#define LL_UCPD_SR_RXMSGEND         UCPD_SR_RXMSGEND              /*!< Rx message received                            */
+#define LL_UCPD_SR_RXERR            UCPD_SR_RXERR                 /*!< Rx error                                       */
+#define LL_UCPD_SR_TYPECEVT1        UCPD_SR_TYPECEVT1             /*!< Type C voltage level event on CC1              */
+#define LL_UCPD_SR_TYPECEVT2        UCPD_SR_TYPECEVT2             /*!< Type C voltage level event on CC2              */
+#define LL_UCPD_SR_TYPEC_VSTATE_CC1 UCPD_SR_TYPEC_VSTATE_CC1      /*!<Status of DC level on CC1 pin                   */
+#define LL_UCPD_SR_TYPEC_VSTATE_CC2 UCPD_SR_TYPEC_VSTATE_CC2      /*!<Status of DC level on CC2 pin                   */
+#define LL_UCPD_SR_FRSEVT           UCPD_SR_FRSEVT                /*!<Fast Role Swap detection event                  */
 
 /**
   * @}
@@ -115,44 +115,43 @@ typedef struct
   * @brief    IT defines which can be used with LL_UCPD_ReadReg and  LL_UCPD_WriteReg functions
   * @{
   */
-#define LL_UCPD_IMR_TXIS             UCPD_IMR_TXISIE               /*!< Enable transmit interrupt status            */
-#define LL_UCPD_IMR_TXMSGDISC        UCPD_IMR_TXMSGDISCIE          /*!< Enable transmit message discarded interrupt */
-#define LL_UCPD_IMR_TXMSGSENT        UCPD_IMR_TXMSGSENTIE          /*!< Enable transmit message sent interrupt      */
-#define LL_UCPD_IMR_TXMSGABT         UCPD_IMR_TXMSGABTIE           /*!< Enable transmit message abort interrupt     */
-#define LL_UCPD_IMR_HRSTDISC         UCPD_IMR_HRSTDISCIE           /*!< Enable HRST discarded interrupt             */
-#define LL_UCPD_IMR_HRSTSENT         UCPD_IMR_HRSTSENTIE           /*!< Enable HRST sent interrupt                  */
-#define LL_UCPD_IMR_TXUND            UCPD_IMR_TXUNDIE              /*!< Enable tx data underrun condition interrupt */
-#define LL_UCPD_IMR_RXNE             UCPD_IMR_RXNEIE               /*!< Enable Receive data register not empty interrupt  */
-#define LL_UCPD_IMR_RXORDDET         UCPD_IMR_RXORDDETIE           /*!< Enable Rx ordered set (4 K-codes) detected interrupt  */
-#define LL_UCPD_IMR_RXHRSTDET        UCPD_IMR_RXHRSTDETIE          /*!< Enable Rx Hard Reset detect interrupt  */
-#define LL_UCPD_IMR_RXOVR            UCPD_IMR_RXOVRIE              /*!< Enable Rx data overflow interrupt  */
-#define LL_UCPD_IMR_RXMSGEND         UCPD_IMR_RXMSGEND             /*!< Enable Rx message received  */
-#define LL_UCPD_IMR_RXERR            UCPD_IMR_RXMSGENDIE           /*!< Enable Rx error  */
-#define LL_UCPD_IMR_TYPECEVT1        UCPD_IMR_TYPECEVT1IE          /*!< Enable Type C voltage level event on CC1  */
-#define LL_UCPD_IMR_TYPECEVT2        UCPD_IMR_TYPECEVT2IE          /*!< Enable Type C voltage level event on CC2  */
-#define LL_UCPD_IMR_FRSEVT           UCPD_IMR_FRSEVTIE             /*!< Enable fast Role Swap detection event  */
+#define LL_UCPD_IMR_TXIS             UCPD_IMR_TXISIE              /*!< Enable transmit interrupt status                     */
+#define LL_UCPD_IMR_TXMSGDISC        UCPD_IMR_TXMSGDISCIE         /*!< Enable transmit message discarded interrupt          */
+#define LL_UCPD_IMR_TXMSGSENT        UCPD_IMR_TXMSGSENTIE         /*!< Enable transmit message sent interrupt               */
+#define LL_UCPD_IMR_TXMSGABT         UCPD_IMR_TXMSGABTIE          /*!< Enable transmit message abort interrupt              */
+#define LL_UCPD_IMR_HRSTDISC         UCPD_IMR_HRSTDISCIE          /*!< Enable HRST discarded interrupt                      */
+#define LL_UCPD_IMR_HRSTSENT         UCPD_IMR_HRSTSENTIE          /*!< Enable HRST sent interrupt                           */
+#define LL_UCPD_IMR_TXUND            UCPD_IMR_TXUNDIE             /*!< Enable tx data underrun condition interrupt          */
+#define LL_UCPD_IMR_RXNE             UCPD_IMR_RXNEIE              /*!< Enable Receive data register not empty interrupt     */
+#define LL_UCPD_IMR_RXORDDET         UCPD_IMR_RXORDDETIE          /*!< Enable Rx ordered set (4 K-codes) detected interrupt */
+#define LL_UCPD_IMR_RXHRSTDET        UCPD_IMR_RXHRSTDETIE         /*!< Enable Rx Hard Reset detect interrupt                */
+#define LL_UCPD_IMR_RXOVR            UCPD_IMR_RXOVRIE             /*!< Enable Rx data overflow interrupt                    */
+#define LL_UCPD_IMR_RXMSGEND         UCPD_IMR_RXMSGENDIE          /*!< Enable Rx message received                           */
+#define LL_UCPD_IMR_TYPECEVT1        UCPD_IMR_TYPECEVT1IE         /*!< Enable Type C voltage level event on CC1             */
+#define LL_UCPD_IMR_TYPECEVT2        UCPD_IMR_TYPECEVT2IE         /*!< Enable Type C voltage level event on CC2             */
+#define LL_UCPD_IMR_FRSEVT           UCPD_IMR_FRSEVTIE            /*!< Enable fast Role Swap detection event                */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_ORDERSET orderset value
-  * @brief    definition of the usual orderset
+/** @defgroup UCPD_LL_EC_ORDERSET Ordered sets value
+  * @brief    definition of the usual Ordered sets
   * @{
   */
-#define LL_UCPD_SYNC1 0x18u
-#define LL_UCPD_SYNC2 0x11u
-#define LL_UCPD_SYNC3 0x06u
-#define LL_UCPD_RST1  0x07u
-#define LL_UCPD_RST2  0x19u
-#define LL_UCPD_EOP   0x0Du
+#define LL_UCPD_SYNC1 0x18u                                       /*!< K-code for Startsynch #1                             */
+#define LL_UCPD_SYNC2 0x11u                                       /*!< K-code for Startsynch #2                             */
+#define LL_UCPD_SYNC3 0x06u                                       /*!< K-code for Startsynch #3                             */
+#define LL_UCPD_RST1  0x07u                                       /*!< K-code for Hard Reset #1                             */
+#define LL_UCPD_RST2  0x19u                                       /*!< K-code for Hard Reset #2                             */
+#define LL_UCPD_EOP   0x0Du                                       /*!< K-code for EOP End of Packet                         */
 
-#define LL_UCPD_ORDERED_SET_SOP         (LL_UCPD_SYNC1 | (LL_UCPD_SYNC1<<5u) | (LL_UCPD_SYNC1<<10u) | (LL_UCPD_SYNC2<<15u))
-#define LL_UCPD_ORDERED_SET_SOP1        (LL_UCPD_SYNC1 | (LL_UCPD_SYNC1<<5u) | (LL_UCPD_SYNC3<<10u) | (LL_UCPD_SYNC3<<15u))
-#define LL_UCPD_ORDERED_SET_SOP2        (LL_UCPD_SYNC1 | (LL_UCPD_SYNC3<<5u) | (LL_UCPD_SYNC1<<10u) | (LL_UCPD_SYNC3<<15u))
-#define LL_UCPD_ORDERED_SET_HARD_RESET  (LL_UCPD_RST1  | (LL_UCPD_RST1<<5u)  | (LL_UCPD_RST1<<10u)  | (LL_UCPD_RST2<<15u ))
-#define LL_UCPD_ORDERED_SET_CABLE_RESET (LL_UCPD_RST1  | (LL_UCPD_SYNC1<<5u) | (LL_UCPD_RST1<<10u)  | (LL_UCPD_SYNC3<<15u))
-#define LL_UCPD_ORDERED_SET_SOP1_DEBUG  (LL_UCPD_SYNC1 | (LL_UCPD_RST2<<5u)  | (LL_UCPD_RST2<<10u)  | (LL_UCPD_SYNC3<<15u))
-#define LL_UCPD_ORDERED_SET_SOP2_DEBUG  (LL_UCPD_SYNC1 | (LL_UCPD_RST2<<5u)  | (LL_UCPD_SYNC3<<10u) | (LL_UCPD_SYNC2<<15u))
+#define LL_UCPD_ORDERED_SET_SOP         (LL_UCPD_SYNC1 | (LL_UCPD_SYNC1<<5u) | (LL_UCPD_SYNC1<<10u) | (LL_UCPD_SYNC2<<15u)) /*!< SOP Ordered set coding         */
+#define LL_UCPD_ORDERED_SET_SOP1        (LL_UCPD_SYNC1 | (LL_UCPD_SYNC1<<5u) | (LL_UCPD_SYNC3<<10u) | (LL_UCPD_SYNC3<<15u)) /*!< SOP' Ordered set coding        */
+#define LL_UCPD_ORDERED_SET_SOP2        (LL_UCPD_SYNC1 | (LL_UCPD_SYNC3<<5u) | (LL_UCPD_SYNC1<<10u) | (LL_UCPD_SYNC3<<15u)) /*!< SOP'' Ordered set coding       */
+#define LL_UCPD_ORDERED_SET_HARD_RESET  (LL_UCPD_RST1  | (LL_UCPD_RST1<<5u)  | (LL_UCPD_RST1<<10u)  | (LL_UCPD_RST2<<15u )) /*!< Hard Reset Ordered set coding  */
+#define LL_UCPD_ORDERED_SET_CABLE_RESET (LL_UCPD_RST1  | (LL_UCPD_SYNC1<<5u) | (LL_UCPD_RST1<<10u)  | (LL_UCPD_SYNC3<<15u)) /*!< Cable Reset Ordered set coding */
+#define LL_UCPD_ORDERED_SET_SOP1_DEBUG  (LL_UCPD_SYNC1 | (LL_UCPD_RST2<<5u)  | (LL_UCPD_RST2<<10u)  | (LL_UCPD_SYNC3<<15u)) /*!< SOP' Debug Ordered set coding  */
+#define LL_UCPD_ORDERED_SET_SOP2_DEBUG  (LL_UCPD_SYNC1 | (LL_UCPD_RST2<<5u)  | (LL_UCPD_SYNC3<<10u) | (LL_UCPD_SYNC2<<15u)) /*!< SOP'' Debug Ordered set coding */
 /**
   * @}
   */
@@ -160,59 +159,59 @@ typedef struct
 /** @defgroup UCPD_LL_EC_MODE Role Mode
   * @{
   */
-#define LL_UCPD_ROLE_SNK             UCPD_CR_ANAMODE        /*!< Mode SNK Rd         */
-#define LL_UCPD_ROLE_SRC             0x0U
+#define LL_UCPD_ROLE_SNK             UCPD_CR_ANAMODE              /*!< Mode SNK Rd                                    */
+#define LL_UCPD_ROLE_SRC             0x0U                         /*!< Mode SRC Rp                                    */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_RESISTOR resistor value
+/** @defgroup UCPD_LL_EC_RESISTOR Resistor value
   * @{
   */
-#define LL_UCPD_RESISTOR_DEFAULT    UCPD_CR_ANASUBMODE_0   /*!< Rp default  */
-#define LL_UCPD_RESISTOR_1_5A       UCPD_CR_ANASUBMODE_1   /*!< Rp 1.5 A    */
-#define LL_UCPD_RESISTOR_3_0A       UCPD_CR_ANASUBMODE     /*!< Rp 3.0 A    */
-#define LL_UCPD_RESISTOR_NONE       0x0U                    /*!< No resistor */
+#define LL_UCPD_RESISTOR_DEFAULT    UCPD_CR_ANASUBMODE_0          /*!< Rp default                                     */
+#define LL_UCPD_RESISTOR_1_5A       UCPD_CR_ANASUBMODE_1          /*!< Rp 1.5 A                                       */
+#define LL_UCPD_RESISTOR_3_0A       UCPD_CR_ANASUBMODE            /*!< Rp 3.0 A                                       */
+#define LL_UCPD_RESISTOR_NONE       0x0U                          /*!< No resistor                                    */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_CFG1_ORDERSET orderset configuration
+/** @defgroup UCPD_LL_EC_CFG1_ORDERSET ordered set configuration
   * @{
   */
-#define LL_UCPD_ORDERSET_SOP         UCPD_CFG1_RXORDSETEN_0
-#define LL_UCPD_ORDERSET_SOP1        UCPD_CFG1_RXORDSETEN_1
-#define LL_UCPD_ORDERSET_SOP2        UCPD_CFG1_RXORDSETEN_2
-#define LL_UCPD_ORDERSET_HARDRST     UCPD_CFG1_RXORDSETEN_3
-#define LL_UCPD_ORDERSET_CABLERST    UCPD_CFG1_RXORDSETEN_4
-#define LL_UCPD_ORDERSET_SOP1_DEBUG  UCPD_CFG1_RXORDSETEN_5
-#define LL_UCPD_ORDERSET_SOP2_DEBUG  UCPD_CFG1_RXORDSETEN_6
-#define LL_UCPD_ORDERSET_SOP_EXT1    UCPD_CFG1_RXORDSETEN_7
-#define LL_UCPD_ORDERSET_SOP_EXT2    UCPD_CFG1_RXORDSETEN_8
+#define LL_UCPD_ORDERSET_SOP         UCPD_CFG1_RXORDSETEN_0       /*!< SOP Ordered set detection enabled              */
+#define LL_UCPD_ORDERSET_SOP1        UCPD_CFG1_RXORDSETEN_1       /*!< SOP' Ordered set detection enabled             */
+#define LL_UCPD_ORDERSET_SOP2        UCPD_CFG1_RXORDSETEN_2       /*!< SOP'' Ordered set detection enabled            */
+#define LL_UCPD_ORDERSET_HARDRST     UCPD_CFG1_RXORDSETEN_3       /*!< Hard Reset Ordered set detection enabled       */
+#define LL_UCPD_ORDERSET_CABLERST    UCPD_CFG1_RXORDSETEN_4       /*!< Cable Reset Ordered set detection enabled      */
+#define LL_UCPD_ORDERSET_SOP1_DEBUG  UCPD_CFG1_RXORDSETEN_5       /*!< SOP' Debug Ordered set detection enabled       */
+#define LL_UCPD_ORDERSET_SOP2_DEBUG  UCPD_CFG1_RXORDSETEN_6       /*!< SOP'' Debug Ordered set detection enabled      */
+#define LL_UCPD_ORDERSET_SOP_EXT1    UCPD_CFG1_RXORDSETEN_7       /*!< SOP extension#1 Ordered set detection enabled  */
+#define LL_UCPD_ORDERSET_SOP_EXT2    UCPD_CFG1_RXORDSETEN_8       /*!< SOP extension#2 Ordered set detection enabled  */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_CCxEVT  ccxevt
+/** @defgroup UCPD_LL_EC_CCxEVT  CCx event
   * @{
   */
-#define LL_UCPD_SNK_CC1_VOPEN      0x00u
-#define LL_UCPD_SNK_CC1_VRP        UCPD_SR_TYPEC_VSTATE_CC1_0
-#define LL_UCPD_SNK_CC1_VRP15A     UCPD_SR_TYPEC_VSTATE_CC1_1
-#define LL_UCPD_SNK_CC1_VRP30A     (UCPD_SR_TYPEC_VSTATE_CC1_0 | UCPD_SR_TYPEC_VSTATE_CC1_1)
+#define LL_UCPD_SNK_CC1_VOPEN      0x00u                                                      /*!< CC1 Sink Open state              */
+#define LL_UCPD_SNK_CC1_VRP        UCPD_SR_TYPEC_VSTATE_CC1_0                                 /*!< CC1 Sink vRP default state       */
+#define LL_UCPD_SNK_CC1_VRP15A     UCPD_SR_TYPEC_VSTATE_CC1_1                                 /*!< CC1 Sink vRP 1.5A state          */
+#define LL_UCPD_SNK_CC1_VRP30A     (UCPD_SR_TYPEC_VSTATE_CC1_0 | UCPD_SR_TYPEC_VSTATE_CC1_1)  /*!< CC1 Sink vRP 3.0A state          */
 
-#define LL_UCPD_SNK_CC2_VOPEN      0x00u
-#define LL_UCPD_SNK_CC2_VRP        UCPD_SR_TYPEC_VSTATE_CC2_0
-#define LL_UCPD_SNK_CC2_VRP15A     UCPD_SR_TYPEC_VSTATE_CC2_1
-#define LL_UCPD_SNK_CC2_VRP30A     (UCPD_SR_TYPEC_VSTATE_CC2_0 | UCPD_SR_TYPEC_VSTATE_CC2_1)
+#define LL_UCPD_SNK_CC2_VOPEN      0x00u                                                      /*!< CC2 Sink Open state              */
+#define LL_UCPD_SNK_CC2_VRP        UCPD_SR_TYPEC_VSTATE_CC2_0                                 /*!< CC2 Sink vRP default state       */
+#define LL_UCPD_SNK_CC2_VRP15A     UCPD_SR_TYPEC_VSTATE_CC2_1                                 /*!< CC2 Sink vRP 1.5A state          */
+#define LL_UCPD_SNK_CC2_VRP30A     (UCPD_SR_TYPEC_VSTATE_CC2_0 | UCPD_SR_TYPEC_VSTATE_CC2_1)  /*!< CC2 Sink vRP 3.0A state          */
 
-#define LL_UCPD_SRC_CC1_VRA        0x0U
-#define LL_UCPD_SRC_CC1_VRD        UCPD_SR_TYPEC_VSTATE_CC1_0
-#define LL_UCPD_SRC_CC1_OPEN       UCPD_SR_TYPEC_VSTATE_CC1_1
+#define LL_UCPD_SRC_CC1_VRA        0x0U                                                      /*!< CC1 Source vRA state              */
+#define LL_UCPD_SRC_CC1_VRD        UCPD_SR_TYPEC_VSTATE_CC1_0                                /*!< CC1 Source vRD state              */
+#define LL_UCPD_SRC_CC1_OPEN       UCPD_SR_TYPEC_VSTATE_CC1_1                                /*!< CC1 Source Open state             */
 
-#define LL_UCPD_SRC_CC2_VRA        0x0U
-#define LL_UCPD_SRC_CC2_VRD        UCPD_SR_TYPEC_VSTATE_CC2_0
-#define LL_UCPD_SRC_CC2_OPEN       UCPD_SR_TYPEC_VSTATE_CC2_1
+#define LL_UCPD_SRC_CC2_VRA        0x0U                                                      /*!< CC2 Source vRA state              */
+#define LL_UCPD_SRC_CC2_VRD        UCPD_SR_TYPEC_VSTATE_CC2_0                                /*!< CC2 Source vRD state              */
+#define LL_UCPD_SRC_CC2_OPEN       UCPD_SR_TYPEC_VSTATE_CC2_1                                /*!< CC2 Source Open state             */
 /**
   * @}
   */
@@ -220,65 +219,65 @@ typedef struct
 /** @defgroup UCPD_LL_EC_PSC prescaler for UCPDCLK
   * @{
   */
-#define LL_UCPD_PSC_DIV1            0x0u
-#define LL_UCPD_PSC_DIV2            UCPD_CFG1_PSC_UCPDCLK_0
-#define LL_UCPD_PSC_DIV4            UCPD_CFG1_PSC_UCPDCLK_1
-#define LL_UCPD_PSC_DIV8            (UCPD_CFG1_PSC_UCPDCLK_1 | UCPD_CFG1_PSC_UCPDCLK_0)
-#define LL_UCPD_PSC_DIV16           UCPD_CFG1_PSC_UCPDCLK_2
+#define LL_UCPD_PSC_DIV1            0x0u                                                     /*!< Bypass pre-scaling / divide by 1  */
+#define LL_UCPD_PSC_DIV2            UCPD_CFG1_PSC_UCPDCLK_0                                  /*!< Pre-scale clock by dividing by 2  */
+#define LL_UCPD_PSC_DIV4            UCPD_CFG1_PSC_UCPDCLK_1                                  /*!< Pre-scale clock by dividing by 4  */
+#define LL_UCPD_PSC_DIV8            (UCPD_CFG1_PSC_UCPDCLK_1 | UCPD_CFG1_PSC_UCPDCLK_0)      /*!< Pre-scale clock by dividing by 8  */
+#define LL_UCPD_PSC_DIV16           UCPD_CFG1_PSC_UCPDCLK_2                                  /*!< Pre-scale clock by dividing by 16 */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_CCENABLE cc pin enable
+/** @defgroup UCPD_LL_EC_CCENABLE CC pin enable
   * @{
   */
-#define LL_UCPD_CCENABLE_NONE       0x0U
-#define LL_UCPD_CCENABLE_CC1        UCPD_CR_CCENABLE_0
-#define LL_UCPD_CCENABLE_CC2        UCPD_CR_CCENABLE_1
-#define LL_UCPD_CCENABLE_CC1CC2     (UCPD_CR_CCENABLE_0 | UCPD_CR_CCENABLE_1)
+#define LL_UCPD_CCENABLE_NONE       0x0U                                                     /*!< Neither PHY is activated (e.g. disabled state of source)          */
+#define LL_UCPD_CCENABLE_CC1        UCPD_CR_CCENABLE_0                                       /*!< Controls apply to only CC1                                        */
+#define LL_UCPD_CCENABLE_CC2        UCPD_CR_CCENABLE_1                                       /*!< Controls apply to only CC1                                        */
+#define LL_UCPD_CCENABLE_CC1CC2     (UCPD_CR_CCENABLE_0 | UCPD_CR_CCENABLE_1)                /*!< Controls apply to both CC1 and CC2 (normal usage for sink/source) */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_CCPIN cc pin selection
+/** @defgroup UCPD_LL_EC_CCPIN CC pin selection
   * @{
   */
-#define LL_UCPD_CCPIN_CC1           0x0U
-#define LL_UCPD_CCPIN_CC2           UCPD_CR_PHYCCSEL
+#define LL_UCPD_CCPIN_CC1           0x0U                    /*!< Use CC1 IO for power delivery communication              */
+#define LL_UCPD_CCPIN_CC2           UCPD_CR_PHYCCSEL        /*!< Use CC2 IO for power delivery communication              */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_RXMODE rx mode
+/** @defgroup UCPD_LL_EC_RXMODE Receiver mode
   * @{
   */
-#define LL_UCPD_RXMODE_NORMAL           0x0U
-#define LL_UCPD_RXMODE_BIST_TEST_DATA   UCPD_CR_RXMODE
+#define LL_UCPD_RXMODE_NORMAL           0x0U                /*!< Normal receive mode                                      */
+#define LL_UCPD_RXMODE_BIST_TEST_DATA   UCPD_CR_RXMODE      /*!< BIST receive mode (BIST Test Data Mode)                  */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_TXMODE tx mode
+/** @defgroup UCPD_LL_EC_TXMODE Type of Tx packet
   * @{
   */
-#define LL_UCPD_TXMODE_NORMAL           0x0U
-#define LL_UCPD_TXMODE_CABLE_RESET      UCPD_CR_TXMODE_0
-#define LL_UCPD_TXMODE_BIST_CARRIER2    UCPD_CR_TXMODE_1
+#define LL_UCPD_TXMODE_NORMAL           0x0U                /*!< Initiate the transfer of a Tx message                    */
+#define LL_UCPD_TXMODE_CABLE_RESET      UCPD_CR_TXMODE_0    /*!< Trigger a the transfer of a Cable Reset sequence         */
+#define LL_UCPD_TXMODE_BIST_CARRIER2    UCPD_CR_TXMODE_1    /*!< Trigger a BIST test sequence send (BIST Carrier Mode 2)  */
 /**
   * @}
   */
 
-/** @defgroup UCPD_LL_EC_RXORDSET rx orderset
+/** @defgroup UCPD_LL_EC_RXORDSET Rx ordered set code detected
   * @{
   */
-#define LL_UCPD_RXORDSET_SOP             0x0U
-#define LL_UCPD_RXORDSET_SOP1            UCPD_RX_ORDSET_RXORDSET_0
-#define LL_UCPD_RXORDSET_SOP2            UCPD_RX_ORDSET_RXORDSET_1
-#define LL_UCPD_RXORDSET_SOP1_DEBUG      (UCPD_RX_ORDSET_RXORDSET_0 | UCPD_RX_ORDSET_RXORDSET_1)
-#define LL_UCPD_RXORDSET_SOP2_DEBUG      UCPD_RX_ORDSET_RXORDSET_2
-#define LL_UCPD_RXORDSET_CABLE_RESET     (UCPD_RX_ORDSET_RXORDSET_2 | UCPD_RX_ORDSET_RXORDSET_0)
-#define LL_UCPD_RXORDSET_SOPEXT1         (UCPD_RX_ORDSET_RXORDSET_2 | UCPD_RX_ORDSET_RXORDSET_1)
-#define LL_UCPD_RXORDSET_SOPEXT2         (UCPD_RX_ORDSET_RXORDSET_2 | UCPD_RX_ORDSET_RXORDSET_1 | UCPD_RX_ORDSET_RXORDSET_0)
+#define LL_UCPD_RXORDSET_SOP             0x0U                                                                                 /*!< SOP code detected in receiver              */
+#define LL_UCPD_RXORDSET_SOP1            UCPD_RX_ORDSET_RXORDSET_0                                                            /*!< SOP' code detected in receiver             */
+#define LL_UCPD_RXORDSET_SOP2            UCPD_RX_ORDSET_RXORDSET_1                                                            /*!< SOP'' code detected in receiver            */
+#define LL_UCPD_RXORDSET_SOP1_DEBUG      (UCPD_RX_ORDSET_RXORDSET_0 | UCPD_RX_ORDSET_RXORDSET_1)                              /*!< SOP' Debug code detected in receiver       */
+#define LL_UCPD_RXORDSET_SOP2_DEBUG      UCPD_RX_ORDSET_RXORDSET_2                                                            /*!< SOP'' Debug code detected in receiver      */
+#define LL_UCPD_RXORDSET_CABLE_RESET     (UCPD_RX_ORDSET_RXORDSET_2 | UCPD_RX_ORDSET_RXORDSET_0)                              /*!< Cable Reset code detected in receiver      */
+#define LL_UCPD_RXORDSET_SOPEXT1         (UCPD_RX_ORDSET_RXORDSET_2 | UCPD_RX_ORDSET_RXORDSET_1)                              /*!< SOP extension#1 code detected in receiver  */
+#define LL_UCPD_RXORDSET_SOPEXT2         (UCPD_RX_ORDSET_RXORDSET_2 | UCPD_RX_ORDSET_RXORDSET_1 | UCPD_RX_ORDSET_RXORDSET_0)  /*!< SOP extension#2 code detected in receiver  */
 /**
   * @}
   */

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_usart.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_usart.h
@@ -32,7 +32,7 @@ extern "C" {
   * @{
   */
 
-#if defined (USART1) || defined (USART2) || defined (USART3) || defined (USART4)
+#if defined (USART1) || defined (USART2) || defined (USART3) || defined (USART4) || defined (USART5) || defined (USART6)
 
 /** @defgroup USART_LL USART
   * @{
@@ -357,18 +357,18 @@ typedef struct
 /** @defgroup USART_LL_EC_PRESCALER Clock Source Prescaler
   * @{
   */
-#define LL_USART_PRESCALER_DIV1                 0x00000000U                                                                   /*!< Input clock not devided   */
-#define LL_USART_PRESCALER_DIV2                 (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock devided by 2  */
-#define LL_USART_PRESCALER_DIV4                 (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock devided by 4  */
-#define LL_USART_PRESCALER_DIV6                 (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 6  */
-#define LL_USART_PRESCALER_DIV8                 (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock devided by 8  */
-#define LL_USART_PRESCALER_DIV10                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 10 */
-#define LL_USART_PRESCALER_DIV12                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 12 */
-#define LL_USART_PRESCALER_DIV16                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 16 */
-#define LL_USART_PRESCALER_DIV32                (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock devided by 32 */
-#define LL_USART_PRESCALER_DIV64                (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 64 */
-#define LL_USART_PRESCALER_DIV128               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 128 */
-#define LL_USART_PRESCALER_DIV256               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 256 */
+#define LL_USART_PRESCALER_DIV1                 0x00000000U                                                                   /*!< Input clock not divided   */
+#define LL_USART_PRESCALER_DIV2                 (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock divided by 2  */
+#define LL_USART_PRESCALER_DIV4                 (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock divided by 4  */
+#define LL_USART_PRESCALER_DIV6                 (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 6  */
+#define LL_USART_PRESCALER_DIV8                 (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock divided by 8  */
+#define LL_USART_PRESCALER_DIV10                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 10 */
+#define LL_USART_PRESCALER_DIV12                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock divided by 12 */
+#define LL_USART_PRESCALER_DIV16                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock divided by 16 */
+#define LL_USART_PRESCALER_DIV32                (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock divided by 32 */
+#define LL_USART_PRESCALER_DIV64                (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 64 */
+#define LL_USART_PRESCALER_DIV128               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock divided by 128 */
+#define LL_USART_PRESCALER_DIV256               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock divided by 256 */
 /**
   * @}
   */
@@ -645,7 +645,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabled(USART_TypeDef *USARTx)
 
 /**
   * @brief  FIFO Mode Enable
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          FIFOEN        LL_USART_EnableFIFO
   * @param  USARTx USART Instance
@@ -658,7 +658,7 @@ __STATIC_INLINE void LL_USART_EnableFIFO(USART_TypeDef *USARTx)
 
 /**
   * @brief  FIFO Mode Disable
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          FIFOEN        LL_USART_DisableFIFO
   * @param  USARTx USART Instance
@@ -671,7 +671,7 @@ __STATIC_INLINE void LL_USART_DisableFIFO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if FIFO Mode is enabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          FIFOEN        LL_USART_IsEnabledFIFO
   * @param  USARTx USART Instance
@@ -684,7 +684,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledFIFO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure TX FIFO Threshold
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTCFG       LL_USART_SetTXFIFOThreshold
   * @param  USARTx USART Instance
@@ -704,7 +704,7 @@ __STATIC_INLINE void LL_USART_SetTXFIFOThreshold(USART_TypeDef *USARTx, uint32_t
 
 /**
   * @brief  Return TX FIFO Threshold Configuration
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTCFG       LL_USART_GetTXFIFOThreshold
   * @param  USARTx USART Instance
@@ -723,7 +723,7 @@ __STATIC_INLINE uint32_t LL_USART_GetTXFIFOThreshold(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure RX FIFO Threshold
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTCFG       LL_USART_SetRXFIFOThreshold
   * @param  USARTx USART Instance
@@ -743,7 +743,7 @@ __STATIC_INLINE void LL_USART_SetRXFIFOThreshold(USART_TypeDef *USARTx, uint32_t
 
 /**
   * @brief  Return RX FIFO Threshold Configuration
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTCFG       LL_USART_GetRXFIFOThreshold
   * @param  USARTx USART Instance
@@ -762,7 +762,7 @@ __STATIC_INLINE uint32_t LL_USART_GetRXFIFOThreshold(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure TX and RX FIFOs Threshold
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTCFG       LL_USART_ConfigFIFOsThreshold\n
   *         CR3          RXFTCFG       LL_USART_ConfigFIFOsThreshold
@@ -792,7 +792,7 @@ __STATIC_INLINE void LL_USART_ConfigFIFOsThreshold(USART_TypeDef *USARTx, uint32
   * @brief  USART enabled in STOP Mode.
   * @note   When this function is enabled, USART is able to wake up the MCU from Stop mode, provided that
   *         USART clock selection is HSI or LSE in RCC.
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR1          UESM          LL_USART_EnableInStopMode
   * @param  USARTx USART Instance
@@ -806,7 +806,7 @@ __STATIC_INLINE void LL_USART_EnableInStopMode(USART_TypeDef *USARTx)
 /**
   * @brief  USART disabled in STOP Mode.
   * @note   When this function is disabled, USART is not able to wake up the MCU from Stop mode
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR1          UESM          LL_USART_DisableInStopMode
   * @param  USARTx USART Instance
@@ -819,7 +819,7 @@ __STATIC_INLINE void LL_USART_DisableInStopMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if USART is enabled in STOP Mode (able to wake up MCU from Stop mode or not)
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR1          UESM          LL_USART_IsEnabledInStopMode
   * @param  USARTx USART Instance
@@ -1062,7 +1062,7 @@ __STATIC_INLINE uint32_t LL_USART_GetOverSampling(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure if Clock pulse of the last data bit is output to the SCLK pin or not
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          LBCL          LL_USART_SetLastClkPulseOutput
   * @param  USARTx USART Instance
@@ -1079,7 +1079,7 @@ __STATIC_INLINE void LL_USART_SetLastClkPulseOutput(USART_TypeDef *USARTx, uint3
 /**
   * @brief  Retrieve Clock pulse of the last data bit output configuration
   *         (Last bit Clock pulse output to the SCLK pin or not)
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          LBCL          LL_USART_GetLastClkPulseOutput
   * @param  USARTx USART Instance
@@ -1094,7 +1094,7 @@ __STATIC_INLINE uint32_t LL_USART_GetLastClkPulseOutput(USART_TypeDef *USARTx)
 
 /**
   * @brief  Select the phase of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPHA          LL_USART_SetClockPhase
   * @param  USARTx USART Instance
@@ -1110,7 +1110,7 @@ __STATIC_INLINE void LL_USART_SetClockPhase(USART_TypeDef *USARTx, uint32_t Cloc
 
 /**
   * @brief  Return phase of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPHA          LL_USART_GetClockPhase
   * @param  USARTx USART Instance
@@ -1125,7 +1125,7 @@ __STATIC_INLINE uint32_t LL_USART_GetClockPhase(USART_TypeDef *USARTx)
 
 /**
   * @brief  Select the polarity of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPOL          LL_USART_SetClockPolarity
   * @param  USARTx USART Instance
@@ -1141,7 +1141,7 @@ __STATIC_INLINE void LL_USART_SetClockPolarity(USART_TypeDef *USARTx, uint32_t C
 
 /**
   * @brief  Return polarity of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPOL          LL_USART_GetClockPolarity
   * @param  USARTx USART Instance
@@ -1156,7 +1156,7 @@ __STATIC_INLINE uint32_t LL_USART_GetClockPolarity(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure Clock signal format (Phase Polarity and choice about output of last bit clock pulse)
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clock Phase configuration using @ref LL_USART_SetClockPhase() function
@@ -1184,7 +1184,7 @@ __STATIC_INLINE void LL_USART_ConfigClock(USART_TypeDef *USARTx, uint32_t Phase,
 
 /**
   * @brief  Configure Clock source prescaler for baudrate generator and oversampling
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll PRESC        PRESCALER     LL_USART_SetPrescaler
   * @param  USARTx USART Instance
@@ -1210,7 +1210,7 @@ __STATIC_INLINE void LL_USART_SetPrescaler(USART_TypeDef *USARTx, uint32_t Presc
 
 /**
   * @brief  Retrieve the Clock source prescaler for baudrate generator and oversampling
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll PRESC        PRESCALER     LL_USART_GetPrescaler
   * @param  USARTx USART Instance
@@ -1235,7 +1235,7 @@ __STATIC_INLINE uint32_t LL_USART_GetPrescaler(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Clock output on SCLK pin
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CLKEN         LL_USART_EnableSCLKOutput
   * @param  USARTx USART Instance
@@ -1248,7 +1248,7 @@ __STATIC_INLINE void LL_USART_EnableSCLKOutput(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Clock output on SCLK pin
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CLKEN         LL_USART_DisableSCLKOutput
   * @param  USARTx USART Instance
@@ -1261,7 +1261,7 @@ __STATIC_INLINE void LL_USART_DisableSCLKOutput(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Clock output on SCLK pin is enabled
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CLKEN         LL_USART_IsEnabledSCLKOutput
   * @param  USARTx USART Instance
@@ -1480,7 +1480,7 @@ __STATIC_INLINE uint32_t LL_USART_GetTransferBitOrder(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Auto Baud-Rate Detection
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABREN         LL_USART_EnableAutoBaudRate
   * @param  USARTx USART Instance
@@ -1493,7 +1493,7 @@ __STATIC_INLINE void LL_USART_EnableAutoBaudRate(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Auto Baud-Rate Detection
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABREN         LL_USART_DisableAutoBaudRate
   * @param  USARTx USART Instance
@@ -1506,7 +1506,7 @@ __STATIC_INLINE void LL_USART_DisableAutoBaudRate(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Auto Baud-Rate Detection mechanism is enabled
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABREN         LL_USART_IsEnabledAutoBaud
   * @param  USARTx USART Instance
@@ -1519,7 +1519,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledAutoBaud(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set Auto Baud-Rate mode bits
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABRMODE       LL_USART_SetAutoBaudRateMode
   * @param  USARTx USART Instance
@@ -1537,7 +1537,7 @@ __STATIC_INLINE void LL_USART_SetAutoBaudRateMode(USART_TypeDef *USARTx, uint32_
 
 /**
   * @brief  Return Auto Baud-Rate mode
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABRMODE       LL_USART_GetAutoBaudRateMode
   * @param  USARTx USART Instance
@@ -1644,7 +1644,7 @@ __STATIC_INLINE uint32_t LL_USART_GetNodeAddressLen(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable RTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_EnableRTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1657,7 +1657,7 @@ __STATIC_INLINE void LL_USART_EnableRTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable RTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_DisableRTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1670,7 +1670,7 @@ __STATIC_INLINE void LL_USART_DisableRTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable CTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSE          LL_USART_EnableCTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1683,7 +1683,7 @@ __STATIC_INLINE void LL_USART_EnableCTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable CTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSE          LL_USART_DisableCTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1696,7 +1696,7 @@ __STATIC_INLINE void LL_USART_DisableCTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure HW Flow Control mode (both CTS and RTS)
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_SetHWFlowCtrl\n
   *         CR3          CTSE          LL_USART_SetHWFlowCtrl
@@ -1715,7 +1715,7 @@ __STATIC_INLINE void LL_USART_SetHWFlowCtrl(USART_TypeDef *USARTx, uint32_t Hard
 
 /**
   * @brief  Return HW Flow Control configuration (both CTS and RTS)
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_GetHWFlowCtrl\n
   *         CR3          CTSE          LL_USART_GetHWFlowCtrl
@@ -1799,7 +1799,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledOverrunDetect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Select event type for Wake UP Interrupt Flag (WUS[1:0] bits)
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUS           LL_USART_SetWKUPType
   * @param  USARTx USART Instance
@@ -1816,7 +1816,7 @@ __STATIC_INLINE void LL_USART_SetWKUPType(USART_TypeDef *USARTx, uint32_t Type)
 
 /**
   * @brief  Return event type for Wake UP Interrupt Flag (WUS[1:0] bits)
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUS           LL_USART_GetWKUPType
   * @param  USARTx USART Instance
@@ -1864,7 +1864,7 @@ __STATIC_INLINE void LL_USART_SetBaudRate(USART_TypeDef *USARTx, uint32_t Periph
                                           uint32_t BaudRate)
 {
   uint32_t usartdiv;
-  register uint32_t brrtemp;
+  uint32_t brrtemp;
 
   if (PrescalerValue > LL_USART_PRESCALER_DIV256)
   {
@@ -1912,9 +1912,9 @@ __STATIC_INLINE void LL_USART_SetBaudRate(USART_TypeDef *USARTx, uint32_t Periph
 __STATIC_INLINE uint32_t LL_USART_GetBaudRate(USART_TypeDef *USARTx, uint32_t PeriphClk, uint32_t PrescalerValue,
                                               uint32_t OverSampling)
 {
-  register uint32_t usartdiv;
-  register uint32_t brrresult = 0x0U;
-  register uint32_t periphclkpresc = (uint32_t)(PeriphClk / (USART_PRESCALER_TAB[(uint8_t)PrescalerValue]));
+  uint32_t usartdiv;
+  uint32_t brrresult = 0x0U;
+  uint32_t periphclkpresc = (uint32_t)(PeriphClk / (USART_PRESCALER_TAB[(uint8_t)PrescalerValue]));
 
   usartdiv = USARTx->BRR;
 
@@ -1996,7 +1996,7 @@ __STATIC_INLINE uint32_t LL_USART_GetBlockLength(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable IrDA mode
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IREN          LL_USART_EnableIrda
   * @param  USARTx USART Instance
@@ -2009,7 +2009,7 @@ __STATIC_INLINE void LL_USART_EnableIrda(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable IrDA mode
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IREN          LL_USART_DisableIrda
   * @param  USARTx USART Instance
@@ -2022,7 +2022,7 @@ __STATIC_INLINE void LL_USART_DisableIrda(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if IrDA mode is enabled
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IREN          LL_USART_IsEnabledIrda
   * @param  USARTx USART Instance
@@ -2035,7 +2035,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIrda(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure IrDA Power Mode (Normal or Low Power)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IRLP          LL_USART_SetIrdaPowerMode
   * @param  USARTx USART Instance
@@ -2051,7 +2051,7 @@ __STATIC_INLINE void LL_USART_SetIrdaPowerMode(USART_TypeDef *USARTx, uint32_t P
 
 /**
   * @brief  Retrieve IrDA Power Mode configuration (Normal or Low Power)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IRLP          LL_USART_GetIrdaPowerMode
   * @param  USARTx USART Instance
@@ -2067,7 +2067,7 @@ __STATIC_INLINE uint32_t LL_USART_GetIrdaPowerMode(USART_TypeDef *USARTx)
 /**
   * @brief  Set Irda prescaler value, used for dividing the USART clock source
   *         to achieve the Irda Low Power frequency (8 bits value)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_SetIrdaPrescaler
   * @param  USARTx USART Instance
@@ -2082,7 +2082,7 @@ __STATIC_INLINE void LL_USART_SetIrdaPrescaler(USART_TypeDef *USARTx, uint32_t P
 /**
   * @brief  Return Irda prescaler value, used for dividing the USART clock source
   *         to achieve the Irda Low Power frequency (8 bits value)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_GetIrdaPrescaler
   * @param  USARTx USART Instance
@@ -2103,7 +2103,7 @@ __STATIC_INLINE uint32_t LL_USART_GetIrdaPrescaler(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Smartcard NACK transmission
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          NACK          LL_USART_EnableSmartcardNACK
   * @param  USARTx USART Instance
@@ -2116,7 +2116,7 @@ __STATIC_INLINE void LL_USART_EnableSmartcardNACK(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Smartcard NACK transmission
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          NACK          LL_USART_DisableSmartcardNACK
   * @param  USARTx USART Instance
@@ -2129,7 +2129,7 @@ __STATIC_INLINE void LL_USART_DisableSmartcardNACK(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Smartcard NACK transmission is enabled
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          NACK          LL_USART_IsEnabledSmartcardNACK
   * @param  USARTx USART Instance
@@ -2142,7 +2142,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledSmartcardNACK(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Smartcard mode
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCEN          LL_USART_EnableSmartcard
   * @param  USARTx USART Instance
@@ -2155,7 +2155,7 @@ __STATIC_INLINE void LL_USART_EnableSmartcard(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Smartcard mode
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCEN          LL_USART_DisableSmartcard
   * @param  USARTx USART Instance
@@ -2168,7 +2168,7 @@ __STATIC_INLINE void LL_USART_DisableSmartcard(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Smartcard mode is enabled
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCEN          LL_USART_IsEnabledSmartcard
   * @param  USARTx USART Instance
@@ -2181,7 +2181,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledSmartcard(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set Smartcard Auto-Retry Count value (SCARCNT[2:0] bits)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @note   This bit-field specifies the number of retries in transmit and receive, in Smartcard mode.
   *         In transmission mode, it specifies the number of automatic retransmission retries, before
@@ -2200,7 +2200,7 @@ __STATIC_INLINE void LL_USART_SetSmartcardAutoRetryCount(USART_TypeDef *USARTx, 
 
 /**
   * @brief  Return Smartcard Auto-Retry Count value (SCARCNT[2:0] bits)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCARCNT       LL_USART_GetSmartcardAutoRetryCount
   * @param  USARTx USART Instance
@@ -2214,7 +2214,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardAutoRetryCount(USART_TypeDef *USAR
 /**
   * @brief  Set Smartcard prescaler value, used for dividing the USART clock
   *         source to provide the SMARTCARD Clock (5 bits value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_SetSmartcardPrescaler
   * @param  USARTx USART Instance
@@ -2229,7 +2229,7 @@ __STATIC_INLINE void LL_USART_SetSmartcardPrescaler(USART_TypeDef *USARTx, uint3
 /**
   * @brief  Return Smartcard prescaler value, used for dividing the USART clock
   *         source to provide the SMARTCARD Clock (5 bits value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_GetSmartcardPrescaler
   * @param  USARTx USART Instance
@@ -2243,7 +2243,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardPrescaler(USART_TypeDef *USARTx)
 /**
   * @brief  Set Smartcard Guard time value, expressed in nb of baud clocks periods
   *         (GT[7:0] bits : Guard time value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         GT            LL_USART_SetSmartcardGuardTime
   * @param  USARTx USART Instance
@@ -2258,7 +2258,7 @@ __STATIC_INLINE void LL_USART_SetSmartcardGuardTime(USART_TypeDef *USARTx, uint3
 /**
   * @brief  Return Smartcard Guard time value, expressed in nb of baud clocks periods
   *         (GT[7:0] bits : Guard time value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         GT            LL_USART_GetSmartcardGuardTime
   * @param  USARTx USART Instance
@@ -2279,7 +2279,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardGuardTime(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Single Wire Half-Duplex mode
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @rmtoll CR3          HDSEL         LL_USART_EnableHalfDuplex
   * @param  USARTx USART Instance
@@ -2292,7 +2292,7 @@ __STATIC_INLINE void LL_USART_EnableHalfDuplex(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Single Wire Half-Duplex mode
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @rmtoll CR3          HDSEL         LL_USART_DisableHalfDuplex
   * @param  USARTx USART Instance
@@ -2305,7 +2305,7 @@ __STATIC_INLINE void LL_USART_DisableHalfDuplex(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Single Wire Half-Duplex mode is enabled
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @rmtoll CR3          HDSEL         LL_USART_IsEnabledHalfDuplex
   * @param  USARTx USART Instance
@@ -2325,7 +2325,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledHalfDuplex(USART_TypeDef *USARTx)
   */
 /**
   * @brief  Enable SPI Synchronous Slave mode
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          SLVEN         LL_USART_EnableSPISlave
   * @param  USARTx USART Instance
@@ -2338,7 +2338,7 @@ __STATIC_INLINE void LL_USART_EnableSPISlave(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable SPI Synchronous Slave mode
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          SLVEN         LL_USART_DisableSPISlave
   * @param  USARTx USART Instance
@@ -2351,7 +2351,7 @@ __STATIC_INLINE void LL_USART_DisableSPISlave(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if  SPI Synchronous Slave mode is enabled
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          SLVEN         LL_USART_IsEnabledSPISlave
   * @param  USARTx USART Instance
@@ -2364,7 +2364,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlave(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable SPI Slave Selection using NSS input pin
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @note   SPI Slave Selection depends on NSS input pin
   *         (The slave is selected when NSS is low and deselected when NSS is high).
@@ -2379,7 +2379,7 @@ __STATIC_INLINE void LL_USART_EnableSPISlaveSelect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable SPI Slave Selection using NSS input pin
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @note   SPI Slave will be always selected and NSS input pin will be ignored.
   * @rmtoll CR2          DIS_NSS       LL_USART_DisableSPISlaveSelect
@@ -2393,7 +2393,7 @@ __STATIC_INLINE void LL_USART_DisableSPISlaveSelect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if  SPI Slave Selection depends on NSS input pin
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          DIS_NSS       LL_USART_IsEnabledSPISlaveSelect
   * @param  USARTx USART Instance
@@ -2414,7 +2414,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlaveSelect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set LIN Break Detection Length
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDL          LL_USART_SetLINBrkDetectionLen
   * @param  USARTx USART Instance
@@ -2430,7 +2430,7 @@ __STATIC_INLINE void LL_USART_SetLINBrkDetectionLen(USART_TypeDef *USARTx, uint3
 
 /**
   * @brief  Return LIN Break Detection Length
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDL          LL_USART_GetLINBrkDetectionLen
   * @param  USARTx USART Instance
@@ -2445,7 +2445,7 @@ __STATIC_INLINE uint32_t LL_USART_GetLINBrkDetectionLen(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable LIN mode
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LINEN         LL_USART_EnableLIN
   * @param  USARTx USART Instance
@@ -2458,7 +2458,7 @@ __STATIC_INLINE void LL_USART_EnableLIN(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable LIN mode
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LINEN         LL_USART_DisableLIN
   * @param  USARTx USART Instance
@@ -2471,7 +2471,7 @@ __STATIC_INLINE void LL_USART_DisableLIN(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if LIN mode is enabled
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LINEN         LL_USART_IsEnabledLIN
   * @param  USARTx USART Instance
@@ -2492,7 +2492,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledLIN(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set DEDT (Driver Enable De-Assertion Time), Time value expressed on 5 bits ([4:0] bits).
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEDT          LL_USART_SetDEDeassertionTime
   * @param  USARTx USART Instance
@@ -2506,7 +2506,7 @@ __STATIC_INLINE void LL_USART_SetDEDeassertionTime(USART_TypeDef *USARTx, uint32
 
 /**
   * @brief  Return DEDT (Driver Enable De-Assertion Time)
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEDT          LL_USART_GetDEDeassertionTime
   * @param  USARTx USART Instance
@@ -2519,7 +2519,7 @@ __STATIC_INLINE uint32_t LL_USART_GetDEDeassertionTime(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set DEAT (Driver Enable Assertion Time), Time value expressed on 5 bits ([4:0] bits).
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEAT          LL_USART_SetDEAssertionTime
   * @param  USARTx USART Instance
@@ -2533,7 +2533,7 @@ __STATIC_INLINE void LL_USART_SetDEAssertionTime(USART_TypeDef *USARTx, uint32_t
 
 /**
   * @brief  Return DEAT (Driver Enable Assertion Time)
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEAT          LL_USART_GetDEAssertionTime
   * @param  USARTx USART Instance
@@ -2546,7 +2546,7 @@ __STATIC_INLINE uint32_t LL_USART_GetDEAssertionTime(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Driver Enable (DE) Mode
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEM           LL_USART_EnableDEMode
   * @param  USARTx USART Instance
@@ -2559,7 +2559,7 @@ __STATIC_INLINE void LL_USART_EnableDEMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Driver Enable (DE) Mode
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEM           LL_USART_DisableDEMode
   * @param  USARTx USART Instance
@@ -2572,7 +2572,7 @@ __STATIC_INLINE void LL_USART_DisableDEMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Driver Enable (DE) Mode is enabled
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEM           LL_USART_IsEnabledDEMode
   * @param  USARTx USART Instance
@@ -2585,7 +2585,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledDEMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Select Driver Enable Polarity
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEP           LL_USART_SetDESignalPolarity
   * @param  USARTx USART Instance
@@ -2601,7 +2601,7 @@ __STATIC_INLINE void LL_USART_SetDESignalPolarity(USART_TypeDef *USARTx, uint32_
 
 /**
   * @brief  Return Driver Enable Polarity
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEP           LL_USART_GetDESignalPolarity
   * @param  USARTx USART Instance
@@ -2664,7 +2664,7 @@ __STATIC_INLINE void LL_USART_ConfigAsyncMode(USART_TypeDef *USARTx)
   *           - IREN bit in the USART_CR3 register,
   *           - HDSEL bit in the USART_CR3 register.
   *         This function also sets the USART in Synchronous mode.
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2702,7 +2702,7 @@ __STATIC_INLINE void LL_USART_ConfigSyncMode(USART_TypeDef *USARTx)
   *           - IREN bit in the USART_CR3 register,
   *           - HDSEL bit in the USART_CR3 register.
   *         This function also set the UART/USART in LIN mode.
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear CLKEN in CR2 using @ref LL_USART_DisableSCLKOutput() function
@@ -2742,7 +2742,7 @@ __STATIC_INLINE void LL_USART_ConfigLINMode(USART_TypeDef *USARTx)
   *           - SCEN bit in the USART_CR3 register,
   *           - IREN bit in the USART_CR3 register,
   *         This function also sets the UART/USART in Half Duplex mode.
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2781,7 +2781,7 @@ __STATIC_INLINE void LL_USART_ConfigHalfDuplexMode(USART_TypeDef *USARTx)
   *         This function also configures Stop bits to 1.5 bits and
   *         sets the USART in Smartcard mode (SCEN bit).
   *         Clock Output is also enabled (CLKEN).
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2823,7 +2823,7 @@ __STATIC_INLINE void LL_USART_ConfigSmartcardMode(USART_TypeDef *USARTx)
   *           - SCEN bit in the USART_CR3 register,
   *           - HDSEL bit in the USART_CR3 register.
   *         This function also sets the UART/USART in IRDA mode (IREN bit).
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2959,7 +2959,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_IDLE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART Read Data Register or USART RX FIFO Not Empty Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          RXNE_RXFNE    LL_USART_IsActiveFlag_RXNE_RXFNE
   * @param  USARTx USART Instance
@@ -2986,7 +2986,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TC(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART Transmit Data Register Empty or USART TX FIFO Not Full Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          TXE_TXFNF     LL_USART_IsActiveFlag_TXE_TXFNF
   * @param  USARTx USART Instance
@@ -2999,7 +2999,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXE_TXFNF(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART LIN Break Detection Flag is set or not
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll ISR          LBDF          LL_USART_IsActiveFlag_LBD
   * @param  USARTx USART Instance
@@ -3012,7 +3012,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_LBD(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART CTS interrupt Flag is set or not
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll ISR          CTSIF         LL_USART_IsActiveFlag_nCTS
   * @param  USARTx USART Instance
@@ -3025,7 +3025,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_nCTS(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART CTS Flag is set or not
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll ISR          CTS           LL_USART_IsActiveFlag_CTS
   * @param  USARTx USART Instance
@@ -3049,7 +3049,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RTO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART End Of Block Flag is set or not
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll ISR          EOBF          LL_USART_IsActiveFlag_EOB
   * @param  USARTx USART Instance
@@ -3062,7 +3062,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_EOB(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the SPI Slave Underrun error flag is set or not
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll ISR          UDR           LL_USART_IsActiveFlag_UDR
   * @param  USARTx USART Instance
@@ -3075,7 +3075,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_UDR(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART Auto-Baud Rate Error Flag is set or not
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll ISR          ABRE          LL_USART_IsActiveFlag_ABRE
   * @param  USARTx USART Instance
@@ -3088,7 +3088,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ABRE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART Auto-Baud Rate Flag is set or not
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll ISR          ABRF          LL_USART_IsActiveFlag_ABR
   * @param  USARTx USART Instance
@@ -3145,7 +3145,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RWU(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART Wake Up from stop mode Flag is set or not
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll ISR          WUF           LL_USART_IsActiveFlag_WKUP
   * @param  USARTx USART Instance
@@ -3180,7 +3180,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_REACK(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART TX FIFO Empty Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          TXFE          LL_USART_IsActiveFlag_TXFE
   * @param  USARTx USART Instance
@@ -3193,7 +3193,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXFE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART RX FIFO Full Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          RXFF          LL_USART_IsActiveFlag_RXFF
   * @param  USARTx USART Instance
@@ -3217,7 +3217,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TCBGT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART TX FIFO Threshold Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          TXFT          LL_USART_IsActiveFlag_TXFT
   * @param  USARTx USART Instance
@@ -3230,7 +3230,7 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXFT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART RX FIFO Threshold Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          RXFT          LL_USART_IsActiveFlag_RXFT
   * @param  USARTx USART Instance
@@ -3298,7 +3298,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_IDLE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear TX FIFO Empty Flag
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ICR          TXFECF        LL_USART_ClearFlag_TXFE
   * @param  USARTx USART Instance
@@ -3333,7 +3333,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_TCBGT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear LIN Break Detection Flag
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll ICR          LBDCF         LL_USART_ClearFlag_LBD
   * @param  USARTx USART Instance
@@ -3346,7 +3346,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_LBD(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear CTS Interrupt Flag
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll ICR          CTSCF         LL_USART_ClearFlag_nCTS
   * @param  USARTx USART Instance
@@ -3370,7 +3370,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_RTO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear End Of Block Flag
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll ICR          EOBCF         LL_USART_ClearFlag_EOB
   * @param  USARTx USART Instance
@@ -3383,7 +3383,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_EOB(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear SPI Slave Underrun Flag
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll ICR          UDRCF         LL_USART_ClearFlag_UDR
   * @param  USARTx USART Instance
@@ -3407,7 +3407,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_CM(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear Wake Up from stop mode Flag
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll ICR          WUCF          LL_USART_ClearFlag_WKUP
   * @param  USARTx USART Instance
@@ -3442,7 +3442,7 @@ __STATIC_INLINE void LL_USART_EnableIT_IDLE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable RX Not Empty and RX FIFO Not Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        RXNEIE_RXFNEIE  LL_USART_EnableIT_RXNE_RXFNE
   * @param  USARTx USART Instance
@@ -3469,7 +3469,7 @@ __STATIC_INLINE void LL_USART_EnableIT_TC(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable TX Empty and TX FIFO Not Full Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1         TXEIE_TXFNFIE  LL_USART_EnableIT_TXE_TXFNF
   * @param  USARTx USART Instance
@@ -3515,7 +3515,7 @@ __STATIC_INLINE void LL_USART_EnableIT_RTO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable End Of Block Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR1          EOBIE         LL_USART_EnableIT_EOB
   * @param  USARTx USART Instance
@@ -3528,7 +3528,7 @@ __STATIC_INLINE void LL_USART_EnableIT_EOB(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable TX FIFO Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          TXFEIE        LL_USART_EnableIT_TXFE
   * @param  USARTx USART Instance
@@ -3552,7 +3552,7 @@ __STATIC_INLINE void LL_USART_EnableIT_RXFF(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable LIN Break Detection Interrupt
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDIE         LL_USART_EnableIT_LBD
   * @param  USARTx USART Instance
@@ -3580,7 +3580,7 @@ __STATIC_INLINE void LL_USART_EnableIT_ERROR(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable CTS Interrupt
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSIE         LL_USART_EnableIT_CTS
   * @param  USARTx USART Instance
@@ -3593,7 +3593,7 @@ __STATIC_INLINE void LL_USART_EnableIT_CTS(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Wake Up from Stop Mode Interrupt
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUFIE         LL_USART_EnableIT_WKUP
   * @param  USARTx USART Instance
@@ -3606,7 +3606,7 @@ __STATIC_INLINE void LL_USART_EnableIT_WKUP(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable TX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTIE        LL_USART_EnableIT_TXFT
   * @param  USARTx USART Instance
@@ -3619,7 +3619,7 @@ __STATIC_INLINE void LL_USART_EnableIT_TXFT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Smartcard Transmission Complete Before Guard Time Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          TCBGTIE       LL_USART_EnableIT_TCBGT
   * @param  USARTx USART Instance
@@ -3632,7 +3632,7 @@ __STATIC_INLINE void LL_USART_EnableIT_TCBGT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable RX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTIE        LL_USART_EnableIT_RXFT
   * @param  USARTx USART Instance
@@ -3659,7 +3659,7 @@ __STATIC_INLINE void LL_USART_DisableIT_IDLE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable RX Not Empty and RX FIFO Not Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        RXNEIE_RXFNEIE  LL_USART_DisableIT_RXNE_RXFNE
   * @param  USARTx USART Instance
@@ -3686,7 +3686,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TC(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable TX Empty and TX FIFO Not Full Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        TXEIE_TXFNFIE  LL_USART_DisableIT_TXE_TXFNF
   * @param  USARTx USART Instance
@@ -3732,7 +3732,7 @@ __STATIC_INLINE void LL_USART_DisableIT_RTO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable End Of Block Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR1          EOBIE         LL_USART_DisableIT_EOB
   * @param  USARTx USART Instance
@@ -3745,7 +3745,7 @@ __STATIC_INLINE void LL_USART_DisableIT_EOB(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable TX FIFO Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          TXFEIE        LL_USART_DisableIT_TXFE
   * @param  USARTx USART Instance
@@ -3758,7 +3758,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TXFE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable RX FIFO Full Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          RXFFIE        LL_USART_DisableIT_RXFF
   * @param  USARTx USART Instance
@@ -3771,7 +3771,7 @@ __STATIC_INLINE void LL_USART_DisableIT_RXFF(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable LIN Break Detection Interrupt
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDIE         LL_USART_DisableIT_LBD
   * @param  USARTx USART Instance
@@ -3799,7 +3799,7 @@ __STATIC_INLINE void LL_USART_DisableIT_ERROR(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable CTS Interrupt
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSIE         LL_USART_DisableIT_CTS
   * @param  USARTx USART Instance
@@ -3812,7 +3812,7 @@ __STATIC_INLINE void LL_USART_DisableIT_CTS(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Wake Up from Stop Mode Interrupt
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUFIE         LL_USART_DisableIT_WKUP
   * @param  USARTx USART Instance
@@ -3825,7 +3825,7 @@ __STATIC_INLINE void LL_USART_DisableIT_WKUP(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable TX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTIE        LL_USART_DisableIT_TXFT
   * @param  USARTx USART Instance
@@ -3838,7 +3838,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TXFT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Smartcard Transmission Complete Before Guard Time Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          TCBGTIE       LL_USART_DisableIT_TCBGT
   * @param  USARTx USART Instance
@@ -3851,7 +3851,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TCBGT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable RX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTIE        LL_USART_DisableIT_RXFT
   * @param  USARTx USART Instance
@@ -3878,7 +3878,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_IDLE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART RX Not Empty and USART RX FIFO Not Empty Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        RXNEIE_RXFNEIE  LL_USART_IsEnabledIT_RXNE_RXFNE
   * @param  USARTx USART Instance
@@ -3905,7 +3905,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TC(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART TX Empty and USART TX FIFO Not Full Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1         TXEIE_TXFNFIE  LL_USART_IsEnabledIT_TXE_TXFNF
   * @param  USARTx USART Instance
@@ -3951,7 +3951,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RTO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART End Of Block Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR1          EOBIE         LL_USART_IsEnabledIT_EOB
   * @param  USARTx USART Instance
@@ -3964,7 +3964,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_EOB(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART TX FIFO Empty Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          TXFEIE        LL_USART_IsEnabledIT_TXFE
   * @param  USARTx USART Instance
@@ -3977,7 +3977,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXFE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART RX FIFO Full Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          RXFFIE        LL_USART_IsEnabledIT_RXFF
   * @param  USARTx USART Instance
@@ -3990,7 +3990,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXFF(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART LIN Break Detection Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDIE         LL_USART_IsEnabledIT_LBD
   * @param  USARTx USART Instance
@@ -4014,7 +4014,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_ERROR(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART CTS Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSIE         LL_USART_IsEnabledIT_CTS
   * @param  USARTx USART Instance
@@ -4027,7 +4027,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_CTS(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the USART Wake Up from Stop Mode Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUFIE         LL_USART_IsEnabledIT_WKUP
   * @param  USARTx USART Instance
@@ -4040,7 +4040,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_WKUP(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if USART TX FIFO Threshold Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTIE        LL_USART_IsEnabledIT_TXFT
   * @param  USARTx USART Instance
@@ -4053,7 +4053,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXFT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if the Smartcard Transmission Complete Before Guard Time Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          TCBGTIE       LL_USART_IsEnabledIT_TCBGT
   * @param  USARTx USART Instance
@@ -4066,7 +4066,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TCBGT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Check if USART RX FIFO Threshold Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTIE        LL_USART_IsEnabledIT_RXFT
   * @param  USARTx USART Instance
@@ -4196,7 +4196,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledDMADeactOnRxErr(USART_TypeDef *USARTx
   */
 __STATIC_INLINE uint32_t LL_USART_DMA_GetRegAddr(USART_TypeDef *USARTx, uint32_t Direction)
 {
-  register uint32_t data_reg_addr;
+  uint32_t data_reg_addr;
 
   if (Direction == LL_USART_DMA_REG_DATA_TRANSMIT)
   {
@@ -4276,7 +4276,7 @@ __STATIC_INLINE void LL_USART_TransmitData9(USART_TypeDef *USARTx, uint16_t Valu
 
 /**
   * @brief  Request an Automatic Baud Rate measurement on next received data frame
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll RQR          ABRRQ         LL_USART_RequestAutoBaudRate
   * @param  USARTx USART Instance
@@ -4311,7 +4311,7 @@ __STATIC_INLINE void LL_USART_RequestEnterMuteMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Request a Receive Data and FIFO flush
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @note   Allows to discard the received data without reading them, and avoid an overrun
   *         condition.
@@ -4326,7 +4326,7 @@ __STATIC_INLINE void LL_USART_RequestRxDataFlush(USART_TypeDef *USARTx)
 
 /**
   * @brief  Request a Transmit data and FIFO flush
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll RQR          TXFRQ         LL_USART_RequestTxDataFlush
   * @param  USARTx USART Instance
@@ -4363,7 +4363,7 @@ void        LL_USART_ClockStructInit(LL_USART_ClockInitTypeDef *USART_ClockInitS
   * @}
   */
 
-#endif /* USART1 || USART2 || USART3 || USART4 */
+#endif /* USART1 || USART2 || USART3 || USART4 || USART5 || USART6 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_usb.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_usb.h
@@ -1,0 +1,881 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_ll_usb.h
+  * @author  MCD Application Team
+  * @brief   Header file of USB Low Layer HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32G0xx_LL_USB_H
+#define STM32G0xx_LL_USB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal_def.h"
+
+#if defined (USB_DRD_FS)
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup USB_LL
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  USB Mode definition
+  */
+
+
+typedef enum
+{
+  USB_DEVICE_MODE  = 0,
+  USB_HOST_MODE    = 1
+} USB_DRD_ModeTypeDef;
+
+/**
+  * @brief  URB States definition
+  */
+typedef enum
+{
+  URB_IDLE = 0,
+  URB_DONE,
+  URB_NOTREADY,
+  URB_NYET,
+  URB_ERROR,
+  URB_STALL
+} USB_DRD_URBStateTypeDef;
+
+/**
+  * @brief  Host channel States  definition
+  */
+typedef enum
+{
+  HC_IDLE = 0,
+  HC_XFRC,
+  HC_HALTED,
+  HC_NAK,
+  HC_NYET,
+  HC_STALL,
+  HC_XACTERR,
+  HC_BBLERR,
+  HC_DATATGLERR,
+  HC_ACK
+} USB_DRD_HCStateTypeDef;
+
+/**
+  * USB HOST Double buffer Isochronous State
+  */
+typedef enum
+{
+  USB_PMABUF_EMPTY = 0U,
+  USB_PMABUF_NOT_EMPTY = 1U
+} USB_BuffStateTypedDef;
+
+/**
+  * @brief  USB Instance Initialization Structure definition
+  */
+typedef struct
+{
+  uint32_t dev_endpoints;           /*!< Device Endpoints number.
+                                         This parameter depends on the used USB core.
+                                         This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
+
+  uint32_t Host_channels;           /*!< Host Channels number.
+                                         This parameter Depends on the used USB core.
+                                         This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
+
+  uint32_t speed;                   /*!< USB Core speed.
+                                         This parameter can be any value of @ref USB_Core_Speed                 */
+
+  uint32_t ep0_mps;                 /*!< Set the Endpoint 0 Max Packet size.                                    */
+
+  uint32_t phy_itface;              /*!< Select the used PHY interface.
+                                         This parameter can be any value of @ref USB_Core_PHY                   */
+
+  uint32_t Sof_enable;              /*!< Enable or disable the output of the SOF signal.                        */
+
+  uint32_t low_power_enable;        /*!< Enable or disable the low power mode.                                  */
+
+  uint32_t lpm_enable;              /*!< Enable or disable Link Power Management.                               */
+
+  uint32_t battery_charging_enable; /*!< Enable or disable Battery charging.                                    */
+
+  uint32_t vbus_sensing_enable;     /*!< Enable or disable the VBUS Sensing feature.                            */
+
+  uint32_t bulk_doublebuffer_enable;  /*!< Enable or disable the double buffer mode on bulk EP                  */
+
+  uint32_t iso_singlebuffer_enable;   /*!< Enable or disable the Single buffer mode on Isochronous  EP          */
+} USB_DRD_CfgTypeDef;
+
+typedef struct
+{
+  uint8_t   num;                  /*!< Endpoint number
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 15   */
+
+  uint8_t   is_in;                /*!< Endpoint direction
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
+
+  uint8_t   is_stall;             /*!< Endpoint stall condition
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
+
+  uint8_t   type;                 /*!< Endpoint type
+                                       This parameter can be any value of @ref USB_EP_Type_                     */
+
+  uint16_t  pmaadress;            /*!< PMA Address
+                                       This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+
+  uint16_t  pmaaddr0;             /*!< PMA Address0
+                                       This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+
+  uint16_t  pmaaddr1;             /*!< PMA Address1
+                                       This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+
+  uint8_t   doublebuffer;         /*!< Double buffer enable
+                                       This parameter can be 0 or 1                                              */
+
+  uint8_t   data_pid_start;       /*!< Initial data PID
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
+
+  uint16_t  tx_fifo_num;          /*!< Transmission FIFO number
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 15   */
+
+  uint32_t  maxpacket;            /*!< Endpoint Max packet size
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 64KB */
+
+  uint8_t   *xfer_buff;           /*!< Pointer to transfer buffer                                               */
+
+  uint32_t  xfer_len;             /*!< Current transfer length                                                  */
+
+  uint32_t  xfer_count;           /*!< Partial transfer length in case of multi packet transfer                 */
+
+  uint32_t  xfer_len_db;          /*!< double buffer transfer length used with bulk double buffer in            */
+
+  uint8_t   xfer_fill_db;         /*!< double buffer Need to Fill new buffer  used with bulk_in                 */
+} USB_DRD_EPTypeDef;
+
+typedef struct
+{
+  uint8_t   dev_addr;           /*!< USB device address.
+                                     This parameter must be a number between Min_Data = 1 and Max_Data = 255    */
+
+  uint8_t   phy_ch_num;         /*!< Host channel number.
+                                     This parameter must be a number between Min_Data = 1 and Max_Data = 15     */
+
+  uint8_t   ep_num;             /*!< Endpoint number.
+                                     This parameter must be a number between Min_Data = 1 and Max_Data = 15     */
+
+  uint8_t   ch_dir;             /*!< channel direction
+                                     This parameter store the physical channel direction IN/OUT/BIDIR           */
+
+  uint8_t   speed;              /*!< USB Host speed.
+                                     This parameter can be any value of @ref USB_Core_Speed_                    */
+
+  uint8_t   ep_type;            /*!< Endpoint Type.
+                                     This parameter can be any value of @ref USB_EP_Type_                       */
+
+  uint16_t  max_packet;         /*!< Endpoint Max packet size.
+                                     This parameter must be a number between Min_Data = 0 and Max_Data = 64KB   */
+
+  uint8_t   data_pid;           /*!< Initial data PID.
+                                     This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint8_t   *xfer_buff;         /*!< Pointer to transfer buffer.                                                */
+
+  uint32_t  xfer_len;           /*!< Current transfer length.                                                   */
+
+  uint32_t  xfer_len_db;        /*!< Current transfer length used in double buffer mode.                        */
+
+  uint32_t  xfer_count;         /*!< Partial transfer length in case of multi packet transfer.                  */
+
+  uint8_t   toggle_in;          /*!< IN transfer current toggle flag.
+                                     This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint8_t   toggle_out;         /*!< OUT transfer current toggle flag
+                                     This parameter must be a number between Min_Data = 0 and Max_Data = 1      */
+
+  uint32_t  ErrCnt;             /*!< Host channel error count.                                                 */
+
+  uint16_t  pmaadress;          /*!< PMA Address
+                                     This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+
+  uint16_t  pmaaddr0;           /*!< PMA Address0
+                                     This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+
+  uint16_t  pmaaddr1;           /*!< PMA Address1
+                                     This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+
+  uint8_t   doublebuffer;       /*!< Double buffer enable
+                                     This parameter can be 0 or 1                                              */
+
+  USB_BuffStateTypedDef  pmabuff0_state;   /*!< PMA Buffer0 State empty / notEmpty : used in double buffer OUT isochronous */
+
+  USB_BuffStateTypedDef  pmabuff1_state;   /*!< PMA Buffer1 State empty / notEmpty : used in double buffer OUT isochronous */
+
+  USB_DRD_URBStateTypeDef urb_state;  /*!< URB state.
+                                            This parameter can be any value of @ref USB_OTG_URBStateTypeDef */
+
+  USB_DRD_HCStateTypeDef state;       /*!< Host Channel state.
+                                            This parameter can be any value of @ref USB_OTG_HCStateTypeDef  */
+} USB_DRD_HCTypeDef;
+
+
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
+  * @{
+  */
+
+
+/** @defgroup USB_LL_EP0_MPS USB Low Layer EP0 MPS
+  * @{
+  */
+#define EP_MPS_64                              0U
+#define EP_MPS_32                              1U
+#define EP_MPS_16                              2U
+#define EP_MPS_8                               3U
+/**
+  * @}
+  */
+
+/** @defgroup USB_LL_EP_Type USB Low Layer EP Type
+  * @{
+  */
+#define EP_TYPE_CTRL                           0U
+#define EP_TYPE_ISOC                           1U
+#define EP_TYPE_BULK                           2U
+#define EP_TYPE_INTR                           3U
+#define EP_TYPE_MSK                            3U
+/**
+  * @}
+  */
+
+/** @defgroup USB_LL Device Speed
+  * @{
+  */
+#define USBD_FS_SPEED                          2U
+#define USBH_FSLS_SPEED                        1U
+/**
+  * @}
+  */
+
+#define BTABLE_ADDRESS                         0x000U
+
+#define EP_ADDR_MSK                            0x7U
+
+/*!< USB Speed */
+#define USB_DRD_SPEED_FS                       1U
+#define USB_DRD_SPEED_LS                       2U
+#define USB_DRD_SPEED_LSFS                     3U
+
+/*!< PID */
+#define HC_PID_DATA0                           0U
+#define HC_PID_DATA2                           1U
+#define HC_PID_DATA1                           2U
+#define HC_PID_SETUP                           3U
+
+/*!< Channel Direction  */
+#define CH_IN_DIR                              1U
+#define CH_OUT_DIR                             0U
+
+/*!< Number of used channels in the Application */
+#ifndef USB_DRD_USED_CHANNELS
+#define USB_DRD_USED_CHANNELS                  8U
+#endif /* USB_DRD_USED_CHANNELS */
+
+/* First available address in PMA */
+#define PMA_START_ADDR          (0x10U + (8U *(USB_DRD_USED_CHANNELS - 2U)))
+#define PMA_END_ADDR             USB_DRD_PMA_SIZE
+
+
+/**
+  * used for USB_HC_DoubleBuffer API
+  */
+#define USB_DRD_DBUFF_ENBALE                   1U
+#define USB_DRD_DBUFF_DISABLE                  2U
+
+
+/* Exported macro ------------------------------------------------------------*/
+/**
+  * @}
+  */
+/********************  Bit definition for USB_COUNTn_RX register  *************/
+#define USB_CNTRX_NBLK_MSK                    (0x1FU << 26)
+#define USB_CNTRX_BLSIZE                      (0x1U << 31)
+
+
+/*Set Channel/Endpoint to the USB Register */
+#define USB_DRD_SET_CHEP(USBx, bEpChNum, wRegValue)  (*(__IO uint32_t *)(&(USBx)->CHEP0R + (bEpChNum)) = (uint32_t)(wRegValue))
+
+/*Get Channel/Endpoint from the USB Register */
+#define USB_DRD_GET_CHEP(USBx, bEpChNum)             (*(__IO uint32_t *)(&(USBx)->CHEP0R + (bEpChNum)))
+
+
+/**
+  * @brief free buffer used from the application realizing it to the line
+  *         toggles bit SW_BUF in the double buffered endpoint register
+  * @param USBx USB device.
+  * @param   bEpChNum, bDir
+  * @retval None
+  */
+#define USB_DRD_FreeUserBuffer(USBx, bEpChNum, bDir) \
+  do { \
+    if ((bDir) == 0U) \
+    { \
+      /* OUT double buffered endpoint */ \
+      USB_DRD_TX_DTOG((USBx), (bEpChNum)); \
+    } \
+    else if ((bDir) == 1U) \
+    { \
+      /* IN double buffered endpoint */ \
+      USB_DRD_RX_DTOG((USBx), (bEpChNum)); \
+    } \
+  } while(0)
+
+
+/**
+  * @brief Set the Setup bit in the corresponding channel, when a Setup
+     transaction is needed.
+  * @param USBx USB device.
+  * @param   bEpChNum
+  * @retval None
+  */
+#define USB_DRD_CHEP_TX_SETUP(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) ; \
+    \
+    /*Set Setup bit*/ \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_SETUP)); \
+  } while(0)
+
+
+/**
+  * @brief  Clears bit ERR_RX in the Channel register
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_CLEAR_CHEP_RX_ERR(USBx, bChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bChNum)); \
+    _wRegVal = (_wRegVal & USB_CHEP_REG_MASK & (~USB_CHEP_ERRRX) & (~USB_CHEP_VTRX)) | \
+               (USB_CHEP_VTTX | USB_CHEP_ERRTX); \
+    \
+    USB_DRD_SET_CHEP((USBx), (bChNum), _wRegVal); \
+  } while(0) /* USB_DRD_CLEAR_CHEP_RX_ERR */
+
+
+/**
+  * @brief  Clears bit ERR_TX in the Channel register
+  * @param  USBx USB peripheral instance register address.
+  * @param  bChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_CLEAR_CHEP_TX_ERR(USBx, bChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bChNum)); \
+    _wRegVal = (_wRegVal & USB_CHEP_REG_MASK & (~USB_CHEP_ERRTX) & (~USB_CHEP_VTTX)) | \
+               (USB_CHEP_VTRX|USB_CHEP_ERRRX); \
+    \
+    USB_DRD_SET_CHEP((USBx), (bChNum), _wRegVal); \
+  } while(0) /* USB_DRD_CLEAR_CHEP_TX_ERR */
+
+
+/**
+  * @brief  sets the status for tx transfer (bits STAT_TX[1:0]).
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  wState new state
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_TX_STATUS(USBx, bEpChNum, wState) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_CHEP_TX_DTOGMASK; \
+    /* toggle first bit ? */ \
+    if ((USB_CHEP_TX_DTOG1 & (wState)) != 0U) \
+    { \
+      _wRegVal ^= USB_CHEP_TX_DTOG1; \
+    } \
+    /* toggle second bit ?  */ \
+    if ((USB_CHEP_TX_DTOG2 & (wState)) != 0U) \
+    { \
+      _wRegVal ^= USB_CHEP_TX_DTOG2; \
+    } \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTRX| USB_CHEP_VTTX)); \
+  } while(0) /* USB_DRD_SET_CHEP_TX_STATUS */
+
+
+/**
+  * @brief  sets the status for rx transfer (bits STAT_TX[1:0])
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  wState new state
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_RX_STATUS(USBx, bEpChNum, wState) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_CHEP_RX_DTOGMASK; \
+    /* toggle first bit ? */ \
+    if ((USB_CHEP_RX_DTOG1 & (wState)) != 0U) \
+    { \
+      _wRegVal ^= USB_CHEP_RX_DTOG1; \
+    } \
+    /* toggle second bit ? */ \
+    if ((USB_CHEP_RX_DTOG2 & (wState)) != 0U) \
+    { \
+      _wRegVal ^= USB_CHEP_RX_DTOG2; \
+    } \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTRX | USB_CHEP_VTTX)); \
+  } while(0) /* USB_DRD_SET_CHEP_RX_STATUS */
+
+
+/**
+  * @brief  gets the status for tx/rx transfer (bits STAT_TX[1:0]
+  *         /STAT_RX[1:0])
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval status
+  */
+#define USB_DRD_GET_CHEP_TX_STATUS(USBx, bEpChNum)     ((uint16_t)USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_DRD_CHEP_TX_STTX)
+#define USB_DRD_GET_CHEP_RX_STATUS(USBx, bEpChNum)     ((uint16_t)USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_DRD_CHEP_RX_STRX)
+
+
+/**
+  * @brief  set  EP_KIND bit.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_KIND(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_CHEP_REG_MASK; \
+    \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTRX | USB_CHEP_VTTX | USB_CHEP_KIND)); \
+  } while(0) /* USB_DRD_SET_CHEP_KIND */
+
+
+/**
+  * @brief  clear EP_KIND bit.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_CLEAR_CHEP_KIND(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_EP_KIND_MASK; \
+    \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTRX | USB_CHEP_VTTX)); \
+  } while(0) /* USB_DRD_CLEAR_CHEP_KIND */
+
+
+/**
+  * @brief  Clears bit CTR_RX / CTR_TX in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_CLEAR_RX_CHEP_CTR(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & (0xFFFF7FFFU & USB_CHEP_REG_MASK); \
+    \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTTX)); \
+  } while(0) /* USB_CLEAR_RX_CHEP_CTR */
+
+#define USB_DRD_CLEAR_TX_CHEP_CTR(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & (0xFFFFFF7FU & USB_CHEP_REG_MASK); \
+    \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTRX)); \
+  } while(0) /* USB_CLEAR_TX_CHEP_CTR */
+
+
+/**
+  * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_RX_DTOG(USBx, bEpChNum) \
+  do { \
+    uint32_t _wEPVal; \
+    \
+    _wEPVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_CHEP_REG_MASK; \
+    \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wEPVal | USB_CHEP_VTRX | USB_CHEP_VTTX | USB_CHEP_DTOG_RX)); \
+  } while(0) /* USB_DRD_RX_DTOG */
+
+#define USB_DRD_TX_DTOG(USBx, bEpChNum) \
+  do { \
+    uint32_t _wEPVal; \
+    \
+    _wEPVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_CHEP_REG_MASK; \
+    \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wEPVal | USB_CHEP_VTRX | USB_CHEP_VTTX | USB_CHEP_DTOG_TX)); \
+  } while(0) /* USB_TX_DTOG */
+
+
+/**
+  * @brief  Clears DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_CLEAR_RX_DTOG(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)); \
+    \
+    if ((_wRegVal & USB_CHEP_DTOG_RX) != 0U) \
+    { \
+      USB_DRD_RX_DTOG((USBx), (bEpChNum)); \
+    } \
+  } while(0) /* USB_DRD_CLEAR_RX_DTOG */
+
+#define USB_DRD_CLEAR_TX_DTOG(USBx, bEpChNum) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    _wRegVal = USB_DRD_GET_CHEP((USBx), (bEpChNum)); \
+    \
+    if ((_wRegVal & USB_CHEP_DTOG_TX) != 0U) \
+    { \
+      USB_DRD_TX_DTOG((USBx), (bEpChNum)); \
+    } \
+  } while(0) /* USB_DRD_CLEAR_TX_DTOG */
+
+
+/**
+  * @brief  Sets address in an endpoint register.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  bAddr Address.
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_ADDRESS(USBx, bEpChNum, bAddr) \
+  do { \
+    uint32_t _wRegVal; \
+    \
+    /*Read the USB->CHEPx into _wRegVal, Reset(DTOGRX/STRX/DTOGTX/STTX) and set the EpAddress*/ \
+    _wRegVal = (USB_DRD_GET_CHEP((USBx), (bEpChNum)) & USB_CHEP_REG_MASK) | (bAddr); \
+    \
+    /*Set _wRegVal in USB->CHEPx and set Transmit/Receive Valid Transfer  (x=bEpChNum)*/ \
+    USB_DRD_SET_CHEP((USBx), (bEpChNum), (_wRegVal | USB_CHEP_VTRX | USB_CHEP_VTTX)); \
+  } while(0) /* USB_DRD_SET_CHEP_ADDRESS */
+
+
+/* PMA API Buffer Descriptor Management ------------------------------------------------------------*/
+/* Buffer Descriptor Table   TXBD0/RXBD0 --- > TXBD7/RXBD7  8 possible descriptor
+* The buffer descriptor is located inside the packet buffer memory (USB_PMA_BUFF)
+*          TXBD    [Reserve         |Countx| Address_Tx]
+*          RXBD    [BLSIEZ|NUM_Block |CounRx| Address_Rx] */
+
+/* Set TX Buffer Descriptor Address Field */
+#define USB_DRD_SET_CHEP_TX_ADDRESS(USBx, bEpChNum, wAddr) \
+  do { \
+    /* Reset old Address */ \
+    (USB_DRD_PMA_BUFF + (bEpChNum))->TXBD &= USB_PMA_TXBD_ADDMSK; \
+    \
+    /* Bit0 & Bit1 should be =0 PMA must be Word aligned */ \
+    (USB_DRD_PMA_BUFF + (bEpChNum))->TXBD |= (uint32_t)(((uint32_t)(wAddr) >> 2U) << 2U); \
+  } while(0) /* USB_DRD_SET_CHEP_TX_ADDRESS */
+
+/* Set RX Buffer Descriptor Address Field */
+#define USB_DRD_SET_CHEP_RX_ADDRESS(USBx, bEpChNum, wAddr) \
+  do { \
+    /* Reset old Address */ \
+    (USB_DRD_PMA_BUFF + (bEpChNum))->RXBD &= USB_PMA_RXBD_ADDMSK; \
+    \
+    /* Bit0 & Bit1 should be =0 PMA must be Word aligned */ \
+    (USB_DRD_PMA_BUFF + (bEpChNum))->RXBD |= (uint32_t)(((uint32_t)(wAddr) >> 2U) << 2U); \
+  } while(0) /* USB_SET_CHEP_RX_ADDRESS */
+
+
+/**
+  * @brief  Sets counter of rx buffer with no. of blocks.
+  * @param  pdwReg Register pointer
+  * @param  wCount Counter.
+  * @param  wNBlocks no. of Blocks.
+  * @retval None
+  */
+#define USB_DRD_CALC_BLK32(pdwReg, wCount, wNBlocks) \
+  do { \
+    /* Divide PacketSize by 32 to calculate the Nb of Block32 */ \
+    (wNBlocks) =((uint32_t)(wCount) >> 5U); \
+    if (((uint32_t)(wCount) % 32U) == 0U)  \
+    { \
+      (wNBlocks)--; \
+    } \
+    \
+    (pdwReg)|= (uint32_t)((((wNBlocks) << 26U)) | USB_CNTRX_BLSIZE); \
+  } while(0) /* USB_DRD_CALC_BLK32 */
+
+#define USB_DRD_CALC_BLK2(pdwReg, wCount, wNBlocks) \
+  do { \
+    /* Divide PacketSize by 32 to calculate the Nb of Block32 */ \
+    (wNBlocks) = (uint32_t)((uint32_t)(wCount) >> 1U); \
+    if (((wCount) & 0x1U) != 0U) \
+    { \
+      (wNBlocks)++; \
+    } \
+    (pdwReg) |= (uint32_t)((wNBlocks) << 26U); \
+  } while(0) /* USB_DRD_CALC_BLK2 */
+
+#define USB_DRD_SET_CHEP_CNT_RX_REG(pdwReg, wCount) \
+  do { \
+    uint32_t wNBlocks; \
+    \
+    (pdwReg) &= USB_PMA_RXBD_COUNTMSK; \
+    if ((wCount) == 0U) \
+    { \
+      (pdwReg) &= (uint32_t)~USB_CNTRX_NBLK_MSK; \
+      (pdwReg) |= USB_CNTRX_BLSIZE; \
+    } \
+    else if((wCount) <= 62U) \
+    { \
+      USB_DRD_CALC_BLK2((pdwReg), (wCount), wNBlocks); \
+    } \
+    else \
+    { \
+      USB_DRD_CALC_BLK32((pdwReg), (wCount), wNBlocks); \
+    } \
+  } while(0) /* USB_DRD_SET_CHEP_CNT_RX_REG */
+
+
+/**
+  * @brief  sets counter for the tx/rx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  wCount Counter value.
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_TX_CNT(USBx,bEpChNum, wCount) \
+  do { \
+    /* Reset old TX_Count value */ \
+    (USB_DRD_PMA_BUFF + (bEpChNum))->TXBD &= USB_PMA_TXBD_COUNTMSK; \
+    \
+    /* Set the wCount in the dedicated EP_TXBuffer */ \
+    (USB_DRD_PMA_BUFF + (bEpChNum))->TXBD |= (uint32_t)((uint32_t)(wCount) << 16U); \
+  } while(0)
+
+
+#define USB_DRD_SET_CHEP_RX_DBUF0_CNT(USBx, bEpChNum, wCount)      USB_DRD_SET_CHEP_CNT_RX_REG(((USB_DRD_PMA_BUFF + (bEpChNum))->TXBD), (wCount))
+#define USB_DRD_SET_CHEP_RX_CNT(USBx, bEpChNum, wCount)            USB_DRD_SET_CHEP_CNT_RX_REG(((USB_DRD_PMA_BUFF + (bEpChNum))->RXBD), (wCount))
+
+
+/**
+  * @brief  gets counter of the tx buffer.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval Counter value
+  */
+#define USB_DRD_GET_CHEP_TX_CNT(USBx, bEpChNum)           (((USB_DRD_PMA_BUFF + (bEpChNum))->TXBD & 0x03FF0000U) >>16U)
+#define USB_DRD_GET_CHEP_RX_CNT(USBx, bEpChNum)           (((USB_DRD_PMA_BUFF + (bEpChNum))->RXBD & 0x03FF0000U) >>16U)
+
+#define USB_DRD_GET_EP_TX_CNT                             USB_GET_CHEP_TX_CNT
+#define USB_DRD_GET_CH_TX_CNT                             USB_GET_CHEP_TX_CNT
+
+#define USB_DRD_GET_EP_RX_CNT                             USB_DRD_GET_CHEP_RX_CNT
+#define USB_DRD_GET_CH_RX_CNT                             USB_DRD_GET_CHEP_RX_CNT
+/**
+  * @brief  Sets buffer 0/1 address in a double buffer endpoint.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  wBuf0Addr buffer 0 address.
+  * @retval Counter value
+  */
+#define USB_DRD_SET_CHEP_DBUF0_ADDR(USBx, bEpChNum, wBuf0Addr)    USB_DRD_SET_CHEP_TX_ADDRESS((USBx), (bEpChNum), (wBuf0Addr))
+#define USB_DRD_SET_CHEP_DBUF1_ADDR(USBx, bEpChNum, wBuf1Addr)    USB_DRD_SET_CHEP_RX_ADDRESS((USBx), (bEpChNum), (wBuf1Addr))
+
+
+/**
+  * @brief  Sets addresses in a double buffer endpoint.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  wBuf0Addr: buffer 0 address.
+  * @param  wBuf1Addr = buffer 1 address.
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_DBUF_ADDR(USBx, bEpChNum, wBuf0Addr, wBuf1Addr) \
+  do { \
+    USB_DRD_SET_CHEP_DBUF0_ADDR((USBx), (bEpChNum), (wBuf0Addr)); \
+    USB_DRD_SET_CHEP_DBUF1_ADDR((USBx), (bEpChNum), (wBuf1Addr)); \
+  } while(0) /* USB_DRD_SET_CHEP_DBUF_ADDR */
+
+
+/**
+  * @brief  Gets buffer 0/1 address of a double buffer endpoint.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @param  bDir endpoint dir  EP_DBUF_OUT = OUT
+  *         EP_DBUF_IN  = IN
+  * @param  wCount: Counter value
+  * @retval None
+  */
+#define USB_DRD_SET_CHEP_DBUF0_CNT(USBx, bEpChNum, bDir, wCount) \
+  do { \
+    if ((bDir) == 0U) \
+    { \
+      /* OUT endpoint */ \
+      USB_DRD_SET_CHEP_RX_DBUF0_CNT((USBx), (bEpChNum), (wCount)); \
+    } \
+    else \
+    { \
+      if ((bDir) == 1U) \
+      { \
+        /* IN endpoint */ \
+        USB_DRD_SET_CHEP_TX_CNT((USBx), (bEpChNum), (wCount)); \
+      } \
+    } \
+  } while(0) /* USB_DRD_SET_CHEP_DBUF0_CNT */
+
+#define USB_DRD_SET_CHEP_DBUF1_CNT(USBx, bEpChNum, bDir, wCount) \
+  do { \
+    if ((bDir) == 0U) \
+    { \
+      /* OUT endpoint */ \
+      USB_DRD_SET_CHEP_RX_CNT((USBx), (bEpChNum), (wCount)); \
+    } \
+    else \
+    { \
+      if ((bDir) == 1U) \
+      { \
+        /* IN endpoint */ \
+        (USB_DRD_PMA_BUFF + (bEpChNum))->RXBD &= USB_PMA_TXBD_COUNTMSK; \
+        (USB_DRD_PMA_BUFF + (bEpChNum))->RXBD |= (uint32_t)((uint32_t)(wCount) << 16U); \
+      } \
+    } \
+  } while(0) /* USB_DRD_SET_CHEP_DBUF1_CNT */
+
+#define USB_DRD_SET_CHEP_DBUF_CNT(USBx, bEpChNum, bDir, wCount) \
+  do { \
+    USB_DRD_SET_CHEP_DBUF0_CNT((USBx), (bEpChNum), (bDir), (wCount)); \
+    USB_DRD_SET_CHEP_DBUF1_CNT((USBx), (bEpChNum), (bDir), (wCount)); \
+  } while(0) /* USB_DRD_SET_EPCH_DBUF_CNT  */
+
+/**
+  * @brief  Gets buffer 0/1 rx/tx counter for double buffering.
+  * @param  USBx USB peripheral instance register address.
+  * @param  bEpChNum Endpoint Number.
+  * @retval None
+  */
+#define USB_DRD_GET_CHEP_DBUF0_CNT(USBx, bEpChNum)     (USB_DRD_GET_CHEP_TX_CNT((USBx), (bEpChNum)))
+#define USB_DRD_GET_CHEP_DBUF1_CNT(USBx, bEpChNum)     (USB_DRD_GET_CHEP_RX_CNT((USBx), (bEpChNum)))
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup USB_LL_Exported_Functions USB Low Layer Exported Functions
+  * @{
+  */
+
+
+HAL_StatusTypeDef USB_CoreInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_DevInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_EnableGlobalInt(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_DisableGlobalInt(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_SetCurrentMode(USB_DRD_TypeDef *USBx, USB_DRD_ModeTypeDef mode);
+
+#if defined (HAL_PCD_MODULE_ENABLED)
+HAL_StatusTypeDef USB_ActivateEndpoint(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep);
+HAL_StatusTypeDef USB_DeactivateEndpoint(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPStartXfer(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPSetStall(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPClearStall(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep);
+#endif
+
+HAL_StatusTypeDef USB_SetDevAddress(USB_DRD_TypeDef *USBx, uint8_t address);
+HAL_StatusTypeDef USB_DevConnect(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_DevDisconnect(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_StopDevice(USB_DRD_TypeDef *USBx);
+uint32_t          USB_ReadInterrupts(USB_DRD_TypeDef *USBx);
+
+HAL_StatusTypeDef USB_ResetPort(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_HostInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_HC_IN_Halt(USB_DRD_TypeDef *USBx, uint8_t phy_ch);
+HAL_StatusTypeDef USB_HC_OUT_Halt(USB_DRD_TypeDef *USBx, uint8_t phy_ch);
+HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx, USB_DRD_HCTypeDef *hc);
+
+uint32_t          USB_GetHostSpeed(USB_DRD_TypeDef *USBx);
+uint32_t          USB_GetCurrentFrame(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_StopHost(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_HC_DoubleBuffer(USB_DRD_TypeDef *USBx, uint8_t phy_ch_num, uint8_t db_state);
+HAL_StatusTypeDef USB_HC_Init(USB_DRD_TypeDef *USBx, uint8_t phy_ch_num, uint8_t epnum,
+                              uint8_t dev_address, uint8_t speed, uint8_t ep_type, uint16_t mps);
+
+HAL_StatusTypeDef USB_ActivateRemoteWakeup(USB_DRD_TypeDef *USBx);
+HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_DRD_TypeDef *USBx);
+
+void              USB_WritePMA(USB_DRD_TypeDef *USBx, uint8_t *pbUsrBuf,
+                               uint16_t wPMABufAddr, uint16_t wNBytes);
+
+void              USB_ReadPMA(USB_DRD_TypeDef *USBx, uint8_t *pbUsrBuf,
+                              uint16_t wPMABufAddr, uint16_t wNBytes);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* defined (USB_DRD_FS) */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* STM32G0xx_LL_USB_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_utils.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_utils.h
@@ -152,12 +152,33 @@ typedef struct
 /** @defgroup UTILS_EC_PACKAGETYPE PACKAGE TYPE
   * @{
   */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define LL_UTILS_PACKAGETYPE_QFP100         0x00000000U /*!< LQFP100  package type                               */
+#define LL_UTILS_PACKAGETYPE_QFN32_GP       0x00000001U /*!< LQFP32/UFQFPN32 General purpose (GP)                */
+#define LL_UTILS_PACKAGETYPE_QFN32_N        0x00000002U /*!< LQFP32/UFQFPN32 N-version                           */
+#define LL_UTILS_PACKAGETYPE_QFN48_GP       0x00000004U /*!< LQFP48/UFQPN48 General purpose (GP)                 */
+#define LL_UTILS_PACKAGETYPE_QFN48_N        0x00000005U /*!< LQFP48/UFQPN48 N-version                            */
+#define LL_UTILS_PACKAGETYPE_WLCSP52        0x00000006U /*!< WLCSP52                                             */
+#define LL_UTILS_PACKAGETYPE_QFN64_GP       0x00000007U /*!< LQFP64 General purpose (GP)                         */
+#define LL_UTILS_PACKAGETYPE_QFN64_N        0x00000008U /*!< LQFP64 N-version                                    */
+#define LL_UTILS_PACKAGETYPE_BGA64_N        0x0000000AU /*!< UFBGA64 N-version                                   */
+#define LL_UTILS_PACKAGETYPE_QFP80          0x0000000BU /*!< LQFP80  package type                                */
+#define LL_UTILS_PACKAGETYPE_BGA100         0x0000000CU /*!< UBGA100  package type                               */
+#elif defined(STM32G061xx) || defined(STM32G051xx) || defined(STM32G050xx) || defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#define LL_UTILS_PACKAGETYPE_SO8            0x00000001U /*!< SO8 package type                                    */
+#define LL_UTILS_PACKAGETYPE_WLCSP18        0x00000002U /*!< WLCSP18 package type                                */
+#define LL_UTILS_PACKAGETYPE_TSSOP20        0x00000003U /*!< TSSOP20 package type                                */
+#define LL_UTILS_PACKAGETYPE_QFP28          0x00000004U /*!< UFQFPN28 package type                               */
+#define LL_UTILS_PACKAGETYPE_QFN32          0x00000005U /*!< UFQFPN32 / LQFP32 package type                      */
+#define LL_UTILS_PACKAGETYPE_QFN48          0x00000007U /*!< UFQFPN48 / LQFP48 package type                      */
+#elif defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
 #define LL_UTILS_PACKAGETYPE_QFN28_GP       0x00000000U /*!< UFQFPN28 general purpose (GP) package type          */
 #define LL_UTILS_PACKAGETYPE_QFN28_PD       0x00000001U /*!< UFQFPN28 Power Delivery (PD)                        */
 #define LL_UTILS_PACKAGETYPE_QFN32_GP       0x00000004U /*!< UFQFPN32 / LQFP32 general purpose (GP) package type */
 #define LL_UTILS_PACKAGETYPE_QFN32_PD       0x00000005U /*!< UFQFPN32 / LQFP32 Power Delivery (PD) package type  */
 #define LL_UTILS_PACKAGETYPE_QFN48          0x00000008U /*!< UFQFPN48 / LQFP488 package type                     */
-#define LL_UTILS_PACKAGETYPE_QFP64          0x0000000CU /*!< LQPF648 package type                                */
+#define LL_UTILS_PACKAGETYPE_QFP64          0x0000000CU /*!< LQPF64 package type                                 */
+#endif
 /**
   * @}
   */
@@ -217,18 +238,43 @@ __STATIC_INLINE uint32_t LL_GetFlashSize(void)
 
 /**
   * @brief  Get Package type
-  * @retval Returned value can be one of the following values:
+  * @retval PKG[3:0]: Package type - This parameter can be a value of @ref UTILS_EC_PACKAGETYPE
+  * @if defined(STM32G0C1xx)
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFP100
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN32_GP
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN32_N
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN48_GP
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN48_N
+  *         @arg @ref LL_UTILS_PACKAGETYPE_WLCSP52
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN64_GP
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN64_N
+  *         @arg @ref LL_UTILS_PACKAGETYPE_BGA64_N
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFP80
+  *         @arg @ref LL_UTILS_PACKAGETYPE_BGA100
+  * @elif defined(STM32G061xx) || defined(STM32G041xx)
+  *         @arg @ref LL_UTILS_PACKAGETYPE_SO8
+  *         @arg @ref LL_UTILS_PACKAGETYPE_WLCSP18
+  *         @arg @ref LL_UTILS_PACKAGETYPE_TSSOP20
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFP28
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN32
+  *         @arg @ref LL_UTILS_PACKAGETYPE_QFN48
+  * @elif defined(STM32G081xx)
   *         @arg @ref LL_UTILS_PACKAGETYPE_QFN28_GP
   *         @arg @ref LL_UTILS_PACKAGETYPE_QFN28_PD
   *         @arg @ref LL_UTILS_PACKAGETYPE_QFN32_GP
   *         @arg @ref LL_UTILS_PACKAGETYPE_QFN32_PD
   *         @arg @ref LL_UTILS_PACKAGETYPE_QFN48
   *         @arg @ref LL_UTILS_PACKAGETYPE_QFP64
+  * @endif
   *
   */
 __STATIC_INLINE uint32_t LL_GetPackageType(void)
 {
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+  return (uint32_t)(READ_REG(*((uint32_t *)PACKAGE_BASE_ADDRESS)) & 0x1FU);
+#else
   return (uint32_t)(READ_REG(*((uint32_t *)PACKAGE_BASE_ADDRESS)) & 0xFU);
+#endif
 }
 
 /**
@@ -272,7 +318,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
                                          LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypass,
                                          LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
-ErrorStatus LL_SetFlashLatency(uint32_t HCLK_Frequency);
+ErrorStatus LL_SetFlashLatency(uint32_t HCLKFrequency);
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_wwdg.h
+++ b/stm32cube/stm32g0xx/drivers/include/stm32g0xx_ll_wwdg.h
@@ -33,6 +33,7 @@ extern "C" {
   */
 
 #if defined (WWDG)
+
 /** @defgroup WWDG_LL WWDG
   * @{
   */
@@ -57,8 +58,8 @@ extern "C" {
   */
 
 /** @defgroup WWDG_LL_EC_PRESCALER  PRESCALER
-* @{
-*/
+  * @{
+  */
 #define LL_WWDG_PRESCALER_1                 0x00000000u                                               /*!< WWDG counter clock = (PCLK1/4096)/1 */
 #define LL_WWDG_PRESCALER_2                 WWDG_CFR_WDGTB_0                                          /*!< WWDG counter clock = (PCLK1/4096)/2 */
 #define LL_WWDG_PRESCALER_4                 WWDG_CFR_WDGTB_1                                          /*!< WWDG counter clock = (PCLK1/4096)/4 */
@@ -182,7 +183,7 @@ __STATIC_INLINE uint32_t LL_WWDG_GetCounter(WWDG_TypeDef *WWDGx)
   *         @arg @ref LL_WWDG_PRESCALER_32
   *         @arg @ref LL_WWDG_PRESCALER_64
   *         @arg @ref LL_WWDG_PRESCALER_128
-* @retval None
+  * @retval None
   */
 __STATIC_INLINE void LL_WWDG_SetPrescaler(WWDG_TypeDef *WWDGx, uint32_t Prescaler)
 {

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal.c
@@ -53,10 +53,10 @@
   * @{
   */
 /**
- * @brief STM32G0xx HAL Driver version number
-   */
+  * @brief STM32G0xx HAL Driver version number
+  */
 #define __STM32G0xx_HAL_VERSION_MAIN   (0x01U) /*!< [31:24] main version */
-#define __STM32G0xx_HAL_VERSION_SUB1   (0x03U) /*!< [23:16] sub1 version */
+#define __STM32G0xx_HAL_VERSION_SUB1   (0x04U) /*!< [23:16] sub1 version */
 #define __STM32G0xx_HAL_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
 #define __STM32G0xx_HAL_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
 #define __STM32G0xx_HAL_VERSION         ((__STM32G0xx_HAL_VERSION_MAIN << 24U)\
@@ -79,7 +79,7 @@
   */
 __IO uint32_t uwTick;
 uint32_t uwTickPrio = (1UL << __NVIC_PRIO_BITS); /* Invalid PRIO */
-uint32_t uwTickFreq = HAL_TICK_FREQ_DEFAULT;  /* 1KHz */
+HAL_TickFreqTypeDef uwTickFreq = HAL_TICK_FREQ_DEFAULT;  /* 1KHz */
 /**
   * @}
   */
@@ -241,10 +241,11 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
   HAL_StatusTypeDef  status = HAL_OK;
 
-  if (uwTickFreq != 0U)
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that doesn't take the value zero)*/
+  if ((uint32_t)uwTickFreq != 0U)
   {
     /*Configure the SysTick to have interrupt in 1ms time basis*/
-    if (HAL_SYSTICK_Config(SystemCoreClock / (1000U /uwTickFreq)) == 0U)
+    if (HAL_SYSTICK_Config(SystemCoreClock / (1000U /(uint32_t)uwTickFreq)) == 0U)
     {
       /* Configure the SysTick IRQ priority */
       if (TickPriority < (1UL << __NVIC_PRIO_BITS))
@@ -306,7 +307,7 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   */
 __weak void HAL_IncTick(void)
 {
-  uwTick += uwTickFreq;
+  uwTick += (uint32_t)uwTickFreq;
 }
 
 /**
@@ -333,18 +334,26 @@ uint32_t HAL_GetTickPrio(void)
   * @brief Set new tick Freq.
   * @retval status
   */
-HAL_StatusTypeDef HAL_SetTickFreq(uint32_t Freq)
+HAL_StatusTypeDef HAL_SetTickFreq(HAL_TickFreqTypeDef Freq)
 {
   HAL_StatusTypeDef status  = HAL_OK;
+  HAL_TickFreqTypeDef prevTickFreq;
   assert_param(IS_TICKFREQ(Freq));
 
   if (uwTickFreq != Freq)
   {
+    /* Back up uwTickFreq frequency */
+    prevTickFreq = uwTickFreq;
+
+    /* Update uwTickFreq global variable used by HAL_InitTick() */
+    uwTickFreq = Freq;
+
     /* Apply the new tick Freq  */
     status = HAL_InitTick(uwTickPrio);
-    if (status == HAL_OK)
+    if (status != HAL_OK)
     {
-      uwTickFreq = Freq;
+      /* Restore previous tick frequency */
+      uwTickFreq = prevTickFreq;
     }
   }
 
@@ -355,7 +364,7 @@ HAL_StatusTypeDef HAL_SetTickFreq(uint32_t Freq)
   * @brief return tick frequency.
   * @retval tick period in Hz
   */
-uint32_t HAL_GetTickFreq(void)
+HAL_TickFreqTypeDef HAL_GetTickFreq(void)
 {
   return uwTickFreq;
 }
@@ -584,6 +593,11 @@ void HAL_SYSCFG_VREFBUF_HighImpedanceConfig(uint32_t Mode)
 
 /**
   * @brief  Tune the Internal Voltage Reference buffer (VREFBUF).
+  * @note   VrefBuf voltage scale is calibrated in production for each device,
+  *         using voltage scale 1. This calibration value is loaded
+  *         as default trimming value at device power up.
+  *         This trimming value can be fine tuned for voltage scales 0 and 1
+  *         using this function.
   * @retval None
   */
 void HAL_SYSCFG_VREFBUF_TrimmingConfig(uint32_t TrimmingValue)
@@ -678,7 +692,7 @@ void HAL_SYSCFG_DisableRemap(uint32_t PinRemap)
   CLEAR_BIT(SYSCFG->CFGR1, PinRemap);
 }
 
-#if defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#if defined(SYSCFG_CDEN_SUPPORT)
 /**
   * @brief  Enable Clamping Diode on specified IO
   * @param  PinConfig specifies on which pins clamping Diode has to be enabled
@@ -706,7 +720,7 @@ void HAL_SYSCFG_DisableClampingDiode(uint32_t PinConfig)
   assert_param(IS_SYSCFG_CLAMPINGDIODE(PinConfig));
   CLEAR_BIT(SYSCFG->CFGR2, PinConfig);
 }
-#endif
+#endif /* SYSCFG_CDEN_SUPPORT */
 
 #if defined (SYSCFG_CFGR1_UCPD1_STROBE) || defined (SYSCFG_CFGR1_UCPD2_STROBE)
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_adc.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_adc.c
@@ -3,7 +3,7 @@
   * @file    stm32g0xx_hal_adc.c
   * @author  MCD Application Team
   * @brief   This file provides firmware functions to manage the following
-  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          functionalities of the Analog to Digital Converter (ADC)
   *          peripheral:
   *           + Initialization and de-initialization functions
   *             ++ Initialization and Configuration of ADC
@@ -322,7 +322,8 @@
 #define ADC_CHANNEL_CONF_RDY_TIMEOUT    (1UL)
 
 /* Register CHSELR bits corresponding to ranks 2 to 8 .                     */
-#define ADC_CHSELR_SQ2_TO_SQ8           (ADC_CHSELR_SQ2 | ADC_CHSELR_SQ3 | ADC_CHSELR_SQ4 | ADC_CHSELR_SQ5 | ADC_CHSELR_SQ6 | ADC_CHSELR_SQ7 | ADC_CHSELR_SQ8)
+#define ADC_CHSELR_SQ2_TO_SQ8           (ADC_CHSELR_SQ2 | ADC_CHSELR_SQ3 | ADC_CHSELR_SQ4 | \
+                                         ADC_CHSELR_SQ5 | ADC_CHSELR_SQ6 | ADC_CHSELR_SQ7 | ADC_CHSELR_SQ8)
 
 /**
   * @}
@@ -383,7 +384,7 @@ static void ADC_DMAError(DMA_HandleTypeDef *hdma);
   * @param hadc ADC handle
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmpCFGR1 = 0UL;
@@ -392,7 +393,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
   __IO uint32_t wait_loop_index = 0UL;
 
   /* Check ADC handle */
-  if(hadc == NULL)
+  if (hadc == NULL)
   {
     return HAL_ERROR;
   }
@@ -417,11 +418,11 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 
   assert_param(IS_ADC_TRIGGER_FREQ(hadc->Init.TriggerFrequencyMode));
 
-  if(hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  if (hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
   {
     assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
 
-    if(hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
+    if (hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
     {
       assert_param(IS_ADC_REGULAR_NB_CONV(hadc->Init.NbrOfConversion));
     }
@@ -433,7 +434,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 
   /* Actions performed only if ADC is coming from state reset:                */
   /* - Initialization of ADC MSP                                              */
-  if(hadc->State == HAL_ADC_STATE_RESET)
+  if (hadc->State == HAL_ADC_STATE_RESET)
   {
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
     /* Init the ADC Callback settings */
@@ -464,7 +465,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     hadc->Lock = HAL_UNLOCKED;
   }
 
-  if(LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
+  if (LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
   {
     /* Enable ADC internal voltage regulator */
     LL_ADC_EnableInternalRegulator(hadc->Instance);
@@ -475,7 +476,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     /*       CPU processing cycles, scaling in us split to not          */
     /*       exceed 32 bits register capacity and handle low frequency. */
     wait_loop_index = ((LL_ADC_DELAY_INTERNAL_REGUL_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL)));
-    while(wait_loop_index != 0UL)
+    while (wait_loop_index != 0UL)
     {
       wait_loop_index--;
     }
@@ -484,7 +485,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
   /* Verification that ADC voltage regulator is correctly enabled, whether    */
   /* or not ADC is coming from state reset (if any potential problem of       */
   /* clocking, voltage regulator would not be enabled).                       */
-  if(LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
+  if (LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
   {
     /* Update ADC state machine to error */
     SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
@@ -501,9 +502,9 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
   /* called to update a parameter on the fly).                                */
   tmp_adc_reg_is_conversion_on_going = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
 
-  if(   ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
-     && (tmp_adc_reg_is_conversion_on_going == 0UL)
-    )
+  if (((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
+      && (tmp_adc_reg_is_conversion_on_going == 0UL)
+     )
   {
     /* Set ADC state */
     ADC_STATE_CLR_SET(hadc->State,
@@ -517,6 +518,8 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     /*  - Internal voltage regulator (no parameter in HAL ADC init structure) */
     /*  - Clock configuration                                                 */
     /*  - ADC resolution                                                      */
+    /*  - Oversampling                                                        */
+    /*  - Trigger frequency mode                                              */
     /* Note: If low power mode AutoPowerOff is enabled, ADC enable            */
     /*       and disable phases are performed automatically by hardware       */
     /*       (in this case, flag ADC_FLAG_RDY is not set).                    */
@@ -532,22 +535,39 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 
       /* Configuration of ADC resolution                                      */
       MODIFY_REG(hadc->Instance->CFGR1,
-                 ADC_CFGR1_RES        ,
-                 hadc->Init.Resolution );
+                 ADC_CFGR1_RES,
+                 hadc->Init.Resolution);
 
-      /* Configuration of ADC clock mode: clock source AHB or HSI with        */
-      /* selectable prescaler.                                                */
-      MODIFY_REG(hadc->Instance->CFGR2                       ,
-                 ADC_CFGR2_CKMODE                            ,
-                 hadc->Init.ClockPrescaler & ADC_CFGR2_CKMODE );
+      tmpCFGR2 |= ((hadc->Init.ClockPrescaler & ADC_CFGR2_CKMODE) |
+                   hadc->Init.Oversampling.Ratio         |
+                   hadc->Init.Oversampling.RightBitShift |
+                   hadc->Init.Oversampling.TriggeredMode |
+                   hadc->Init.TriggerFrequencyMode
+                  );
 
+      if (hadc->Init.OversamplingMode == ENABLE)
+      {
+        SET_BIT(tmpCFGR2, ADC_CFGR2_OVSE);
+      }
+
+      MODIFY_REG(hadc->Instance->CFGR2,
+                 ADC_CFGR2_CKMODE |
+                 ADC_CFGR2_LFTRIG |
+                 ADC_CFGR2_OVSE   |
+                 ADC_CFGR2_OVSR   |
+                 ADC_CFGR2_OVSS   |
+                 ADC_CFGR2_TOVS,
+                 tmpCFGR2);
+
+      /* Configuration of ADC clock mode: asynchronous clock source           */
+      /* with selectable prescaler.                                           */
       if (((hadc->Init.ClockPrescaler) != ADC_CLOCK_SYNC_PCLK_DIV1) &&
           ((hadc->Init.ClockPrescaler) != ADC_CLOCK_SYNC_PCLK_DIV2) &&
           ((hadc->Init.ClockPrescaler) != ADC_CLOCK_SYNC_PCLK_DIV4))
       {
-        MODIFY_REG(ADC1_COMMON->CCR                         ,
-                   ADC_CCR_PRESC                            ,
-                   hadc->Init.ClockPrescaler & ADC_CCR_PRESC );
+        MODIFY_REG(ADC1_COMMON->CCR,
+                   ADC_CCR_PRESC,
+                   hadc->Init.ClockPrescaler & ADC_CCR_PRESC);
       }
     }
 
@@ -563,13 +583,13 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     /*  - resolution                                                          */
     /*  - scan direction                                                      */
     /*  - DMA continuous request                                              */
-    tmpCFGR1 |= (ADC_CFGR1_AUTOWAIT((uint32_t)hadc->Init.LowPowerAutoWait)        |
-                 ADC_CFGR1_AUTOOFF((uint32_t)hadc->Init.LowPowerAutoPowerOff)     |
-                 ADC_CFGR1_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)    |
-                 ADC_CFGR1_OVERRUN(hadc->Init.Overrun)                            |
-                 hadc->Init.DataAlign                                             |
-                 ADC_SCAN_SEQ_MODE(hadc->Init.ScanConvMode)                       |
-                 ADC_CFGR1_DMACONTREQ((uint32_t)hadc->Init.DMAContinuousRequests)  );
+    tmpCFGR1 |= (ADC_CFGR1_AUTOWAIT((uint32_t)hadc->Init.LowPowerAutoWait)      |
+                 ADC_CFGR1_AUTOOFF((uint32_t)hadc->Init.LowPowerAutoPowerOff)   |
+                 ADC_CFGR1_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)  |
+                 ADC_CFGR1_OVERRUN(hadc->Init.Overrun)                          |
+                 hadc->Init.DataAlign                                           |
+                 ADC_SCAN_SEQ_MODE(hadc->Init.ScanConvMode)                     |
+                 ADC_CFGR1_DMACONTREQ((uint32_t)hadc->Init.DMAContinuousRequests));
 
     /* Update setting of discontinuous mode only if continuous mode is disabled */
     if (hadc->Init.DiscontinuousConvMode == ENABLE)
@@ -600,25 +620,8 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     /*       software start.                                                  */
     if (hadc->Init.ExternalTrigConv != ADC_SOFTWARE_START)
     {
-      tmpCFGR1 |= ( (hadc->Init.ExternalTrigConv & ADC_CFGR1_EXTSEL) |
-                     hadc->Init.ExternalTrigConvEdge );
-    }
-
-    /* Configuration of ADC:                                                  */
-    /*  - oversampling enable                                                 */
-    /*  - oversampling ratio                                                  */
-    /*  - oversampling shift                                                  */
-    /*  - oversampling discontinuous mode (triggered mode)                    */
-    /*  - trigger frequency mode                                              */
-    tmpCFGR2 |= ( hadc->Init.Oversampling.Ratio         |
-                  hadc->Init.Oversampling.RightBitShift |
-                  hadc->Init.Oversampling.TriggeredMode |
-                  hadc->Init.TriggerFrequencyMode
-                  );
-
-    if (hadc->Init.OversamplingMode == ENABLE)
-    {
-      SET_BIT(tmpCFGR2, ADC_CFGR2_OVSE);
+      tmpCFGR1 |= ((hadc->Init.ExternalTrigConv & ADC_CFGR1_EXTSEL) |
+                   hadc->Init.ExternalTrigConvEdge);
     }
 
     /* Update ADC configuration register with previous settings */
@@ -632,16 +635,16 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
                ADC_CFGR1_EXTEN   |
                ADC_CFGR1_ALIGN   |
                ADC_CFGR1_SCANDIR |
-               ADC_CFGR1_DMACFG     ,
-               tmpCFGR1              );
+               ADC_CFGR1_DMACFG,
+               tmpCFGR1);
 
     MODIFY_REG(hadc->Instance->CFGR2,
                ADC_CFGR2_LFTRIG |
                ADC_CFGR2_OVSE   |
                ADC_CFGR2_OVSR   |
                ADC_CFGR2_OVSS   |
-               ADC_CFGR2_TOVS       ,
-               tmpCFGR2              );
+               ADC_CFGR2_TOVS,
+               tmpCFGR2);
 
     /* Channel sampling time configuration */
     LL_ADC_SetSamplingTimeCommonChannels(hadc->Instance, LL_ADC_SAMPLINGTIME_COMMON_1, hadc->Init.SamplingTimeCommon1);
@@ -657,29 +660,30 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     /*   parameter "NbrOfConversion".                                         */
     /*   Channels must be configured into each rank using function            */
     /*   "HAL_ADC_ConfigChannel()".                                           */
-    if(hadc->Init.ScanConvMode == ADC_SCAN_DISABLE)
+    if (hadc->Init.ScanConvMode == ADC_SCAN_DISABLE)
     {
       /* Set sequencer scan length by clearing ranks above rank 1             */
       /* and do not modify rank 1 value.                                      */
       SET_BIT(hadc->Instance->CHSELR,
               ADC_CHSELR_SQ2_TO_SQ8);
     }
-    else if(hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
+    else if (hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
     {
       /* Count number of ranks available in HAL ADC handle variable */
       uint32_t ADCGroupRegularSequencerRanksCount;
 
       /* Parse all ranks from 1 to 8 */
-      for(ADCGroupRegularSequencerRanksCount = 0UL; ADCGroupRegularSequencerRanksCount < (8UL); ADCGroupRegularSequencerRanksCount++)
+      for (ADCGroupRegularSequencerRanksCount = 0UL; ADCGroupRegularSequencerRanksCount < (8UL); ADCGroupRegularSequencerRanksCount++)
       {
         /* Check each sequencer rank until value of end of sequence */
-        if(((hadc->ADCGroupRegularSequencerRanks >> (ADCGroupRegularSequencerRanksCount * 4UL)) & ADC_CHSELR_SQ1) == ADC_CHSELR_SQ1)
+        if (((hadc->ADCGroupRegularSequencerRanks >> (ADCGroupRegularSequencerRanksCount * 4UL)) & ADC_CHSELR_SQ1) ==
+            ADC_CHSELR_SQ1)
         {
           break;
         }
       }
 
-      if(ADCGroupRegularSequencerRanksCount == 1UL)
+      if (ADCGroupRegularSequencerRanksCount == 1UL)
       {
         /* Set ADC group regular sequencer:                                   */
         /* Set sequencer scan length by clearing ranks above rank 1           */
@@ -693,7 +697,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
         /*  - Set ADC group regular sequencer to value memorized              */
         /*    in HAL ADC handle                                               */
         /*    Note: This value maybe be initialized at a unknown value,       */
-        /*          therefore afer the first call of "HAL_ADC_Init()",        */
+        /*          therefore after the first call of "HAL_ADC_Init()",       */
         /*          each rank corresponding to parameter "NbrOfConversion"    */
         /*          must be set using "HAL_ADC_ConfigChannel()".              */
         /*  - Set sequencer scan length by clearing ranks above maximum rank  */
@@ -711,7 +715,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
     /* set into separate dedicated function, and bits of ADC resolution set   */
     /* out of temporary variable 'tmpCFGR1').                                 */
     if ((hadc->Instance->CFGR1 & ~(ADC_CFGR1_AWD1CH | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL | ADC_CFGR1_RES))
-         == tmpCFGR1)
+        == tmpCFGR1)
     {
       /* Set ADC error code to none */
       ADC_CLEAR_ERRORCODE(hadc);
@@ -765,12 +769,12 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
   /* Check ADC handle */
-  if(hadc == NULL)
+  if (hadc == NULL)
   {
     return HAL_ERROR;
   }
@@ -796,6 +800,9 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
       /* Change ADC state */
       hadc->State = HAL_ADC_STATE_READY;
     }
+
+    /* Disable ADC internal voltage regulator */
+    LL_ADC_DisableInternalRegulator(hadc->Instance);
   }
 
   /* Note: HAL ADC deInit is done independently of ADC conversion stop        */
@@ -809,13 +816,13 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
   __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 |
                               ADC_IT_AWD1  | ADC_IT_OVR  |
                               ADC_IT_EOS   | ADC_IT_EOC  |
-                              ADC_IT_EOSMP | ADC_IT_RDY   ) );
+                              ADC_IT_EOSMP | ADC_IT_RDY));
 
   /* Reset register ISR */
   __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD3  | ADC_FLAG_AWD2 |
                               ADC_FLAG_AWD1  | ADC_FLAG_OVR  |
                               ADC_FLAG_EOS   | ADC_FLAG_EOC  |
-                              ADC_FLAG_EOSMP | ADC_FLAG_RDY   ) );
+                              ADC_FLAG_EOSMP | ADC_FLAG_RDY));
 
   /* Reset register CR */
   /* Bits ADC_CR_ADCAL, ADC_CR_ADSTP, ADC_CR_ADSTART are in access mode     */
@@ -825,7 +832,7 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
   hadc->Instance->CFGR1 &= ~(ADC_CFGR1_AWD1CH   | ADC_CFGR1_AWD1EN  | ADC_CFGR1_AWD1SGL | ADC_CFGR1_DISCEN |
                              ADC_CFGR1_AUTOFF  | ADC_CFGR1_WAIT   | ADC_CFGR1_CONT   | ADC_CFGR1_OVRMOD |
                              ADC_CFGR1_EXTEN   | ADC_CFGR1_EXTSEL | ADC_CFGR1_ALIGN  | ADC_CFGR1_RES    |
-                             ADC_CFGR1_SCANDIR | ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN                      );
+                             ADC_CFGR1_SCANDIR | ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN);
 
   /* Reset register CFGR2 */
   /* Note: Update of ADC clock mode is conditioned to ADC state disabled:   */
@@ -851,7 +858,7 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
   /* Performs a global reset of the entire ADC peripheral: ADC state is     */
   /* forced to a similar state after device power-on.                       */
   /* If needed, copy-paste and uncomment the following reset code into      */
-  /* function "void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)":              */
+  /* function "void HAL_ADC_MspDeInit(ADC_HandleTypeDef *hadc)":            */
   /*                                                                        */
   /*  __HAL_RCC_ADC1_FORCE_RESET()                                          */
   /*  __HAL_RCC_ADC1_RELEASE_RESET()                                        */
@@ -890,7 +897,7 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -907,7 +914,7 @@ __weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
   *         the core clock reset all ADC instances).
   * @retval None
   */
-__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -939,7 +946,8 @@ __weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID,
+                                           pADC_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -1146,8 +1154,8 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
   */
 
 /** @defgroup ADC_Exported_Functions_Group2 ADC Input and Output operation functions
- *  @brief    ADC IO operation functions
- *
+  *  @brief    ADC IO operation functions
+  *
 @verbatim
  ===============================================================================
                       ##### IO operation functions #####
@@ -1173,7 +1181,7 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
   * @param hadc ADC handle
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
@@ -1243,7 +1251,7 @@ HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval HAL status.
   */
-HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
@@ -1297,7 +1305,7 @@ HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
   * @param Timeout Timeout value in millisecond.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Timeout)
 {
   uint32_t tickstart;
   uint32_t tmp_Flag_End;
@@ -1336,12 +1344,12 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Ti
   tickstart = HAL_GetTick();
 
   /* Wait until End of unitary conversion or sequence conversions flag is raised */
-  while((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+  while ((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
   {
     /* Check if timeout is disabled (set to infinite wait) */
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
       {
         /* Update ADC state machine to timeout */
         SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
@@ -1359,12 +1367,12 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Ti
 
   /* Determine whether any further conversion upcoming on group regular       */
   /* by external trigger, continuous mode or scan sequence on going.          */
-  if(   (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
-     && (hadc->Init.ContinuousConvMode == DISABLE)
-    )
+  if ((LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
+      && (hadc->Init.ContinuousConvMode == DISABLE)
+     )
   {
     /* Check whether end of sequence is reached */
-    if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+    if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))
     {
       /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit             */
       /* ADSTART==0 (no conversion on going)                                  */
@@ -1424,7 +1432,7 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Ti
   *         to macro __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventType, uint32_t Timeout)
 {
   uint32_t tickstart;
 
@@ -1436,12 +1444,12 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventTy
   tickstart = HAL_GetTick();
 
   /* Check selected event flag */
-  while(__HAL_ADC_GET_FLAG(hadc, EventType) == 0UL)
+  while (__HAL_ADC_GET_FLAG(hadc, EventType) == 0UL)
   {
     /* Check if timeout is disabled (set to infinite wait) */
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
       {
         /* Update ADC state machine to timeout */
         SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
@@ -1454,79 +1462,79 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventTy
     }
   }
 
-  switch(EventType)
+  switch (EventType)
   {
-  /* End Of Sampling event */
-  case ADC_EOSMP_EVENT:
-    /* Set ADC state */
-    SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOSMP);
-
-    /* Clear the End Of Sampling flag */
-    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP);
-
-    break;
-
-  /* Analog watchdog (level out of window) event */
-  /* Note: In case of several analog watchdog enabled, if needed to know      */
-  /* which one triggered and on which ADCx, test ADC state of analog watchdog */
-  /* flags HAL_ADC_STATE_AWD1/2/3 using function "HAL_ADC_GetState()".        */
-  /* For example:                                                             */
-  /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD1) != 0UL) "          */
-  /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD2) != 0UL) "          */
-  /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD3) != 0UL) "          */
-
-  /* Check analog watchdog 1 flag */
-  case ADC_AWD_EVENT:
-    /* Set ADC state */
-    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
-
-    /* Clear ADC analog watchdog flag */
-    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
-
-    break;
-
-  /* Check analog watchdog 2 flag */
-  case ADC_AWD2_EVENT:
-    /* Set ADC state */
-    SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
-
-    /* Clear ADC analog watchdog flag */
-    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
-
-    break;
-
-  /* Check analog watchdog 3 flag */
-  case ADC_AWD3_EVENT:
-    /* Set ADC state */
-    SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
-
-    /* Clear ADC analog watchdog flag */
-    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
-
-    break;
-
-  /* Overrun event */
-  default: /* Case ADC_OVR_EVENT */
-    /* If overrun is set to overwrite previous data, overrun event is not     */
-    /* considered as an error.                                                */
-    /* (cf ref manual "Managing conversions without using the DMA and without */
-    /* overrun ")                                                             */
-    if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
-    {
+    /* End Of Sampling event */
+    case ADC_EOSMP_EVENT:
       /* Set ADC state */
-      SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOSMP);
 
-      /* Set ADC error code to overrun */
-      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
-    }
-    else
-    {
-      /* Clear ADC Overrun flag only if Overrun is set to ADC_OVR_DATA_OVERWRITTEN
-         otherwise, data register is potentially overwritten by new converted data as soon
-         as OVR is cleared. */
-      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
-    }
-    break;
+      /* Clear the End Of Sampling flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP);
+
+      break;
+
+    /* Analog watchdog (level out of window) event */
+    /* Note: In case of several analog watchdog enabled, if needed to know      */
+    /* which one triggered and on which ADCx, test ADC state of analog watchdog */
+    /* flags HAL_ADC_STATE_AWD1/2/3 using function "HAL_ADC_GetState()".        */
+    /* For example:                                                             */
+    /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD1) != 0UL) "          */
+    /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD2) != 0UL) "          */
+    /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD3) != 0UL) "          */
+
+    /* Check analog watchdog 1 flag */
+    case ADC_AWD_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+
+      /* Clear ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+
+      break;
+
+    /* Check analog watchdog 2 flag */
+    case ADC_AWD2_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+
+      /* Clear ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+
+      break;
+
+    /* Check analog watchdog 3 flag */
+    case ADC_AWD3_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+
+      /* Clear ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+
+      break;
+
+    /* Overrun event */
+    default: /* Case ADC_OVR_EVENT */
+      /* If overrun is set to overwrite previous data, overrun event is not     */
+      /* considered as an error.                                                */
+      /* (cf ref manual "Managing conversions without using the DMA and without */
+      /* overrun ")                                                             */
+      if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+      {
+        /* Set ADC state */
+        SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+
+        /* Set ADC error code to overrun */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+      }
+      else
+      {
+        /* Clear ADC Overrun flag only if Overrun is set to ADC_OVR_DATA_OVERWRITTEN
+           otherwise, data register is potentially overwritten by new converted data as soon
+           as OVR is cleared. */
+        __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+      }
+      break;
   }
 
   /* Return function status */
@@ -1551,7 +1559,7 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventTy
   * @param hadc ADC handle
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
@@ -1595,7 +1603,7 @@ HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
       __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
 
       /* Enable ADC end of conversion interrupt */
-      switch(hadc->Init.EOCSelection)
+      switch (hadc->Init.EOCSelection)
       {
         case ADC_EOC_SEQ_CONV:
           __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOS);
@@ -1645,7 +1653,7 @@ HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval HAL status.
   */
-HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
@@ -1695,7 +1703,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
   * @param Length Number of data to be transferred from ADC peripheral to memory
   * @retval HAL status.
   */
-HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
@@ -1793,7 +1801,7 @@ HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, ui
   * @param hadc ADC handle
   * @retval HAL status.
   */
-HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 
@@ -1811,7 +1819,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
   {
     /* Disable the DMA channel (in case of DMA in circular mode or stop       */
     /* while DMA transfer is on going)                                        */
-    if(hadc->DMA_Handle->State == HAL_DMA_STATE_BUSY)
+    if (hadc->DMA_Handle->State == HAL_DMA_STATE_BUSY)
     {
       tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
 
@@ -1827,8 +1835,8 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
     __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
 
     /* 2. Disable the ADC peripheral */
-    /* Update "tmp_hal_status" only if DMA channel disabling passed, to keep  */
-    /* in memory a potential failing status.                                  */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to keep in memory a potential failing status.                          */
     if (tmp_hal_status == HAL_OK)
     {
       tmp_hal_status = ADC_Disable(hadc);
@@ -1877,7 +1885,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval ADC group regular conversion data
   */
-uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef *hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -1894,7 +1902,7 @@ uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc)
 {
   uint32_t overrun_error = 0UL; /* flag set if overrun occurrence has to be considered as an error */
   uint32_t tmp_isr = hadc->Instance->ISR;
@@ -1905,7 +1913,7 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
   assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
 
   /* ========== Check End of Sampling flag for ADC group regular ========== */
-  if(((tmp_isr & ADC_FLAG_EOSMP) == ADC_FLAG_EOSMP) && ((tmp_ier & ADC_IT_EOSMP) == ADC_IT_EOSMP))
+  if (((tmp_isr & ADC_FLAG_EOSMP) == ADC_FLAG_EOSMP) && ((tmp_ier & ADC_IT_EOSMP) == ADC_IT_EOSMP))
   {
     /* Update state machine on end of sampling status if not in error state */
     if ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
@@ -1922,12 +1930,12 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
 #endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
 
     /* Clear regular group conversion flag */
-    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP );
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP);
   }
 
   /* ====== Check ADC group regular end of unitary conversion sequence conversions ===== */
-  if((((tmp_isr & ADC_FLAG_EOC) == ADC_FLAG_EOC) && ((tmp_ier & ADC_IT_EOC) == ADC_IT_EOC)) ||
-     (((tmp_isr & ADC_FLAG_EOS) == ADC_FLAG_EOS) && ((tmp_ier & ADC_IT_EOS) == ADC_IT_EOS))  )
+  if ((((tmp_isr & ADC_FLAG_EOC) == ADC_FLAG_EOC) && ((tmp_ier & ADC_IT_EOC) == ADC_IT_EOC)) ||
+      (((tmp_isr & ADC_FLAG_EOS) == ADC_FLAG_EOS) && ((tmp_ier & ADC_IT_EOS) == ADC_IT_EOS)))
   {
     /* Update state machine on conversion status if not in error state */
     if ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
@@ -1939,12 +1947,12 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
     /* Determine whether any further conversion upcoming on group regular     */
     /* by external trigger, continuous mode or scan sequence on going         */
     /* to disable interruption.                                               */
-    if(   (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
-       && (hadc->Init.ContinuousConvMode == DISABLE)
-      )
+    if ((LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
+        && (hadc->Init.ContinuousConvMode == DISABLE)
+       )
     {
       /* If End of Sequence is reached, disable interrupts */
-      if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+      if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))
       {
         /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit           */
         /* ADSTART==0 (no conversion on going)                                */
@@ -1976,7 +1984,7 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
     /* Note: Into callback function "HAL_ADC_ConvCpltCallback()",             */
     /*       to determine if conversion has been triggered from EOC or EOS,   */
     /*       possibility to use:                                              */
-    /*        " if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_EOS)) "                */
+    /*        " if ( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_EOS)) "               */
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
     hadc->ConvCpltCallback(hadc);
 #else
@@ -1988,7 +1996,7 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
     /*       conversion flags clear induces the release of the preserved data.*/
     /*       Therefore, if the preserved data value is needed, it must be     */
     /*       read preliminarily into HAL_ADC_ConvCpltCallback().              */
-    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS) );
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS));
   }
 
   /* ========== Check Analog watchdog 1 flag ========== */
@@ -2104,7 +2112,7 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -2119,7 +2127,7 @@ __weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -2134,7 +2142,7 @@ __weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -2171,8 +2179,8 @@ __weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
   */
 
 /** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
- *  @brief    Peripheral Control functions
- *
+  * @brief    Peripheral Control functions
+  *
 @verbatim
  ===============================================================================
              ##### Peripheral Control functions #####
@@ -2202,7 +2210,7 @@ __weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
   * @param sConfig Structure of ADC channel assigned to ADC group regular.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConfTypeDef *sConfig)
 {
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmp_config_internal_channel;
@@ -2213,8 +2221,8 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
   assert_param(IS_ADC_CHANNEL(sConfig->Channel));
   assert_param(IS_ADC_SAMPLING_TIME_COMMON(sConfig->SamplingTime));
 
-  if((hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED)          ||
-     (hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED_BACKWARD)   )
+  if ((hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED)       ||
+      (hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED_BACKWARD))
   {
     assert_param(IS_ADC_REGULAR_RANK_SEQ_FIXED(sConfig->Rank));
   }
@@ -2243,7 +2251,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
     /* Otherwise (sequencer set to fully configurable or to to not fully      */
     /* configurable with channel rank to be set), configure the selected      */
     /* channel.                                                               */
-    if(sConfig->Rank != ADC_RANK_NONE)
+    if (sConfig->Rank != ADC_RANK_NONE)
     {
       /* Regular sequence configuration */
       /* Note: ADC channel configuration requires few ADC clock cycles        */
@@ -2251,8 +2259,8 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
       /*       induce that a specific wait time is not necessary.             */
       /*       For more details on ADC channel configuration ready,           */
       /*       refer to function "LL_ADC_IsActiveFlag_CCRDY()".               */
-      if((hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED)         ||
-         (hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED_BACKWARD)  )
+      if ((hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED)       ||
+          (hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED_BACKWARD))
       {
         /* Sequencer set to not fully configurable:                           */
         /* Set the channel by enabling the corresponding bitfield.            */
@@ -2272,7 +2280,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
         /* apply the configuration in ADC register.                           */
         /* Note: Otherwise, configuration is not applied.                     */
         /*       To apply it, parameter'NbrOfConversion' must be increased.   */
-        if(((sConfig->Rank >> 2UL) + 1UL) <= hadc->Init.NbrOfConversion)
+        if (((sConfig->Rank >> 2UL) + 1UL) <= hadc->Init.NbrOfConversion)
         {
           LL_ADC_REG_SetSequencerRanks(hadc->Instance, sConfig->Rank, sConfig->Channel);
         }
@@ -2287,34 +2295,39 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
       /* Note: these internal measurement paths can be disabled using         */
       /*       HAL_ADC_DeInit() or removing the channel from sequencer with   */
       /*       channel configuration parameter "Rank".                        */
-      if(__LL_ADC_IS_CHANNEL_INTERNAL(sConfig->Channel))
+      if (__LL_ADC_IS_CHANNEL_INTERNAL(sConfig->Channel))
       {
         tmp_config_internal_channel = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
 
         /* If the requested internal measurement path has already been enabled,   */
         /* bypass the configuration processing.                                   */
-        if ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_TEMPSENSOR) == 0UL))
+        if ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) &&
+            ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_TEMPSENSOR) == 0UL))
         {
-          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_TEMPSENSOR | tmp_config_internal_channel);
+          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance),
+                                         LL_ADC_PATH_INTERNAL_TEMPSENSOR | tmp_config_internal_channel);
 
           /* Delay for temperature sensor stabilization time */
           /* Wait loop initialization and execution */
           /* Note: Variable divided by 2 to compensate partially              */
           /*       CPU processing cycles, scaling in us split to not          */
           /*       exceed 32 bits register capacity and handle low frequency. */
-          wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL)));
-          while(wait_loop_index != 0UL)
+          wait_loop_index = (((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL))) + 1UL);
+          while (wait_loop_index != 0UL)
           {
             wait_loop_index--;
           }
         }
         else if ((sConfig->Channel == ADC_CHANNEL_VBAT) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VBAT) == 0UL))
         {
-          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_VBAT | tmp_config_internal_channel);
+          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance),
+                                         LL_ADC_PATH_INTERNAL_VBAT | tmp_config_internal_channel);
         }
-        else if ((sConfig->Channel == ADC_CHANNEL_VREFINT) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VREFINT) == 0UL))
+        else if ((sConfig->Channel == ADC_CHANNEL_VREFINT) &&
+                 ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VREFINT) == 0UL))
         {
-          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_VREFINT | tmp_config_internal_channel);
+          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance),
+                                         LL_ADC_PATH_INTERNAL_VREFINT | tmp_config_internal_channel);
         }
         else
         {
@@ -2329,8 +2342,8 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
       /*       Sequencer rank cannot be disabled, only affected to            */
       /*       another channel.                                               */
       /*       To remove a rank, use parameter 'NbrOfConversion".             */
-      if((hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED)         ||
-         (hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED_BACKWARD)  )
+      if ((hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED)       ||
+          (hadc->Init.ScanConvMode == ADC_SCAN_SEQ_FIXED_BACKWARD))
       {
         /* Sequencer set to not fully configurable:                           */
         /* Reset the channel by disabling the corresponding bitfield.         */
@@ -2340,21 +2353,24 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
       /* Management of internal measurement channels: Vbat/VrefInt/TempSensor.  */
       /* If internal channel selected, enable dedicated internal buffers and    */
       /* paths.                                                                 */
-      if(__LL_ADC_IS_CHANNEL_INTERNAL(sConfig->Channel))
+      if (__LL_ADC_IS_CHANNEL_INTERNAL(sConfig->Channel))
       {
         tmp_config_internal_channel = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
 
         if (sConfig->Channel == ADC_CHANNEL_TEMPSENSOR)
         {
-          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), ~LL_ADC_PATH_INTERNAL_TEMPSENSOR & tmp_config_internal_channel);
+          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance),
+                                         ~LL_ADC_PATH_INTERNAL_TEMPSENSOR & tmp_config_internal_channel);
         }
         else if (sConfig->Channel == ADC_CHANNEL_VBAT)
         {
-          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), ~LL_ADC_PATH_INTERNAL_VBAT & tmp_config_internal_channel);
+          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance),
+                                         ~LL_ADC_PATH_INTERNAL_VBAT & tmp_config_internal_channel);
         }
         else if (sConfig->Channel == ADC_CHANNEL_VREFINT)
         {
-          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), ~LL_ADC_PATH_INTERNAL_VREFINT & tmp_config_internal_channel);
+          LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance),
+                                         ~LL_ADC_PATH_INTERNAL_VREFINT & tmp_config_internal_channel);
         }
         else
         {
@@ -2392,7 +2408,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
   *         The setting of these parameters is conditioned to ADC state.
   *         For parameters constraints, see comments of structure
   *         "ADC_AnalogWDGConfTypeDef".
-  * @note   On this STM32 serie, analog watchdog thresholds can be modified
+  * @note   On this STM32 series, analog watchdog thresholds can be modified
   *         while ADC conversion is on going.
   *         In this case, some constraints must be taken into account:
   *         the programmed threshold values are effective from the next
@@ -2404,7 +2420,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConf
   * @param AnalogWDGConfig Structure of ADC analog watchdog configuration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDGConfTypeDef *AnalogWDGConfig)
 {
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmpAWDHighThresholdShifted;
@@ -2416,7 +2432,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
   assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
   assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
 
-  if(AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)
+  if (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)
   {
     assert_param(IS_ADC_CHANNEL(AnalogWDGConfig->Channel));
   }
@@ -2447,15 +2463,16 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
   if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
   {
     /* Analog watchdog configuration */
-    if(AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
+    if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
     {
       /* Configuration of analog watchdog:                                    */
       /*  - Set the analog watchdog enable mode: one or overall group of      */
       /*    channels.                                                         */
-      switch(AnalogWDGConfig->WatchdogMode)
+      switch (AnalogWDGConfig->WatchdogMode)
       {
         case ADC_ANALOGWATCHDOG_SINGLE_REG:
-          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, __LL_ADC_ANALOGWD_CHANNEL_GROUP(AnalogWDGConfig->Channel, LL_ADC_GROUP_REGULAR));
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1,
+                                          __LL_ADC_ANALOGWD_CHANNEL_GROUP(AnalogWDGConfig->Channel, LL_ADC_GROUP_REGULAR));
           break;
 
         case ADC_ANALOGWATCHDOG_ALL_REG:
@@ -2477,7 +2494,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
       LL_ADC_ClearFlag_AWD1(hadc->Instance);
 
       /* Configure ADC analog watchdog interrupt */
-      if(AnalogWDGConfig->ITMode == ENABLE)
+      if (AnalogWDGConfig->ITMode == ENABLE)
       {
         LL_ADC_EnableIT_AWD1(hadc->Instance);
       }
@@ -2489,7 +2506,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
     /* Case of ADC_ANALOGWATCHDOG_2 or ADC_ANALOGWATCHDOG_3 */
     else
     {
-      switch(AnalogWDGConfig->WatchdogMode)
+      switch (AnalogWDGConfig->WatchdogMode)
       {
         case ADC_ANALOGWATCHDOG_SINGLE_REG:
           /* Update AWD by bitfield to keep the possibility to monitor        */
@@ -2525,7 +2542,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
         LL_ADC_ClearFlag_AWD2(hadc->Instance);
 
         /* Configure ADC analog watchdog interrupt */
-        if(AnalogWDGConfig->ITMode == ENABLE)
+        if (AnalogWDGConfig->ITMode == ENABLE)
         {
           LL_ADC_EnableIT_AWD2(hadc->Instance);
         }
@@ -2547,7 +2564,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
         LL_ADC_ClearFlag_AWD3(hadc->Instance);
 
         /* Configure ADC analog watchdog interrupt */
-        if(AnalogWDGConfig->ITMode == ENABLE)
+        if (AnalogWDGConfig->ITMode == ENABLE)
         {
           LL_ADC_EnableIT_AWD3(hadc->Instance);
         }
@@ -2561,7 +2578,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
   }
 
   /* Analog watchdog thresholds configuration */
-  if(AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
+  if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
   {
     /* Shift the offset with respect to the selected ADC resolution:        */
     /* Thresholds have to be left-aligned on bit 11, the LSB (right bits)   */
@@ -2580,7 +2597,8 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
   }
 
   /* Set ADC analog watchdog thresholds value of both thresholds high and low */
-  LL_ADC_ConfigAnalogWDThresholds(hadc->Instance, AnalogWDGConfig->WatchdogNumber, tmpAWDHighThresholdShifted, tmpAWDLowThresholdShifted);
+  LL_ADC_ConfigAnalogWDThresholds(hadc->Instance, AnalogWDGConfig->WatchdogNumber, tmpAWDHighThresholdShifted,
+                                  tmpAWDLowThresholdShifted);
 
   /* Process unlocked */
   __HAL_UNLOCK(hadc);
@@ -2595,8 +2613,8 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
   */
 
 /** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
- *  @brief    ADC Peripheral State functions
- *
+  *  @brief    ADC Peripheral State functions
+  *
 @verbatim
  ===============================================================================
             ##### Peripheral state and errors functions #####
@@ -2621,7 +2639,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDG
   * @param hadc ADC handle
   * @retval ADC handle state (bitfield on 32 bits)
   */
-uint32_t HAL_ADC_GetState(ADC_HandleTypeDef* hadc)
+uint32_t HAL_ADC_GetState(ADC_HandleTypeDef *hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -2662,7 +2680,7 @@ uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
   * @param  hadc ADC handle
   * @retval HAL status.
   */
-HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef *hadc)
 {
   uint32_t tickstart;
 
@@ -2685,9 +2703,9 @@ HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc)
     /* Get tick count */
     tickstart = HAL_GetTick();
 
-    while((hadc->Instance->CR & ADC_CR_ADSTART) != 0UL)
+    while ((hadc->Instance->CR & ADC_CR_ADSTART) != 0UL)
     {
-      if((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      if ((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
       {
         /* Update ADC state machine to error */
         SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
@@ -2712,9 +2730,10 @@ HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval HAL status.
   */
-HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef *hadc)
 {
   uint32_t tickstart;
+  __IO uint32_t wait_loop_index = 0UL;
 
   /* ADC enable and wait for ADC ready (in case of ADC is disabled or         */
   /* enabling phase not yet completed: flag ADC ready not yet set).           */
@@ -2737,6 +2756,20 @@ HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
     /* Enable the ADC peripheral */
     LL_ADC_Enable(hadc->Instance);
 
+    if ((LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) & LL_ADC_PATH_INTERNAL_TEMPSENSOR) != 0UL)
+    {
+      /* Delay for temperature sensor buffer stabilization time */
+      /* Wait loop initialization and execution */
+      /* Note: Variable divided by 2 to compensate partially              */
+      /*       CPU processing cycles, scaling in us split to not          */
+      /*       exceed 32 bits register capacity and handle low frequency. */
+      wait_loop_index = (((LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL))) + 1UL);
+      while (wait_loop_index != 0UL)
+      {
+        wait_loop_index--;
+      }
+    }
+
     /* If low power mode AutoPowerOff is enabled, power-on/off phases are     */
     /* performed automatically by hardware and flag ADC ready is not set.     */
     if (hadc->Init.LowPowerAutoPowerOff != ENABLE)
@@ -2744,7 +2777,7 @@ HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
       /* Wait for ADC effectively enabled */
       tickstart = HAL_GetTick();
 
-      while(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == 0UL)
+      while (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == 0UL)
       {
         /*  If ADEN bit is set less than 4 ADC clock cycles after the ADCAL bit
             has been cleared (after a calibration), ADEN bit is reset by the
@@ -2754,12 +2787,12 @@ HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
             4 ADC clock cycle duration */
         /* Note: Test of ADC enabled required due to hardware constraint to     */
         /*       not enable ADC if already enabled.                             */
-        if(LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+        if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
         {
           LL_ADC_Enable(hadc->Instance);
         }
 
-        if((HAL_GetTick() - tickstart) > ADC_ENABLE_TIMEOUT)
+        if ((HAL_GetTick() - tickstart) > ADC_ENABLE_TIMEOUT)
         {
           /* Update ADC state machine to error */
           SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
@@ -2784,7 +2817,7 @@ HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval HAL status.
   */
-HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef *hadc)
 {
   uint32_t tickstart;
   const uint32_t tmp_adc_is_disable_on_going = LL_ADC_IsDisableOngoing(hadc->Instance);
@@ -2792,12 +2825,12 @@ HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
   /* Verification if ADC is not already disabled:                             */
   /* Note: forbidden to disable ADC (set bit ADC_CR_ADDIS) if ADC is already  */
   /*       disabled.                                                          */
-  if (   (LL_ADC_IsEnabled(hadc->Instance) != 0UL)
+  if ((LL_ADC_IsEnabled(hadc->Instance) != 0UL)
       && (tmp_adc_is_disable_on_going == 0UL)
      )
   {
     /* Check if conditions to disable the ADC are fulfilled */
-    if((hadc->Instance->CR & (ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN)
+    if ((hadc->Instance->CR & (ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN)
     {
       /* Disable the ADC peripheral */
       LL_ADC_Disable(hadc->Instance);
@@ -2818,9 +2851,9 @@ HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
     /* Get tick count */
     tickstart = HAL_GetTick();
 
-    while((hadc->Instance->CR & ADC_CR_ADEN) != 0UL)
+    while ((hadc->Instance->CR & ADC_CR_ADEN) != 0UL)
     {
-      if((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
+      if ((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
       {
         /* Update ADC state machine to error */
         SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
@@ -2845,7 +2878,7 @@ HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
 static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
 {
   /* Retrieve ADC handle corresponding to current DMA handle */
-  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  ADC_HandleTypeDef *hadc = (ADC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
   /* Update state machine on conversion status if not in error state */
   if ((hadc->State & (HAL_ADC_STATE_ERROR_INTERNAL | HAL_ADC_STATE_ERROR_DMA)) == 0UL)
@@ -2856,12 +2889,12 @@ static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
     /* Determine whether any further conversion upcoming on group regular     */
     /* by external trigger, continuous mode or scan sequence on going         */
     /* to disable interruption.                                               */
-    if(   (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
-       && (hadc->Init.ContinuousConvMode == DISABLE)
-      )
+    if ((LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
+        && (hadc->Init.ContinuousConvMode == DISABLE)
+       )
     {
       /* If End of Sequence is reached, disable interrupts */
-      if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+      if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))
       {
         /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit           */
         /* ADSTART==0 (no conversion on going)                                */
@@ -2923,7 +2956,7 @@ static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
 static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)
 {
   /* Retrieve ADC handle corresponding to current DMA handle */
-  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  ADC_HandleTypeDef *hadc = (ADC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
   /* Half conversion callback */
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
@@ -2941,7 +2974,7 @@ static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)
 static void ADC_DMAError(DMA_HandleTypeDef *hdma)
 {
   /* Retrieve ADC handle corresponding to current DMA handle */
-  ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  ADC_HandleTypeDef *hadc = (ADC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
   /* Set ADC state */
   SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_adc_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_adc_ex.c
@@ -3,7 +3,7 @@
   * @file    stm32g0xx_hal_adc_ex.c
   * @author  MCD Application Team
   * @brief   This file provides firmware functions to manage the following
-  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          functionalities of the Analog to Digital Converter (ADC)
   *          peripheral:
   *           + Operation functions
   *             ++ Calibration
@@ -101,7 +101,7 @@
   * @param  hadc       ADC handle
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
   __IO uint32_t wait_loop_index = 0UL;
@@ -127,8 +127,8 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
                       HAL_ADC_STATE_BUSY_INTERNAL);
 
     /* Disable ADC DMA transfer request during calibration */
-    /* Note: Specificity of this STM32 serie: Calibration factor is           */
-    /*       available in data register and also transfered by DMA.           */
+    /* Note: Specificity of this STM32 series: Calibration factor is          */
+    /*       available in data register and also transferred by DMA.          */
     /*       To not insert ADC calibration factor among ADC conversion data   */
     /*       in array variable, DMA transfer must be disabled during          */
     /*       calibration.                                                     */
@@ -139,7 +139,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
     SET_BIT(hadc->Instance->CR, ADC_CR_ADCAL);
 
     /* Wait for calibration completion */
-    while(LL_ADC_IsCalibrationOnGoing(hadc->Instance) != 0UL)
+    while (LL_ADC_IsCalibrationOnGoing(hadc->Instance) != 0UL)
     {
       wait_loop_index++;
       if (wait_loop_index >= ADC_CALIBRATION_TIMEOUT)
@@ -184,7 +184,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle.
   * @retval Calibration value.
   */
-uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc)
+uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef *hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -200,7 +200,7 @@ uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc)
   * @param CalibrationFactor Calibration factor (coded on 7 bits maximum)
   * @retval HAL state
   */
-HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32_t CalibrationFactor)
+HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t CalibrationFactor)
 {
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmp_adc_is_conversion_on_going_regular;
@@ -216,7 +216,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32
   /* factors register: ADC must be enabled, no conversion on going.           */
   tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
 
-  if (   (LL_ADC_IsEnabled(hadc->Instance) != 0UL)
+  if ((LL_ADC_IsEnabled(hadc->Instance) != 0UL)
       && (tmp_adc_is_conversion_on_going_regular == 0UL)
      )
   {
@@ -246,7 +246,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -261,7 +261,7 @@ __weak void HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -277,7 +277,7 @@ __weak void HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -292,7 +292,7 @@ __weak void HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval None
   */
-__weak void HAL_ADCEx_ChannelConfigReadyCallback(ADC_HandleTypeDef* hadc)
+__weak void HAL_ADCEx_ChannelConfigReadyCallback(ADC_HandleTypeDef *hadc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hadc);
@@ -315,7 +315,7 @@ __weak void HAL_ADCEx_ChannelConfigReadyCallback(ADC_HandleTypeDef* hadc)
   * @param hadc ADC handle
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef* hadc)
+HAL_StatusTypeDef HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef *hadc)
 {
   HAL_StatusTypeDef tmp_hal_status;
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_comp.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_comp.c
@@ -91,11 +91,11 @@
 
      The compilation flag USE_HAL_COMP_REGISTER_CALLBACKS, when set to 1,
      allows the user to configure dynamically the driver callbacks.
-     Use Functions @ref HAL_COMP_RegisterCallback()
+     Use Functions HAL_COMP_RegisterCallback()
      to register an interrupt callback.
     [..]
 
-     Function @ref HAL_COMP_RegisterCallback() allows to register following callbacks:
+     Function HAL_COMP_RegisterCallback() allows to register following callbacks:
        (+) TriggerCallback       : callback for COMP trigger.
        (+) MspInitCallback       : callback for Msp Init.
        (+) MspDeInitCallback     : callback for Msp DeInit.
@@ -103,11 +103,11 @@
      and a pointer to the user callback function.
     [..]
 
-     Use function @ref HAL_COMP_UnRegisterCallback to reset a callback to the default
+     Use function HAL_COMP_UnRegisterCallback to reset a callback to the default
      weak function.
     [..]
 
-     @ref HAL_COMP_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     HAL_COMP_UnRegisterCallback takes as parameters the HAL peripheral handle,
      and the Callback ID.
      This function allows to reset following callbacks:
        (+) TriggerCallback       : callback for COMP trigger.
@@ -115,27 +115,27 @@
        (+) MspDeInitCallback     : callback for Msp DeInit.
      [..]
 
-     By default, after the @ref HAL_COMP_Init() and when the state is @ref HAL_COMP_STATE_RESET
+     By default, after the HAL_COMP_Init() and when the state is HAL_COMP_STATE_RESET
      all callbacks are set to the corresponding weak functions:
-     example @ref HAL_COMP_TriggerCallback().
+     example HAL_COMP_TriggerCallback().
      Exception done for MspInit and MspDeInit functions that are
-     reset to the legacy weak functions in the @ref HAL_COMP_Init()/ @ref HAL_COMP_DeInit() only when
+     reset to the legacy weak functions in the HAL_COMP_Init()/ HAL_COMP_DeInit() only when
      these callbacks are null (not registered beforehand).
     [..]
 
-     If MspInit or MspDeInit are not null, the @ref HAL_COMP_Init()/ @ref HAL_COMP_DeInit()
+     If MspInit or MspDeInit are not null, the HAL_COMP_Init()/ HAL_COMP_DeInit()
      keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
      [..]
 
-     Callbacks can be registered/unregistered in @ref HAL_COMP_STATE_READY state only.
+     Callbacks can be registered/unregistered in HAL_COMP_STATE_READY state only.
      Exception done MspInit/MspDeInit functions that can be registered/unregistered
-     in @ref HAL_COMP_STATE_READY or @ref HAL_COMP_STATE_RESET state,
+     in HAL_COMP_STATE_READY or HAL_COMP_STATE_RESET state,
      thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
     [..]
 
      Then, the user first registers the MspInit/MspDeInit user callbacks
-     using @ref HAL_COMP_RegisterCallback() before calling @ref HAL_COMP_DeInit()
-     or @ref HAL_COMP_Init() function.
+     using HAL_COMP_RegisterCallback() before calling HAL_COMP_DeInit()
+     or HAL_COMP_Init() function.
      [..]
 
      When the compilation flag USE_HAL_COMP_REGISTER_CALLBACKS is set to 0 or
@@ -237,6 +237,10 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
   uint32_t comp_voltage_scaler_initialized; /* Value "0" if comparator voltage scaler is not initialized */
   __IO uint32_t wait_loop_index = 0UL;
   HAL_StatusTypeDef status = HAL_OK;
+#if defined(COMP3)
+  __IO uint32_t * comp_common_odd;
+  __IO uint32_t * comp_common_even;
+#endif
 
   /* Check the COMP handle allocation and lock status */
   if(hcomp == NULL)
@@ -258,7 +262,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
     assert_param(IS_COMP_HYSTERESIS(hcomp->Init.Hysteresis));
     assert_param(IS_COMP_BLANKINGSRC_INSTANCE(hcomp->Instance, hcomp->Init.BlankingSrce));
     assert_param(IS_COMP_TRIGGERMODE(hcomp->Init.TriggerMode));
-    assert_param(IS_COMP_WINDOWMODE(hcomp->Init.WindowMode));
+    assert_param(IS_COMP_WINDOWMODE(hcomp->Instance, hcomp->Init.WindowMode));
     if(hcomp->Init.WindowMode != COMP_WINDOWMODE_DISABLE)
     {
       assert_param(IS_COMP_WINDOWOUTPUT(hcomp->Init.WindowOutput));
@@ -321,6 +325,64 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
     /* Note: Window mode bit is located into 1 out of the 2 pairs of COMP     */
     /*       instances. Therefore, this function can update another COMP      */
     /*       instance that the one currently selected.                        */
+#if defined(COMP3)
+    if(hcomp->Instance == COMP3)
+    {
+      /* Note: Exception for STM32G0 devices featuring ADC3 instance: in common   */
+      /*       group of COMP2 and COMP3, instances odd and even are inverted.     */
+      /*       Perform switch of parameter selected.                              */
+      comp_common_odd = &(COMP23_COMMON->CSR_EVEN);
+      comp_common_even = &(COMP23_COMMON->CSR_ODD);
+    }
+    else
+    {
+      comp_common_odd = &(COMP12_COMMON->CSR_ODD);
+      comp_common_even = &(COMP12_COMMON->CSR_EVEN);
+    }
+
+    if(hcomp->Init.WindowMode == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)
+    {
+      CLEAR_BIT(*comp_common_odd, COMP_CSR_WINMODE);
+      SET_BIT(*comp_common_even, COMP_CSR_WINMODE);
+    }
+    else if(hcomp->Init.WindowMode == COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON)
+    {
+      SET_BIT(*comp_common_odd, COMP_CSR_WINMODE);
+      CLEAR_BIT(*comp_common_even, COMP_CSR_WINMODE);
+    }
+    else
+    {
+      CLEAR_BIT(*comp_common_odd, COMP_CSR_WINMODE);
+      CLEAR_BIT(*comp_common_even, COMP_CSR_WINMODE);
+    }
+
+    /* Set window mode output */
+    /* Note: Window mode mode output can also be used when window mode        */
+    /*       is disabled, to use comparators in independent mode with their   */
+    /*       output connected through exclusive-or circuitry.                 */
+    switch (hcomp->Init.WindowOutput)
+    {
+      case COMP_WINDOWOUTPUT_COMP1: /* idem COMP_WINDOWOUTPUT_COMP3 (same literal value) */
+        SET_BIT(*comp_common_odd, COMP_CSR_WINOUT);
+        CLEAR_BIT(*comp_common_even, COMP_CSR_WINOUT);
+        break;
+
+      case COMP_WINDOWOUTPUT_COMP2:
+        CLEAR_BIT(*comp_common_odd, COMP_CSR_WINOUT);
+        SET_BIT(*comp_common_even, COMP_CSR_WINOUT);
+        break;
+
+      case COMP_WINDOWOUTPUT_BOTH:
+        SET_BIT(*comp_common_odd, COMP_CSR_WINOUT);
+        SET_BIT(*comp_common_even, COMP_CSR_WINOUT);
+        break;
+
+      default: /* COMP_WINDOWOUTPUT_EACH_COMP */
+        CLEAR_BIT(*comp_common_odd, COMP_CSR_WINOUT);
+        CLEAR_BIT(*comp_common_even, COMP_CSR_WINOUT);
+        break;
+    }
+#else
     if(hcomp->Init.WindowMode == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)
     {
       CLEAR_BIT(COMP12_COMMON->CSR_ODD, COMP_CSR_WINMODE);
@@ -363,6 +425,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
         CLEAR_BIT(COMP12_COMMON->CSR_EVEN, COMP_CSR_WINOUT);
         break;
     }
+#endif
 
     /* Delay for COMP scaler bridge voltage stabilization */
     /* Apply the delay if voltage scaler bridge is required and not already enabled */
@@ -814,15 +877,43 @@ void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
 {
   /* Get the EXTI line corresponding to the selected COMP instance */
   uint32_t exti_line = COMP_GET_EXTI_LINE(hcomp->Instance);
-  uint32_t comparator_window_mode_odd = READ_BIT(COMP12_COMMON->CSR_ODD, COMP_CSR_WINMODE);
-  uint32_t comparator_window_mode_even = READ_BIT(COMP12_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+  uint32_t comparator_window_mode;
+  uint32_t comparator_window_exti_lines;
+
+#if defined(COMP3)
+  if(hcomp->Instance == COMP3)
+  {
+    /* Case of window mode with COMP2 and COMP3 */
+    comparator_window_mode = READ_BIT(COMP23_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+    comparator_window_exti_lines = (COMP_EXTI_LINE_COMP2 | COMP_EXTI_LINE_COMP3);
+  }
+  else
+  {
+    comparator_window_mode = READ_BIT(COMP23_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+    if( (hcomp->Instance == COMP2) && (comparator_window_mode != 0UL))
+    {
+      /* Case of window mode with COMP2 and COMP3 */
+      comparator_window_exti_lines = (COMP_EXTI_LINE_COMP2 | COMP_EXTI_LINE_COMP3);
+    }
+    else
+    {
+      /* Case of window mode with COMP1 and COMP2 */
+      comparator_window_mode = READ_BIT(COMP12_COMMON->CSR_ODD, COMP_CSR_WINMODE);
+      comparator_window_mode |= READ_BIT(COMP12_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+      comparator_window_exti_lines = (COMP_EXTI_LINE_COMP1 | COMP_EXTI_LINE_COMP2);
+    }
+  }
+#else
+    comparator_window_mode = READ_BIT(COMP12_COMMON->CSR_ODD, COMP_CSR_WINMODE);
+    comparator_window_mode |= READ_BIT(COMP12_COMMON->CSR_EVEN, COMP_CSR_WINMODE);
+    comparator_window_exti_lines = (COMP_EXTI_LINE_COMP1 | COMP_EXTI_LINE_COMP2);
+#endif
 
   /* Check COMP EXTI flag */
   if(LL_EXTI_IsActiveRisingFlag_0_31(exti_line) != 0UL)
   {
     /* Check whether comparator is in independent or window mode */
-    if(   (comparator_window_mode_odd != 0UL)
-       || (comparator_window_mode_even != 0UL))
+    if(comparator_window_mode != 0UL)
     {
       /* Clear COMP EXTI line pending bit of the pair of comparators          */
       /* in window mode.                                                      */
@@ -831,7 +922,7 @@ void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
       /*       (low or high ) to the other "out of window" area (high or low).*/
       /*       Both flags must be cleared to call comparator trigger          */
       /*       callback is called once.                                       */
-      LL_EXTI_ClearRisingFlag_0_31((COMP_EXTI_LINE_COMP1 | COMP_EXTI_LINE_COMP2));
+      LL_EXTI_ClearRisingFlag_0_31(comparator_window_exti_lines);
     }
     else
     {
@@ -849,8 +940,7 @@ void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
   else if(LL_EXTI_IsActiveFallingFlag_0_31(exti_line) != 0UL)
   {
     /* Check whether comparator is in independent or window mode */
-    if(   (comparator_window_mode_odd != 0UL)
-       || (comparator_window_mode_even != 0UL))
+    if(comparator_window_mode != 0UL)
     {
       /* Clear COMP EXTI line pending bit of the pair of comparators          */
       /* in window mode.                                                      */
@@ -859,7 +949,7 @@ void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
       /*       (low or high ) to the other "out of window" area (high or low).*/
       /*       Both flags must be cleared to call comparator trigger          */
       /*       callback is called once.                                       */
-      LL_EXTI_ClearFallingFlag_0_31((COMP_EXTI_LINE_COMP1 | COMP_EXTI_LINE_COMP2));
+      LL_EXTI_ClearFallingFlag_0_31(comparator_window_exti_lines);
     }
     else
     {

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_crc_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_crc_ex.c
@@ -11,7 +11,7 @@
             ##### How to use this driver #####
 ================================================================================
     [..]
-         (+) Set user-defined generating polynomial thru HAL_CRCEx_Polynomial_Set()
+         (+) Set user-defined generating polynomial through HAL_CRCEx_Polynomial_Set()
          (+) Configure Input or Output data inversion
 
   @endverbatim

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_cryp.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_cryp.c
@@ -6,7 +6,7 @@
   *          This file provides firmware functions to manage the following
   *          functionalities of the Cryptography (CRYP) peripheral:
   *           + Initialization, de-initialization, set config and get config  functions
-  *           + DES/TDES, AES processing functions
+  *           + AES processing functions
   *           + DMA callback functions
   *           + CRYP IRQ handler management
   *           + Peripheral State functions
@@ -32,8 +32,8 @@
              (+++) Associate the initialized DMA handle to the CRYP DMA handle
                  using  __HAL_LINKDMA()
              (+++) Configure the priority and enable the NVIC for the transfer complete
-                 interrupt on the two DMA Streams. The output stream should have higher
-                 priority than the input stream HAL_NVIC_SetPriority() and HAL_NVIC_EnableIRQ()
+                 interrupt on the two DMA channels. The output channel should have higher
+                 priority than the input channel HAL_NVIC_SetPriority() and HAL_NVIC_EnableIRQ().
 
       (#)Initialize the CRYP according to the specified parameters :
          (##) The data type: 1-bit, 8-bit, 16-bit or 32-bit.
@@ -44,9 +44,13 @@
              (+++) In some specific configurations, the key is written by the application
                    code out of the HAL scope. In that case, user can still resort to the
                    HAL APIs as usual but must make sure that pKey pointer is set to NULL.
+         (##) The DataWidthUnit field. It specifies whether the data length (or the payload length for authentication
+               algorithms) is in words or bytes.
          (##) The Header used only in AES GCM and CCM Algorithm for authentication.
-         (##) The HeaderSize The size of header buffer in word.
-         (##) The B0 block is the first authentication block used only  in AES CCM mode.
+         (##) The HeaderSize providing the size of the header buffer in words or bytes, depending upon HeaderWidthUnit field.
+         (##) The HeaderWidthUnit field. It specifies whether the header length (for authentication algorithms) is in words or bytes.
+         (##) The B0 block is the first authentication block used only in AES CCM mode.
+         (##) The KeyIVConfigSkip used to process several messages in a row (please see more information below).
 
       (#)Three processing (encryption/decryption) functions are available:
          (##) Polling mode: encryption and decryption APIs are blocking functions
@@ -155,83 +159,24 @@
          (##) Final phase: peripheral generates the authenticated tag (T) using the last block of data.
       (#)  structure of message construction in GCM is defined as below  :
          (##) 16 bytes Initial Counter Block (ICB)composed of IV and counter
-
-                                  ICB
-          +-------------------------------------------------------+
-          |       Initialization vector (IV)      |  Counter      |
-          |----------------|----------------|-----------|---------|
-         127              95                63            31       0
-
-
-              Bit Number    Register           Contents
-              ----------   ---------------       -----------
-              127 ...96    CRYP_IV1R[31:0]     ICB[127:96]
-              95  ...64    CRYP_IV1L[31:0]     B0[95:64]
-              63 ... 32    CRYP_IV0R[31:0]     ICB[63:32]
-              31 ... 0     CRYP_IV0L[31:0]     ICB[31:0], where 32-bit counter= 0x2
-
-
-
          (##) The authenticated header A (also knows as Additional Authentication Data AAD)
           this part of the message is only authenticated, not encrypted.
          (##) The plaintext message P is both authenticated and encrypted as ciphertext.
           GCM standard specifies that ciphertext has same bit length as the plaintext.
          (##) The last block is composed of the length of A (on 64 bits) and the length of ciphertext
           (on 64 bits)
-                                 GCM last block definition
-          +-------------------------------------------------------------------+
-          |  Bit[0]   |  Bit[32]           |  Bit[64]  | Bit[96]              |
-          |-----------|--------------------|-----------|----------------------|
-          |   0x0     | Header length[31:0]|     0x0   | Payload length[31:0] |
-          |-----------|--------------------|-----------|----------------------|
+
+    [..]  A more detailed description of the GCM message structure is available below.
 
     [..]  This section describe The AES Counter with Cipher Block Chaining-Message
           Authentication Code (CCM) supported by both CRYP1 and TinyAES peripheral:
       (#)  Specific parameters for CCM  :
 
-         (##) B0 block  : According to NIST Special Publication 800-38C,
-            The first block B0 is formatted as follows, where l(m) is encoded in
-            most-significant-byte first order:
-
-                Octet Number   Contents
-                ------------   ---------
-                0              Flags
-                1 ... 15-q     Nonce N
-                16-q ... 15    Q
-
-            the Flags field is formatted as follows:
-
-                Bit Number   Contents
-                ----------   ----------------------
-                7            Reserved (always zero)
-                6            Adata
-                5 ... 3      (t-2)/2
-                2 ... 0      [q-1]3
-
-              - Q: a bit string representation of the octet length of P (plaintext)
-              - q The octet length of the binary representation of the octet length of the payload
-              - A nonce (N), n The octet length of the where n+q=15.
-              - Flags: most significant octet containing four flags for control information,
-              - t The octet length of the MAC.
-         (##) B1 block (header) : associated data length(a) concatenated with Associated Data (A)
-              the associated data length expressed in bytes (a) defined as below:
-            - If 0 < a < 216-28, then it is encoded as [a]16, i.e. two octets
-            - If 216-28 < a < 232, then it is encoded as 0xff || 0xfe || [a]32, i.e. six octets
-            - If 232 < a < 264, then it is encoded as 0xff || 0xff || [a]64, i.e. ten octets
+         (##) B0 block  : follows NIST Special Publication 800-38C,
+         (##) B1 block (header)
          (##) CTRx block  : control blocks
-            - Generation of CTR1 from first block B0 information :
-              equal to B0 with first 5 bits zeroed and most significant bits storing octet
-              length of P also zeroed, then incremented by one
 
-                Bit Number    Register           Contents
-                ----------   ---------------       -----------
-                127 ...96    CRYP_IV1R[31:0]     B0[127:96], where Q length bits are set to 0, except for
-                                                 bit 0 that is set to 1
-                95  ...64    CRYP_IV1L[31:0]     B0[95:64]
-                63 ... 32    CRYP_IV0R[31:0]     B0[63:32]
-                31 ... 0     CRYP_IV0L[31:0]     B0[31:0], where flag bits set to 0
-
-            - Generation of CTR0: same as CTR1 with bit[0] set to zero.
+    [..]  A detailed description of the CCM message structure is available below.
 
       (#)  Four phases are performed in CCM for CRYP1 peripheral:
          (##) Init phase: peripheral prepares the GCM hash subkey (H) and do the IV processing
@@ -253,11 +198,11 @@
   [..]
   The compilation define  USE_HAL_CRYP_REGISTER_CALLBACKS when set to 1
   allows the user to configure dynamically the driver callbacks.
-  Use Functions @ref HAL_CRYP_RegisterCallback() or HAL_CRYP_RegisterXXXCallback()
+  Use Functions HAL_CRYP_RegisterCallback() or HAL_CRYP_RegisterXXXCallback()
   to register an interrupt callback.
 
   [..]
-  Function @ref HAL_CRYP_RegisterCallback() allows to register following callbacks:
+  Function HAL_CRYP_RegisterCallback() allows to register following callbacks:
     (+) InCpltCallback     :  Input FIFO transfer completed callback.
     (+) OutCpltCallback    : Output FIFO transfer completed callback.
     (+) ErrorCallback      : callback for error detection.
@@ -267,9 +212,9 @@
   and a pointer to the user callback function.
 
   [..]
-  Use function @ref HAL_CRYP_UnRegisterCallback() to reset a callback to the default
+  Use function HAL_CRYP_UnRegisterCallback() to reset a callback to the default
   weak function.
-  @ref HAL_CRYP_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+  HAL_CRYP_UnRegisterCallback() takes as parameters the HAL peripheral handle,
   and the Callback ID.
   This function allows to reset following callbacks:
     (+) InCpltCallback     :  Input FIFO transfer completed callback.
@@ -279,13 +224,13 @@
     (+) MspDeInitCallback  : CRYP MspDeInit.
 
   [..]
-  By default, after the @ref HAL_CRYP_Init() and when the state is HAL_CRYP_STATE_RESET
+  By default, after the HAL_CRYP_Init() and when the state is HAL_CRYP_STATE_RESET
   all callbacks are set to the corresponding weak functions :
-  examples @ref HAL_CRYP_InCpltCallback() , @ref HAL_CRYP_OutCpltCallback().
+  examples HAL_CRYP_InCpltCallback() , HAL_CRYP_OutCpltCallback().
   Exception done for MspInit and MspDeInit functions that are
-  reset to the legacy weak function in the @ref HAL_CRYP_Init()/ @ref HAL_CRYP_DeInit() only when
+  reset to the legacy weak function in the HAL_CRYP_Init()/ HAL_CRYP_DeInit() only when
   these callbacks are null (not registered beforehand).
-  if not, MspInit or MspDeInit are not null, the @ref HAL_CRYP_Init() / @ref HAL_CRYP_DeInit()
+  if not, MspInit or MspDeInit are not null, the HAL_CRYP_Init() / HAL_CRYP_DeInit()
   keep and use the user MspInit/MspDeInit functions (registered beforehand)
 
   [..]
@@ -294,8 +239,8 @@
   in HAL_CRYP_STATE_READY or HAL_CRYP_STATE_RESET state,
   thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
   In that case first register the MspInit/MspDeInit user callbacks
-  using @ref HAL_CRYP_RegisterCallback() before calling @ref HAL_CRYP_DeInit()
-  or @ref HAL_CRYP_Init() function.
+  using HAL_CRYP_RegisterCallback() before calling HAL_CRYP_DeInit()
+  or HAL_CRYP_Init() function.
 
   [..]
   When The compilation define USE_HAL_CRYP_REGISTER_CALLBACKS is set to 0 or
@@ -380,6 +325,7 @@
 #define  CRYP_PHASE_HEADER_SUSPENDED     0x00000004U    /*!< GCM/GMAC/CCM header phase is suspended */
 #define  CRYP_PHASE_PAYLOAD_SUSPENDED    0x00000005U    /*!< GCM/CCM payload phase is suspended     */
 #endif /* USE_HAL_CRYP_SUSPEND_RESUME */
+#define  CRYP_PHASE_HEADER_DMA_FEED      0x00000006U    /*!< GCM/GMAC/CCM header is fed to the peripheral in DMA mode */
 
 #define CRYP_OPERATINGMODE_ENCRYPT                   0x00000000U     /*!< Encryption mode(Mode 1)  */
 #define CRYP_OPERATINGMODE_KEYDERIVATION             AES_CR_MODE_0   /*!< Key derivation mode  only used when performing ECB and CBC decryptions (Mode 2) */
@@ -404,9 +350,7 @@
   * @{
   */
 
-#define CRYP_SET_PHASE(__HANDLE__, __PHASE__)  do{(__HANDLE__)->Instance->CR &= (uint32_t)(~AES_CR_GCMPH);\
-                                                  (__HANDLE__)->Instance->CR |= (uint32_t)(__PHASE__);\
-                                                 }while(0U)
+#define CRYP_SET_PHASE(__HANDLE__, __PHASE__)   MODIFY_REG((__HANDLE__)->Instance->CR, AES_CR_GCMPH, (uint32_t)(__PHASE__))
 
 /**
   * @}
@@ -420,6 +364,7 @@
   */
 
 static void CRYP_SetDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uint16_t Size, uint32_t outputaddr);
+static HAL_StatusTypeDef CRYP_SetHeaderDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uint16_t Size);
 static void CRYP_DMAInCplt(DMA_HandleTypeDef *hdma);
 static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma);
 static void CRYP_DMAError(DMA_HandleTypeDef *hdma);
@@ -429,6 +374,7 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
 static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp);
 static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase_DMA(CRYP_HandleTypeDef *hcryp);
+static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_AESGCM_Process_DMA(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_AESGCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t Timeout);
@@ -442,6 +388,7 @@ static HAL_StatusTypeDef CRYP_AES_Decrypt_IT(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_AES_Encrypt_IT(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_AES_Decrypt_DMA(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_WaitOnCCFlag(CRYP_HandleTypeDef *hcryp, uint32_t Timeout);
+static void CRYP_ClearCCFlagWhenHigh(CRYP_HandleTypeDef *hcryp, uint32_t Timeout);
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
 static void CRYP_Read_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output);
 static void CRYP_Write_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input);
@@ -477,13 +424,13 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp);
       (+) DeInitialize the CRYP MSP
       (+) configure CRYP (HAL_CRYP_SetConfig) with the specified parameters in the CRYP_ConfigTypeDef
           Parameters which are configured in This section are :
-          (+) Key size
-          (+) Data Type : 32,16, 8 or 1bit
-          (+) AlgoMode :
-              - for CRYP1 peripheral :
+          (++) Key size
+          (++) Data Type : 32,16, 8 or 1bit
+          (++) AlgoMode :
+              (+++) for CRYP1 peripheral :
                  ECB and CBC in DES/TDES Standard
                  ECB,CBC,CTR,GCM/GMAC and CCM in AES Standard.
-              - for TinyAES2 peripheral, only ECB,CBC,CTR,GCM/GMAC and CCM in AES Standard are supported.
+              (+++) for TinyAES2 peripheral, only ECB,CBC,CTR,GCM/GMAC and CCM in AES Standard are supported.
       (+) Get CRYP configuration (HAL_CRYP_GetConfig) from the specified parameters in the CRYP_HandleTypeDef
 
 @endverbatim
@@ -981,11 +928,15 @@ void HAL_CRYP_ProcessSuspend(CRYP_HandleTypeDef *hcryp)
   */
 HAL_StatusTypeDef HAL_CRYP_Suspend(CRYP_HandleTypeDef *hcryp)
 {
+  HAL_CRYP_STATETypeDef state;
+
   /* Request suspension */
   HAL_CRYP_ProcessSuspend(hcryp);
 
-  while ((HAL_CRYP_GetState(hcryp) != HAL_CRYP_STATE_SUSPENDED) && \
-          (HAL_CRYP_GetState(hcryp) != HAL_CRYP_STATE_READY));
+  do
+  {
+    state = HAL_CRYP_GetState(hcryp);
+  } while ((state != HAL_CRYP_STATE_SUSPENDED) && (state != HAL_CRYP_STATE_READY));
 
   if (HAL_CRYP_GetState(hcryp) == HAL_CRYP_STATE_READY)
   {
@@ -1019,7 +970,8 @@ HAL_StatusTypeDef HAL_CRYP_Suspend(CRYP_HandleTypeDef *hcryp)
     hcryp->CrypOutCount_saved      = hcryp->CrypOutCount;
     hcryp->Phase_saved             = hcryp->Phase;
     hcryp->State_saved             = hcryp->State;
-    hcryp->Size_saved              = ( (hcryp->Init.DataWidthUnit == CRYP_DATAWIDTHUNIT_WORD) ? hcryp->Size /4 : hcryp->Size);
+    hcryp->Size_saved              = ( (hcryp->Init.DataWidthUnit == CRYP_DATAWIDTHUNIT_WORD) ? (hcryp->Size /4U) : hcryp->Size);
+    hcryp->SizesSum_saved          = hcryp->SizesSum;
     hcryp->AutoKeyDerivation_saved = hcryp->AutoKeyDerivation;
     hcryp->CrypHeaderCount_saved   = hcryp->CrypHeaderCount;
     hcryp->SuspendRequest          = HAL_CRYP_SUSPEND_NONE;
@@ -1049,6 +1001,12 @@ HAL_StatusTypeDef HAL_CRYP_Suspend(CRYP_HandleTypeDef *hcryp)
   */
 HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
 {
+  /* Check the CRYP handle allocation */
+  if (hcryp == NULL)
+  {
+    return HAL_ERROR;
+  }
+
   if (hcryp->State_saved != HAL_CRYP_STATE_SUSPENDED)
   {
     /* CRYP was not suspended */
@@ -1075,16 +1033,14 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
         hcryp->Init.pInitVect     = hcryp->IV_saved;
       }
       __HAL_CRYP_DISABLE(hcryp);
-      if (HAL_CRYP_Init(hcryp) != HAL_OK)
-      {
-        return HAL_ERROR;
-      }
+      (void) HAL_CRYP_Init(hcryp);
     }
     else    /* Authentication algorithms case */
     {
       /* Restore low-priority block CRYP handle parameters */
       hcryp->Phase           = hcryp->Phase_saved;
       hcryp->CrypHeaderCount = hcryp->CrypHeaderCount_saved;
+      hcryp->SizesSum        = hcryp->SizesSum_saved;
 
       /* Disable AES and write-back SUSPxR registers */;
       __HAL_CRYP_DISABLE(hcryp);
@@ -1094,8 +1050,6 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
       hcryp->Instance->CR = hcryp->CR_saved;
       CRYP_Write_KeyRegisters(hcryp, hcryp->Key_saved, hcryp->Init.KeySize);
       CRYP_Write_IVRegisters(hcryp, hcryp->IV_saved);
-      __HAL_CRYP_ENABLE_IT(hcryp,CRYP_IT_CCFIE | CRYP_IT_ERRIE);
-      __HAL_CRYP_ENABLE(hcryp);
 
       /* At the same time, set handle state back to READY to be able to resume the AES calculations
       without the processing APIs returning HAL_BUSY when called. */
@@ -1157,12 +1111,87 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
   * @{
   */
 
+/* GCM message structure additional details
+
+                                  ICB
+          +-------------------------------------------------------+
+          |       Initialization vector (IV)      |  Counter      |
+          |----------------|----------------|-----------|---------|
+         127              95                63            31       0
+
+
+              Bit Number    Register           Contents
+              ----------   ---------------       -----------
+              127 ...96    CRYP_IV1R[31:0]     ICB[127:96]
+              95  ...64    CRYP_IV1L[31:0]     B0[95:64]
+              63 ... 32    CRYP_IV0R[31:0]     ICB[63:32]
+              31 ... 0     CRYP_IV0L[31:0]     ICB[31:0], where 32-bit counter= 0x2
+
+
+
+                                 GCM last block definition
+          +-------------------------------------------------------------------+
+          |  Bit[0]   |  Bit[32]           |  Bit[64]  | Bit[96]              |
+          |-----------|--------------------|-----------|----------------------|
+          |   0x0     | Header length[31:0]|     0x0   | Payload length[31:0] |
+          |-----------|--------------------|-----------|----------------------|
+
+*/
+
+/* CCM message blocks description
+
+         (##) B0 block  : According to NIST Special Publication 800-38C,
+            The first block B0 is formatted as follows, where l(m) is encoded in
+            most-significant-byte first order:
+
+                Octet Number   Contents
+                ------------   ---------
+                0              Flags
+                1 ... 15-q     Nonce N
+                16-q ... 15    Q
+
+            the Flags field is formatted as follows:
+
+                Bit Number   Contents
+                ----------   ----------------------
+                7            Reserved (always zero)
+                6            Adata
+                5 ... 3      (t-2)/2
+                2 ... 0      [q-1]3
+
+              - Q: a bit string representation of the octet length of P (plaintext)
+              - q The octet length of the binary representation of the octet length of the payload
+              - A nonce (N), n The octet length of the where n+q=15.
+              - Flags: most significant octet containing four flags for control information,
+              - t The octet length of the MAC.
+         (##) B1 block (header) : associated data length(a) concatenated with Associated Data (A)
+              the associated data length expressed in bytes (a) defined as below:
+            - If 0 < a < 216-28, then it is encoded as [a]16, i.e. two octets
+            - If 216-28 < a < 232, then it is encoded as 0xff || 0xfe || [a]32, i.e. six octets
+            - If 232 < a < 264, then it is encoded as 0xff || 0xff || [a]64, i.e. ten octets
+         (##) CTRx block  : control blocks
+            - Generation of CTR1 from first block B0 information :
+              equal to B0 with first 5 bits zeroed and most significant bits storing octet
+              length of P also zeroed, then incremented by one
+
+                Bit Number    Register           Contents
+                ----------   ---------------       -----------
+                127 ...96    CRYP_IV1R[31:0]     B0[127:96], where Q length bits are set to 0, except for
+                                                 bit 0 that is set to 1
+                95  ...64    CRYP_IV1L[31:0]     B0[95:64]
+                63 ... 32    CRYP_IV0R[31:0]     B0[63:32]
+                31 ... 0     CRYP_IV0L[31:0]     B0[31:0], where flag bits set to 0
+
+            - Generation of CTR0: same as CTR1 with bit[0] set to zero.
+
+*/
+
 /**
   * @brief  Encryption mode.
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  Input Pointer to the input buffer (plaintext)
-  * @param  Size Length of the plaintext buffer in word.
+  * @param  Size Length of the plaintext buffer in bytes or words (depending upon DataWidthUnit field)
   * @param  Output Pointer to the output buffer(ciphertext)
   * @param  Timeout Specify Timeout value
   * @retval HAL status
@@ -1171,6 +1200,12 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
 {
   uint32_t algo;
   HAL_StatusTypeDef status;
+#ifdef  USE_FULL_ASSERT
+  uint32_t algo_assert = (hcryp->Instance->CR) & AES_CR_CHMOD;
+
+  /* Check input buffer size */
+  assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
+#endif
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1256,7 +1291,7 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  Input Pointer to the input buffer (ciphertext )
-  * @param  Size Length of the plaintext buffer in word.
+  * @param  Size Length of the plaintext buffer in bytes or words (depending upon DataWidthUnit field)
   * @param  Output Pointer to the output buffer(plaintext)
   * @param  Timeout Specify Timeout value
   * @retval HAL status
@@ -1265,6 +1300,12 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
 {
   HAL_StatusTypeDef status;
   uint32_t algo;
+#ifdef  USE_FULL_ASSERT
+  uint32_t algo_assert = (hcryp->Instance->CR) & AES_CR_CHMOD;
+
+  /* Check input buffer size */
+  assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
+#endif
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1350,7 +1391,7 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  Input Pointer to the input buffer (plaintext)
-  * @param  Size Length of the plaintext buffer in word
+  * @param  Size Length of the plaintext buffer in bytes or words (depending upon DataWidthUnit field)
   * @param  Output Pointer to the output buffer(ciphertext)
   * @retval HAL status
   */
@@ -1358,6 +1399,12 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
 {
   HAL_StatusTypeDef status;
   uint32_t algo;
+#ifdef  USE_FULL_ASSERT
+  uint32_t algo_assert = (hcryp->Instance->CR) & AES_CR_CHMOD;
+
+  /* Check input buffer size */
+  assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
+#endif
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1374,8 +1421,8 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
      hcryp->ResumingFlag = 0U;
      if (hcryp->Phase != CRYP_PHASE_HEADER_SUSPENDED)
      {
-       hcryp->CrypInCount = hcryp->CrypInCount_saved;
-       hcryp->CrypOutCount = hcryp->CrypOutCount_saved;
+       hcryp->CrypInCount = (uint16_t) hcryp->CrypInCount_saved;
+       hcryp->CrypOutCount = (uint16_t) hcryp->CrypOutCount_saved;
      }
      else
      {
@@ -1454,7 +1501,7 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  Input Pointer to the input buffer (ciphertext )
-  * @param  Size Length of the plaintext buffer in word.
+  * @param  Size Length of the plaintext buffer in bytes or words (depending upon DataWidthUnit field)
   * @param  Output Pointer to the output buffer(plaintext)
   * @retval HAL status
   */
@@ -1462,6 +1509,12 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
 {
   HAL_StatusTypeDef status;
   uint32_t algo;
+#ifdef  USE_FULL_ASSERT
+  uint32_t algo_assert = (hcryp->Instance->CR) & AES_CR_CHMOD;
+
+  /* Check input buffer size */
+  assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
+#endif
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1478,8 +1531,8 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
      hcryp->ResumingFlag = 0U;
      if (hcryp->Phase != CRYP_PHASE_HEADER_SUSPENDED)
      {
-       hcryp->CrypInCount = hcryp->CrypInCount_saved;
-       hcryp->CrypOutCount = hcryp->CrypOutCount_saved;
+       hcryp->CrypInCount = (uint16_t) hcryp->CrypInCount_saved;
+       hcryp->CrypOutCount = (uint16_t) hcryp->CrypOutCount_saved;
      }
      else
      {
@@ -1557,7 +1610,7 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  Input Pointer to the input buffer (plaintext)
-  * @param  Size Length of the plaintext buffer in word.
+  * @param  Size Length of the plaintext buffer in bytes or words (depending upon DataWidthUnit field)
   * @param  Output Pointer to the output buffer(ciphertext)
   * @retval HAL status
   */
@@ -1566,6 +1619,12 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
   HAL_StatusTypeDef status;
   uint32_t algo;
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
+#ifdef  USE_FULL_ASSERT
+  uint32_t algo_assert = (hcryp->Instance->CR) & AES_CR_CHMOD;
+
+  /* Check input buffer size */
+  assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
+#endif
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1678,7 +1737,7 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  Input Pointer to the input buffer (ciphertext )
-  * @param  Size Length of the plaintext buffer in word
+  * @param  Size Length of the plaintext buffer in bytes or words (depending upon DataWidthUnit field)
   * @param  Output Pointer to the output buffer(plaintext)
   * @retval HAL status
   */
@@ -1686,6 +1745,12 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
 {
   HAL_StatusTypeDef status;
   uint32_t algo;
+#ifdef  USE_FULL_ASSERT
+  uint32_t algo_assert = (hcryp->Instance->CR) & AES_CR_CHMOD;
+
+  /* Check input buffer size */
+  assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
+#endif
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1810,7 +1875,7 @@ void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp)
     /* Clear computation complete flag */
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
 
-    if (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC)
+    if ((hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC) || (hcryp->Init.Algorithm == CRYP_AES_CCM))
     {
 
       /* if header phase */
@@ -1819,18 +1884,6 @@ void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp)
         CRYP_GCMCCM_SetHeaderPhase_IT(hcryp);
       }
       else  /* if payload phase */
-      {
-        CRYP_GCMCCM_SetPayloadPhase_IT(hcryp);
-      }
-    }
-    else if (hcryp->Init.Algorithm == CRYP_AES_CCM)
-    {
-      /* if header phase */
-      if (hcryp->Init.HeaderSize >=  hcryp->CrypHeaderCount)
-      {
-        CRYP_GCMCCM_SetHeaderPhase_IT(hcryp);
-      }
-      else   /* if payload phase */
       {
         CRYP_GCMCCM_SetPayloadPhase_IT(hcryp);
       }
@@ -2443,9 +2496,80 @@ static HAL_StatusTypeDef CRYP_AES_Decrypt_DMA(CRYP_HandleTypeDef *hcryp)
 static void CRYP_DMAInCplt(DMA_HandleTypeDef *hdma)
 {
   CRYP_HandleTypeDef *hcryp = (CRYP_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+  uint32_t loopcounter;
+  uint32_t headersize_in_bytes;
+  uint32_t tmp;
+  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
 
   /* Stop the DMA transfers to the IN FIFO by clearing to "0" the DMAINEN */
   CLEAR_BIT(hcryp->Instance->CR, AES_CR_DMAINEN);
+
+  if (hcryp->Phase == CRYP_PHASE_HEADER_DMA_FEED)
+  {
+    /* DMA is disabled, CCF is meaningful. Wait for computation completion before moving forward */
+    CRYP_ClearCCFlagWhenHigh(hcryp, CRYP_TIMEOUT_GCMCCMHEADERPHASE);
+
+    /* Set the phase */
+    hcryp->Phase = CRYP_PHASE_PROCESS;
+
+    if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
+    {
+      headersize_in_bytes = hcryp->Init.HeaderSize * 4U;
+    }
+    else
+    {
+      headersize_in_bytes = hcryp->Init.HeaderSize;
+    }
+
+    if ((headersize_in_bytes % 16U) != 0U)
+    {
+      /* Write last words that couldn't be fed by DMA */
+      hcryp->CrypHeaderCount = (uint16_t)((headersize_in_bytes / 16U) * 4U);
+      for (loopcounter = 0U; (loopcounter < ((headersize_in_bytes / 4U) % 4U)); loopcounter++)
+      {
+        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        hcryp->CrypHeaderCount++ ;
+      }
+      /* If the header size is a multiple of words */
+      if ((headersize_in_bytes % 4U) == 0U)
+      {
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
+      }
+      else
+      {
+        /* Enter last bytes, padded with zeros */
+        tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        tmp &= mask[(hcryp->Init.DataType * 2U) + (headersize_in_bytes % 4U)];
+        hcryp->Instance->DINR = tmp;
+        loopcounter++;
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
+      }
+
+      /* Wait for computation completion before moving forward */
+      CRYP_ClearCCFlagWhenHigh(hcryp, CRYP_TIMEOUT_GCMCCMHEADERPHASE);
+    } /* if ((headersize_in_bytes % 16U) != 0U) */
+
+    /* Set to 0 the number of non-valid bytes using NPBLB register*/
+    MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
+
+    /* Select payload phase once the header phase is performed */
+    CRYP_SET_PHASE(hcryp, CRYP_PHASE_PAYLOAD);
+
+    /* Initiate payload DMA IN and processed data DMA OUT transfers */
+    (void)CRYP_GCMCCM_SetPayloadPhase_DMA(hcryp);
+  }
 
   /* Call input data transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -2467,7 +2591,7 @@ static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma)
   uint32_t count;
   uint32_t npblb;
   uint32_t lastwordsize;
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t temp[4];  /* Temporary CrypOutBuff */
   uint32_t mode;
 
   CRYP_HandleTypeDef *hcryp = (CRYP_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
@@ -2520,44 +2644,21 @@ static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma)
     }
 
     /*Wait on CCF flag*/
-    count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
-    do
-    {
-      count-- ;
-      if (count == 0U)
-      {
-        /* Disable the CRYP peripheral clock */
-        __HAL_CRYP_DISABLE(hcryp);
-
-        /* Change state */
-        hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-        hcryp->State = HAL_CRYP_STATE_READY;
-
-        /* Process unlocked */
-        __HAL_UNLOCK(hcryp);
-
-#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-        /*Call registered error callback*/
-        hcryp->ErrorCallback(hcryp);
-#else
-        /*Call legacy weak error callback*/
-        HAL_CRYP_ErrorCallback(hcryp);
-#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
-      }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
-
-    /* Clear CCF flag */
-    __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
+    CRYP_ClearCCFlagWhenHigh(hcryp, CRYP_TIMEOUT_GCMCCMHEADERPHASE);
 
     /*Read the output block from the output FIFO */
     for (count = 0U; count < 4U; count++)
     {
       /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
-      temp = hcryp->Instance->DOUTR;
+      temp[count] = hcryp->Instance->DOUTR;
+    }
 
-      *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
+    count = 0U;
+    while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (count<4U))
+    {
+      *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[count];
       hcryp->CrypOutCount++;
+      count++;
     }
   }
 
@@ -2616,7 +2717,7 @@ static void CRYP_DMAError(DMA_HandleTypeDef *hdma)
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @param  inputaddr address of the input buffer
-  * @param  Size size of the input buffer, must be a multiple of 16.
+  * @param  Size size of the input and output buffers in words, must be a multiple of 4
   * @param  outputaddr address of the output buffer
   * @retval None
   */
@@ -2675,6 +2776,43 @@ static void CRYP_SetDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uin
 }
 
 /**
+  * @brief  Set the DMA configuration and start the header DMA transfer
+  * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  inputaddr address of the input buffer
+  * @param  Size size of the input buffer in words, must be a multiple of 4
+  * @retval None
+  */
+static HAL_StatusTypeDef CRYP_SetHeaderDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uint16_t Size)
+{
+  /* Set the CRYP DMA transfer complete callback */
+  hcryp->hdmain->XferCpltCallback = CRYP_DMAInCplt;
+
+  /* Set the DMA input error callback */
+  hcryp->hdmain->XferErrorCallback = CRYP_DMAError;
+
+  /* Mark that header is fed to the peripheral in DMA mode */
+  hcryp->Phase = CRYP_PHASE_HEADER_DMA_FEED;
+  /* Enable the DMA input stream */
+  if (HAL_DMA_Start_IT(hcryp->hdmain, inputaddr, (uint32_t)&hcryp->Instance->DINR, Size) != HAL_OK)
+  {
+    /* DMA error code field */
+    hcryp->ErrorCode |= HAL_CRYP_ERROR_DMA;
+    hcryp->State = HAL_CRYP_STATE_READY;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcryp);
+    return HAL_ERROR;
+    /* Call error callback */
+  }
+
+  /* Enable IN DMA requests */
+  SET_BIT(hcryp->Instance->CR, AES_CR_DMAINEN);
+
+  return HAL_OK;
+}
+
+/**
   * @brief  Process Data: Write Input data in polling mode and used in AES functions.
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
@@ -2684,7 +2822,8 @@ static void CRYP_SetDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uin
 static void CRYP_AES_ProcessData(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
 {
 
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t temp[4];  /* Temporary CrypOutBuff */
+  uint32_t i;
 
   /* Write the input block in the IN FIFO */
   hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
@@ -2721,19 +2860,17 @@ static void CRYP_AES_ProcessData(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
   __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
 
   /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer*/
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-  hcryp->CrypOutCount++;
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount)   = temp;
-  hcryp->CrypOutCount++;
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-  hcryp->CrypOutCount++;
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount)   = temp;
-  hcryp->CrypOutCount++;
-
+  for (i = 0U; i < 4U; i++)
+  {
+    temp[i] = hcryp->Instance->DOUTR;
+  }
+  i= 0U;
+  while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (i<4U))
+  {
+    *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[i];
+    hcryp->CrypOutCount++;
+    i++;
+  }
 }
 
 /**
@@ -2746,24 +2883,23 @@ static void CRYP_AES_ProcessData(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
   */
 static void CRYP_AES_IT(CRYP_HandleTypeDef *hcryp)
 {
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t temp[4];  /* Temporary CrypOutBuff */
+  uint32_t i;
 
   if (hcryp->State == HAL_CRYP_STATE_BUSY)
   {
     /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer*/
-    temp  = hcryp->Instance->DOUTR;
-    *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-    hcryp->CrypOutCount++;
-    temp  = hcryp->Instance->DOUTR;
-    *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount)   = temp;
-    hcryp->CrypOutCount++;
-    temp  = hcryp->Instance->DOUTR;
-    *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-    hcryp->CrypOutCount++;
-    temp  = hcryp->Instance->DOUTR;
-    *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount)   = temp;
-    hcryp->CrypOutCount++;
-
+    for (i = 0U; i < 4U; i++)
+    {
+      temp[i] = hcryp->Instance->DOUTR;
+    }
+    i= 0U;
+    while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (i<4U))
+    {
+      *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[i];
+      hcryp->CrypOutCount++;
+      i++;
+    }
     if (hcryp->CrypOutCount ==  (hcryp->Size / 4U))
     {
       /* Disable Computation Complete flag and errors interrupts */
@@ -2900,7 +3036,7 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
   uint32_t tickstart;
   uint32_t wordsize = ((uint32_t)hcryp->Size / 4U) ;
   uint32_t npblb;
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t temp[4];  /* Temporary CrypOutBuff */
   uint32_t index;
   uint32_t lastwordsize;
   uint32_t incount;  /* Temporary CrypInCount Value */
@@ -3079,9 +3215,11 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
     for (index = 0U; index < 4U; index++)
     {
       /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
-      temp = hcryp->Instance->DOUTR;
-
-      *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
+      temp[index] = hcryp->Instance->DOUTR;
+    }
+    for (index = 0U; index < lastwordsize; index++)
+    {
+      *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp[index];
       hcryp->CrypOutCount++;
     }
   }
@@ -3103,6 +3241,12 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
   uint32_t lastwordsize;
   uint32_t npblb;
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
+  uint32_t headersize_in_bytes;
+  uint32_t tmp;
+  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+
 
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
   if ((hcryp->Phase == CRYP_PHASE_HEADER_SUSPENDED) || (hcryp->Phase == CRYP_PHASE_PAYLOAD_SUSPENDED))
@@ -3111,6 +3255,17 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
     return HAL_OK;
   }
 #endif /* USE_HAL_CRYP_SUSPEND_RESUME */
+
+  /* Manage header size given in bytes to handle cases where
+     header size is not a multiple of 4 bytes */
+  if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
+  {
+    headersize_in_bytes = hcryp->Init.HeaderSize * 4U;
+  }
+  else
+  {
+    headersize_in_bytes = hcryp->Init.HeaderSize;
+  }
 
   if (hcryp->Init.KeyIVConfigSkip == CRYP_KEYIVCONFIG_ONCE)
   {
@@ -3278,27 +3433,43 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         }
       }
     }
-    else if ((hcryp->Init.HeaderSize) < 4U)
+    /* Enter header data */
+    /* Cher first whether header length is small enough to enter the full header in one shot */
+    else if (headersize_in_bytes <= 16U)
     {
-      for (loopcounter = 0U; loopcounter < hcryp->Init.HeaderSize ; loopcounter++)
+      /* Write header data, padded with zeros if need be */
+      for (loopcounter = 0U; (loopcounter < (headersize_in_bytes / 4U)); loopcounter++)
       {
         hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
         hcryp->CrypHeaderCount++ ;
       }
+      /* If the header size is a multiple of words */
+      if ((headersize_in_bytes % 4U) == 0U)
+      {
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+          hcryp->CrypHeaderCount++;
+        }
+      }
+      else
+      {
+        /* Enter last bytes, padded with zeros */
+        tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        tmp &= mask[(hcryp->Init.DataType * 2U) + (headersize_in_bytes % 4U)];
+        hcryp->Instance->DINR = tmp;
+        loopcounter++;
+        hcryp->CrypHeaderCount++ ;
+        /* Pad the data with zeros to have a complete block */
       while (loopcounter < 4U)
       {
-        /* pad the data with zeros to have a complete block */
         hcryp->Instance->DINR = 0x0U;
         loopcounter++;
+          hcryp->CrypHeaderCount++;
+        }
       }
-      /* Set the phase */
-      hcryp->Phase = CRYP_PHASE_PROCESS;
-
-      /* Select payload phase once the header phase is performed */
-      CRYP_SET_PHASE(hcryp, CRYP_PHASE_PAYLOAD);
-
-      /* Set to 0 the number of non-valid bytes using NPBLB register*/
-      MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
 
       /* Call Input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -3311,7 +3482,8 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
     }
     else
     {
-      /* Write the input block in the IN FIFO */
+      /* Write the first input header block in the Input FIFO,
+         the following header data will be fed after interrupt occurrence */
       hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
       hcryp->CrypHeaderCount++;
       hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
@@ -3423,12 +3595,7 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
   */
 static HAL_StatusTypeDef CRYP_AESGCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
 {
-  __IO uint32_t count;
-  uint16_t wordsize = hcryp->Size / 4U ;
-  uint32_t index;
-  uint32_t npblb;
-  uint32_t lastwordsize;
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t count;
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
 
   if (hcryp->Init.KeyIVConfigSkip == CRYP_KEYIVCONFIG_ONCE)
@@ -3507,119 +3674,15 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
       return HAL_ERROR;
     }
 
-    /************************ Payload phase ************************************/
-
-    /* Set the phase */
-    hcryp->Phase = CRYP_PHASE_PROCESS;
-
-    /* Set to 0 the number of non-valid bytes using NPBLB register*/
-    MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
-
-    /* Select payload phase once the header phase is performed */
-    CRYP_SET_PHASE(hcryp, CRYP_PHASE_PAYLOAD);
-
+  }
+  else
+  {
+    /* Initialization and header phases already done, only do payload phase */
+    if (CRYP_GCMCCM_SetPayloadPhase_DMA(hcryp) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
   } /* if (DoKeyIVConfig == 1U) */
-
-  if (hcryp->Size == 0U)
-  {
-    /* Process unLocked */
-    __HAL_UNLOCK(hcryp);
-
-    /* Change the CRYP state and phase */
-    hcryp->State = HAL_CRYP_STATE_READY;
-  }
-  else if (hcryp->Size >= 16U)
-  {
-    /*DMA transfer must not include the last block in case of Size is not %16 */
-    wordsize = wordsize - (wordsize % 4U);
-
-    /*DMA transfer */
-    CRYP_SetDMAConfig(hcryp, (uint32_t)(hcryp->pCrypInBuffPtr), wordsize, (uint32_t)(hcryp->pCrypOutBuffPtr));
-  }
-  else /* length of input data is < 16 */
-  {
-    /* Compute the number of padding bytes in last block of payload */
-    npblb = 16U - (uint32_t)hcryp->Size;
-
-    /* Set Npblb in case of AES GCM payload encryption to get right tag*/
-    if ((hcryp->Instance->CR & AES_CR_MODE) == CRYP_OPERATINGMODE_ENCRYPT)
-    {
-      /* Specify the number of non-valid bytes using NPBLB register*/
-      MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, npblb << 20U);
-    }
-
-    /* Enable CRYP to start the final phase */
-    __HAL_CRYP_ENABLE(hcryp);
-
-    /* Number of valid words (lastwordsize) in last block */
-    if ((npblb % 4U) == 0U)
-    {
-      lastwordsize = (16U - npblb) / 4U;
-    }
-    else
-    {
-      lastwordsize = ((16U - npblb) / 4U) + 1U;
-    }
-
-    /*  last block optionally pad the data with zeros*/
-    for (index = 0U; index < lastwordsize; index ++)
-    {
-      /* Write the last Input block in the IN FIFO */
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
-      hcryp->CrypInCount++;
-    }
-    while (index < 4U)
-    {
-      /* pad the data with zeros to have a complete block */
-      hcryp->Instance->DINR  = 0U;
-      index++;
-    }
-    /* Wait for CCF flag to be raised */
-    count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
-    do
-    {
-      count-- ;
-      if (count == 0U)
-      {
-        /* Disable the CRYP peripheral clock */
-        __HAL_CRYP_DISABLE(hcryp);
-
-        /* Change state */
-        hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-        hcryp->State = HAL_CRYP_STATE_READY;
-
-        /* Process unlocked */
-        __HAL_UNLOCK(hcryp);
-#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-        /*Call registered error callback*/
-        hcryp->ErrorCallback(hcryp);
-#else
-        /*Call legacy weak error callback*/
-        HAL_CRYP_ErrorCallback(hcryp);
-#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
-      }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
-
-    /* Clear CCF Flag */
-    __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
-
-    /*Read the output block from the output FIFO */
-    for (index = 0U; index < 4U; index++)
-    {
-      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
-      temp = hcryp->Instance->DOUTR;
-
-      *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-      hcryp->CrypOutCount++;
-    }
-
-    /* Change the CRYP state to ready */
-    hcryp->State = HAL_CRYP_STATE_READY;
-
-    /* Process unlocked */
-    __HAL_UNLOCK(hcryp);
-  }
 
   /* Return function status */
   return HAL_OK;
@@ -3641,7 +3704,7 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
   uint32_t loopcounter;
   uint32_t npblb;
   uint32_t lastwordsize;
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t temp[4] ;  /* Temporary CrypOutBuff */
   uint32_t incount;  /* Temporary CrypInCount Value */
   uint32_t outcount;  /* Temporary CrypOutCount Value */
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
@@ -3813,9 +3876,11 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
     for (loopcounter = 0U; loopcounter < 4U; loopcounter++)
     {
       /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
-      temp = hcryp->Instance->DOUTR;
-
-      *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
+      temp[loopcounter] = hcryp->Instance->DOUTR;
+    }
+    for (loopcounter = 0U; loopcounter<lastwordsize; loopcounter++)
+    {
+      *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[loopcounter];
       hcryp->CrypOutCount++;
     }
   }
@@ -4133,12 +4198,7 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
   */
 static HAL_StatusTypeDef CRYP_AESCCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
 {
-  __IO uint32_t count    = 0U;
-  uint16_t wordsize = hcryp->Size / 4U ;
-  uint32_t index;
-  uint32_t npblb;
-  uint32_t lastwordsize;
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t count;
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
 
   if (hcryp->Init.KeyIVConfigSkip == CRYP_KEYIVCONFIG_ONCE)
@@ -4219,116 +4279,15 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
       return HAL_ERROR;
     }
 
-    /******************** Payload phase *****************************************/
-
-    /* Set the phase */
-    hcryp->Phase = CRYP_PHASE_PROCESS;
-
-    /* Set to 0 the number of non-valid bytes using NPBLB register*/
-    MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
-
-    /* Select payload phase once the header phase is performed */
-    MODIFY_REG(hcryp->Instance->CR, AES_CR_GCMPH, CRYP_PHASE_PAYLOAD);
-
+  }
+  else
+  {
+    /* Initialization and header phases already done, only do payload phase */
+    if (CRYP_GCMCCM_SetPayloadPhase_DMA(hcryp) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
   } /* if (DoKeyIVConfig == 1U) */
-
-  if (hcryp->Size == 0U)
-  {
-    /* Process unLocked */
-    __HAL_UNLOCK(hcryp);
-
-    /* Change the CRYP state and phase */
-    hcryp->State = HAL_CRYP_STATE_READY;
-  }
-  else if (hcryp->Size >= 16U)
-  {
-    /*DMA transfer must not include the last block in case of Size is not %16 */
-    wordsize = wordsize - (wordsize % 4U);
-
-    /*DMA transfer */
-    CRYP_SetDMAConfig(hcryp, (uint32_t)(hcryp->pCrypInBuffPtr), wordsize, (uint32_t)(hcryp->pCrypOutBuffPtr));
-  }
-  else /* length of input data is < 16 */
-  {
-    /* Compute the number of padding bytes in last block of payload */
-    npblb = 16U - (uint32_t)hcryp->Size;
-
-    /* Set Npblb in case of AES CCM payload decryption to get right tag*/
-    if ((hcryp->Instance->CR & AES_CR_MODE) == CRYP_OPERATINGMODE_DECRYPT)
-    {
-      /* Specify the number of non-valid bytes using NPBLB register*/
-      MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, npblb << 20U);
-    }
-
-    /* Number of valid words (lastwordsize) in last block */
-    if ((npblb % 4U) == 0U)
-    {
-      lastwordsize = (16U - npblb) / 4U;
-    }
-    else
-    {
-      lastwordsize = ((16U - npblb) / 4U) + 1U;
-    }
-
-    /*  last block optionally pad the data with zeros*/
-    for (index = 0U; index < lastwordsize; index ++)
-    {
-      /* Write the last Input block in the IN FIFO */
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
-      hcryp->CrypInCount++;
-    }
-    while (index < 4U)
-    {
-      /* pad the data with zeros to have a complete block */
-      hcryp->Instance->DINR  = 0U;
-      index++;
-    }
-    /* Wait for CCF flag to be raised */
-    count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
-    do
-    {
-      count-- ;
-      if (count == 0U)
-      {
-        /* Disable the CRYP peripheral clock */
-        __HAL_CRYP_DISABLE(hcryp);
-
-        /* Change state */
-        hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-        hcryp->State = HAL_CRYP_STATE_READY;
-
-        /* Process unlocked */
-        __HAL_UNLOCK(hcryp);
-#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-        /*Call registered error callback*/
-        hcryp->ErrorCallback(hcryp);
-#else
-        /*Call legacy weak error callback*/
-        HAL_CRYP_ErrorCallback(hcryp);
-#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
-      }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
-
-    /* Clear CCF Flag */
-    __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
-
-    /*Read the output block from the output FIFO */
-    for (index = 0U; index < 4U; index++)
-    {
-      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
-      temp = hcryp->Instance->DOUTR;
-
-      *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-      hcryp->CrypOutCount++;
-    }
-
-    /* Change the CRYP state to ready */
-    hcryp->State = HAL_CRYP_STATE_READY;
-
-    /* Process unlocked */
-    __HAL_UNLOCK(hcryp);
-  }
 
   /* Return function status */
   return HAL_OK;
@@ -4343,29 +4302,28 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
 static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
 {
   uint32_t loopcounter;
-  uint32_t temp;  /* Temporary CrypOutBuff */
+  uint32_t temp[4];  /* Temporary CrypOutBuff */
   uint32_t lastwordsize;
   uint32_t npblb;
   uint32_t mode;
   uint16_t incount;  /* Temporary CrypInCount Value */
   uint16_t outcount;  /* Temporary CrypOutCount Value */
+  uint32_t i;
 
   /***************************** Payload phase *******************************/
 
   /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer*/
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-  hcryp->CrypOutCount++;
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount)   = temp;
-  hcryp->CrypOutCount++;
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + (hcryp->CrypOutCount)) = temp;
-  hcryp->CrypOutCount++;
-  temp  = hcryp->Instance->DOUTR;
-  *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount)   = temp;
-  hcryp->CrypOutCount++;
-
+  for (i = 0U; i < 4U; i++)
+  {
+    temp[i] = hcryp->Instance->DOUTR;
+  }
+  i= 0U;
+  while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (i<4U))
+  {
+    *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[i];
+    hcryp->CrypOutCount++;
+    i++;
+  }
   incount = hcryp->CrypInCount;
   outcount = hcryp->CrypOutCount;
   if ((outcount >=  (hcryp->Size / 4U)) && ((incount * 4U) >=  hcryp->Size))
@@ -4482,6 +4440,122 @@ static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
 
 
 /**
+  * @brief  Sets the payload phase in DMA mode
+  * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval state
+  */
+static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcryp)
+{
+  uint16_t wordsize = hcryp->Size / 4U ;
+  uint32_t index;
+  uint32_t npblb;
+  uint32_t lastwordsize;
+  uint32_t temp[4];  /* Temporary CrypOutBuff */
+  uint32_t count;
+  uint32_t reg;
+
+  /************************ Payload phase ************************************/
+  if (hcryp->Size == 0U)
+  {
+    /* Process unLocked */
+    __HAL_UNLOCK(hcryp);
+
+    /* Change the CRYP state and phase */
+    hcryp->State = HAL_CRYP_STATE_READY;
+  }
+  else if (hcryp->Size >= 16U)
+  {
+    /*DMA transfer must not include the last block in case of Size is not %16 */
+    wordsize = wordsize - (wordsize % 4U);
+
+    /*DMA transfer */
+    CRYP_SetDMAConfig(hcryp, (uint32_t)(hcryp->pCrypInBuffPtr), wordsize, (uint32_t)(hcryp->pCrypOutBuffPtr));
+  }
+  else /* length of input data is < 16 */
+  {
+    /* Compute the number of padding bytes in last block of payload */
+    npblb = 16U - (uint32_t)hcryp->Size;
+
+    /* Set Npblb in case of AES GCM payload encryption or AES CCM payload decryption to get right tag*/
+    reg = hcryp->Instance->CR & (AES_CR_CHMOD|AES_CR_MODE);
+    if ((reg == (CRYP_AES_GCM_GMAC|CRYP_OPERATINGMODE_ENCRYPT)) ||\
+        (reg == (CRYP_AES_CCM|CRYP_OPERATINGMODE_DECRYPT)))
+    {
+      /* Specify the number of non-valid bytes using NPBLB register*/
+      MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, npblb << 20U);
+    }
+
+    /* Number of valid words (lastwordsize) in last block */
+    if ((npblb % 4U) == 0U)
+    {
+      lastwordsize = (16U - npblb) / 4U;
+    }
+    else
+    {
+      lastwordsize = ((16U - npblb) / 4U) + 1U;
+    }
+
+    /*  last block optionally pad the data with zeros*/
+    for (index = 0U; index < lastwordsize; index ++)
+    {
+      /* Write the last Input block in the IN FIFO */
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->CrypInCount++;
+    }
+    while (index < 4U)
+    {
+      /* pad the data with zeros to have a complete block */
+      hcryp->Instance->DINR  = 0U;
+      index++;
+    }
+    /* Wait for CCF flag to be raised */
+    count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
+    do
+    {
+      count-- ;
+      if (count == 0U)
+      {
+        /* Disable the CRYP peripheral clock */
+        __HAL_CRYP_DISABLE(hcryp);
+
+        /* Change state */
+        hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
+        hcryp->State = HAL_CRYP_STATE_READY;
+
+        /* Process unlocked */
+        __HAL_UNLOCK(hcryp);
+        return HAL_ERROR;
+      }
+    }
+    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+
+    /* Clear CCF Flag */
+    __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
+
+    /*Read the output block from the output FIFO */
+    for (index = 0U; index < 4U; index++)
+    {
+      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
+      temp[index] = hcryp->Instance->DOUTR;
+    }
+    for (index = 0U; index < lastwordsize; index++)
+    {
+      *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[index];
+      hcryp->CrypOutCount++;
+    }
+
+    /* Change the CRYP state to ready */
+    hcryp->State = HAL_CRYP_STATE_READY;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hcryp);
+  }
+
+  return HAL_OK;
+}
+
+/**
   * @brief  Sets the header phase in polling mode
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module(Header & HeaderSize)
@@ -4491,10 +4565,23 @@ static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
 static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
 {
   uint32_t loopcounter;
+  uint32_t size_in_bytes;
+  uint32_t tmp;
+  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
 
   /***************************** Header phase for GCM/GMAC or CCM *********************************/
+  if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
+  {
+    size_in_bytes = hcryp->Init.HeaderSize * 4U;
+  }
+  else
+  {
+    size_in_bytes = hcryp->Init.HeaderSize;
+  }
 
-  if ((hcryp->Init.HeaderSize != 0U))
+  if ((size_in_bytes != 0U))
   {
     /* Select header phase */
     CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
@@ -4502,10 +4589,11 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
     /* Enable the CRYP peripheral */
     __HAL_CRYP_ENABLE(hcryp);
 
-    if ((hcryp->Init.HeaderSize % 4U) == 0U)
+    /* If size_in_bytes is a multiple of blocks (a multiple of four 32-bits words ) */
+    if ((size_in_bytes % 16U) == 0U)
     {
-      /* HeaderSize %4, no padding */
-      for (loopcounter = 0U; (loopcounter < hcryp->Init.HeaderSize); loopcounter += 4U)
+      /*  No padding */
+      for (loopcounter = 0U; (loopcounter < (size_in_bytes / 4U)); loopcounter += 4U)
       {
         /* Write the input block in the data input register */
         hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
@@ -4536,8 +4624,8 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
     }
     else
     {
-      /*Write header block in the IN FIFO without last block */
-      for (loopcounter = 0U; (loopcounter < ((hcryp->Init.HeaderSize) - (hcryp->Init.HeaderSize % 4U))); loopcounter += 4U)
+      /* Write header block in the IN FIFO without last block */
+      for (loopcounter = 0U; (loopcounter < ((size_in_bytes / 16U) * 4U)); loopcounter += 4U)
       {
         /* Write the input block in the data input register */
         hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
@@ -4565,17 +4653,35 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
         /* Clear CCF flag */
         __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
       }
-      /*  Last block optionally pad the data with zeros*/
-      for (loopcounter = 0U; (loopcounter < (hcryp->Init.HeaderSize % 4U)); loopcounter++)
+      /* Write last complete words */
+      for (loopcounter = 0U; (loopcounter < ((size_in_bytes / 4U) % 4U)); loopcounter++)
       {
         hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
         hcryp->CrypHeaderCount++ ;
       }
-      while (loopcounter < 4U)
+      /* If the header size is a multiple of words */
+      if ((size_in_bytes % 4U) == 0U)
       {
-        /*Pad the data with zeros to have a complete block */
-        hcryp->Instance->DINR = 0x0U;
-        loopcounter++;
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
+      }
+      else
+      {
+         /* Enter last bytes, padded with zeros */
+         tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+         tmp &= mask[(hcryp->Init.DataType * 2U) + (size_in_bytes % 4U)];
+         hcryp->Instance->DINR = tmp;
+         loopcounter++;
+         /* Pad the data with zeros to have a complete block */
+         while (loopcounter < 4U)
+         {
+           hcryp->Instance->DINR = 0x0U;
+           loopcounter++;
+         }
       }
 
       if (CRYP_WaitOnCCFlag(hcryp, Timeout) != HAL_OK)
@@ -4597,17 +4703,14 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
   }
   else
   {
-    if (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC)
-    {
-      /*Workaround 1: only AES, before re-enabling the peripheral, datatype can be configured.*/
-      MODIFY_REG(hcryp->Instance->CR, AES_CR_DATATYPE, hcryp->Init.DataType);
+    /*Workaround 1: only AES, before re-enabling the peripheral, datatype can be configured.*/
+    MODIFY_REG(hcryp->Instance->CR, AES_CR_DATATYPE, hcryp->Init.DataType);
 
-      /* Select header phase */
-      CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
+    /* Select header phase */
+    CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
 
-      /* Enable the CRYP peripheral */
-      __HAL_CRYP_ENABLE(hcryp);
-    }
+    /* Enable the CRYP peripheral */
+    __HAL_CRYP_ENABLE(hcryp);
   }
   /* Return function status */
   return HAL_OK;
@@ -4621,143 +4724,112 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
   */
 static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase_DMA(CRYP_HandleTypeDef *hcryp)
 {
-  __IO uint32_t count  = 0U;
   uint32_t loopcounter;
+  uint32_t headersize_in_bytes;
+  uint32_t tmp;
+  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
 
   /***************************** Header phase for GCM/GMAC or CCM *********************************/
-  if ((hcryp->Init.HeaderSize != 0U))
+  if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
   {
-    /* Select header phase */
-    CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
+    headersize_in_bytes = hcryp->Init.HeaderSize * 4U;
+  }
+  else
+  {
+    headersize_in_bytes = hcryp->Init.HeaderSize;
+  }
 
-    /* Enable the CRYP peripheral */
-    __HAL_CRYP_ENABLE(hcryp);
+  /* Select header phase */
+  CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
 
-    if ((hcryp->Init.HeaderSize % 4U) == 0U)
+  /* Enable the CRYP peripheral */
+  __HAL_CRYP_ENABLE(hcryp);
+
+  /* Set the phase */
+  hcryp->Phase = CRYP_PHASE_PROCESS;
+
+  /* If header size is at least equal to 16 bytes, feed the header through DMA.
+     If size_in_bytes is not a multiple of blocks (is not a multiple of four 32-bit words ),
+     last bytes feeding and padding will be done in CRYP_DMAInCplt() */
+  if (headersize_in_bytes >= 16U)
+  {
+    /* Initiate header DMA transfer */
+    if (CRYP_SetHeaderDMAConfig(hcryp, (uint32_t)(hcryp->Init.Header), (uint16_t)((headersize_in_bytes / 16U) * 4U)) != HAL_OK)
     {
-      /* HeaderSize %4, no padding */
-      for (loopcounter = 0U; (loopcounter < hcryp->Init.HeaderSize); loopcounter += 4U)
-      {
-        /* Write the input block in the data input register */
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-
-        /*Wait on CCF flag*/
-        count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
-        do
-        {
-          count-- ;
-          if (count == 0U)
-          {
-            /* Disable the CRYP peripheral clock */
-            __HAL_CRYP_DISABLE(hcryp);
-
-            /* Change state */
-            hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-            hcryp->State = HAL_CRYP_STATE_READY;
-
-            /* Process unlocked */
-            __HAL_UNLOCK(hcryp);
-            return HAL_ERROR;
-          }
-        }
-        while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
-
-        /* Clear CCF flag */
-        __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
-      }
-    }
-    else
-    {
-      /*Write header block in the IN FIFO without last block */
-      for (loopcounter = 0U; (loopcounter < ((hcryp->Init.HeaderSize) - (hcryp->Init.HeaderSize % 4U))); loopcounter += 4U)
-      {
-        /* Write the Input block in the Data Input register */
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-
-        /*Wait on CCF flag*/
-        count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
-        do
-        {
-          count-- ;
-          if (count == 0U)
-          {
-            /* Disable the CRYP peripheral clock */
-            __HAL_CRYP_DISABLE(hcryp);
-
-            /* Change state */
-            hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-            hcryp->State = HAL_CRYP_STATE_READY;
-
-            /* Process unlocked */
-            __HAL_UNLOCK(hcryp);
-            return HAL_ERROR;
-          }
-        }
-        while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
-
-        /* Clear CCF flag */
-        __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
-      }
-      /*  Last block optionally pad the data with zeros*/
-      for (loopcounter = 0U; (loopcounter < (hcryp->Init.HeaderSize % 4U)); loopcounter++)
-      {
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-        hcryp->CrypHeaderCount++ ;
-      }
-      while (loopcounter < 4U)
-      {
-        /* Pad the data with zeros to have a complete block */
-        hcryp->Instance->DINR = 0x0U;
-        loopcounter++;
-      }
-
-      /*Wait on CCF flag*/
-      count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
-      do
-      {
-        count-- ;
-        if (count == 0U)
-        {
-          /* Disable the CRYP peripheral clock */
-          __HAL_CRYP_DISABLE(hcryp);
-
-          /* Change state */
-          hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-          hcryp->State = HAL_CRYP_STATE_READY;
-
-          /* Process unlocked */
-          __HAL_UNLOCK(hcryp);
-          return HAL_ERROR;
-        }
-      }
-      while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
-
-      /* Clear CCF flag */
-      __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
+      return HAL_ERROR;
     }
   }
   else
   {
-    /* Select header phase */
-    CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
+    if (headersize_in_bytes != 0U)
+    {
+      /* Header length is larger than 0 and strictly less than 16 bytes */
+      /* Write last complete words */
+      for (loopcounter = 0U; (loopcounter < (headersize_in_bytes / 4U)); loopcounter++)
+      {
+        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        hcryp->CrypHeaderCount++ ;
+      }
+      /* If the header size is a multiple of words */
+      if ((headersize_in_bytes % 4U) == 0U)
+      {
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
+      }
+      else
+      {
+        /* Enter last bytes, padded with zeros */
+        tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        tmp &= mask[(hcryp->Init.DataType * 2U) + (headersize_in_bytes % 4U)];
+        hcryp->Instance->DINR = tmp;
+        loopcounter++;
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
+      }
 
-    /* Enable the CRYP peripheral */
-    __HAL_CRYP_ENABLE(hcryp);
-  }
+      if (CRYP_WaitOnCCFlag(hcryp, CRYP_TIMEOUT_GCMCCMHEADERPHASE) != HAL_OK)
+      {
+        /* Disable the CRYP peripheral clock */
+        __HAL_CRYP_DISABLE(hcryp);
+
+        /* Change state */
+        hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
+        hcryp->State = HAL_CRYP_STATE_READY;
+
+        /* Process unlocked */
+        __HAL_UNLOCK(hcryp);
+        return HAL_ERROR;
+      }
+      /* Clear CCF flag */
+      __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
+    } /* if (headersize_in_bytes != 0U) */
+
+    /* Move to payload phase if header length is null or
+       if the header length was less than 16 and header written by software instead of DMA */
+
+    /* Set to 0 the number of non-valid bytes using NPBLB register*/
+    MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
+
+    /* Select payload phase once the header phase is performed */
+    CRYP_SET_PHASE(hcryp, CRYP_PHASE_PAYLOAD);
+
+    /* Initiate payload DMA IN and processed data DMA OUT transfers */
+    if (CRYP_GCMCCM_SetPayloadPhase_DMA(hcryp) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+  } /* if (headersize_in_bytes >= 16U) */
+
   /* Return function status */
   return HAL_OK;
 }
@@ -4774,9 +4846,25 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
   uint32_t lastwordsize;
   uint32_t npblb;
   uint32_t mode;
+  uint32_t headersize_in_bytes;
+  uint32_t tmp;
+  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+
+  if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
+  {
+    headersize_in_bytes = hcryp->Init.HeaderSize * 4U;
+  }
+  else
+  {
+    headersize_in_bytes = hcryp->Init.HeaderSize;
+  }
 
   /***************************** Header phase *********************************/
-  if (hcryp->Init.HeaderSize ==  hcryp->CrypHeaderCount)
+  /* Test whether or not the header phase is over.
+     If the test below is true, move to payload phase */
+  if (headersize_in_bytes <= ((uint32_t)(hcryp->CrypHeaderCount) * 4U))
   {
     /* Set the phase */
     hcryp->Phase = CRYP_PHASE_PROCESS;
@@ -4861,9 +4949,9 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
       }
     }
   }
-  else if ((((hcryp->Init.HeaderSize) - (hcryp->CrypHeaderCount)) >= 4U))
+  else if ((((headersize_in_bytes / 4U) - (hcryp->CrypHeaderCount)) >= 4U))
   {
-
+    /* Can enter full 4 header words */
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
     /* If suspension flag has been raised, suspend processing
        only if not already at the end of the header */
@@ -4898,19 +4986,40 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
     hcryp->CrypHeaderCount++;
   }
   }
-  else /*HeaderSize < 4 or HeaderSize >4 & HeaderSize %4 != 0*/
+  else /* Write last header block (4 words), padded with zeros if needed */
   {
-    /*  Last block optionally pad the data with zeros*/
-    for (loopcounter = 0U; loopcounter < (hcryp->Init.HeaderSize % 4U); loopcounter++)
+
+    for (loopcounter = 0U; (loopcounter < ((headersize_in_bytes / 4U) % 4U)); loopcounter++)
     {
       hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
       hcryp->CrypHeaderCount++ ;
     }
+    /* If the header size is a multiple of words */
+    if ((headersize_in_bytes % 4U) == 0U)
+    {
+      /* Pad the data with zeros to have a complete block */
+      while (loopcounter < 4U)
+      {
+        hcryp->Instance->DINR = 0x0U;
+        loopcounter++;
+        hcryp->CrypHeaderCount++;
+      }
+    }
+    else
+    {
+      /* Enter last bytes, padded with zeros */
+      tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      tmp &= mask[(hcryp->Init.DataType * 2U) + (headersize_in_bytes % 4U)];
+      hcryp->Instance->DINR = tmp;
+      loopcounter++;
+      hcryp->CrypHeaderCount++;
+      /* Pad the data with zeros to have a complete block */
     while (loopcounter < 4U)
     {
-      /* pad the data with zeros to have a complete block */
       hcryp->Instance->DINR = 0x0U;
       loopcounter++;
+        hcryp->CrypHeaderCount++;
+      }
     }
   }
 }
@@ -4920,6 +5029,7 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module.
   * @param  Timeout Timeout duration.
+  * @note   This function can only be used in thread mode.
   * @retval HAL status
   */
 static HAL_StatusTypeDef CRYP_WaitOnCCFlag(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
@@ -4943,6 +5053,47 @@ static HAL_StatusTypeDef CRYP_WaitOnCCFlag(CRYP_HandleTypeDef *hcryp, uint32_t T
   return HAL_OK;
 }
 
+/**
+  * @brief  Wait for Computation Complete Flag (CCF) to raise then clear it.
+  * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module.
+  * @param  Timeout Timeout duration.
+  * @note   This function can be used in thread or handler mode.
+  * @retval HAL status
+  */
+static void CRYP_ClearCCFlagWhenHigh(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
+{
+  uint32_t count = Timeout;
+
+  do
+  {
+    count-- ;
+    if (count == 0U)
+    {
+      /* Disable the CRYP peripheral clock */
+      __HAL_CRYP_DISABLE(hcryp);
+
+      /* Change state */
+      hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
+
+      /* Process unlocked */
+      __HAL_UNLOCK(hcryp);
+      hcryp->State = HAL_CRYP_STATE_READY;
+
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+    /*Call registered error callback*/
+    hcryp->ErrorCallback(hcryp);
+#else
+    /*Call legacy weak error callback*/
+    HAL_CRYP_ErrorCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
+    }
+  }
+  while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+
+  /* Clear CCF flag */
+  __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
+}
 
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
 /**
@@ -5006,7 +5157,7 @@ static void CRYP_Read_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Outp
   __IO uint32_t count = 0U;
 
   /* In case of GCM payload phase encryption, check that suspension can be carried out */
-  if (READ_BIT(hcryp->Instance->CR, (AES_CR_CHMOD|AES_CR_GCMPH|AES_CR_MODE)) == (CRYP_AES_GCM_GMAC|AES_CR_GCMPH_1|0x0))
+  if (READ_BIT(hcryp->Instance->CR, (AES_CR_CHMOD|AES_CR_GCMPH|AES_CR_MODE)) == (CRYP_AES_GCM_GMAC|AES_CR_GCMPH_1|0x0U))
   {
 
       /* Wait for BUSY flag to be cleared */
@@ -5144,21 +5295,21 @@ static void CRYP_Write_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input, 
   if (KeySize == CRYP_KEYSIZE_256B)
   {
     hcryp->Instance->KEYR7 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
     hcryp->Instance->KEYR6 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
     hcryp->Instance->KEYR5 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
     hcryp->Instance->KEYR4 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
   }
 
     hcryp->Instance->KEYR3 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
     hcryp->Instance->KEYR2 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
     hcryp->Instance->KEYR1 = *(uint32_t*)(keyaddr);
-    keyaddr+=4;
+    keyaddr+=4U;
     hcryp->Instance->KEYR0 = *(uint32_t*)(keyaddr);
 }
 
@@ -5170,9 +5321,19 @@ static void CRYP_Write_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input, 
   */
 static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
 {
-  uint32_t loopcounter = 0U;
-  uint32_t lastwordsize =0;
-  uint32_t npblb = 0U ;
+  uint32_t loopcounter;
+  uint16_t lastwordsize;
+  uint16_t npblb;
+  uint32_t cr_temp;
+
+
+  __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_ERR_CLEAR | CRYP_CCF_CLEAR);
+
+  /* Enable computation complete flag and error interrupts */
+  __HAL_CRYP_ENABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
+
+  /* Enable the CRYP peripheral */
+  __HAL_CRYP_ENABLE(hcryp);
 
   /* Case of header phase resumption =================================================*/
   if (hcryp->Phase == CRYP_PHASE_HEADER_SUSPENDED)
@@ -5183,7 +5344,7 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
     /* Select header phase */
     CRYP_SET_PHASE(hcryp, CRYP_PHASE_HEADER);
 
-    if (((hcryp->Init.HeaderSize) - (hcryp->CrypHeaderCount) >= 4U))
+    if ((((hcryp->Init.HeaderSize) - (hcryp->CrypHeaderCount)) >= 4U))
     {
       /* Write the input block in the IN FIFO */
       hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount );
@@ -5212,73 +5373,77 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
     }
   }
   /* Case of payload phase resumption =================================================*/
-  else if (hcryp->Phase == CRYP_PHASE_PAYLOAD_SUSPENDED)
+  else
   {
-
-    /* Set the phase */
-    hcryp->Phase = CRYP_PHASE_PROCESS;
-
-   /* Select payload phase once the header phase is performed */
-   MODIFY_REG(hcryp->Instance->CR, AES_CR_GCMPH, CRYP_PHASE_PAYLOAD);
-
-   /* Set to 0 the number of non-valid bytes using NPBLB register*/
-   MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
-
-    if ((hcryp->Size/4) - (hcryp->CrypInCount) >= 4U)
+    if (hcryp->Phase == CRYP_PHASE_PAYLOAD_SUSPENDED)
     {
-      /* Write the input block in the IN FIFO */
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
-      hcryp->CrypInCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
-      hcryp->CrypInCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
-      hcryp->CrypInCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
-      hcryp->CrypInCount++;
-      if((hcryp->CrypInCount ==  hcryp->Size) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC))
-      {
-        /* Call output transfer complete callback */
-#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1)
-        /*Call registered Input complete callback*/
-        hcryp->InCpltCallback(hcryp);
-#else
-        /*Call legacy weak Input complete callback*/
-        HAL_CRYP_InCpltCallback(hcryp);
-#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
-      }
-    }
-    else /* Last block of payload < 128bit*/
-    {
-      /* Compute the number of padding bytes in last block of payload */
-      npblb = ((hcryp->Size/16U)+1U)*16U- (hcryp->Size);
-      if((((hcryp->Instance->CR & AES_CR_MODE) == CRYP_OPERATINGMODE_ENCRYPT) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC)) ||
-         (((hcryp->Instance->CR & AES_CR_MODE) == CRYP_OPERATINGMODE_DECRYPT) && (hcryp->Init.Algorithm == CRYP_AES_CCM)))
-      {
-        /* Specify the number of non-valid bytes using NPBLB register*/
-        MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, npblb<< 20U);
-      }
 
-      /* Number of valid words (lastwordsize) in last block */
-      if (npblb % 4U ==0U)
-      {
-        lastwordsize = (16U-npblb)/4U;
-      }
-      else
-      {
-        lastwordsize = (16U-npblb)/4U +1U;
-      }
+      /* Set the phase */
+      hcryp->Phase = CRYP_PHASE_PROCESS;
 
-      /*  Last block optionally pad the data with zeros*/
-      for(loopcounter = 0U; loopcounter < lastwordsize; loopcounter++)
+      /* Select payload phase once the header phase is performed */
+      MODIFY_REG(hcryp->Instance->CR, AES_CR_GCMPH, CRYP_PHASE_PAYLOAD);
+
+      /* Set to 0 the number of non-valid bytes using NPBLB register*/
+      MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
+
+      if (((hcryp->Size/4U) - (hcryp->CrypInCount)) >= 4U)
       {
-        hcryp->Instance->DINR = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        /* Write the input block in the IN FIFO */
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
         hcryp->CrypInCount++;
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->CrypInCount++;
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->CrypInCount++;
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->CrypInCount++;
+        if((hcryp->CrypInCount ==  hcryp->Size) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC))
+        {
+          /* Call output transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1)
+          /*Call registered Input complete callback*/
+          hcryp->InCpltCallback(hcryp);
+#else
+          /*Call legacy weak Input complete callback*/
+          HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
+        }
       }
-      while(loopcounter < 4U )
+      else /* Last block of payload < 128bit*/
       {
-        /* pad the data with zeros to have a complete block */
-        hcryp->Instance->DINR = 0x0U;
-        loopcounter++;
+        /* Compute the number of padding bytes in last block of payload */
+        npblb = (((hcryp->Size/16U)+1U)*16U) - (hcryp->Size);
+        cr_temp = hcryp->Instance->CR;
+        if((((cr_temp & AES_CR_MODE) == CRYP_OPERATINGMODE_ENCRYPT) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC)) ||
+           (((cr_temp& AES_CR_MODE) == CRYP_OPERATINGMODE_DECRYPT) && (hcryp->Init.Algorithm == CRYP_AES_CCM)))
+        {
+          /* Specify the number of non-valid bytes using NPBLB register*/
+            MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, ((uint32_t)npblb)<< 20U);
+        }
+
+        /* Number of valid words (lastwordsize) in last block */
+        if ((npblb % 4U) ==0U)
+        {
+          lastwordsize = (16U-npblb)/4U;
+        }
+        else
+        {
+          lastwordsize = ((16U-npblb)/4U) +1U;
+        }
+
+        /*  Last block optionally pad the data with zeros*/
+        for(loopcounter = 0U; loopcounter < lastwordsize; loopcounter++)
+        {
+          hcryp->Instance->DINR = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+          hcryp->CrypInCount++;
+        }
+        while(loopcounter < 4U )
+        {
+          /* pad the data with zeros to have a complete block */
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
       }
     }
   }

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_cryp_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_cryp_ex.c
@@ -99,9 +99,16 @@
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_GenerateAuthTAG(CRYP_HandleTypeDef *hcryp, uint32_t *AuthTag, uint32_t Timeout)
 {
   uint32_t tickstart;
+  /* Assume first Init.HeaderSize is in words */
   uint64_t headerlength = (uint64_t)hcryp->Init.HeaderSize * 32U; /* Header length in bits */
-  uint64_t inputlength = (uint64_t)hcryp->SizesSum * 8U; /* input length in bits */
+  uint64_t inputlength = (uint64_t)hcryp->SizesSum * 8U; /* Input length in bits */
   uint32_t tagaddr = (uint32_t)AuthTag;
+
+  /* Correct headerlength if Init.HeaderSize is actually in bytes */
+  if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_BYTE)
+  {
+    headerlength /= 4U;
+  }
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_dac.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_dac.c
@@ -1314,7 +1314,7 @@ HAL_StatusTypeDef HAL_DAC_RegisterCallback(DAC_HandleTypeDef *hdac, HAL_DAC_Call
   * @param  hdac DAC handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
-  *          @arg @ref HAL_DAC_CH1_COMPLETE_CB_ID          DAC CH1 tranfer Complete Callback ID
+  *          @arg @ref HAL_DAC_CH1_COMPLETE_CB_ID          DAC CH1 Transfer Complete Callback ID
   *          @arg @ref HAL_DAC_CH1_HALF_COMPLETE_CB_ID     DAC CH1 Half Complete Callback ID
   *          @arg @ref HAL_DAC_CH1_ERROR_ID                DAC CH1 Error Callback ID
   *          @arg @ref HAL_DAC_CH1_UNDERRUN_CB_ID          DAC CH1 UnderRun Callback ID

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_dma.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_dma.c
@@ -3,8 +3,8 @@
   * @file    stm32g0xx_hal_dma.c
   * @author  MCD Application Team
   * @brief   DMA HAL module driver.
-  *         This file provides firmware functions to manage the following
-  *         functionalities of the Direct Memory Access (DMA) peripheral:
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Direct Memory Access (DMA) peripheral:
   *           + Initialization and de-initialization functions
   *           + IO operation functions
   *           + Peripheral State and errors functions
@@ -23,9 +23,10 @@
        Circular or Normal mode, Channel Priority level, Source and Destination Increment mode
        using HAL_DMA_Init() function.
 
-       Prior to HAL_DMA_Init the CLK shall be enabled for both DMA & DMAMUX
+       Prior to HAL_DMA_Init the peripheral clock shall be enabled for both DMA & DMAMUX
        thanks to:
-       DMA1   :       __HAL_RCC_DMA1_CLK_ENABLE();
+      (##) DMA1 or DMA2: __HAL_RCC_DMA1_CLK_ENABLE() or  __HAL_RCC_DMA2_CLK_ENABLE();
+      (##) DMAMUX1:      __HAL_RCC_DMAMUX1_CLK_ENABLE();
 
    (#) Use HAL_DMA_GetState() function to return the DMA state and HAL_DMA_GetError() in case of error
        detection.
@@ -33,31 +34,31 @@
    (#) Use HAL_DMA_Abort() function to abort the current transfer
 
      -@-   In Memory-to-Memory transfer mode, Circular mode is not allowed.
+
      *** Polling mode IO operation ***
      =================================
-    [..]
-          (+) Use HAL_DMA_Start() to start DMA transfer after the configuration of Source
-              address and destination address and the Length of data to be transferred
-          (+) Use HAL_DMA_PollForTransfer() to poll for the end of current transfer, in this
-              case a fixed Timeout can be configured by User depending from his application.
+     [..]
+       (+) Use HAL_DMA_Start() to start DMA transfer after the configuration of Source
+           address and destination address and the Length of data to be transferred
+       (+) Use HAL_DMA_PollForTransfer() to poll for the end of current transfer, in this
+           case a fixed Timeout can be configured by User depending from his application.
 
      *** Interrupt mode IO operation ***
      ===================================
-    [..]
-          (+) Configure the DMA interrupt priority using HAL_NVIC_SetPriority()
-          (+) Enable the DMA IRQ handler using HAL_NVIC_EnableIRQ()
-          (+) Use HAL_DMA_Start_IT() to start DMA transfer after the configuration of
-              Source address and destination address and the Length of data to be transferred.
-              In this case the DMA interrupt is configured
-          (+) Use HAL_DMA_IRQHandler() called under DMA_IRQHandler() Interrupt subroutine
-          (+) At the end of data transfer HAL_DMA_IRQHandler() function is executed and user can
-              add his own function by customization of function pointer XferCpltCallback and
-              XferErrorCallback (i.e. a member of DMA handle structure).
+     [..]
+       (+) Configure the DMA interrupt priority using HAL_NVIC_SetPriority()
+       (+) Enable the DMA IRQ handler using HAL_NVIC_EnableIRQ()
+       (+) Use HAL_DMA_Start_IT() to start DMA transfer after the configuration of
+           Source address and destination address and the Length of data to be transferred.
+           In this case the DMA interrupt is configured
+       (+) Use HAL_DMA_IRQHandler() called under DMA_IRQHandler() Interrupt subroutine
+       (+) At the end of data transfer HAL_DMA_IRQHandler() function is executed and user can
+              add his own function to register callbacks with HAL_DMA_RegisterCallback().
 
      *** DMA HAL driver macros list ***
      =============================================
-      [..]
-       Below the list of most used macros in DMA HAL driver.
+     [..]
+       Below the list of macros in DMA HAL driver.
 
        (+) __HAL_DMA_ENABLE: Enable the specified DMA Channel.
        (+) __HAL_DMA_DISABLE: Disable the specified DMA Channel.
@@ -65,7 +66,7 @@
        (+) __HAL_DMA_CLEAR_FLAG: Clear the DMA Channel pending flags.
        (+) __HAL_DMA_ENABLE_IT: Enable the specified DMA Channel interrupts.
        (+) __HAL_DMA_DISABLE_IT: Disable the specified DMA Channel interrupts.
-       (+) __HAL_DMA_GET_IT_SOURCE: Check whether the specified DMA Channel interrupt has occurred or not.
+       (+) __HAL_DMA_GET_IT_SOURCE: Check whether the specified DMA Channel interrupt is enabled or not.
 
      [..]
       (@) You can refer to the DMA HAL driver header file for more useful macros
@@ -142,10 +143,10 @@ static void DMA_CalcDMAMUXRequestGenBaseAndMask(DMA_HandleTypeDef *hdma);
   */
 
 /**
-  * @brief  Initialize the DMA according to the specified
-  *         parameters in the DMA_InitTypeDef and initialize the associated handle.
-  * @param  hdma  Pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
+  * @brief Initialize the DMA according to the specified
+  *        parameters in the DMA_InitTypeDef and initialize the associated handle.
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
@@ -166,8 +167,25 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
   assert_param(IS_DMA_MODE(hdma->Init.Mode));
   assert_param(IS_DMA_PRIORITY(hdma->Init.Priority));
 
-  /* calculation of the channel index */
+  assert_param(IS_DMA_ALL_REQUEST(hdma->Init.Request));
+
+  /* Compute the channel index */
+#if defined(DMA2)
+  if ((uint32_t)(hdma->Instance) < (uint32_t)(DMA2_Channel1))
+  {
+    /* DMA1 */
+    hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA1_Channel1) / ((uint32_t)DMA1_Channel2 - (uint32_t)DMA1_Channel1)) << 2U;
+    hdma->DmaBaseAddress = DMA1;
+  }
+  else
+  {
+    /* DMA2 */
+    hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA2_Channel1) / ((uint32_t)DMA2_Channel2 - (uint32_t)DMA2_Channel1)) << 2U;
+    hdma->DmaBaseAddress = DMA2;
+  }
+#else
   hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA1_Channel1) / ((uint32_t)DMA1_Channel2 - (uint32_t)DMA1_Channel1)) << 2U;
+#endif
 
   /* Change DMA peripheral state */
   hdma->State = HAL_DMA_STATE_BUSY;
@@ -224,7 +242,7 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
   hdma->ErrorCode = HAL_DMA_ERROR_NONE;
 
   /* Initialize the DMA state*/
-  hdma->State  = HAL_DMA_STATE_READY;
+  hdma->State = HAL_DMA_STATE_READY;
 
   /* Release Lock */
   __HAL_UNLOCK(hdma);
@@ -233,9 +251,9 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  DeInitialize the DMA peripheral.
-  * @param  hdma  pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
+  * @brief DeInitialize the DMA peripheral.
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
@@ -252,14 +270,33 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
   /* Disable the selected DMA Channelx */
   __HAL_DMA_DISABLE(hdma);
 
-  /* calculation of the channel index */
+  /* Compute the channel index */
+#if defined(DMA2)
+  if ((uint32_t)(hdma->Instance) < (uint32_t)(DMA2_Channel1))
+  {
+    /* DMA1 */
+    hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA1_Channel1) / ((uint32_t)DMA1_Channel2 - (uint32_t)DMA1_Channel1)) << 2U;
+    hdma->DmaBaseAddress = DMA1;
+  }
+  else
+  {
+    /* DMA2 */
+    hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA2_Channel1) / ((uint32_t)DMA2_Channel2 - (uint32_t)DMA2_Channel1)) << 2U;
+    hdma->DmaBaseAddress = DMA2;
+  }
+#else
   hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA1_Channel1) / ((uint32_t)DMA1_Channel2 - (uint32_t)DMA1_Channel1)) << 2U;
+#endif
 
   /* Reset DMA Channel control register */
-  hdma->Instance->CCR  = 0U;
+  hdma->Instance->CCR = 0U;
 
   /* Clear all flags */
-  __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_GI1 << (hdma->ChannelIndex & 0x1cU)));
+#if defined(DMA2)
+  hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << (hdma->ChannelIndex & 0x1CU));
+#else
+  __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_GI1 << (hdma->ChannelIndex & 0x1CU)));
+#endif
 
   /* Initialize parameters for DMAMUX channel :
      DMAmuxChannel, DMAmuxChannelStatus and DMAmuxChannelStatusMask */
@@ -287,15 +324,15 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
     hdma->DMAmuxRequestGenStatus->RGCFR = hdma->DMAmuxRequestGenStatusMask;
   }
 
+  hdma->DMAmuxRequestGen = 0U;
+  hdma->DMAmuxRequestGenStatus = 0U;
+  hdma->DMAmuxRequestGenStatusMask = 0U;
+
   /* Clean callbacks */
   hdma->XferCpltCallback = NULL;
   hdma->XferHalfCpltCallback = NULL;
   hdma->XferErrorCallback = NULL;
   hdma->XferAbortCallback = NULL;
-
-  hdma->DMAmuxRequestGen = 0U;
-  hdma->DMAmuxRequestGenStatus = 0U;
-  hdma->DMAmuxRequestGenStatusMask = 0U;
 
   /* Initialize the error code */
   hdma->ErrorCode = HAL_DMA_ERROR_NONE;
@@ -327,15 +364,16 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
       (+) Abort DMA transfer
       (+) Poll for transfer complete
       (+) Handle DMA interrupt request
+      (+) Register and Unregister DMA callbacks
 
 @endverbatim
   * @{
   */
 
 /**
-  * @brief  Start the DMA Transfer.
+  * @brief Start the DMA Transfer.
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
+  *             the configuration information for the specified DMA Channel.
   * @param SrcAddress The source memory Buffer address
   * @param DstAddress The destination memory Buffer address
   * @param DataLength The length of data to be transferred from source to destination
@@ -351,10 +389,12 @@ HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, ui
   /* Process locked */
   __HAL_LOCK(hdma);
 
-  if (HAL_DMA_STATE_READY == hdma->State)
+  if (hdma->State == HAL_DMA_STATE_READY)
   {
     /* Change DMA peripheral state */
     hdma->State = HAL_DMA_STATE_BUSY;
+
+    /* Initialize the error code */
     hdma->ErrorCode = HAL_DMA_ERROR_NONE;
 
     /* Disable the peripheral */
@@ -368,21 +408,23 @@ HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, ui
   }
   else
   {
+    /* Change the error code */
+    hdma->ErrorCode = HAL_DMA_ERROR_BUSY;
+
     /* Process Unlocked */
     __HAL_UNLOCK(hdma);
-    status = HAL_BUSY;
-  }
 
-  /* Process locked */
-  __HAL_UNLOCK(hdma);
+    /* Return error status */
+    status = HAL_ERROR;
+  }
 
   return status;
 }
 
 /**
-  * @brief  Start the DMA Transfer with interrupt enabled.
+  * @brief Start the DMA Transfer with interrupt enabled.
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
+  *             the configuration information for the specified DMA Channel.
   * @param SrcAddress The source memory Buffer address
   * @param DstAddress The destination memory Buffer address
   * @param DataLength The length of data to be transferred from source to destination
@@ -398,7 +440,7 @@ HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress,
   /* Process locked */
   __HAL_LOCK(hdma);
 
-  if (HAL_DMA_STATE_READY == hdma->State)
+  if (hdma->State == HAL_DMA_STATE_READY)
   {
     /* Change DMA peripheral state */
     hdma->State = HAL_DMA_STATE_BUSY;
@@ -442,24 +484,24 @@ HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress,
   }
   else
   {
+    /* Change the error code */
+    hdma->ErrorCode = HAL_DMA_ERROR_BUSY;
+
     /* Process Unlocked */
     __HAL_UNLOCK(hdma);
 
-    /* Remain BUSY */
-    status = HAL_BUSY;
+    /* Return error status */
+    status = HAL_ERROR;
   }
-
-  /* Process unlocked */
-  __HAL_UNLOCK(hdma);
 
   return status;
 }
 
 /**
-  * @brief  Abort the DMA Transfer.
+  * @brief Abort the DMA Transfer.
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
-    * @retval HAL status
+  *             the configuration information for the specified DMA Channel.
+  * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
 {
@@ -470,7 +512,7 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
   }
 
   /* Check the DMA peripheral state */
-  if(hdma->State != HAL_DMA_STATE_BUSY)
+  if (hdma->State != HAL_DMA_STATE_BUSY)
   {
     hdma->ErrorCode = HAL_DMA_ERROR_NO_XFER;
 
@@ -491,7 +533,11 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
     __HAL_DMA_DISABLE(hdma);
 
     /* Clear all flags */
-    __HAL_DMA_CLEAR_FLAG(hdma, ((DMA_FLAG_GI1) << (hdma->ChannelIndex  & 0x1cU)));
+#if defined(DMA2)
+    hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << (hdma->ChannelIndex & 0x1CU));
+#else
+    __HAL_DMA_CLEAR_FLAG(hdma, ((DMA_FLAG_GI1) << (hdma->ChannelIndex  & 0x1CU)));
+#endif
 
     /* Clear the DMAMUX synchro overrun flag */
     hdma->DMAmuxChannelStatus->CFR = hdma->DMAmuxChannelStatusMask;
@@ -517,20 +563,16 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  Aborts the DMA Transfer in Interrupt mode.
-  * @param  hdma    pointer to a DMA_HandleTypeDef structure that contains
-  *                 the configuration information for the specified DMA Stream.
+  * @brief Aborts the DMA Transfer in Interrupt mode.
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMA_Abort_IT(DMA_HandleTypeDef *hdma)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process Unlocked/locked */
-  __HAL_UNLOCK(hdma);
-  __HAL_LOCK(hdma);
-
-  if (HAL_DMA_STATE_BUSY != hdma->State)
+  if (hdma->State != HAL_DMA_STATE_BUSY)
   {
     /* no transfer ongoing */
     hdma->ErrorCode = HAL_DMA_ERROR_NO_XFER;
@@ -549,7 +591,11 @@ HAL_StatusTypeDef HAL_DMA_Abort_IT(DMA_HandleTypeDef *hdma)
     hdma->DMAmuxChannel->CCR &= ~DMAMUX_CxCR_SOIE;
 
     /* Clear all flags */
-    __HAL_DMA_CLEAR_FLAG(hdma, ((DMA_FLAG_GI1) << (hdma->ChannelIndex & 0x1cU)));
+#if defined(DMA2)
+    hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << (hdma->ChannelIndex & 0x1CU));
+#else
+    __HAL_DMA_CLEAR_FLAG(hdma, ((DMA_FLAG_GI1) << (hdma->ChannelIndex & 0x1CU)));
+#endif
 
     /* Clear the DMAMUX synchro overrun flag */
     hdma->DMAmuxChannelStatus->CFR = hdma->DMAmuxChannelStatusMask;
@@ -580,9 +626,9 @@ HAL_StatusTypeDef HAL_DMA_Abort_IT(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  Polling for transfer complete.
+  * @brief Polling for transfer complete.
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                  the configuration information for the specified DMA Channel.
+  *             the configuration information for the specified DMA Channel.
   * @param CompleteLevel Specifies the DMA level complete.
   * @param Timeout Timeout duration.
   * @retval HAL status
@@ -592,10 +638,7 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
   uint32_t temp;
   uint32_t tickstart;
 
-  /* Process unlocked */
-  __HAL_UNLOCK(hdma);
-
-  if (HAL_DMA_STATE_BUSY != hdma->State)
+  if (hdma->State != HAL_DMA_STATE_BUSY)
   {
     /* no transfer ongoing */
     hdma->ErrorCode = HAL_DMA_ERROR_NO_XFER;
@@ -614,25 +657,26 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
   if (HAL_DMA_FULL_TRANSFER == CompleteLevel)
   {
     /* Transfer Complete flag */
-    temp = DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1cU);
+    temp = DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1CU);
   }
   else
   {
     /* Half Transfer Complete flag */
-    temp = DMA_FLAG_HT1 << (hdma->ChannelIndex  & 0x1cU);
+    temp = DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1CU);
   }
 
   /* Get tick */
   tickstart = HAL_GetTick();
 
-  while (0U == __HAL_DMA_GET_FLAG(hdma, temp))
+#if defined(DMA2)
+  while ((hdma->DmaBaseAddress->ISR & temp) == 0U)
   {
-    if (0U != __HAL_DMA_GET_FLAG(hdma, (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1cU))))
+    if ((hdma->DmaBaseAddress->ISR & (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1CU))) != 0U)
     {
       /* When a DMA transfer error occurs */
       /* A hardware clear of its EN bits is performed */
       /* Clear all flags */
-      __HAL_DMA_CLEAR_FLAG(hdma, ((DMA_FLAG_GI1) << (hdma->ChannelIndex & 0x1cU)));
+      hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << (hdma->ChannelIndex & 0x1CU));
 
       /* Update error code */
       hdma->ErrorCode = HAL_DMA_ERROR_TE;
@@ -645,10 +689,32 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
 
       return HAL_ERROR;
     }
+#else
+  while (0U == __HAL_DMA_GET_FLAG(hdma, temp))
+  {
+    if (0U != __HAL_DMA_GET_FLAG(hdma, (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1CU))))
+    {
+      /* When a DMA transfer error occurs */
+      /* A hardware clear of its EN bits is performed */
+      /* Clear all flags */
+      __HAL_DMA_CLEAR_FLAG(hdma, ((DMA_FLAG_GI1) << (hdma->ChannelIndex & 0x1CU)));
+
+      /* Update error code */
+      hdma->ErrorCode = HAL_DMA_ERROR_TE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+
+      return HAL_ERROR;
+    }
+#endif
     /* Check for the Timeout */
     if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
       {
         /* Update error code */
         hdma->ErrorCode = HAL_DMA_ERROR_TIMEOUT;
@@ -694,7 +760,14 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
   if (HAL_DMA_FULL_TRANSFER == CompleteLevel)
   {
     /* Clear the transfer complete flag */
-    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1cU)));
+#if defined(DMA2)
+    hdma->DmaBaseAddress->IFCR = (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1CU));
+#else
+    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1CU)));
+#endif
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hdma);
 
     /* The selected Channelx EN bit is cleared (DMA is disabled and
     all transfers are complete) */
@@ -703,74 +776,83 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
   else
   {
     /* Clear the half transfer complete flag */
-    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1cU)));
+#if defined(DMA2)
+    hdma->DmaBaseAddress->IFCR = (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1CU));
+#else
+    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1CU)));
+#endif
   }
-
-  /* Process unlocked */
-  __HAL_UNLOCK(hdma);
 
   return HAL_OK;
 }
 
 /**
-  * @brief  Handle DMA interrupt request.
-  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
+  * @brief Handle DMA interrupt request.
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval None
   */
 void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
 {
+#if defined(DMA2)
+  uint32_t flag_it = hdma->DmaBaseAddress->ISR;
+#else
   uint32_t flag_it = DMA1->ISR;
+#endif
   uint32_t source_it = hdma->Instance->CCR;
 
   /* Half Transfer Complete Interrupt management ******************************/
-  if (((flag_it & (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1cU))) != 0U) && ((source_it & DMA_IT_HT) != 0U))
+  if (((flag_it & (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1CU))) != 0U) && ((source_it & DMA_IT_HT) != 0U))
   {
-    /* Disable the half transfer interrupt if the DMA mode is not CIRCULAR */
-    if ((hdma->Instance->CCR & DMA_CCR_CIRC) == 0U)
-    {
-      /* Disable the half transfer interrupt */
-      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_HT);
-    }
-    /* Clear the half transfer complete flag */
-    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1cU)));
+      /* Disable the half transfer interrupt if the DMA mode is not CIRCULAR */
+      if ((hdma->Instance->CCR & DMA_CCR_CIRC) == 0U)
+      {
+        /* Disable the half transfer interrupt */
+        __HAL_DMA_DISABLE_IT(hdma, DMA_IT_HT);
+      }
+      /* Clear the half transfer complete flag */
+#if defined(DMA2)
+      hdma->DmaBaseAddress->IFCR = DMA_ISR_HTIF1 << (hdma->ChannelIndex & 0x1CU);
+#else
+      __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_HT1 << (hdma->ChannelIndex & 0x1CU)));
+#endif
 
-    /* DMA peripheral state is not updated in Half Transfer */
-    /* but in Transfer Complete case */
+      /* DMA peripheral state is not updated in Half Transfer */
+      /* but in Transfer Complete case */
 
-    if (hdma->XferHalfCpltCallback != NULL)
-    {
-      /* Half transfer callback */
-      hdma->XferHalfCpltCallback(hdma);
-    }
+      if (hdma->XferHalfCpltCallback != NULL)
+      {
+        /* Half transfer callback */
+        hdma->XferHalfCpltCallback(hdma);
+      }
   }
 
   /* Transfer Complete Interrupt management ***********************************/
-  else if ((0U != (flag_it & (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1cU)))) && (0U != (source_it & DMA_IT_TC)))
+  else if ((0U != (flag_it & (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1CU)))) && (0U != (source_it & DMA_IT_TC)))
   {
-    if ((hdma->Instance->CCR & DMA_CCR_CIRC) == 0U)
-    {
-      /* Disable the transfer complete and error interrupt */
-      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TE | DMA_IT_TC);
+      if ((hdma->Instance->CCR & DMA_CCR_CIRC) == 0U)
+      {
+        /* Disable the transfer complete and error interrupt */
+        __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TE | DMA_IT_TC);
 
-      /* Change the DMA state */
-      hdma->State = HAL_DMA_STATE_READY;
-    }
-    /* Clear the transfer complete flag */
-    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1cU)));
+        /* Change the DMA state */
+        hdma->State = HAL_DMA_STATE_READY;
+      }
+      /* Clear the transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_TC1 << (hdma->ChannelIndex & 0x1CU)));
 
-    /* Process Unlocked */
-    __HAL_UNLOCK(hdma);
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
 
-    if (hdma->XferCpltCallback != NULL)
-    {
-      /* Transfer complete callback */
-      hdma->XferCpltCallback(hdma);
-    }
+      if (hdma->XferCpltCallback != NULL)
+      {
+        /* Transfer complete callback */
+        hdma->XferCpltCallback(hdma);
+      }
   }
 
   /* Transfer Error Interrupt management **************************************/
-  else if (((flag_it & (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1cU)))!= 0U) && ((source_it & DMA_IT_TE) != 0U))
+  else if (((flag_it & (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1CU))) != 0U) && ((source_it & DMA_IT_TE) != 0U))
   {
     /* When a DMA transfer error occurs */
     /* A hardware clear of its EN bits is performed */
@@ -778,7 +860,11 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
     __HAL_DMA_DISABLE_IT(hdma, (DMA_IT_TC | DMA_IT_HT | DMA_IT_TE));
 
     /* Clear all flags */
-    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_GI1 << (hdma->ChannelIndex& 0x1cU)));
+#if defined(DMA2)
+    hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << (hdma->ChannelIndex & 0x1CU));
+#else
+    __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_GI1 << (hdma->ChannelIndex & 0x1CU)));
+#endif
 
     /* Update error code */
     hdma->ErrorCode = HAL_DMA_ERROR_TE;
@@ -803,13 +889,13 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  Register callbacks
-  * @param  hdma                  pointer to a DMA_HandleTypeDef structure that contains
-  *                               the configuration information for the specified DMA Stream.
-  * @param  CallbackID            User Callback identifer
-  *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
-  * @param  pCallback             pointer to private callbacsk function which has pointer to
-  *                               a DMA_HandleTypeDef structure as parameter.
+  * @brief Register callbacks
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
+  * @param CallbackID User Callback identifier
+  *                   a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
+  * @param pCallback Pointer to private callbacsk function which has pointer to
+  *                  a DMA_HandleTypeDef structure as parameter.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_CallbackIDTypeDef CallbackID, void (* pCallback)(DMA_HandleTypeDef *_hdma))
@@ -819,7 +905,7 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
   /* Process locked */
   __HAL_LOCK(hdma);
 
-  if (HAL_DMA_STATE_READY == hdma->State)
+  if (hdma->State == HAL_DMA_STATE_READY)
   {
     switch (CallbackID)
     {
@@ -856,11 +942,11 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
 }
 
 /**
-  * @brief  UnRegister callbacks
-  * @param  hdma                  pointer to a DMA_HandleTypeDef structure that contains
-  *                               the configuration information for the specified DMA Stream.
-  * @param  CallbackID            User Callback identifer
-  *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
+  * @brief UnRegister callbacks
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
+  * @param CallbackID User Callback identifier
+  *                   a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMA_UnRegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_CallbackIDTypeDef CallbackID)
@@ -870,7 +956,7 @@ HAL_StatusTypeDef HAL_DMA_UnRegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Ca
   /* Process locked */
   __HAL_LOCK(hdma);
 
-  if (HAL_DMA_STATE_READY == hdma->State)
+  if (hdma->State == HAL_DMA_STATE_READY)
   {
     switch (CallbackID)
     {
@@ -936,9 +1022,9 @@ HAL_StatusTypeDef HAL_DMA_UnRegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Ca
   */
 
 /**
-  * @brief  Return the DMA hande state.
+  * @brief Return the DMA handle state.
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA Channel.
+  *             the configuration information for the specified DMA Channel.
   * @retval HAL state
   */
 HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma)
@@ -948,13 +1034,14 @@ HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  Return the DMA error code.
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *              the configuration information for the specified DMA Channel.
+  * @brief Return the DMA error code.
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval DMA Error Code
   */
 uint32_t HAL_DMA_GetError(DMA_HandleTypeDef *hdma)
 {
+  /* Return the DMA error code */
   return hdma->ErrorCode;
 }
 
@@ -971,9 +1058,9 @@ uint32_t HAL_DMA_GetError(DMA_HandleTypeDef *hdma)
   */
 
 /**
-  * @brief  Sets the DMA Transfer parameter.
+  * @brief Sets the DMA Transfer parameter.
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA Channel.
+  *             the configuration information for the specified DMA Channel.
   * @param SrcAddress The source memory Buffer address
   * @param DstAddress The destination memory Buffer address
   * @param DataLength The length of data to be transferred from source to destination
@@ -991,12 +1078,16 @@ static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t
   }
 
   /* Clear all flags */
-  __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_GI1 << (hdma->ChannelIndex & 0x1cU)));
+#if defined(DMA2)
+  hdma->DmaBaseAddress->IFCR = (DMA_ISR_GIF1 << (hdma->ChannelIndex & 0x1CU));
+#else
+  __HAL_DMA_CLEAR_FLAG(hdma, (DMA_FLAG_GI1 << (hdma->ChannelIndex & 0x1CU)));
+#endif
 
   /* Configure DMA Channel data length */
   hdma->Instance->CNDTR = DataLength;
 
-  /* Peripheral to Memory */
+  /* Memory to Peripheral */
   if ((hdma->Init.Direction) == DMA_MEMORY_TO_PERIPH)
   {
     /* Configure DMA Channel destination address */
@@ -1005,7 +1096,7 @@ static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t
     /* Configure DMA Channel source address */
     hdma->Instance->CMAR = SrcAddress;
   }
-  /* Memory to Peripheral */
+  /* Peripheral to Memory */
   else
   {
     /* Configure DMA Channel source address */
@@ -1017,25 +1108,54 @@ static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t
 }
 
 /**
-  * @brief  Updates the DMA handle with the DMAMUX  channel and status mask depending on stream number
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA Stream.
+  * @brief Updates the DMA handle with the DMAMUX  channel and status mask depending on channel number
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval None
   */
 static void DMA_CalcDMAMUXChannelBaseAndMask(DMA_HandleTypeDef *hdma)
 {
   uint32_t channel_number;
 
-  channel_number = (((uint32_t)hdma->Instance & 0xFFU) - 8U) / 20U;
+#if defined(DMA2)
+  /* check if instance is not outside the DMA channel range */
+  if ((uint32_t)hdma->Instance < (uint32_t)DMA2_Channel1)
+  {
+    /* DMA1 */
+    /* Associate a DMA Channel to a DMAMUX channel */
+    hdma->DMAmuxChannel = (DMAMUX1_Channel0 + (hdma->ChannelIndex >> 2U));
+
+    /* Prepare channel_number used for DMAmuxChannelStatusMask computation */
+    channel_number = (((uint32_t)hdma->Instance & 0xFFU) - 8U) / 20U;
+  }
+  else
+  {
+    /* DMA2 */
+    /* Associate a DMA Channel to a DMAMUX channel */
+    hdma->DMAmuxChannel = (DMAMUX1_Channel7 + (hdma->ChannelIndex >> 2U));
+
+    /* Prepare channel_number used for DMAmuxChannelStatusMask computation */
+    channel_number = (((((uint32_t)hdma->Instance & 0xFFU) - 8U) / 20U) + 7U);
+  }
+#else
+  /* Associate a DMA Channel to a DMAMUX channel */
   hdma->DMAmuxChannel = (DMAMUX_Channel_TypeDef *)(uint32_t)((uint32_t)DMAMUX1_Channel0 + ((hdma->ChannelIndex >> 2U) * ((uint32_t)DMAMUX1_Channel1 - (uint32_t)DMAMUX1_Channel0)));
+
+  /* Prepare channel_number used for DMAmuxChannelStatusMask computation */
+  channel_number = (((uint32_t)hdma->Instance & 0xFFU) - 8U) / 20U;
+#endif
+
+  /* Initialize the field DMAmuxChannelStatus to DMAMUX1_ChannelStatus base */
   hdma->DMAmuxChannelStatus = DMAMUX1_ChannelStatus;
-  hdma->DMAmuxChannelStatusMask = 1UL << (channel_number & 0x1cU);
+
+  /* Initialize the field DMAmuxChannelStatusMask with the corresponding index of the DMAMUX channel selected for the current ChannelIndex */
+  hdma->DMAmuxChannelStatusMask = 1UL << (channel_number & 0x1FU);
 }
 
 /**
-  * @brief  Updates the DMA handle with the DMAMUX  request generator params
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA Stream.
+  * @brief Updates the DMA handle with the DMAMUX  request generator params
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA Channel.
   * @retval None
   */
 
@@ -1048,7 +1168,7 @@ static void DMA_CalcDMAMUXRequestGenBaseAndMask(DMA_HandleTypeDef *hdma)
 
   hdma->DMAmuxRequestGenStatus = DMAMUX1_RequestGenStatus;
 
-  /* here "Request" is either DMA_REQUEST_GENERATOR0 to 4, i.e. <= 4*/
+  /* here "Request" is either DMA_REQUEST_GENERATOR0 to DMA_REQUEST_GENERATOR3, i.e. <= 4*/
   hdma->DMAmuxRequestGenStatusMask = 1UL << ((request - 1U) & 0x3U);
 }
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_dma_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_dma_ex.c
@@ -13,9 +13,8 @@
   ==============================================================================
   [..]
   The DMA Extension HAL driver can be used as follows:
-
-   (+) Configure the DMA_MUX Synchronization Block using HAL_DMAEx_ConfigMuxSync function.
-   (+) Configure the DMA_MUX Request Generator Block using HAL_DMAEx_ConfigMuxRequestGenerator function.
+   (+) Configure the DMAMUX Synchronization Block using HAL_DMAEx_ConfigMuxSync function.
+   (+) Configure the DMAMUX Request Generator Block using HAL_DMAEx_ConfigMuxRequestGenerator function.
        Functions HAL_DMAEx_EnableMuxRequestGenerator and HAL_DMAEx_DisableMuxRequestGenerator can then be used
        to respectively enable/disable the request generator.
 
@@ -60,7 +59,7 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private Constants ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
 
 /** @defgroup DMAEx_Exported_Functions DMAEx Exported Functions
@@ -76,20 +75,22 @@
  ===============================================================================
     [..]  This section provides functions allowing to:
 
-    (+) Configure the DMA_MUX Synchronization Block using HAL_DMAEx_ConfigMuxSync function.
-    (+) Configure the DMA_MUX Request Generator Block using HAL_DMAEx_ConfigMuxRequestGenerator function.
+    (+) Configure the DMAMUX Synchronization Block using HAL_DMAEx_ConfigMuxSync function.
+    (+) Configure the DMAMUX Request Generator Block using HAL_DMAEx_ConfigMuxRequestGenerator function.
        Functions HAL_DMAEx_EnableMuxRequestGenerator and HAL_DMAEx_DisableMuxRequestGenerator can then be used
        to respectively enable/disable the request generator.
+    (+) Handle DMAMUX interrupts using HAL_DMAEx_MUX_IRQHandler : should be called from
+        the DMAMUX IRQ handler
 
 @endverbatim
   * @{
   */
 
 /**
-  * @brief  Configure the DMAMUX synchronization parameters for a given DMA channel (instance).
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA channel.
-  * @param  pSyncConfig Pointer to HAL_DMA_MuxSyncConfigTypeDef : contains the DMAMUX synchronization parameters
+  * @brief Configure the DMAMUX synchronization parameters for a given DMA channel (instance).
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA channel.
+  * @param pSyncConfig Pointer to HAL_DMA_MuxSyncConfigTypeDef contains the DMAMUX synchronization parameters
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMAEx_ConfigMuxSync(DMA_HandleTypeDef *hdma, HAL_DMA_MuxSyncConfigTypeDef *pSyncConfig)
@@ -113,9 +114,9 @@ HAL_StatusTypeDef HAL_DMAEx_ConfigMuxSync(DMA_HandleTypeDef *hdma, HAL_DMA_MuxSy
     /* Set the new synchronization parameters (and keep the request ID filled during the Init)*/
     MODIFY_REG(hdma->DMAmuxChannel->CCR, \
                (~DMAMUX_CxCR_DMAREQ_ID), \
-               ((pSyncConfig->SyncSignalID) << DMAMUX_CxCR_SYNC_ID_Pos) | ((pSyncConfig->RequestNumber - 1U) << DMAMUX_CxCR_NBREQ_Pos) | \
-               pSyncConfig->SyncPolarity | ((uint32_t)pSyncConfig->SyncEnable << DMAMUX_CxCR_SE_Pos) | \
-               ((uint32_t)pSyncConfig->EventEnable << DMAMUX_CxCR_EGE_Pos));
+               (pSyncConfig->SyncSignalID | ((pSyncConfig->RequestNumber - 1U) << DMAMUX_CxCR_NBREQ_Pos) | \
+                pSyncConfig->SyncPolarity | ((uint32_t)pSyncConfig->SyncEnable << DMAMUX_CxCR_SE_Pos) | \
+                ((uint32_t)pSyncConfig->EventEnable << DMAMUX_CxCR_EGE_Pos)));
 
     /* Process UnLocked */
     __HAL_UNLOCK(hdma);
@@ -124,22 +125,28 @@ HAL_StatusTypeDef HAL_DMAEx_ConfigMuxSync(DMA_HandleTypeDef *hdma, HAL_DMA_MuxSy
   }
   else
   {
-    /*DMA State not Ready*/
+    /* Set the error code to busy */
+    hdma->ErrorCode = HAL_DMA_ERROR_BUSY;
+
+    /* Return error status */
     return HAL_ERROR;
   }
 }
 
 /**
-  * @brief  Configure the DMAMUX request generator block used by the given DMA channel (instance).
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA channel.
-* @param  pRequestGeneratorConfig Pointer to HAL_DMA_MuxRequestGeneratorConfigTypeDef :
-  *         contains the request generator parameters.
+  * @brief Configure the DMAMUX request generator block used by the given DMA channel (instance).
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA channel.
+  * @param pRequestGeneratorConfig Pointer to HAL_DMA_MuxRequestGeneratorConfigTypeDef
+  *                                contains the request generator parameters.
   *
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMAEx_ConfigMuxRequestGenerator(DMA_HandleTypeDef *hdma, HAL_DMA_MuxRequestGeneratorConfigTypeDef *pRequestGeneratorConfig)
 {
+  HAL_StatusTypeDef status;
+  HAL_DMA_StateTypeDef temp_state = hdma->State;
+
   /* Check the parameters */
   assert_param(IS_DMA_ALL_INSTANCE(hdma->Instance));
 
@@ -151,8 +158,18 @@ HAL_StatusTypeDef HAL_DMAEx_ConfigMuxRequestGenerator(DMA_HandleTypeDef *hdma, H
   /* check if the DMA state is ready
      and DMA is using a DMAMUX request generator block
   */
-  if ((hdma->State == HAL_DMA_STATE_READY) && (hdma->DMAmuxRequestGen != 0U))
+  if (hdma->DMAmuxRequestGen == 0U)
   {
+    /* Set the error code to busy */
+    hdma->ErrorCode = HAL_DMA_ERROR_PARAM;
+
+    /* error status */
+    status = HAL_ERROR;
+  }
+  else if (((hdma->DMAmuxRequestGen->RGCR & DMAMUX_RGxCR_GE) == 0U) && (temp_state == HAL_DMA_STATE_READY))
+  {
+    /* RequestGenerator must be disable prior to the configuration i.e GE bit is 0 */
+
     /* Process Locked */
     __HAL_LOCK(hdma);
 
@@ -167,14 +184,20 @@ HAL_StatusTypeDef HAL_DMAEx_ConfigMuxRequestGenerator(DMA_HandleTypeDef *hdma, H
   }
   else
   {
-    return HAL_ERROR;
+    /* Set the error code to busy */
+    hdma->ErrorCode = HAL_DMA_ERROR_BUSY;
+
+    /* error status */
+    status = HAL_ERROR;
   }
+
+  return status;
 }
 
 /**
-  * @brief  Enable the DMAMUX request generator block used by the given DMA channel (instance).
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA channel.
+  * @brief Enable the DMAMUX request generator block used by the given DMA channel (instance).
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA channel.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMAEx_EnableMuxRequestGenerator(DMA_HandleTypeDef *hdma)
@@ -200,9 +223,9 @@ HAL_StatusTypeDef HAL_DMAEx_EnableMuxRequestGenerator(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  Disable the DMAMUX request generator block used by the given DMA channel (instance).
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *                     the configuration information for the specified DMA channel.
+  * @brief Disable the DMAMUX request generator block used by the given DMA channel (instance).
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA channel.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DMAEx_DisableMuxRequestGenerator(DMA_HandleTypeDef *hdma)
@@ -228,9 +251,9 @@ HAL_StatusTypeDef HAL_DMAEx_DisableMuxRequestGenerator(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  Handles DMAMUX interrupt request.
-  * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
-  *               the configuration information for the specified DMA channel.
+  * @brief Handles DMAMUX interrupt request.
+  * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
+  *             the configuration information for the specified DMA channel.
   * @retval None
   */
 void HAL_DMAEx_MUX_IRQHandler(DMA_HandleTypeDef *hdma)

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_exti.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_exti.c
@@ -32,7 +32,7 @@
         (++) Falling
 
     (+) Exti lines 0 to 15 are linked to gpio pin number 0 to 15. Gpio port can
-        be selected throught multiplexer.
+        be selected through multiplexer.
 
                      ##### How to use this driver #####
   ==============================================================================

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_fdcan.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_fdcan.c
@@ -1,0 +1,3455 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_fdcan.c
+  * @author  MCD Application Team
+  * @brief   FDCAN HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Flexible DataRate Controller Area Network
+  *          (FDCAN) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Configuration and Control functions
+  *           + Peripheral State and Error functions
+  *
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (#) Initialize the FDCAN peripheral using HAL_FDCAN_Init function.
+
+      (#) If needed , configure the reception filters and optional features using
+          the following configuration functions:
+            (++) HAL_FDCAN_ConfigFilter
+            (++) HAL_FDCAN_ConfigGlobalFilter
+            (++) HAL_FDCAN_ConfigExtendedIdMask
+            (++) HAL_FDCAN_ConfigRxFifoOverwrite
+            (++) HAL_FDCAN_ConfigRamWatchdog
+            (++) HAL_FDCAN_ConfigTimestampCounter
+            (++) HAL_FDCAN_EnableTimestampCounter
+            (++) HAL_FDCAN_DisableTimestampCounter
+            (++) HAL_FDCAN_ConfigTimeoutCounter
+            (++) HAL_FDCAN_EnableTimeoutCounter
+            (++) HAL_FDCAN_DisableTimeoutCounter
+            (++) HAL_FDCAN_ConfigTxDelayCompensation
+            (++) HAL_FDCAN_EnableTxDelayCompensation
+            (++) HAL_FDCAN_DisableTxDelayCompensation
+            (++) HAL_FDCAN_EnableISOMode
+            (++) HAL_FDCAN_DisableISOMode
+            (++) HAL_FDCAN_EnableEdgeFiltering
+            (++) HAL_FDCAN_DisableEdgeFiltering
+
+      (#) Start the FDCAN module using HAL_FDCAN_Start function. At this level
+          the node is active on the bus: it can send and receive messages.
+
+      (#) The following Tx control functions can only be called when the FDCAN
+          module is started:
+            (++) HAL_FDCAN_AddMessageToTxFifoQ
+            (++) HAL_FDCAN_AbortTxRequest
+
+      (#) After having submitted a Tx request in Tx Fifo or Queue, it is possible to
+          get Tx buffer location used to place the Tx request thanks to
+          HAL_FDCAN_GetLatestTxFifoQRequestBuffer API.
+          It is then possible to abort later on the corresponding Tx Request using
+          HAL_FDCAN_AbortTxRequest API.
+
+      (#) When a message is received into the FDCAN message RAM, it can be
+          retrieved using the HAL_FDCAN_GetRxMessage function.
+
+      (#) Calling the HAL_FDCAN_Stop function stops the FDCAN module by entering
+          it to initialization mode and re-enabling access to configuration
+          registers through the configuration functions listed here above.
+
+      (#) All other control functions can be called any time after initialization
+          phase, no matter if the FDCAN module is started or stopped.
+
+      *** Polling mode operation ***
+      ==============================
+    [..]
+        (#) Reception and transmission states can be monitored via the following
+            functions:
+              (++) HAL_FDCAN_IsTxBufferMessagePending
+              (++) HAL_FDCAN_GetRxFifoFillLevel
+              (++) HAL_FDCAN_GetTxFifoFreeLevel
+
+      *** Interrupt mode operation ***
+      ================================
+      [..]
+        (#) There are two interrupt lines: line 0 and 1.
+            By default, all interrupts are assigned to line 0. Interrupt lines
+            can be configured using HAL_FDCAN_ConfigInterruptLines function.
+
+        (#) Notifications are activated using HAL_FDCAN_ActivateNotification
+            function. Then, the process can be controlled through one of the
+            available user callbacks: HAL_FDCAN_xxxCallback.
+
+  *** Callback registration ***
+  =============================================
+
+  The compilation define  USE_HAL_FDCAN_REGISTER_CALLBACKS when set to 1
+  allows the user to configure dynamically the driver callbacks.
+  Use Function @ref HAL_FDCAN_RegisterCallback() or HAL_FDCAN_RegisterXXXCallback()
+  to register an interrupt callback.
+
+  Function @ref HAL_FDCAN_RegisterCallback() allows to register following callbacks:
+    (+) TxFifoEmptyCallback          : Tx Fifo Empty Callback.
+    (+) HighPriorityMessageCallback  : High Priority Message Callback.
+    (+) TimestampWraparoundCallback  : Timestamp Wraparound Callback.
+    (+) TimeoutOccurredCallback      : Timeout Occurred Callback.
+    (+) ErrorCallback                : Error Callback.
+    (+) MspInitCallback              : FDCAN MspInit.
+    (+) MspDeInitCallback            : FDCAN MspDeInit.
+  This function takes as parameters the HAL peripheral handle, the Callback ID
+  and a pointer to the user callback function.
+
+  For specific callbacks TxEventFifoCallback, RxFifo0Callback, RxFifo1Callback,
+  TxBufferCompleteCallback, TxBufferAbortCallback and ErrorStatusCallback use dedicated
+  register callbacks : respectively @ref HAL_FDCAN_RegisterTxEventFifoCallback(),
+  @ref HAL_FDCAN_RegisterRxFifo0Callback(), @ref HAL_FDCAN_RegisterRxFifo1Callback(),
+  @ref HAL_FDCAN_RegisterTxBufferCompleteCallback(), @ref HAL_FDCAN_RegisterTxBufferAbortCallback()
+  and @ref HAL_FDCAN_RegisterErrorStatusCallback().
+
+  Use function @ref HAL_FDCAN_UnRegisterCallback() to reset a callback to the default
+  weak function.
+  @ref HAL_FDCAN_UnRegisterCallback takes as parameters the HAL peripheral handle,
+  and the Callback ID.
+  This function allows to reset following callbacks:
+    (+) TxFifoEmptyCallback          : Tx Fifo Empty Callback.
+    (+) HighPriorityMessageCallback  : High Priority Message Callback.
+    (+) TimestampWraparoundCallback  : Timestamp Wraparound Callback.
+    (+) TimeoutOccurredCallback      : Timeout Occurred Callback.
+    (+) ErrorCallback                : Error Callback.
+    (+) MspInitCallback              : FDCAN MspInit.
+    (+) MspDeInitCallback            : FDCAN MspDeInit.
+
+  For specific callbacks TxEventFifoCallback, RxFifo0Callback, RxFifo1Callback,
+  TxBufferCompleteCallback and TxBufferAbortCallback, use dedicated
+  unregister callbacks : respectively @ref HAL_FDCAN_UnRegisterTxEventFifoCallback(),
+  @ref HAL_FDCAN_UnRegisterRxFifo0Callback(), @ref HAL_FDCAN_UnRegisterRxFifo1Callback(),
+  @ref HAL_FDCAN_UnRegisterTxBufferCompleteCallback(), @ref HAL_FDCAN_UnRegisterTxBufferAbortCallback()
+  and @ref HAL_FDCAN_UnRegisterErrorStatusCallback().
+
+  By default, after the @ref HAL_FDCAN_Init() and when the state is HAL_FDCAN_STATE_RESET,
+  all callbacks are set to the corresponding weak functions:
+  examples @ref HAL_FDCAN_ErrorCallback().
+  Exception done for MspInit and MspDeInit functions that are
+  reset to the legacy weak function in the @ref HAL_FDCAN_Init()/ @ref HAL_FDCAN_DeInit() only when
+  these callbacks are null (not registered beforehand).
+  if not, MspInit or MspDeInit are not null, the @ref HAL_FDCAN_Init()/ @ref HAL_FDCAN_DeInit()
+  keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
+
+  Callbacks can be registered/unregistered in HAL_FDCAN_STATE_READY state only.
+  Exception done MspInit/MspDeInit that can be registered/unregistered
+  in HAL_FDCAN_STATE_READY or HAL_FDCAN_STATE_RESET state,
+  thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
+  In that case first register the MspInit/MspDeInit user callbacks
+  using @ref HAL_FDCAN_RegisterCallback() before calling @ref HAL_FDCAN_DeInit()
+  or @ref HAL_FDCAN_Init() function.
+
+  When The compilation define USE_HAL_FDCAN_REGISTER_CALLBACKS is set to 0 or
+  not defined, the callback registration feature is not available and all callbacks
+  are set to the corresponding weak functions.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal.h"
+
+#if defined(FDCAN1)
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FDCAN FDCAN
+  * @brief FDCAN HAL module driver
+  * @{
+  */
+
+#ifdef HAL_FDCAN_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/** @addtogroup FDCAN_Private_Constants
+  * @{
+  */
+#define FDCAN_TIMEOUT_VALUE 10U
+
+#define FDCAN_TX_EVENT_FIFO_MASK (FDCAN_IR_TEFL | FDCAN_IR_TEFF | FDCAN_IR_TEFN)
+#define FDCAN_RX_FIFO0_MASK (FDCAN_IR_RF0L | FDCAN_IR_RF0F | FDCAN_IR_RF0N)
+#define FDCAN_RX_FIFO1_MASK (FDCAN_IR_RF1L | FDCAN_IR_RF1F | FDCAN_IR_RF1N)
+#define FDCAN_ERROR_MASK (FDCAN_IR_ELO | FDCAN_IR_WDI | FDCAN_IR_PEA | FDCAN_IR_PED | FDCAN_IR_ARA)
+#define FDCAN_ERROR_STATUS_MASK (FDCAN_IR_EP | FDCAN_IR_EW | FDCAN_IR_BO)
+
+#define FDCAN_ELEMENT_MASK_STDID ((uint32_t)0x1FFC0000U) /* Standard Identifier         */
+#define FDCAN_ELEMENT_MASK_EXTID ((uint32_t)0x1FFFFFFFU) /* Extended Identifier         */
+#define FDCAN_ELEMENT_MASK_RTR   ((uint32_t)0x20000000U) /* Remote Transmission Request */
+#define FDCAN_ELEMENT_MASK_XTD   ((uint32_t)0x40000000U) /* Extended Identifier         */
+#define FDCAN_ELEMENT_MASK_ESI   ((uint32_t)0x80000000U) /* Error State Indicator       */
+#define FDCAN_ELEMENT_MASK_TS    ((uint32_t)0x0000FFFFU) /* Timestamp                   */
+#define FDCAN_ELEMENT_MASK_DLC   ((uint32_t)0x000F0000U) /* Data Length Code            */
+#define FDCAN_ELEMENT_MASK_BRS   ((uint32_t)0x00100000U) /* Bit Rate Switch             */
+#define FDCAN_ELEMENT_MASK_FDF   ((uint32_t)0x00200000U) /* FD Format                   */
+#define FDCAN_ELEMENT_MASK_EFC   ((uint32_t)0x00800000U) /* Event FIFO Control          */
+#define FDCAN_ELEMENT_MASK_MM    ((uint32_t)0xFF000000U) /* Message Marker              */
+#define FDCAN_ELEMENT_MASK_FIDX  ((uint32_t)0x7F000000U) /* Filter Index                */
+#define FDCAN_ELEMENT_MASK_ANMF  ((uint32_t)0x80000000U) /* Accepted Non-matching Frame */
+#define FDCAN_ELEMENT_MASK_ET    ((uint32_t)0x00C00000U) /* Event type                  */
+
+#define SRAMCAN_FLS_NBR                  (28U)         /* Max. Filter List Standard Number      */
+#define SRAMCAN_FLE_NBR                  ( 8U)         /* Max. Filter List Extended Number      */
+#define SRAMCAN_RF0_NBR                  ( 3U)         /* RX FIFO 0 Elements Number             */
+#define SRAMCAN_RF1_NBR                  ( 3U)         /* RX FIFO 1 Elements Number             */
+#define SRAMCAN_TEF_NBR                  ( 3U)         /* TX Event FIFO Elements Number         */
+#define SRAMCAN_TFQ_NBR                  ( 3U)         /* TX FIFO/Queue Elements Number         */
+
+#define SRAMCAN_FLS_SIZE            ( 1U * 4U)         /* Filter Standard Element Size in bytes */
+#define SRAMCAN_FLE_SIZE            ( 2U * 4U)         /* Filter Extended Element Size in bytes */
+#define SRAMCAN_RF0_SIZE            (18U * 4U)         /* RX FIFO 0 Elements Size in bytes      */
+#define SRAMCAN_RF1_SIZE            (18U * 4U)         /* RX FIFO 1 Elements Size in bytes      */
+#define SRAMCAN_TEF_SIZE            ( 2U * 4U)         /* TX Event FIFO Elements Size in bytes  */
+#define SRAMCAN_TFQ_SIZE            (18U * 4U)         /* TX FIFO/Queue Elements Size in bytes  */
+
+#define SRAMCAN_FLSSA ((uint32_t)0)                                                      /* Filter List Standard Start Address */
+#define SRAMCAN_FLESA ((uint32_t)(SRAMCAN_FLSSA + (SRAMCAN_FLS_NBR * SRAMCAN_FLS_SIZE))) /* Filter List Extended Start Address */
+#define SRAMCAN_RF0SA ((uint32_t)(SRAMCAN_FLESA + (SRAMCAN_FLE_NBR * SRAMCAN_FLE_SIZE))) /* Rx FIFO 0 Start Address            */
+#define SRAMCAN_RF1SA ((uint32_t)(SRAMCAN_RF0SA + (SRAMCAN_RF0_NBR * SRAMCAN_RF0_SIZE))) /* Rx FIFO 1 Start Address            */
+#define SRAMCAN_TEFSA ((uint32_t)(SRAMCAN_RF1SA + (SRAMCAN_RF1_NBR * SRAMCAN_RF1_SIZE))) /* Tx Event FIFO Start Address        */
+#define SRAMCAN_TFQSA ((uint32_t)(SRAMCAN_TEFSA + (SRAMCAN_TEF_NBR * SRAMCAN_TEF_SIZE))) /* Tx FIFO/Queue Start Address        */
+#define SRAMCAN_SIZE  ((uint32_t)(SRAMCAN_TFQSA + (SRAMCAN_TFQ_NBR * SRAMCAN_TFQ_SIZE))) /* Message RAM size                   */
+
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+static const uint8_t DLCtoBytes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
+
+/* Private function prototypes -----------------------------------------------*/
+/** @addtogroup FDCAN_Private_Functions_Prototypes
+  * @{
+  */
+static void FDCAN_CalcultateRamBlockAddresses(FDCAN_HandleTypeDef *hfdcan);
+static void FDCAN_CopyMessageToRAM(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxHeaderTypeDef *pTxHeader, uint8_t *pTxData, uint32_t BufferIndex);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup FDCAN_Exported_Functions FDCAN Exported Functions
+  * @{
+  */
+
+/** @defgroup FDCAN_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the FDCAN.
+      (+) De-initialize the FDCAN.
+      (+) Enter FDCAN peripheral in power down mode.
+      (+) Exit power down mode.
+      (+) Register callbacks.
+      (+) Unregister callbacks.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the FDCAN peripheral according to the specified
+  *         parameters in the FDCAN_InitTypeDef structure.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_Init(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t tickstart;
+
+  /* Check FDCAN handle */
+  if (hfdcan == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_ALL_INSTANCE(hfdcan->Instance));
+  if (hfdcan->Instance == FDCAN1)
+  {
+    assert_param(IS_FDCAN_CKDIV(hfdcan->Init.ClockDivider));
+  }
+  assert_param(IS_FDCAN_FRAME_FORMAT(hfdcan->Init.FrameFormat));
+  assert_param(IS_FDCAN_MODE(hfdcan->Init.Mode));
+  assert_param(IS_FUNCTIONAL_STATE(hfdcan->Init.AutoRetransmission));
+  assert_param(IS_FUNCTIONAL_STATE(hfdcan->Init.TransmitPause));
+  assert_param(IS_FUNCTIONAL_STATE(hfdcan->Init.ProtocolException));
+  assert_param(IS_FDCAN_NOMINAL_PRESCALER(hfdcan->Init.NominalPrescaler));
+  assert_param(IS_FDCAN_NOMINAL_SJW(hfdcan->Init.NominalSyncJumpWidth));
+  assert_param(IS_FDCAN_NOMINAL_TSEG1(hfdcan->Init.NominalTimeSeg1));
+  assert_param(IS_FDCAN_NOMINAL_TSEG2(hfdcan->Init.NominalTimeSeg2));
+  if (hfdcan->Init.FrameFormat == FDCAN_FRAME_FD_BRS)
+  {
+    assert_param(IS_FDCAN_DATA_PRESCALER(hfdcan->Init.DataPrescaler));
+    assert_param(IS_FDCAN_DATA_SJW(hfdcan->Init.DataSyncJumpWidth));
+    assert_param(IS_FDCAN_DATA_TSEG1(hfdcan->Init.DataTimeSeg1));
+    assert_param(IS_FDCAN_DATA_TSEG2(hfdcan->Init.DataTimeSeg2));
+  }
+  assert_param(IS_FDCAN_MAX_VALUE(hfdcan->Init.StdFiltersNbr, SRAMCAN_FLS_NBR));
+  assert_param(IS_FDCAN_MAX_VALUE(hfdcan->Init.ExtFiltersNbr, SRAMCAN_FLE_NBR));
+  assert_param(IS_FDCAN_TX_FIFO_QUEUE_MODE(hfdcan->Init.TxFifoQueueMode));
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+  if (hfdcan->State == HAL_FDCAN_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hfdcan->Lock = HAL_UNLOCKED;
+
+    /* Reset callbacks to legacy functions */
+    hfdcan->TxEventFifoCallback         = HAL_FDCAN_TxEventFifoCallback;         /* Legacy weak TxEventFifoCallback         */
+    hfdcan->RxFifo0Callback             = HAL_FDCAN_RxFifo0Callback;             /* Legacy weak RxFifo0Callback             */
+    hfdcan->RxFifo1Callback             = HAL_FDCAN_RxFifo1Callback;             /* Legacy weak RxFifo1Callback             */
+    hfdcan->TxFifoEmptyCallback         = HAL_FDCAN_TxFifoEmptyCallback;         /* Legacy weak TxFifoEmptyCallback         */
+    hfdcan->TxBufferCompleteCallback    = HAL_FDCAN_TxBufferCompleteCallback;    /* Legacy weak TxBufferCompleteCallback    */
+    hfdcan->TxBufferAbortCallback       = HAL_FDCAN_TxBufferAbortCallback;       /* Legacy weak TxBufferAbortCallback       */
+    hfdcan->HighPriorityMessageCallback = HAL_FDCAN_HighPriorityMessageCallback; /* Legacy weak HighPriorityMessageCallback */
+    hfdcan->TimestampWraparoundCallback = HAL_FDCAN_TimestampWraparoundCallback; /* Legacy weak TimestampWraparoundCallback */
+    hfdcan->TimeoutOccurredCallback     = HAL_FDCAN_TimeoutOccurredCallback;     /* Legacy weak TimeoutOccurredCallback     */
+    hfdcan->ErrorCallback               = HAL_FDCAN_ErrorCallback;               /* Legacy weak ErrorCallback               */
+    hfdcan->ErrorStatusCallback         = HAL_FDCAN_ErrorStatusCallback;         /* Legacy weak ErrorStatusCallback         */
+
+    if (hfdcan->MspInitCallback == NULL)
+    {
+      hfdcan->MspInitCallback = HAL_FDCAN_MspInit;  /* Legacy weak MspInit */
+    }
+
+    /* Init the low level hardware: CLOCK, NVIC */
+    hfdcan->MspInitCallback(hfdcan);
+  }
+#else
+  if (hfdcan->State == HAL_FDCAN_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hfdcan->Lock = HAL_UNLOCKED;
+
+    /* Init the low level hardware: CLOCK, NVIC */
+    HAL_FDCAN_MspInit(hfdcan);
+  }
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+
+  /* Exit from Sleep mode */
+  CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_CSR);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Check Sleep mode acknowledge */
+  while ((hfdcan->Instance->CCCR & FDCAN_CCCR_CSA) == FDCAN_CCCR_CSA)
+  {
+    if ((HAL_GetTick() - tickstart) > FDCAN_TIMEOUT_VALUE)
+    {
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_TIMEOUT;
+
+      /* Change FDCAN state */
+      hfdcan->State = HAL_FDCAN_STATE_ERROR;
+
+      return HAL_ERROR;
+    }
+  }
+
+  /* Request initialisation */
+  SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_INIT);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait until the INIT bit into CCCR register is set */
+  while ((hfdcan->Instance->CCCR & FDCAN_CCCR_INIT) == 0U)
+  {
+    /* Check for the Timeout */
+    if ((HAL_GetTick() - tickstart) > FDCAN_TIMEOUT_VALUE)
+    {
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_TIMEOUT;
+
+      /* Change FDCAN state */
+      hfdcan->State = HAL_FDCAN_STATE_ERROR;
+
+      return HAL_ERROR;
+    }
+  }
+
+  /* Enable configuration change */
+  SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_CCE);
+
+  /* Check FDCAN instance */
+  if (hfdcan->Instance == FDCAN1)
+  {
+    /* Configure Clock divider */
+    FDCAN_CONFIG->CKDIV = hfdcan->Init.ClockDivider;
+  }
+
+  /* Set the no automatic retransmission */
+  if (hfdcan->Init.AutoRetransmission == ENABLE)
+  {
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_DAR);
+  }
+  else
+  {
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_DAR);
+  }
+
+  /* Set the transmit pause feature */
+  if (hfdcan->Init.TransmitPause == ENABLE)
+  {
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_TXP);
+  }
+  else
+  {
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_TXP);
+  }
+
+  /* Set the Protocol Exception Handling */
+  if (hfdcan->Init.ProtocolException == ENABLE)
+  {
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_PXHD);
+  }
+  else
+  {
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_PXHD);
+  }
+
+  /* Set FDCAN Frame Format */
+  MODIFY_REG(hfdcan->Instance->CCCR, FDCAN_FRAME_FD_BRS, hfdcan->Init.FrameFormat);
+
+  /* Reset FDCAN Operation Mode */
+  CLEAR_BIT(hfdcan->Instance->CCCR, (FDCAN_CCCR_TEST | FDCAN_CCCR_MON | FDCAN_CCCR_ASM));
+  CLEAR_BIT(hfdcan->Instance->TEST, FDCAN_TEST_LBCK);
+
+  /* Set FDCAN Operating Mode:
+               | Normal | Restricted |    Bus     | Internal | External
+               |        | Operation  | Monitoring | LoopBack | LoopBack
+     CCCR.TEST |   0    |     0      |     0      |    1     |    1
+     CCCR.MON  |   0    |     0      |     1      |    1     |    0
+     TEST.LBCK |   0    |     0      |     0      |    1     |    1
+     CCCR.ASM  |   0    |     1      |     0      |    0     |    0
+  */
+  if (hfdcan->Init.Mode == FDCAN_MODE_RESTRICTED_OPERATION)
+  {
+    /* Enable Restricted Operation mode */
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_ASM);
+  }
+  else if (hfdcan->Init.Mode != FDCAN_MODE_NORMAL)
+  {
+    if (hfdcan->Init.Mode != FDCAN_MODE_BUS_MONITORING)
+    {
+      /* Enable write access to TEST register */
+      SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_TEST);
+
+      /* Enable LoopBack mode */
+      SET_BIT(hfdcan->Instance->TEST, FDCAN_TEST_LBCK);
+
+      if (hfdcan->Init.Mode == FDCAN_MODE_INTERNAL_LOOPBACK)
+      {
+        SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_MON);
+      }
+    }
+    else
+    {
+      /* Enable bus monitoring mode */
+      SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_MON);
+    }
+  }
+  else
+  {
+    /* Nothing to do: normal mode */
+  }
+
+  /* Set the nominal bit timing register */
+  hfdcan->Instance->NBTP = ((((uint32_t)hfdcan->Init.NominalSyncJumpWidth - 1U) << FDCAN_NBTP_NSJW_Pos) | \
+                            (((uint32_t)hfdcan->Init.NominalTimeSeg1 - 1U) << FDCAN_NBTP_NTSEG1_Pos)    | \
+                            (((uint32_t)hfdcan->Init.NominalTimeSeg2 - 1U) << FDCAN_NBTP_NTSEG2_Pos)    | \
+                            (((uint32_t)hfdcan->Init.NominalPrescaler - 1U) << FDCAN_NBTP_NBRP_Pos));
+
+  /* If FD operation with BRS is selected, set the data bit timing register */
+  if (hfdcan->Init.FrameFormat == FDCAN_FRAME_FD_BRS)
+  {
+    hfdcan->Instance->DBTP = ((((uint32_t)hfdcan->Init.DataSyncJumpWidth - 1U) << FDCAN_DBTP_DSJW_Pos)  | \
+                              (((uint32_t)hfdcan->Init.DataTimeSeg1 - 1U) << FDCAN_DBTP_DTSEG1_Pos)     | \
+                              (((uint32_t)hfdcan->Init.DataTimeSeg2 - 1U) << FDCAN_DBTP_DTSEG2_Pos)     | \
+                              (((uint32_t)hfdcan->Init.DataPrescaler - 1U) << FDCAN_DBTP_DBRP_Pos));
+  }
+
+  /* Select between Tx FIFO and Tx Queue operation modes */
+  SET_BIT(hfdcan->Instance->TXBC, hfdcan->Init.TxFifoQueueMode);
+
+  /* Calculate each RAM block address */
+  FDCAN_CalcultateRamBlockAddresses(hfdcan);
+
+  /* Initialize the Latest Tx request buffer index */
+  hfdcan->LatestTxFifoQRequest = 0U;
+
+  /* Initialize the error code */
+  hfdcan->ErrorCode = HAL_FDCAN_ERROR_NONE;
+
+  /* Initialize the FDCAN state */
+  hfdcan->State = HAL_FDCAN_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitializes the FDCAN peripheral registers to their default reset values.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DeInit(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Check FDCAN handle */
+  if (hfdcan == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_ALL_INSTANCE(hfdcan->Instance));
+
+  /* Stop the FDCAN module: return value is voluntary ignored */
+  (void)HAL_FDCAN_Stop(hfdcan);
+
+  /* Disable Interrupt lines */
+  CLEAR_BIT(hfdcan->Instance->ILE, (FDCAN_INTERRUPT_LINE0 | FDCAN_INTERRUPT_LINE1));
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+  if (hfdcan->MspDeInitCallback == NULL)
+  {
+    hfdcan->MspDeInitCallback = HAL_FDCAN_MspDeInit; /* Legacy weak MspDeInit */
+  }
+
+  /* DeInit the low level hardware: CLOCK, NVIC */
+  hfdcan->MspDeInitCallback(hfdcan);
+#else
+  /* DeInit the low level hardware: CLOCK, NVIC */
+  HAL_FDCAN_MspDeInit(hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+
+  /* Reset the FDCAN ErrorCode */
+  hfdcan->ErrorCode = HAL_FDCAN_ERROR_NONE;
+
+  /* Change FDCAN state */
+  hfdcan->State = HAL_FDCAN_STATE_RESET;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the FDCAN MSP.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_MspInit(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the FDCAN MSP.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_MspDeInit(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Enter FDCAN peripheral in sleep mode.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_EnterPowerDownMode(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t tickstart;
+
+  /* Request clock stop */
+  SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_CSR);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait until FDCAN is ready for power down */
+  while ((hfdcan->Instance->CCCR & FDCAN_CCCR_CSA) == 0U)
+  {
+    if ((HAL_GetTick() - tickstart) > FDCAN_TIMEOUT_VALUE)
+    {
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_TIMEOUT;
+
+      /* Change FDCAN state */
+      hfdcan->State = HAL_FDCAN_STATE_ERROR;
+
+      return HAL_ERROR;
+    }
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Exit power down mode.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ExitPowerDownMode(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t tickstart;
+
+  /* Reset clock stop request */
+  CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_CSR);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait until FDCAN exits sleep mode */
+  while ((hfdcan->Instance->CCCR & FDCAN_CCCR_CSA) == FDCAN_CCCR_CSA)
+  {
+    if ((HAL_GetTick() - tickstart) > FDCAN_TIMEOUT_VALUE)
+    {
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_TIMEOUT;
+
+      /* Change FDCAN state */
+      hfdcan->State = HAL_FDCAN_STATE_ERROR;
+
+      return HAL_ERROR;
+    }
+  }
+
+  /* Enter normal operation */
+  CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_INIT);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+/**
+  * @brief  Register a FDCAN CallBack.
+  *         To be used instead of the weak predefined callback
+  * @param  hfdcan pointer to a FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for FDCAN module
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *           @arg @ref HAL_FDCAN_TX_FIFO_EMPTY_CB_ID Tx Fifo Empty callback ID
+  *           @arg @ref HAL_FDCAN_HIGH_PRIO_MESSAGE_CB_ID High priority message callback ID
+  *           @arg @ref HAL_FDCAN_TIMESTAMP_WRAPAROUND_CB_ID Timestamp wraparound callback ID
+  *           @arg @ref HAL_FDCAN_TIMEOUT_OCCURRED_CB_ID Timeout occurred callback ID
+  *           @arg @ref HAL_FDCAN_ERROR_CALLBACK_CB_ID Error callback ID
+  *           @arg @ref HAL_FDCAN_MSPINIT_CB_ID MspInit callback ID
+  *           @arg @ref HAL_FDCAN_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @param  pCallback pointer to the Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterCallback(FDCAN_HandleTypeDef *hfdcan, HAL_FDCAN_CallbackIDTypeDef CallbackID, void (* pCallback)(FDCAN_HandleTypeDef *_hFDCAN))
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_FDCAN_TX_FIFO_EMPTY_CB_ID :
+        hfdcan->TxFifoEmptyCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_HIGH_PRIO_MESSAGE_CB_ID :
+        hfdcan->HighPriorityMessageCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_TIMESTAMP_WRAPAROUND_CB_ID :
+        hfdcan->TimestampWraparoundCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_TIMEOUT_OCCURRED_CB_ID :
+        hfdcan->TimeoutOccurredCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_ERROR_CALLBACK_CB_ID :
+        hfdcan->ErrorCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_MSPINIT_CB_ID :
+        hfdcan->MspInitCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_MSPDEINIT_CB_ID :
+        hfdcan->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hfdcan->State == HAL_FDCAN_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_FDCAN_MSPINIT_CB_ID :
+        hfdcan->MspInitCallback = pCallback;
+        break;
+
+      case HAL_FDCAN_MSPDEINIT_CB_ID :
+        hfdcan->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Unregister a FDCAN CallBack.
+  *         FDCAN callback is redirected to the weak predefined callback
+  * @param  hfdcan pointer to a FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for FDCAN module
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *           @arg @ref HAL_FDCAN_TX_FIFO_EMPTY_CB_ID Tx Fifo Empty callback ID
+  *           @arg @ref HAL_FDCAN_HIGH_PRIO_MESSAGE_CB_ID High priority message callback ID
+  *           @arg @ref HAL_FDCAN_TIMESTAMP_WRAPAROUND_CB_ID Timestamp wraparound callback ID
+  *           @arg @ref HAL_FDCAN_TIMEOUT_OCCURRED_CB_ID Timeout occurred callback ID
+  *           @arg @ref HAL_FDCAN_ERROR_CALLBACK_CB_ID Error callback ID
+  *           @arg @ref HAL_FDCAN_MSPINIT_CB_ID MspInit callback ID
+  *           @arg @ref HAL_FDCAN_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterCallback(FDCAN_HandleTypeDef *hfdcan, HAL_FDCAN_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_FDCAN_TX_FIFO_EMPTY_CB_ID :
+        hfdcan->TxFifoEmptyCallback = HAL_FDCAN_TxFifoEmptyCallback;
+        break;
+
+      case HAL_FDCAN_HIGH_PRIO_MESSAGE_CB_ID :
+        hfdcan->HighPriorityMessageCallback = HAL_FDCAN_HighPriorityMessageCallback;
+        break;
+
+      case HAL_FDCAN_TIMESTAMP_WRAPAROUND_CB_ID :
+        hfdcan->TimestampWraparoundCallback = HAL_FDCAN_TimestampWraparoundCallback;
+        break;
+
+      case HAL_FDCAN_TIMEOUT_OCCURRED_CB_ID :
+        hfdcan->TimeoutOccurredCallback = HAL_FDCAN_TimeoutOccurredCallback;
+        break;
+
+      case HAL_FDCAN_ERROR_CALLBACK_CB_ID :
+        hfdcan->ErrorCallback = HAL_FDCAN_ErrorCallback;
+        break;
+
+      case HAL_FDCAN_MSPINIT_CB_ID :
+        hfdcan->MspInitCallback = HAL_FDCAN_MspInit;
+        break;
+
+      case HAL_FDCAN_MSPDEINIT_CB_ID :
+        hfdcan->MspDeInitCallback = HAL_FDCAN_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hfdcan->State == HAL_FDCAN_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_FDCAN_MSPINIT_CB_ID :
+        hfdcan->MspInitCallback = HAL_FDCAN_MspInit;
+        break;
+
+      case HAL_FDCAN_MSPDEINIT_CB_ID :
+        hfdcan->MspDeInitCallback = HAL_FDCAN_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Register Tx Event Fifo FDCAN Callback
+  *         To be used instead of the weak HAL_FDCAN_TxEventFifoCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @param  pCallback pointer to the Tx Event Fifo Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterTxEventFifoCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_TxEventFifoCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->TxEventFifoCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the Tx Event Fifo FDCAN Callback
+  *         Tx Event Fifo FDCAN Callback is redirected to the weak HAL_FDCAN_TxEventFifoCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterTxEventFifoCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->TxEventFifoCallback = HAL_FDCAN_TxEventFifoCallback; /* Legacy weak TxEventFifoCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Register Rx Fifo 0 FDCAN Callback
+  *         To be used instead of the weak HAL_FDCAN_RxFifo0Callback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @param  pCallback pointer to the Rx Fifo 0 Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterRxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_RxFifo0CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->RxFifo0Callback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the Rx Fifo 0 FDCAN Callback
+  *         Rx Fifo 0 FDCAN Callback is redirected to the weak HAL_FDCAN_RxFifo0Callback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterRxFifo0Callback(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->RxFifo0Callback = HAL_FDCAN_RxFifo0Callback; /* Legacy weak RxFifo0Callback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Register Rx Fifo 1 FDCAN Callback
+  *         To be used instead of the weak HAL_FDCAN_RxFifo1Callback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @param  pCallback pointer to the Rx Fifo 1 Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterRxFifo1Callback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_RxFifo1CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->RxFifo1Callback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the Rx Fifo 1 FDCAN Callback
+  *         Rx Fifo 1 FDCAN Callback is redirected to the weak HAL_FDCAN_RxFifo1Callback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterRxFifo1Callback(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->RxFifo1Callback = HAL_FDCAN_RxFifo1Callback; /* Legacy weak RxFifo1Callback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Register Tx Buffer Complete FDCAN Callback
+  *         To be used instead of the weak HAL_FDCAN_TxBufferCompleteCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @param  pCallback pointer to the Tx Buffer Complete Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterTxBufferCompleteCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_TxBufferCompleteCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->TxBufferCompleteCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the Tx Buffer Complete FDCAN Callback
+  *         Tx Buffer Complete FDCAN Callback is redirected to the weak HAL_FDCAN_TxBufferCompleteCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterTxBufferCompleteCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->TxBufferCompleteCallback = HAL_FDCAN_TxBufferCompleteCallback; /* Legacy weak TxBufferCompleteCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Register Tx Buffer Abort FDCAN Callback
+  *         To be used instead of the weak HAL_FDCAN_TxBufferAbortCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @param  pCallback pointer to the Tx Buffer Abort Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterTxBufferAbortCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_TxBufferAbortCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->TxBufferAbortCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the Tx Buffer Abort FDCAN Callback
+  *         Tx Buffer Abort FDCAN Callback is redirected to the weak HAL_FDCAN_TxBufferAbortCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterTxBufferAbortCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->TxBufferAbortCallback = HAL_FDCAN_TxBufferAbortCallback; /* Legacy weak TxBufferAbortCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Register Error Status FDCAN Callback
+  *         To be used instead of the weak HAL_FDCAN_ErrorStatusCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @param  pCallback pointer to the Error Status Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_RegisterErrorStatusCallback(FDCAN_HandleTypeDef *hfdcan, pFDCAN_ErrorStatusCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->ErrorStatusCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the Error Status FDCAN Callback
+  *         Error Status FDCAN Callback is redirected to the weak HAL_FDCAN_ErrorStatusCallback() predefined callback
+  * @param  hfdcan FDCAN handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_UnRegisterErrorStatusCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    hfdcan->ErrorStatusCallback = HAL_FDCAN_ErrorStatusCallback; /* Legacy weak ErrorStatusCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Exported_Functions_Group2 Configuration functions
+ *  @brief    FDCAN Configuration functions.
+ *
+@verbatim
+  ==============================================================================
+              ##### Configuration functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) HAL_FDCAN_ConfigFilter                  : Configure the FDCAN reception filters
+      (+) HAL_FDCAN_ConfigGlobalFilter            : Configure the FDCAN global filter
+      (+) HAL_FDCAN_ConfigExtendedIdMask          : Configure the extended ID mask
+      (+) HAL_FDCAN_ConfigRxFifoOverwrite         : Configure the Rx FIFO operation mode
+      (+) HAL_FDCAN_ConfigRamWatchdog             : Configure the RAM watchdog
+      (+) HAL_FDCAN_ConfigTimestampCounter        : Configure the timestamp counter
+        (+) HAL_FDCAN_EnableTimestampCounter        : Enable the timestamp counter
+        (+) HAL_FDCAN_DisableTimestampCounter       : Disable the timestamp counter
+        (+) HAL_FDCAN_GetTimestampCounter           : Get the timestamp counter value
+        (+) HAL_FDCAN_ResetTimestampCounter         : Reset the timestamp counter to zero
+      (+) HAL_FDCAN_ConfigTimeoutCounter          : Configure the timeout counter
+        (+) HAL_FDCAN_EnableTimeoutCounter          : Enable the timeout counter
+        (+) HAL_FDCAN_DisableTimeoutCounter         : Disable the timeout counter
+        (+) HAL_FDCAN_GetTimeoutCounter             : Get the timeout counter value
+        (+) HAL_FDCAN_ResetTimeoutCounter           : Reset the timeout counter to its start value
+      (+) HAL_FDCAN_ConfigTxDelayCompensation     : Configure the transmitter delay compensation
+        (+) HAL_FDCAN_EnableTxDelayCompensation     : Enable the transmitter delay compensation
+        (+) HAL_FDCAN_DisableTxDelayCompensation    : Disable the transmitter delay compensation
+      (+) HAL_FDCAN_EnableISOMode                 : Enable ISO 11898-1 protocol mode
+      (+) HAL_FDCAN_DisableISOMode                : Disable ISO 11898-1 protocol mode
+      (+) HAL_FDCAN_EnableEdgeFiltering           : Enable edge filtering during bus integration
+      (+) HAL_FDCAN_DisableEdgeFiltering          : Disable edge filtering during bus integration
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure the FDCAN reception filter according to the specified
+  *         parameters in the FDCAN_FilterTypeDef structure.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  sFilterConfig pointer to an FDCAN_FilterTypeDef structure that
+  *         contains the filter configuration information
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigFilter(FDCAN_HandleTypeDef *hfdcan, FDCAN_FilterTypeDef *sFilterConfig)
+{
+  uint32_t FilterElementW1;
+  uint32_t FilterElementW2;
+  uint32_t *FilterAddress;
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+
+  if ((state == HAL_FDCAN_STATE_READY) || (state == HAL_FDCAN_STATE_BUSY))
+  {
+    /* Check function parameters */
+    assert_param(IS_FDCAN_ID_TYPE(sFilterConfig->IdType));
+    assert_param(IS_FDCAN_FILTER_CFG(sFilterConfig->FilterConfig));
+
+    if (sFilterConfig->IdType == FDCAN_STANDARD_ID)
+    {
+      /* Check function parameters */
+      assert_param(IS_FDCAN_MAX_VALUE(sFilterConfig->FilterIndex, (hfdcan->Init.StdFiltersNbr - 1U)));
+      assert_param(IS_FDCAN_MAX_VALUE(sFilterConfig->FilterID1, 0x7FFU));
+      assert_param(IS_FDCAN_MAX_VALUE(sFilterConfig->FilterID2, 0x7FFU));
+      assert_param(IS_FDCAN_STD_FILTER_TYPE(sFilterConfig->FilterType));
+
+      /* Build filter element */
+      FilterElementW1 = ((sFilterConfig->FilterType << 30U)   |
+                         (sFilterConfig->FilterConfig << 27U) |
+                         (sFilterConfig->FilterID1 << 16U)    |
+                         sFilterConfig->FilterID2);
+
+      /* Calculate filter address */
+      FilterAddress = (uint32_t *)(hfdcan->msgRam.StandardFilterSA + (sFilterConfig->FilterIndex * SRAMCAN_FLS_SIZE));
+
+      /* Write filter element to the message RAM */
+      *FilterAddress = FilterElementW1;
+    }
+    else /* sFilterConfig->IdType == FDCAN_EXTENDED_ID */
+    {
+      /* Check function parameters */
+      assert_param(IS_FDCAN_MAX_VALUE(sFilterConfig->FilterIndex, (hfdcan->Init.ExtFiltersNbr - 1U)));
+      assert_param(IS_FDCAN_MAX_VALUE(sFilterConfig->FilterID1, 0x1FFFFFFFU));
+      assert_param(IS_FDCAN_MAX_VALUE(sFilterConfig->FilterID2, 0x1FFFFFFFU));
+      assert_param(IS_FDCAN_EXT_FILTER_TYPE(sFilterConfig->FilterType));
+
+      /* Build first word of filter element */
+      FilterElementW1 = ((sFilterConfig->FilterConfig << 29U) | sFilterConfig->FilterID1);
+
+      /* Build second word of filter element */
+      FilterElementW2 = ((sFilterConfig->FilterType << 30U) | sFilterConfig->FilterID2);
+
+      /* Calculate filter address */
+      FilterAddress = (uint32_t *)(hfdcan->msgRam.ExtendedFilterSA + (sFilterConfig->FilterIndex * SRAMCAN_FLE_SIZE));
+
+      /* Write filter element to the message RAM */
+      *FilterAddress = FilterElementW1;
+      FilterAddress++;
+      *FilterAddress = FilterElementW2;
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_INITIALIZED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the FDCAN global filter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  NonMatchingStd Defines how received messages with 11-bit IDs that
+  *         do not match any element of the filter list are treated.
+  *         This parameter can be a value of @arg FDCAN_Non_Matching_Frames.
+  * @param  NonMatchingExt Defines how received messages with 29-bit IDs that
+  *         do not match any element of the filter list are treated.
+  *         This parameter can be a value of @arg FDCAN_Non_Matching_Frames.
+  * @param  RejectRemoteStd Filter or reject all the remote 11-bit IDs frames.
+  *         This parameter can be a value of @arg FDCAN_Reject_Remote_Frames.
+  * @param  RejectRemoteExt Filter or reject all the remote 29-bit IDs frames.
+  *         This parameter can be a value of @arg FDCAN_Reject_Remote_Frames.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigGlobalFilter(FDCAN_HandleTypeDef *hfdcan,
+                                               uint32_t NonMatchingStd,
+                                               uint32_t NonMatchingExt,
+                                               uint32_t RejectRemoteStd,
+                                               uint32_t RejectRemoteExt)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_NON_MATCHING(NonMatchingStd));
+  assert_param(IS_FDCAN_NON_MATCHING(NonMatchingExt));
+  assert_param(IS_FDCAN_REJECT_REMOTE(RejectRemoteStd));
+  assert_param(IS_FDCAN_REJECT_REMOTE(RejectRemoteExt));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Configure global filter */
+    MODIFY_REG(hfdcan->Instance->RXGFC, (FDCAN_RXGFC_ANFS |
+                                         FDCAN_RXGFC_ANFE |
+                                         FDCAN_RXGFC_RRFS |
+                                         FDCAN_RXGFC_RRFE),
+                                        ((NonMatchingStd << FDCAN_RXGFC_ANFS_Pos)  |
+                                         (NonMatchingExt << FDCAN_RXGFC_ANFE_Pos)  |
+                                         (RejectRemoteStd << FDCAN_RXGFC_RRFS_Pos) |
+                                         (RejectRemoteExt << FDCAN_RXGFC_RRFE_Pos)));
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the extended ID mask.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  Mask Extended ID Mask.
+            This parameter must be a number between 0 and 0x1FFFFFFF
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigExtendedIdMask(FDCAN_HandleTypeDef *hfdcan, uint32_t Mask)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_MAX_VALUE(Mask, 0x1FFFFFFFU));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Configure the extended ID mask */
+    hfdcan->Instance->XIDAM = Mask;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the Rx FIFO operation mode.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  RxFifo Rx FIFO.
+  *         This parameter can be one of the following values:
+  *           @arg FDCAN_RX_FIFO0: Rx FIFO 0
+  *           @arg FDCAN_RX_FIFO1: Rx FIFO 1
+  * @param  OperationMode operation mode.
+  *         This parameter can be a value of @arg FDCAN_Rx_FIFO_operation_mode.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigRxFifoOverwrite(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo, uint32_t OperationMode)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_RX_FIFO(RxFifo));
+  assert_param(IS_FDCAN_RX_FIFO_MODE(OperationMode));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    if (RxFifo == FDCAN_RX_FIFO0)
+    {
+      /* Select FIFO 0 Operation Mode */
+      MODIFY_REG(hfdcan->Instance->RXGFC, FDCAN_RXGFC_F0OM, (OperationMode << FDCAN_RXGFC_F0OM_Pos));
+    }
+    else /* RxFifo == FDCAN_RX_FIFO1 */
+    {
+      /* Select FIFO 1 Operation Mode */
+      MODIFY_REG(hfdcan->Instance->RXGFC, FDCAN_RXGFC_F1OM, (OperationMode << FDCAN_RXGFC_F1OM_Pos));
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the RAM watchdog.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  CounterStartValue Start value of the Message RAM Watchdog Counter,
+  *         This parameter must be a number between 0x00 and 0xFF,
+  *         with the reset value of 0x00 the counter is disabled.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigRamWatchdog(FDCAN_HandleTypeDef *hfdcan, uint32_t CounterStartValue)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_MAX_VALUE(CounterStartValue, 0xFFU));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Configure the RAM watchdog counter start value */
+    MODIFY_REG(hfdcan->Instance->RWD, FDCAN_RWD_WDC, CounterStartValue);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the timestamp counter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  TimestampPrescaler Timestamp Counter Prescaler.
+  *         This parameter can be a value of @arg FDCAN_Timestamp_Prescaler.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigTimestampCounter(FDCAN_HandleTypeDef *hfdcan, uint32_t TimestampPrescaler)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_TIMESTAMP_PRESCALER(TimestampPrescaler));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Configure prescaler */
+    MODIFY_REG(hfdcan->Instance->TSCC, FDCAN_TSCC_TCP, TimestampPrescaler);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable the timestamp counter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  TimestampOperation Timestamp counter operation.
+  *         This parameter can be a value of @arg FDCAN_Timestamp.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_EnableTimestampCounter(FDCAN_HandleTypeDef *hfdcan, uint32_t TimestampOperation)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_TIMESTAMP(TimestampOperation));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Enable timestamp counter */
+    MODIFY_REG(hfdcan->Instance->TSCC, FDCAN_TSCC_TSS, TimestampOperation);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable the timestamp counter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DisableTimestampCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Disable timestamp counter */
+    CLEAR_BIT(hfdcan->Instance->TSCC, FDCAN_TSCC_TSS);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get the timestamp counter value.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval Timestamp counter value
+  */
+uint16_t HAL_FDCAN_GetTimestampCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  return (uint16_t)(hfdcan->Instance->TSCV);
+}
+
+/**
+  * @brief  Reset the timestamp counter to zero.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ResetTimestampCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  if ((hfdcan->Instance->TSCC & FDCAN_TSCC_TSS) != FDCAN_TIMESTAMP_EXTERNAL)
+  {
+    /* Reset timestamp counter.
+       Actually any write operation to TSCV clears the counter */
+    CLEAR_REG(hfdcan->Instance->TSCV);
+  }
+  else
+  {
+    /* Update error code.
+       Unable to reset external counter */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_SUPPORTED;
+
+    return HAL_ERROR;
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configure the timeout counter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  TimeoutOperation Timeout counter operation.
+  *         This parameter can be a value of @arg FDCAN_Timeout_Operation.
+  * @param  TimeoutPeriod Start value of the timeout down-counter.
+  *         This parameter must be a number between 0x0000 and 0xFFFF
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigTimeoutCounter(FDCAN_HandleTypeDef *hfdcan, uint32_t TimeoutOperation, uint32_t TimeoutPeriod)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_TIMEOUT(TimeoutOperation));
+  assert_param(IS_FDCAN_MAX_VALUE(TimeoutPeriod, 0xFFFFU));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Select timeout operation and configure period */
+    MODIFY_REG(hfdcan->Instance->TOCC, (FDCAN_TOCC_TOS | FDCAN_TOCC_TOP), (TimeoutOperation | (TimeoutPeriod << FDCAN_TOCC_TOP_Pos)));
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable the timeout counter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_EnableTimeoutCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Enable timeout counter */
+    SET_BIT(hfdcan->Instance->TOCC, FDCAN_TOCC_ETOC);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable the timeout counter.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DisableTimeoutCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Disable timeout counter */
+    CLEAR_BIT(hfdcan->Instance->TOCC, FDCAN_TOCC_ETOC);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get the timeout counter value.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval Timeout counter value
+  */
+uint16_t HAL_FDCAN_GetTimeoutCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  return (uint16_t)(hfdcan->Instance->TOCV);
+}
+
+/**
+  * @brief  Reset the timeout counter to its start value.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ResetTimeoutCounter(FDCAN_HandleTypeDef *hfdcan)
+{
+  if ((hfdcan->Instance->TOCC & FDCAN_TOCC_TOS) == FDCAN_TIMEOUT_CONTINUOUS)
+  {
+    /* Reset timeout counter to start value */
+    CLEAR_REG(hfdcan->Instance->TOCV);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code.
+       Unable to reset counter: controlled only by FIFO empty state */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_SUPPORTED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the transmitter delay compensation.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  TdcOffset Transmitter Delay Compensation Offset.
+  *         This parameter must be a number between 0x00 and 0x7F.
+  * @param  TdcFilter Transmitter Delay Compensation Filter Window Length.
+  *         This parameter must be a number between 0x00 and 0x7F.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigTxDelayCompensation(FDCAN_HandleTypeDef *hfdcan, uint32_t TdcOffset, uint32_t TdcFilter)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_MAX_VALUE(TdcOffset, 0x7FU));
+  assert_param(IS_FDCAN_MAX_VALUE(TdcFilter, 0x7FU));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Configure TDC offset and filter window */
+    hfdcan->Instance->TDCR = ((TdcFilter << FDCAN_TDCR_TDCF_Pos) | (TdcOffset << FDCAN_TDCR_TDCO_Pos));
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable the transmitter delay compensation.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_EnableTxDelayCompensation(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Enable transmitter delay compensation */
+    SET_BIT(hfdcan->Instance->DBTP, FDCAN_DBTP_TDC);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable the transmitter delay compensation.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DisableTxDelayCompensation(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Disable transmitter delay compensation */
+    CLEAR_BIT(hfdcan->Instance->DBTP, FDCAN_DBTP_TDC);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable ISO 11898-1 protocol mode.
+  *         CAN FD frame format is according to ISO 11898-1 standard.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_EnableISOMode(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Disable Non ISO protocol mode */
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_NISO);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable ISO 11898-1 protocol mode.
+  *         CAN FD frame format is according to Bosch CAN FD specification V1.0.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DisableISOMode(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Enable Non ISO protocol mode */
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_NISO);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable edge filtering during bus integration.
+  *         Two consecutive dominant tq are required to detect an edge for hard synchronization.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_EnableEdgeFiltering(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Enable edge filtering */
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_EFBI);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable edge filtering during bus integration.
+  *         One dominant tq is required to detect an edge for hard synchronization.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DisableEdgeFiltering(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Disable edge filtering */
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_EFBI);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Exported_Functions_Group3 Control functions
+ *  @brief    Control functions
+ *
+@verbatim
+  ==============================================================================
+                          ##### Control functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) HAL_FDCAN_Start                         : Start the FDCAN module
+      (+) HAL_FDCAN_Stop                          : Stop the FDCAN module and enable access to configuration registers
+      (+) HAL_FDCAN_AddMessageToTxFifoQ           : Add a message to the Tx FIFO/Queue and activate the corresponding transmission request
+      (+) HAL_FDCAN_GetLatestTxFifoQRequestBuffer : Get Tx buffer index of latest Tx FIFO/Queue request
+      (+) HAL_FDCAN_AbortTxRequest                : Abort transmission request
+      (+) HAL_FDCAN_GetRxMessage                  : Get an FDCAN frame from the Rx FIFO zone into the message RAM
+      (+) HAL_FDCAN_GetTxEvent                    : Get an FDCAN Tx event from the Tx Event FIFO zone into the message RAM
+      (+) HAL_FDCAN_GetHighPriorityMessageStatus  : Get high priority message status
+      (+) HAL_FDCAN_GetProtocolStatus             : Get protocol status
+      (+) HAL_FDCAN_GetErrorCounters              : Get error counter values
+      (+) HAL_FDCAN_IsTxBufferMessagePending      : Check if a transmission request is pending on the selected Tx buffer
+      (+) HAL_FDCAN_GetRxFifoFillLevel            : Return Rx FIFO fill level
+      (+) HAL_FDCAN_GetTxFifoFreeLevel            : Return Tx FIFO free level
+      (+) HAL_FDCAN_IsRestrictedOperationMode     : Check if the FDCAN peripheral entered Restricted Operation Mode
+      (+) HAL_FDCAN_ExitRestrictedOperationMode   : Exit Restricted Operation Mode
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start the FDCAN module.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_Start(FDCAN_HandleTypeDef *hfdcan)
+{
+  if (hfdcan->State == HAL_FDCAN_STATE_READY)
+  {
+    /* Change FDCAN peripheral state */
+    hfdcan->State = HAL_FDCAN_STATE_BUSY;
+
+    /* Request leave initialisation */
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_INIT);
+
+    /* Reset the FDCAN ErrorCode */
+    hfdcan->ErrorCode = HAL_FDCAN_ERROR_NONE;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_READY;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Stop the FDCAN module and enable access to configuration registers.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_Stop(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t Counter = 0U;
+
+  if (hfdcan->State == HAL_FDCAN_STATE_BUSY)
+  {
+    /* Request initialisation */
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_INIT);
+
+    /* Wait until the INIT bit into CCCR register is set */
+    while ((hfdcan->Instance->CCCR & FDCAN_CCCR_INIT) == 0U)
+    {
+      /* Check for the Timeout */
+      if (Counter > FDCAN_TIMEOUT_VALUE)
+      {
+        /* Update error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_TIMEOUT;
+
+        /* Change FDCAN state */
+        hfdcan->State = HAL_FDCAN_STATE_ERROR;
+
+        return HAL_ERROR;
+      }
+
+      /* Increment counter */
+      Counter++;
+    }
+
+    /* Reset counter */
+    Counter = 0U;
+
+    /* Exit from Sleep mode */
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_CSR);
+
+    /* Wait until FDCAN exits sleep mode */
+    while ((hfdcan->Instance->CCCR & FDCAN_CCCR_CSA) == FDCAN_CCCR_CSA)
+    {
+      /* Check for the Timeout */
+      if (Counter > FDCAN_TIMEOUT_VALUE)
+      {
+        /* Update error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_TIMEOUT;
+
+        /* Change FDCAN state */
+        hfdcan->State = HAL_FDCAN_STATE_ERROR;
+
+        return HAL_ERROR;
+      }
+
+      /* Increment counter */
+      Counter++;
+    }
+
+    /* Enable configuration change */
+    SET_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_CCE);
+
+    /* Reset Latest Tx FIFO/Queue Request Buffer Index */
+    hfdcan->LatestTxFifoQRequest = 0U;
+
+    /* Change FDCAN peripheral state */
+    hfdcan->State = HAL_FDCAN_STATE_READY;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_STARTED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Add a message to the Tx FIFO/Queue and activate the corresponding transmission request
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  pTxHeader pointer to a FDCAN_TxHeaderTypeDef structure.
+  * @param  pTxData pointer to a buffer containing the payload of the Tx frame.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_AddMessageToTxFifoQ(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxHeaderTypeDef *pTxHeader, uint8_t *pTxData)
+{
+  uint32_t PutIndex;
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_ID_TYPE(pTxHeader->IdType));
+  if (pTxHeader->IdType == FDCAN_STANDARD_ID)
+  {
+    assert_param(IS_FDCAN_MAX_VALUE(pTxHeader->Identifier, 0x7FFU));
+  }
+  else /* pTxHeader->IdType == FDCAN_EXTENDED_ID */
+  {
+    assert_param(IS_FDCAN_MAX_VALUE(pTxHeader->Identifier, 0x1FFFFFFFU));
+  }
+  assert_param(IS_FDCAN_FRAME_TYPE(pTxHeader->TxFrameType));
+  assert_param(IS_FDCAN_DLC(pTxHeader->DataLength));
+  assert_param(IS_FDCAN_ESI(pTxHeader->ErrorStateIndicator));
+  assert_param(IS_FDCAN_BRS(pTxHeader->BitRateSwitch));
+  assert_param(IS_FDCAN_FDF(pTxHeader->FDFormat));
+  assert_param(IS_FDCAN_EFC(pTxHeader->TxEventFifoControl));
+  assert_param(IS_FDCAN_MAX_VALUE(pTxHeader->MessageMarker, 0xFFU));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_BUSY)
+  {
+    /* Check that the Tx FIFO/Queue is not full */
+    if ((hfdcan->Instance->TXFQS & FDCAN_TXFQS_TFQF) != 0U)
+    {
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_FIFO_FULL;
+
+      return HAL_ERROR;
+    }
+    else
+    {
+      /* Retrieve the Tx FIFO PutIndex */
+      PutIndex = ((hfdcan->Instance->TXFQS & FDCAN_TXFQS_TFQPI) >> FDCAN_TXFQS_TFQPI_Pos);
+
+      /* Add the message to the Tx FIFO/Queue */
+      FDCAN_CopyMessageToRAM(hfdcan, pTxHeader, pTxData, PutIndex);
+
+      /* Activate the corresponding transmission request */
+      hfdcan->Instance->TXBAR = ((uint32_t)1 << PutIndex);
+
+      /* Store the Latest Tx FIFO/Queue Request Buffer Index */
+      hfdcan->LatestTxFifoQRequest = ((uint32_t)1 << PutIndex);
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_STARTED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get Tx buffer index of latest Tx FIFO/Queue request
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval Tx buffer index of last Tx FIFO/Queue request
+  *          - Any value of @arg FDCAN_Tx_location if Tx request has been submitted.
+  *          - 0 if no Tx FIFO/Queue request have been submitted.
+  */
+uint32_t HAL_FDCAN_GetLatestTxFifoQRequestBuffer(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Return Last Tx FIFO/Queue Request Buffer */
+  return hfdcan->LatestTxFifoQRequest;
+}
+
+/**
+  * @brief  Abort transmission request
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  BufferIndex buffer index.
+  *         This parameter can be any combination of @arg FDCAN_Tx_location.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_AbortTxRequest(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndex)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_TX_LOCATION_LIST(BufferIndex));
+
+  if (hfdcan->State == HAL_FDCAN_STATE_BUSY)
+  {
+    /* Add cancellation request */
+    hfdcan->Instance->TXBCR = BufferIndex;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_STARTED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get an FDCAN frame from the Rx FIFO zone into the message RAM.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  RxLocation Location of the received message to be read.
+  *         This parameter can be a value of @arg FDCAN_Rx_location.
+  * @param  pRxHeader pointer to a FDCAN_RxHeaderTypeDef structure.
+  * @param  pRxData pointer to a buffer where the payload of the Rx frame will be stored.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_GetRxMessage(FDCAN_HandleTypeDef *hfdcan, uint32_t RxLocation, FDCAN_RxHeaderTypeDef *pRxHeader, uint8_t *pRxData)
+{
+  uint32_t *RxAddress;
+  uint8_t  *pData;
+  uint32_t ByteCounter;
+  uint32_t GetIndex;
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_RX_FIFO(RxLocation));
+
+  if (state == HAL_FDCAN_STATE_BUSY)
+  {
+    if (RxLocation == FDCAN_RX_FIFO0) /* Rx element is assigned to the Rx FIFO 0 */
+    {
+      /* Check that the Rx FIFO 0 is not empty */
+      if ((hfdcan->Instance->RXF0S & FDCAN_RXF0S_F0FL) == 0U)
+      {
+        /* Update error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_FIFO_EMPTY;
+
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Calculate Rx FIFO 0 element address */
+        GetIndex = ((hfdcan->Instance->RXF0S & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos);
+        RxAddress = (uint32_t *)(hfdcan->msgRam.RxFIFO0SA + (GetIndex * SRAMCAN_RF0_SIZE));
+      }
+    }
+    else /* Rx element is assigned to the Rx FIFO 1 */
+    {
+      /* Check that the Rx FIFO 1 is not empty */
+      if ((hfdcan->Instance->RXF1S & FDCAN_RXF1S_F1FL) == 0U)
+      {
+        /* Update error code */
+        hfdcan->ErrorCode |= HAL_FDCAN_ERROR_FIFO_EMPTY;
+
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Calculate Rx FIFO 1 element address */
+        GetIndex = ((hfdcan->Instance->RXF1S & FDCAN_RXF1S_F1GI) >> FDCAN_RXF1S_F1GI_Pos);
+        RxAddress = (uint32_t *)(hfdcan->msgRam.RxFIFO1SA + (GetIndex * SRAMCAN_RF1_SIZE));
+      }
+    }
+
+    /* Retrieve IdType */
+    pRxHeader->IdType = *RxAddress & FDCAN_ELEMENT_MASK_XTD;
+
+    /* Retrieve Identifier */
+    if (pRxHeader->IdType == FDCAN_STANDARD_ID) /* Standard ID element */
+    {
+      pRxHeader->Identifier = ((*RxAddress & FDCAN_ELEMENT_MASK_STDID) >> 18U);
+    }
+    else /* Extended ID element */
+    {
+      pRxHeader->Identifier = (*RxAddress & FDCAN_ELEMENT_MASK_EXTID);
+    }
+
+    /* Retrieve RxFrameType */
+    pRxHeader->RxFrameType = (*RxAddress & FDCAN_ELEMENT_MASK_RTR);
+
+    /* Retrieve ErrorStateIndicator */
+    pRxHeader->ErrorStateIndicator = (*RxAddress & FDCAN_ELEMENT_MASK_ESI);
+
+    /* Increment RxAddress pointer to second word of Rx FIFO element */
+    RxAddress++;
+
+    /* Retrieve RxTimestamp */
+    pRxHeader->RxTimestamp = (*RxAddress & FDCAN_ELEMENT_MASK_TS);
+
+    /* Retrieve DataLength */
+    pRxHeader->DataLength = (*RxAddress & FDCAN_ELEMENT_MASK_DLC);
+
+    /* Retrieve BitRateSwitch */
+    pRxHeader->BitRateSwitch = (*RxAddress & FDCAN_ELEMENT_MASK_BRS);
+
+    /* Retrieve FDFormat */
+    pRxHeader->FDFormat = (*RxAddress & FDCAN_ELEMENT_MASK_FDF);
+
+    /* Retrieve FilterIndex */
+    pRxHeader->FilterIndex = ((*RxAddress & FDCAN_ELEMENT_MASK_FIDX) >> 24U);
+
+    /* Retrieve NonMatchingFrame */
+    pRxHeader->IsFilterMatchingFrame = ((*RxAddress & FDCAN_ELEMENT_MASK_ANMF) >> 31U);
+
+    /* Increment RxAddress pointer to payload of Rx FIFO element */
+    RxAddress++;
+
+    /* Retrieve Rx payload */
+    pData = (uint8_t *)RxAddress;
+    for (ByteCounter = 0; ByteCounter < DLCtoBytes[pRxHeader->DataLength >> 16U]; ByteCounter++)
+    {
+      pRxData[ByteCounter] = pData[ByteCounter];
+    }
+
+    if (RxLocation == FDCAN_RX_FIFO0) /* Rx element is assigned to the Rx FIFO 0 */
+    {
+      /* Acknowledge the Rx FIFO 0 that the oldest element is read so that it increments the GetIndex */
+      hfdcan->Instance->RXF0A = GetIndex;
+    }
+    else /* Rx element is assigned to the Rx FIFO 1 */
+    {
+      /* Acknowledge the Rx FIFO 1 that the oldest element is read so that it increments the GetIndex */
+      hfdcan->Instance->RXF1A = GetIndex;
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_STARTED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get an FDCAN Tx event from the Tx Event FIFO zone into the message RAM.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  pTxEvent pointer to a FDCAN_TxEventFifoTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_GetTxEvent(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxEventFifoTypeDef *pTxEvent)
+{
+  uint32_t *TxEventAddress;
+  uint32_t GetIndex;
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+
+  if (state == HAL_FDCAN_STATE_BUSY)
+  {
+    /* Check that the Tx event FIFO is not empty */
+    if ((hfdcan->Instance->TXEFS & FDCAN_TXEFS_EFFL) == 0U)
+    {
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_FIFO_EMPTY;
+
+      return HAL_ERROR;
+    }
+
+    /* Calculate Tx event FIFO element address */
+    GetIndex = ((hfdcan->Instance->TXEFS & FDCAN_TXEFS_EFGI) >> FDCAN_TXEFS_EFGI_Pos);
+    TxEventAddress = (uint32_t *)(hfdcan->msgRam.TxEventFIFOSA + (GetIndex * SRAMCAN_TEF_SIZE));
+
+    /* Retrieve IdType */
+    pTxEvent->IdType = *TxEventAddress & FDCAN_ELEMENT_MASK_XTD;
+
+    /* Retrieve Identifier */
+    if (pTxEvent->IdType == FDCAN_STANDARD_ID) /* Standard ID element */
+    {
+      pTxEvent->Identifier = ((*TxEventAddress & FDCAN_ELEMENT_MASK_STDID) >> 18U);
+    }
+    else /* Extended ID element */
+    {
+      pTxEvent->Identifier = (*TxEventAddress & FDCAN_ELEMENT_MASK_EXTID);
+    }
+
+    /* Retrieve TxFrameType */
+    pTxEvent->TxFrameType = (*TxEventAddress & FDCAN_ELEMENT_MASK_RTR);
+
+    /* Retrieve ErrorStateIndicator */
+    pTxEvent->ErrorStateIndicator = (*TxEventAddress & FDCAN_ELEMENT_MASK_ESI);
+
+    /* Increment TxEventAddress pointer to second word of Tx Event FIFO element */
+    TxEventAddress++;
+
+    /* Retrieve TxTimestamp */
+    pTxEvent->TxTimestamp = (*TxEventAddress & FDCAN_ELEMENT_MASK_TS);
+
+    /* Retrieve DataLength */
+    pTxEvent->DataLength = (*TxEventAddress & FDCAN_ELEMENT_MASK_DLC);
+
+    /* Retrieve BitRateSwitch */
+    pTxEvent->BitRateSwitch = (*TxEventAddress & FDCAN_ELEMENT_MASK_BRS);
+
+    /* Retrieve FDFormat */
+    pTxEvent->FDFormat = (*TxEventAddress & FDCAN_ELEMENT_MASK_FDF);
+
+    /* Retrieve EventType */
+    pTxEvent->EventType = (*TxEventAddress & FDCAN_ELEMENT_MASK_ET);
+
+    /* Retrieve MessageMarker */
+    pTxEvent->MessageMarker = ((*TxEventAddress & FDCAN_ELEMENT_MASK_MM) >> 24U);
+
+    /* Acknowledge the Tx Event FIFO that the oldest element is read so that it increments the GetIndex */
+    hfdcan->Instance->TXEFA = GetIndex;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_STARTED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get high priority message status.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  HpMsgStatus pointer to an FDCAN_HpMsgStatusTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_GetHighPriorityMessageStatus(FDCAN_HandleTypeDef *hfdcan, FDCAN_HpMsgStatusTypeDef *HpMsgStatus)
+{
+  HpMsgStatus->FilterList = ((hfdcan->Instance->HPMS & FDCAN_HPMS_FLST) >> FDCAN_HPMS_FLST_Pos);
+  HpMsgStatus->FilterIndex = ((hfdcan->Instance->HPMS & FDCAN_HPMS_FIDX) >> FDCAN_HPMS_FIDX_Pos);
+  HpMsgStatus->MessageStorage = (hfdcan->Instance->HPMS & FDCAN_HPMS_MSI);
+  HpMsgStatus->MessageIndex = (hfdcan->Instance->HPMS & FDCAN_HPMS_BIDX);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get protocol status.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  ProtocolStatus pointer to an FDCAN_ProtocolStatusTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_GetProtocolStatus(FDCAN_HandleTypeDef *hfdcan, FDCAN_ProtocolStatusTypeDef *ProtocolStatus)
+{
+  uint32_t StatusReg;
+
+  /* Read the protocol status register */
+  StatusReg = READ_REG(hfdcan->Instance->PSR);
+
+  /* Fill the protocol status structure */
+  ProtocolStatus->LastErrorCode = (StatusReg & FDCAN_PSR_LEC);
+  ProtocolStatus->DataLastErrorCode = ((StatusReg & FDCAN_PSR_DLEC) >> FDCAN_PSR_DLEC_Pos);
+  ProtocolStatus->Activity = (StatusReg & FDCAN_PSR_ACT);
+  ProtocolStatus->ErrorPassive = ((StatusReg & FDCAN_PSR_EP) >> FDCAN_PSR_EP_Pos);
+  ProtocolStatus->Warning = ((StatusReg & FDCAN_PSR_EW) >> FDCAN_PSR_EW_Pos);
+  ProtocolStatus->BusOff = ((StatusReg & FDCAN_PSR_BO) >> FDCAN_PSR_BO_Pos);
+  ProtocolStatus->RxESIflag = ((StatusReg & FDCAN_PSR_RESI) >> FDCAN_PSR_RESI_Pos);
+  ProtocolStatus->RxBRSflag = ((StatusReg & FDCAN_PSR_RBRS) >> FDCAN_PSR_RBRS_Pos);
+  ProtocolStatus->RxFDFflag = ((StatusReg & FDCAN_PSR_REDL) >> FDCAN_PSR_REDL_Pos);
+  ProtocolStatus->ProtocolException = ((StatusReg & FDCAN_PSR_PXE) >> FDCAN_PSR_PXE_Pos);
+  ProtocolStatus->TDCvalue = ((StatusReg & FDCAN_PSR_TDCV) >> FDCAN_PSR_TDCV_Pos);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get error counter values.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  ErrorCounters pointer to an FDCAN_ErrorCountersTypeDef structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_GetErrorCounters(FDCAN_HandleTypeDef *hfdcan, FDCAN_ErrorCountersTypeDef *ErrorCounters)
+{
+  uint32_t CountersReg;
+
+  /* Read the error counters register */
+  CountersReg = READ_REG(hfdcan->Instance->ECR);
+
+  /* Fill the error counters structure */
+  ErrorCounters->TxErrorCnt = ((CountersReg & FDCAN_ECR_TEC) >> FDCAN_ECR_TEC_Pos);
+  ErrorCounters->RxErrorCnt = ((CountersReg & FDCAN_ECR_REC) >> FDCAN_ECR_REC_Pos);
+  ErrorCounters->RxErrorPassive = ((CountersReg & FDCAN_ECR_RP) >> FDCAN_ECR_RP_Pos);
+  ErrorCounters->ErrorLogging = ((CountersReg & FDCAN_ECR_CEL) >> FDCAN_ECR_CEL_Pos);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Check if a transmission request is pending on the selected Tx buffer.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  TxBufferIndex Tx buffer index.
+  *         This parameter can be any combination of @arg FDCAN_Tx_location.
+  * @retval Status
+  *          - 0 : No pending transmission request on TxBufferIndex list
+  *          - 1 : Pending transmission request on TxBufferIndex.
+  */
+uint32_t HAL_FDCAN_IsTxBufferMessagePending(FDCAN_HandleTypeDef *hfdcan, uint32_t TxBufferIndex)
+{
+  /* Check function parameters */
+  assert_param(IS_FDCAN_TX_LOCATION_LIST(TxBufferIndex));
+
+  /* Check pending transmission request on the selected buffer */
+  if ((hfdcan->Instance->TXBRP & TxBufferIndex) == 0U)
+  {
+    return 0;
+  }
+  return 1;
+}
+
+/**
+  * @brief  Return Rx FIFO fill level.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  RxFifo Rx FIFO.
+  *         This parameter can be one of the following values:
+  *           @arg FDCAN_RX_FIFO0: Rx FIFO 0
+  *           @arg FDCAN_RX_FIFO1: Rx FIFO 1
+  * @retval Rx FIFO fill level.
+  */
+uint32_t HAL_FDCAN_GetRxFifoFillLevel(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo)
+{
+  uint32_t FillLevel;
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_RX_FIFO(RxFifo));
+
+  if (RxFifo == FDCAN_RX_FIFO0)
+  {
+    FillLevel = hfdcan->Instance->RXF0S & FDCAN_RXF0S_F0FL;
+  }
+  else /* RxFifo == FDCAN_RX_FIFO1 */
+  {
+    FillLevel = hfdcan->Instance->RXF1S & FDCAN_RXF1S_F1FL;
+  }
+
+  /* Return Rx FIFO fill level */
+  return FillLevel;
+}
+
+/**
+  * @brief  Return Tx FIFO free level: number of consecutive free Tx FIFO
+  *         elements starting from Tx FIFO GetIndex.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval Tx FIFO free level.
+  */
+uint32_t HAL_FDCAN_GetTxFifoFreeLevel(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t FreeLevel;
+
+  FreeLevel = hfdcan->Instance->TXFQS & FDCAN_TXFQS_TFFL;
+
+  /* Return Tx FIFO free level */
+  return FreeLevel;
+}
+
+/**
+  * @brief  Check if the FDCAN peripheral entered Restricted Operation Mode.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval Status
+  *          - 0 : Normal FDCAN operation.
+  *          - 1 : Restricted Operation Mode active.
+  */
+uint32_t HAL_FDCAN_IsRestrictedOperationMode(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t OperationMode;
+
+  /* Get Operation Mode */
+  OperationMode = ((hfdcan->Instance->CCCR & FDCAN_CCCR_ASM) >> FDCAN_CCCR_ASM_Pos);
+
+  return OperationMode;
+}
+
+/**
+  * @brief  Exit Restricted Operation Mode.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ExitRestrictedOperationMode(FDCAN_HandleTypeDef *hfdcan)
+{
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+
+  if ((state == HAL_FDCAN_STATE_READY) || (state == HAL_FDCAN_STATE_BUSY))
+  {
+    /* Exit Restricted Operation mode */
+    CLEAR_BIT(hfdcan->Instance->CCCR, FDCAN_CCCR_ASM);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_INITIALIZED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Exported_Functions_Group4 Interrupts management
+ *  @brief    Interrupts management
+ *
+@verbatim
+  ==============================================================================
+                       ##### Interrupts management #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) HAL_FDCAN_ConfigInterruptLines      : Assign interrupts to either Interrupt line 0 or 1
+      (+) HAL_FDCAN_ActivateNotification      : Enable interrupts
+      (+) HAL_FDCAN_DeactivateNotification    : Disable interrupts
+      (+) HAL_FDCAN_IRQHandler                : Handles FDCAN interrupt request
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Assign interrupts to either Interrupt line 0 or 1.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  ITList indicates which interrupts group will be assigned to the selected interrupt line.
+  *         This parameter can be any combination of @arg FDCAN_Interrupts_Group.
+  * @param  InterruptLine Interrupt line.
+  *         This parameter can be a value of @arg FDCAN_Interrupt_Line.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ConfigInterruptLines(FDCAN_HandleTypeDef *hfdcan, uint32_t ITList, uint32_t InterruptLine)
+{
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_IT_GROUP(ITList));
+  assert_param(IS_FDCAN_IT_LINE(InterruptLine));
+
+  if ((state == HAL_FDCAN_STATE_READY) || (state == HAL_FDCAN_STATE_BUSY))
+  {
+    /* Assign list of interrupts to the selected line */
+    if (InterruptLine == FDCAN_INTERRUPT_LINE0)
+    {
+      CLEAR_BIT(hfdcan->Instance->ILS, ITList);
+    }
+    else /* InterruptLine == FDCAN_INTERRUPT_LINE1 */
+    {
+      SET_BIT(hfdcan->Instance->ILS, ITList);
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_INITIALIZED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enable interrupts.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  ActiveITs indicates which interrupts will be enabled.
+  *         This parameter can be any combination of @arg FDCAN_Interrupts.
+  * @param  BufferIndexes Tx Buffer Indexes.
+  *         This parameter can be any combination of @arg FDCAN_Tx_location.
+  *         This parameter is ignored if ActiveITs does not include one of the following:
+  *           - FDCAN_IT_TX_COMPLETE
+  *           - FDCAN_IT_TX_ABORT_COMPLETE
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_ActivateNotification(FDCAN_HandleTypeDef *hfdcan, uint32_t ActiveITs, uint32_t BufferIndexes)
+{
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+  uint32_t ITs_lines_selection;
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_IT(ActiveITs));
+  if ((ActiveITs & (FDCAN_IT_TX_COMPLETE | FDCAN_IT_TX_ABORT_COMPLETE)) != 0U)
+  {
+    assert_param(IS_FDCAN_TX_LOCATION_LIST(BufferIndexes));
+  }
+
+  if ((state == HAL_FDCAN_STATE_READY) || (state == HAL_FDCAN_STATE_BUSY))
+  {
+    /* Get interrupts line selection */
+    ITs_lines_selection = hfdcan->Instance->ILS;
+
+    /* Enable Interrupt lines */
+    if ((((ActiveITs & FDCAN_IT_LIST_RX_FIFO0)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO0)       == 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_RX_FIFO1)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO1)       == 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_SMSG)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_SMSG)           == 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_TX_FIFO_ERROR)  != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_TX_FIFO_ERROR)  == 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_MISC)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_MISC)           == 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_BIT_LINE_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_BIT_LINE_ERROR) == 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_PROTOCOL_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_PROTOCOL_ERROR) == 0U)))
+    {
+      /* Enable Interrupt line 0 */
+      SET_BIT(hfdcan->Instance->ILE, FDCAN_INTERRUPT_LINE0);
+    }
+    if ((((ActiveITs & FDCAN_IT_LIST_RX_FIFO0)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO0)       != 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_RX_FIFO1)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO1)       != 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_SMSG)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_SMSG)           != 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_TX_FIFO_ERROR)  != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_TX_FIFO_ERROR)  != 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_MISC)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_MISC)           != 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_BIT_LINE_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_BIT_LINE_ERROR) != 0U)) || \
+        (((ActiveITs & FDCAN_IT_LIST_PROTOCOL_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_PROTOCOL_ERROR) != 0U)))
+    {
+      /* Enable Interrupt line 1 */
+      SET_BIT(hfdcan->Instance->ILE, FDCAN_INTERRUPT_LINE1);
+    }
+
+    if ((ActiveITs & FDCAN_IT_TX_COMPLETE) != 0U)
+    {
+      /* Enable Tx Buffer Transmission Interrupt to set TC flag in IR register,
+         but interrupt will only occur if TC is enabled in IE register */
+      SET_BIT(hfdcan->Instance->TXBTIE, BufferIndexes);
+    }
+
+    if ((ActiveITs & FDCAN_IT_TX_ABORT_COMPLETE) != 0U)
+    {
+      /* Enable Tx Buffer Cancellation Finished Interrupt to set TCF flag in IR register,
+         but interrupt will only occur if TCF is enabled in IE register */
+      SET_BIT(hfdcan->Instance->TXBCIE, BufferIndexes);
+    }
+
+    /* Enable the selected interrupts */
+    __HAL_FDCAN_ENABLE_IT(hfdcan, ActiveITs);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_INITIALIZED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable interrupts.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  InactiveITs indicates which interrupts will be disabled.
+  *         This parameter can be any combination of @arg FDCAN_Interrupts.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_FDCAN_DeactivateNotification(FDCAN_HandleTypeDef *hfdcan, uint32_t InactiveITs)
+{
+  HAL_FDCAN_StateTypeDef state = hfdcan->State;
+  uint32_t ITs_enabled;
+  uint32_t ITs_lines_selection;
+
+  /* Check function parameters */
+  assert_param(IS_FDCAN_IT(InactiveITs));
+
+  if ((state == HAL_FDCAN_STATE_READY) || (state == HAL_FDCAN_STATE_BUSY))
+  {
+    /* Disable the selected interrupts */
+    __HAL_FDCAN_DISABLE_IT(hfdcan, InactiveITs);
+
+    if ((InactiveITs & FDCAN_IT_TX_COMPLETE) != 0U)
+    {
+      /* Disable Tx Buffer Transmission Interrupts */
+      CLEAR_REG(hfdcan->Instance->TXBTIE);
+    }
+
+    if ((InactiveITs & FDCAN_IT_TX_ABORT_COMPLETE) != 0U)
+    {
+      /* Disable Tx Buffer Cancellation Finished Interrupt */
+      CLEAR_REG(hfdcan->Instance->TXBCIE);
+    }
+
+    /* Get interrupts enabled and interrupts line selection */
+    ITs_enabled = hfdcan->Instance->IE;
+    ITs_lines_selection = hfdcan->Instance->ILS;
+
+    /* Check if some interrupts are still enabled on interrupt line 0 */
+    if ((((ITs_enabled & FDCAN_IT_LIST_RX_FIFO0)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO0)       == 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_RX_FIFO1)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO1)       == 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_SMSG)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_SMSG)           == 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_TX_FIFO_ERROR)  != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_TX_FIFO_ERROR)  == 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_MISC)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_MISC)           == 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_BIT_LINE_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_BIT_LINE_ERROR) == 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_PROTOCOL_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_PROTOCOL_ERROR) == 0U)))
+    {
+      /* Do nothing */
+    }
+    else /* no more interrupts enabled on interrupt line 0 */
+    {
+      /* Disable interrupt line 0 */
+      CLEAR_BIT(hfdcan->Instance->ILE, FDCAN_INTERRUPT_LINE0);
+    }
+
+    /* Check if some interrupts are still enabled on interrupt line 1 */
+    if ((((ITs_enabled & FDCAN_IT_LIST_RX_FIFO0)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO0)       != 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_RX_FIFO1)       != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_RX_FIFO1)       != 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_SMSG)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_SMSG)           != 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_TX_FIFO_ERROR)  != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_TX_FIFO_ERROR)  != 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_MISC)           != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_MISC)           != 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_BIT_LINE_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_BIT_LINE_ERROR) != 0U)) || \
+        (((ITs_enabled & FDCAN_IT_LIST_PROTOCOL_ERROR) != 0U) && (((ITs_lines_selection) & FDCAN_IT_GROUP_PROTOCOL_ERROR) != 0U)))
+    {
+      /* Do nothing */
+    }
+    else /* no more interrupts enabled on interrupt line 1 */
+    {
+      /* Disable interrupt line 1 */
+      CLEAR_BIT(hfdcan->Instance->ILE, FDCAN_INTERRUPT_LINE1);
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Update error code */
+    hfdcan->ErrorCode |= HAL_FDCAN_ERROR_NOT_INITIALIZED;
+
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Handles FDCAN interrupt request.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL status
+  */
+void HAL_FDCAN_IRQHandler(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t TxEventFifoITs;
+  uint32_t RxFifo0ITs;
+  uint32_t RxFifo1ITs;
+  uint32_t Errors;
+  uint32_t ErrorStatusITs;
+  uint32_t TransmittedBuffers;
+  uint32_t AbortedBuffers;
+
+  TxEventFifoITs = hfdcan->Instance->IR & FDCAN_TX_EVENT_FIFO_MASK;
+  TxEventFifoITs &= hfdcan->Instance->IE;
+  RxFifo0ITs = hfdcan->Instance->IR & FDCAN_RX_FIFO0_MASK;
+  RxFifo0ITs &= hfdcan->Instance->IE;
+  RxFifo1ITs = hfdcan->Instance->IR & FDCAN_RX_FIFO1_MASK;
+  RxFifo1ITs &= hfdcan->Instance->IE;
+  Errors = hfdcan->Instance->IR & FDCAN_ERROR_MASK;
+  Errors &= hfdcan->Instance->IE;
+  ErrorStatusITs = hfdcan->Instance->IR & FDCAN_ERROR_STATUS_MASK;
+  ErrorStatusITs &= hfdcan->Instance->IE;
+
+  /* High Priority Message interrupt management *******************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_RX_HIGH_PRIORITY_MSG) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_RX_HIGH_PRIORITY_MSG) != 0U)
+    {
+      /* Clear the High Priority Message flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_RX_HIGH_PRIORITY_MSG);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->HighPriorityMessageCallback(hfdcan);
+#else
+      /* High Priority Message Callback */
+      HAL_FDCAN_HighPriorityMessageCallback(hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Transmission Abort interrupt management **********************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_TX_ABORT_COMPLETE) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_TX_ABORT_COMPLETE) != 0U)
+    {
+      /* List of aborted monitored buffers */
+      AbortedBuffers = hfdcan->Instance->TXBCF;
+      AbortedBuffers &= hfdcan->Instance->TXBCIE;
+
+      /* Clear the Transmission Cancellation flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_TX_ABORT_COMPLETE);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->TxBufferAbortCallback(hfdcan, AbortedBuffers);
+#else
+      /* Transmission Cancellation Callback */
+      HAL_FDCAN_TxBufferAbortCallback(hfdcan, AbortedBuffers);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Tx event FIFO interrupts management **************************************/
+  if (TxEventFifoITs != 0U)
+  {
+    /* Clear the Tx Event FIFO flags */
+    __HAL_FDCAN_CLEAR_FLAG(hfdcan, TxEventFifoITs);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+    /* Call registered callback*/
+    hfdcan->TxEventFifoCallback(hfdcan, TxEventFifoITs);
+#else
+    /* Tx Event FIFO Callback */
+    HAL_FDCAN_TxEventFifoCallback(hfdcan, TxEventFifoITs);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+  }
+
+  /* Rx FIFO 0 interrupts management ******************************************/
+  if (RxFifo0ITs != 0U)
+  {
+    /* Clear the Rx FIFO 0 flags */
+    __HAL_FDCAN_CLEAR_FLAG(hfdcan, RxFifo0ITs);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+    /* Call registered callback*/
+    hfdcan->RxFifo0Callback(hfdcan, RxFifo0ITs);
+#else
+    /* Rx FIFO 0 Callback */
+    HAL_FDCAN_RxFifo0Callback(hfdcan, RxFifo0ITs);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+  }
+
+  /* Rx FIFO 1 interrupts management ******************************************/
+  if (RxFifo1ITs != 0U)
+  {
+    /* Clear the Rx FIFO 1 flags */
+    __HAL_FDCAN_CLEAR_FLAG(hfdcan, RxFifo1ITs);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+    /* Call registered callback*/
+    hfdcan->RxFifo1Callback(hfdcan, RxFifo1ITs);
+#else
+    /* Rx FIFO 1 Callback */
+    HAL_FDCAN_RxFifo1Callback(hfdcan, RxFifo1ITs);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+  }
+
+  /* Tx FIFO empty interrupt management ***************************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_TX_FIFO_EMPTY) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_TX_FIFO_EMPTY) != 0U)
+    {
+      /* Clear the Tx FIFO empty flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_TX_FIFO_EMPTY);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->TxFifoEmptyCallback(hfdcan);
+#else
+      /* Tx FIFO empty Callback */
+      HAL_FDCAN_TxFifoEmptyCallback(hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Transmission Complete interrupt management *******************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_TX_COMPLETE) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_TX_COMPLETE) != 0U)
+    {
+      /* List of transmitted monitored buffers */
+      TransmittedBuffers = hfdcan->Instance->TXBTO;
+      TransmittedBuffers &= hfdcan->Instance->TXBTIE;
+
+      /* Clear the Transmission Complete flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_TX_COMPLETE);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->TxBufferCompleteCallback(hfdcan, TransmittedBuffers);
+#else
+      /* Transmission Complete Callback */
+      HAL_FDCAN_TxBufferCompleteCallback(hfdcan, TransmittedBuffers);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Timestamp Wraparound interrupt management ********************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_TIMESTAMP_WRAPAROUND) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_TIMESTAMP_WRAPAROUND) != 0U)
+    {
+      /* Clear the Timestamp Wraparound flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_TIMESTAMP_WRAPAROUND);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->TimestampWraparoundCallback(hfdcan);
+#else
+      /* Timestamp Wraparound Callback */
+      HAL_FDCAN_TimestampWraparoundCallback(hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Timeout Occurred interrupt management ************************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_TIMEOUT_OCCURRED) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_TIMEOUT_OCCURRED) != 0U)
+    {
+      /* Clear the Timeout Occurred flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_TIMEOUT_OCCURRED);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->TimeoutOccurredCallback(hfdcan);
+#else
+      /* Timeout Occurred Callback */
+      HAL_FDCAN_TimeoutOccurredCallback(hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Message RAM access failure interrupt management **************************/
+  if (__HAL_FDCAN_GET_FLAG(hfdcan, FDCAN_FLAG_RAM_ACCESS_FAILURE) != 0U)
+  {
+    if (__HAL_FDCAN_GET_IT_SOURCE(hfdcan, FDCAN_IT_RAM_ACCESS_FAILURE) != 0U)
+    {
+      /* Clear the Message RAM access failure flag */
+      __HAL_FDCAN_CLEAR_FLAG(hfdcan, FDCAN_FLAG_RAM_ACCESS_FAILURE);
+
+      /* Update error code */
+      hfdcan->ErrorCode |= HAL_FDCAN_ERROR_RAM_ACCESS;
+    }
+  }
+
+  /* Error Status interrupts management ***************************************/
+  if (ErrorStatusITs != 0U)
+  {
+    /* Clear the Error flags */
+    __HAL_FDCAN_CLEAR_FLAG(hfdcan, ErrorStatusITs);
+
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+      /* Call registered callback*/
+      hfdcan->ErrorStatusCallback(hfdcan, ErrorStatusITs);
+#else
+      /* Error Status Callback */
+      HAL_FDCAN_ErrorStatusCallback(hfdcan, ErrorStatusITs);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+  }
+
+  /* Error interrupts management **********************************************/
+  if (Errors != 0U)
+  {
+    /* Clear the Error flags */
+    __HAL_FDCAN_CLEAR_FLAG(hfdcan, Errors);
+
+    /* Update error code */
+    hfdcan->ErrorCode |= Errors;
+  }
+
+  if (hfdcan->ErrorCode != HAL_FDCAN_ERROR_NONE)
+  {
+#if USE_HAL_FDCAN_REGISTER_CALLBACKS == 1
+    /* Call registered callback*/
+    hfdcan->ErrorCallback(hfdcan);
+#else
+    /* Error Callback */
+    HAL_FDCAN_ErrorCallback(hfdcan);
+#endif /* USE_HAL_FDCAN_REGISTER_CALLBACKS */
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Exported_Functions_Group5 Callback functions
+ *  @brief   FDCAN Callback functions
+ *
+@verbatim
+  ==============================================================================
+                          ##### Callback functions #####
+  ==============================================================================
+    [..]
+    This subsection provides the following callback functions:
+      (+) HAL_FDCAN_TxEventFifoCallback
+      (+) HAL_FDCAN_RxFifo0Callback
+      (+) HAL_FDCAN_RxFifo1Callback
+      (+) HAL_FDCAN_TxFifoEmptyCallback
+      (+) HAL_FDCAN_TxBufferCompleteCallback
+      (+) HAL_FDCAN_TxBufferAbortCallback
+      (+) HAL_FDCAN_HighPriorityMessageCallback
+      (+) HAL_FDCAN_TimestampWraparoundCallback
+      (+) HAL_FDCAN_TimeoutOccurredCallback
+      (+) HAL_FDCAN_ErrorCallback
+      (+) HAL_FDCAN_ErrorStatusCallback
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Tx Event callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  TxEventFifoITs indicates which Tx Event FIFO interrupts are signalled.
+  *         This parameter can be any combination of @arg FDCAN_Tx_Event_Fifo_Interrupts.
+  * @retval None
+  */
+__weak void HAL_FDCAN_TxEventFifoCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t TxEventFifoITs)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  UNUSED(TxEventFifoITs);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_TxEventFifoCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx FIFO 0 callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  RxFifo0ITs indicates which Rx FIFO 0 interrupts are signalled.
+  *         This parameter can be any combination of @arg FDCAN_Rx_Fifo0_Interrupts.
+  * @retval None
+  */
+__weak void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  UNUSED(RxFifo0ITs);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_RxFifo0Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx FIFO 1 callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  RxFifo1ITs indicates which Rx FIFO 1 interrupts are signalled.
+  *         This parameter can be any combination of @arg FDCAN_Rx_Fifo1_Interrupts.
+  * @retval None
+  */
+__weak void HAL_FDCAN_RxFifo1Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo1ITs)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  UNUSED(RxFifo1ITs);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_RxFifo1Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tx FIFO Empty callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_TxFifoEmptyCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_TxFifoEmptyCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Transmission Complete callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  BufferIndexes Indexes of the transmitted buffers.
+  *         This parameter can be any combination of @arg FDCAN_Tx_location.
+  * @retval None
+  */
+__weak void HAL_FDCAN_TxBufferCompleteCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  UNUSED(BufferIndexes);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_TxBufferCompleteCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Transmission Cancellation callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  BufferIndexes Indexes of the aborted buffers.
+  *         This parameter can be any combination of @arg FDCAN_Tx_location.
+  * @retval None
+  */
+__weak void HAL_FDCAN_TxBufferAbortCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t BufferIndexes)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  UNUSED(BufferIndexes);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_TxBufferAbortCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Timestamp Wraparound callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_TimestampWraparoundCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_TimestampWraparoundCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Timeout Occurred callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_TimeoutOccurredCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_TimeoutOccurredCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  High Priority Message callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_HighPriorityMessageCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_HighPriorityMessageCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval None
+  */
+__weak void HAL_FDCAN_ErrorCallback(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error status callback.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  ErrorStatusITs indicates which Error Status interrupts are signaled.
+  *         This parameter can be any combination of @arg FDCAN_Error_Status_Interrupts.
+  * @retval None
+  */
+__weak void HAL_FDCAN_ErrorStatusCallback(FDCAN_HandleTypeDef *hfdcan, uint32_t ErrorStatusITs)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hfdcan);
+  UNUSED(ErrorStatusITs);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FDCAN_ErrorStatusCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FDCAN_Exported_Functions_Group6 Peripheral State functions
+ *  @brief   FDCAN Peripheral State functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to :
+      (+) HAL_FDCAN_GetState()  : Return the FDCAN state.
+      (+) HAL_FDCAN_GetError()  : Return the FDCAN error code if any.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Return the FDCAN state
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval HAL state
+  */
+HAL_FDCAN_StateTypeDef HAL_FDCAN_GetState(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Return FDCAN state */
+  return hfdcan->State;
+}
+
+/**
+  * @brief  Return the FDCAN error code
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval FDCAN Error Code
+  */
+uint32_t HAL_FDCAN_GetError(FDCAN_HandleTypeDef *hfdcan)
+{
+  /* Return FDCAN error code */
+  return hfdcan->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup FDCAN_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Calculate each RAM block start address and size
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @retval none
+ */
+static void FDCAN_CalcultateRamBlockAddresses(FDCAN_HandleTypeDef *hfdcan)
+{
+  uint32_t RAMcounter;
+  uint32_t SramCanInstanceBase = SRAMCAN_BASE;
+#if defined(FDCAN2)
+
+  if (hfdcan->Instance == FDCAN2)
+  {
+    SramCanInstanceBase += SRAMCAN_SIZE;
+  }
+#endif /* FDCAN2 */
+
+  /* Standard filter list start address */
+  hfdcan->msgRam.StandardFilterSA = SramCanInstanceBase + SRAMCAN_FLSSA;
+
+  /* Standard filter elements number */
+  MODIFY_REG(hfdcan->Instance->RXGFC, FDCAN_RXGFC_LSS, (hfdcan->Init.StdFiltersNbr << FDCAN_RXGFC_LSS_Pos));
+
+  /* Extended filter list start address */
+  hfdcan->msgRam.ExtendedFilterSA = SramCanInstanceBase + SRAMCAN_FLESA;
+
+  /* Extended filter elements number */
+  MODIFY_REG(hfdcan->Instance->RXGFC, FDCAN_RXGFC_LSE, (hfdcan->Init.ExtFiltersNbr << FDCAN_RXGFC_LSE_Pos));
+
+  /* Rx FIFO 0 start address */
+  hfdcan->msgRam.RxFIFO0SA = SramCanInstanceBase + SRAMCAN_RF0SA;
+
+  /* Rx FIFO 1 start address */
+  hfdcan->msgRam.RxFIFO1SA = SramCanInstanceBase + SRAMCAN_RF1SA;
+
+  /* Tx event FIFO start address */
+  hfdcan->msgRam.TxEventFIFOSA = SramCanInstanceBase + SRAMCAN_TEFSA;
+
+  /* Tx FIFO/queue start address */
+  hfdcan->msgRam.TxFIFOQSA = SramCanInstanceBase + SRAMCAN_TFQSA;
+
+  /* Flush the allocated Message RAM area */
+  for (RAMcounter = SramCanInstanceBase; RAMcounter < (SramCanInstanceBase + SRAMCAN_SIZE); RAMcounter += 4U)
+  {
+    *(uint32_t *)(RAMcounter) = 0x00000000U;
+  }
+}
+
+/**
+  * @brief  Copy Tx message to the message RAM.
+  * @param  hfdcan pointer to an FDCAN_HandleTypeDef structure that contains
+  *         the configuration information for the specified FDCAN.
+  * @param  pTxHeader pointer to a FDCAN_TxHeaderTypeDef structure.
+  * @param  pTxData pointer to a buffer containing the payload of the Tx frame.
+  * @param  BufferIndex index of the buffer to be configured.
+  * @retval none
+ */
+static void FDCAN_CopyMessageToRAM(FDCAN_HandleTypeDef *hfdcan, FDCAN_TxHeaderTypeDef *pTxHeader, uint8_t *pTxData, uint32_t BufferIndex)
+{
+  uint32_t TxElementW1;
+  uint32_t TxElementW2;
+  uint32_t *TxAddress;
+  uint32_t ByteCounter;
+
+  /* Build first word of Tx header element */
+  if (pTxHeader->IdType == FDCAN_STANDARD_ID)
+  {
+    TxElementW1 = (pTxHeader->ErrorStateIndicator |
+                   FDCAN_STANDARD_ID |
+                   pTxHeader->TxFrameType |
+                   (pTxHeader->Identifier << 18U));
+  }
+  else /* pTxHeader->IdType == FDCAN_EXTENDED_ID */
+  {
+    TxElementW1 = (pTxHeader->ErrorStateIndicator |
+                   FDCAN_EXTENDED_ID |
+                   pTxHeader->TxFrameType |
+                   pTxHeader->Identifier);
+  }
+
+  /* Build second word of Tx header element */
+  TxElementW2 = ((pTxHeader->MessageMarker << 24U) |
+                 pTxHeader->TxEventFifoControl |
+                 pTxHeader->FDFormat |
+                 pTxHeader->BitRateSwitch |
+                 pTxHeader->DataLength);
+
+  /* Calculate Tx element address */
+  TxAddress = (uint32_t *)(hfdcan->msgRam.TxFIFOQSA + (BufferIndex * SRAMCAN_TFQ_SIZE));
+
+  /* Write Tx element header to the message RAM */
+  *TxAddress = TxElementW1;
+  TxAddress++;
+  *TxAddress = TxElementW2;
+  TxAddress++;
+
+  /* Write Tx payload to the message RAM */
+  for (ByteCounter = 0; ByteCounter < DLCtoBytes[pTxHeader->DataLength >> 16U]; ByteCounter += 4U)
+  {
+    *TxAddress = (((uint32_t)pTxData[ByteCounter + 3U] << 24U) |
+                  ((uint32_t)pTxData[ByteCounter + 2U] << 16U) |
+                  ((uint32_t)pTxData[ByteCounter + 1U] << 8U)  |
+                  (uint32_t)pTxData[ByteCounter]);
+    TxAddress++;
+  }
+}
+
+/**
+  * @}
+  */
+#endif /* HAL_FDCAN_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* FDCAN1 */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_flash_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_flash_ex.c
@@ -43,7 +43,7 @@
         (++) Get the value of a write protection area
         (++) Know if the read protection is activated
         (++) Get the value of the user Option Bytes
-        (++) Get Securable memory area and boot entry point informations
+        (++) Get Securable memory area and boot entry point information
 
       (#) Enable or disable debugger usage using HAL_FLASHEx_EnableDebugger and
           HAL_FLASHEx_DisableDebugger.
@@ -91,26 +91,33 @@
 /** @defgroup FLASHEx_Private_Functions FLASHEx Private Functions
  * @{
  */
-static void               FLASH_MassErase(void);
+static void               FLASH_MassErase(uint32_t Banks);
 void                      FLASH_FlushCaches(void);
 static void               FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32_t WRDPEndOffset);
-static void               FLASH_OB_OptrConfig(uint32_t UserType, uint32_t UserConfig, uint32_t RDPLevel);
-#if defined(FLASH_PCROP_SUPPORT)
-static void               FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAddr, uint32_t PCROP1AEndAddr);
-static void               FLASH_OB_PCROP1BConfig(uint32_t PCROP1BStartAddr, uint32_t PCROP1BEndAddr);
-#endif
-#if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
-static void               FLASH_OB_SecMemConfig(uint32_t BootEntry, uint32_t SecSize);
-#endif
 static void               FLASH_OB_GetWRP(uint32_t WRPArea, uint32_t *WRPStartOffset, uint32_t *WRDPEndOffset);
+static void               FLASH_OB_OptrConfig(uint32_t UserType, uint32_t UserConfig, uint32_t RDPLevel);
 static uint32_t           FLASH_OB_GetRDP(void);
 static uint32_t           FLASH_OB_GetUser(void);
 #if defined(FLASH_PCROP_SUPPORT)
+static void               FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAddr, uint32_t PCROP1AEndAddr);
+static void               FLASH_OB_PCROP1BConfig(uint32_t PCROP1BStartAddr, uint32_t PCROP1BEndAddr);
 static void               FLASH_OB_GetPCROP1A(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr);
 static void               FLASH_OB_GetPCROP1B(uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr);
+#if defined(FLASH_DBANK_SUPPORT)
+static void               FLASH_OB_PCROP2AConfig(uint32_t PCROP2AStartAddr, uint32_t PCROP2AEndAddr);
+static void               FLASH_OB_PCROP2BConfig(uint32_t PCROP2BStartAddr, uint32_t PCROP2BEndAddr);
+static void               FLASH_OB_GetPCROP2A(uint32_t *PCROP2AStartAddr, uint32_t *PCROP2AEndAddr);
+static void               FLASH_OB_GetPCROP2B(uint32_t *PCROP2BStartAddr, uint32_t *PCROP2BEndAddr);
+#endif
 #endif
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
+#if defined(FLASH_DBANK_SUPPORT)
+static void               FLASH_OB_SecMemConfig(uint32_t BootEntry, uint32_t SecSize, uint32_t SecSize2);
+static void               FLASH_OB_GetSecMem(uint32_t *BootEntry, uint32_t *SecSize, uint32_t *SecSize2);
+#else
+static void               FLASH_OB_SecMemConfig(uint32_t BootEntry, uint32_t SecSize);
 static void               FLASH_OB_GetSecMem(uint32_t *BootEntry, uint32_t *SecSize);
+#endif
 #endif
 /**
   * @}
@@ -163,10 +170,15 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
 
   if (status == HAL_OK)
   {
+#if !defined(FLASH_DBANK_SUPPORT)
+    /* For single bank product force Banks to Bank 1 */
+    pEraseInit->Banks = FLASH_BANK_1;
+#endif
+
     if (pEraseInit->TypeErase == FLASH_TYPEERASE_MASS)
     {
-      /* Mass erase to be done */
-      FLASH_MassErase();
+      /* Proceed to Mass Erase */
+      FLASH_MassErase(pEraseInit->Banks);
 
       /* Wait for last operation to be completed */
       status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
@@ -179,7 +191,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
       for (index = pEraseInit->Page; index < (pEraseInit->Page + pEraseInit->NbPages); index++)
       {
         /* Start erase page */
-        FLASH_PageErase(index);
+        FLASH_PageErase(pEraseInit->Banks, index);
 
         /* Wait for last operation to be completed */
         status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
@@ -237,16 +249,23 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
   }
   else
   {
+#if !defined(FLASH_DBANK_SUPPORT)
+    /* For single bank product force Banks to Bank 1 */
+    pEraseInit->Banks = FLASH_BANK_1;
+#endif
+    /* Store Bank number */
+    pFlash.Banks = pEraseInit->Banks;
+
     /* Enable End of Operation and Error interrupts */
-    __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP | FLASH_IT_OPERR);
+    FLASH->CR |= FLASH_CR_EOPIE | FLASH_CR_ERRIE;
 
     if (pEraseInit->TypeErase == FLASH_TYPEERASE_MASS)
     {
-      /* Set Page to 0 for Interrupt callback managment */
+      /* Set Page to 0 for Interrupt callback management */
       pFlash.Page = 0;
 
       /* Proceed to Mass Erase */
-      FLASH_MassErase();
+      FLASH_MassErase(pEraseInit->Banks);
     }
     else
     {
@@ -255,7 +274,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
       pFlash.Page = pEraseInit->Page;
 
       /*Erase 1st page and wait for IT */
-      FLASH_PageErase(pEraseInit->Page);
+      FLASH_PageErase(pEraseInit->Banks, pEraseInit->Page);
     }
   }
 
@@ -298,7 +317,7 @@ HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
   /* Option register */
   if ((pOBInit->OptionType & (OPTIONBYTE_RDP | OPTIONBYTE_USER)) == (OPTIONBYTE_RDP | OPTIONBYTE_USER))
   {
-    /* Fully modify OPTR register with RDP & user datas */
+    /* Fully modify OPTR register with RDP & user data */
     FLASH_OB_OptrConfig(pOBInit->USERType, pOBInit->USERConfig, pOBInit->RDPLevel);
   }
   else if ((pOBInit->OptionType & OPTIONBYTE_RDP) != 0x00U)
@@ -336,14 +355,34 @@ HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
       /* Configure the 1B Proprietary code readout protection */
       FLASH_OB_PCROP1BConfig(pOBInit->PCROP1BStartAddr, pOBInit->PCROP1BEndAddr);
     }
+
+#if defined(FLASH_DBANK_SUPPORT)
+    if ((pOBInit->PCROPConfig & OB_PCROP_ZONE2_A) != 0x00U)
+    {
+      /* Configure the 2A Proprietary code readout protection */
+      FLASH_OB_PCROP2AConfig(pOBInit->PCROP2AStartAddr, pOBInit->PCROP2AEndAddr);
+    }
+
+    if ((pOBInit->PCROPConfig & OB_PCROP_ZONE2_B) != 0x00U)
+    {
+      /* Configure the 2B Proprietary code readout protection */
+      FLASH_OB_PCROP2BConfig(pOBInit->PCROP2BStartAddr, pOBInit->PCROP2BEndAddr);
+    }
+#endif
   }
 #endif
+
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
   /* Securable Memory Area Configuration */
   if ((pOBInit->OptionType & OPTIONBYTE_SEC) != 0x00U)
   {
+#if defined(FLASH_DBANK_SUPPORT)
+    /* Configure the securable memory area protection */
+    FLASH_OB_SecMemConfig(pOBInit->BootEntryPoint, pOBInit->SecSize, pOBInit->SecSize2);
+#else
     /* Configure the securable memory area protection */
     FLASH_OB_SecMemConfig(pOBInit->BootEntryPoint, pOBInit->SecSize);
+#endif
   }
 #endif
 
@@ -375,9 +414,8 @@ HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
   *         change that would have been programmed between previous Option byte
   *         loading and current call.
   * @param  pOBInit Pointer to an @ref FLASH_OBProgramInitTypeDef structure that contains the
-  *                  configuration information. The fields pOBInit->WRPArea and
-  *                  pOBInit->PCROPConfig should indicate which area is requested
-  *                  for the WRP and PCROP.
+  *                  configuration information. The fields pOBInit->WRPArea should
+  *                  indicate which area is requested for the WRP.
   * @retval None
   */
 void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
@@ -399,11 +437,21 @@ void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
   FLASH_OB_GetPCROP1A(&(pOBInit->PCROPConfig), &(pOBInit->PCROP1AStartAddr), &(pOBInit->PCROP1AEndAddr));
   FLASH_OB_GetPCROP1B(&(pOBInit->PCROP1BStartAddr), &(pOBInit->PCROP1BEndAddr));
   pOBInit->PCROPConfig |= (OB_PCROP_ZONE_A | OB_PCROP_ZONE_B);
+#if defined(FLASH_DBANK_SUPPORT)
+  FLASH_OB_GetPCROP2A(&(pOBInit->PCROP2AStartAddr), &(pOBInit->PCROP2AEndAddr));
+  FLASH_OB_GetPCROP2B(&(pOBInit->PCROP2BStartAddr), &(pOBInit->PCROP2BEndAddr));
+  pOBInit->PCROPConfig |= (OB_PCROP_ZONE2_A | OB_PCROP_ZONE2_B);
+#endif
 #endif
 
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
+#if defined(FLASH_DBANK_SUPPORT)
+  /* Get the Securable Memory Area protection */
+  FLASH_OB_GetSecMem(&(pOBInit->BootEntryPoint), &(pOBInit->SecSize), &(pOBInit->SecSize2));
+#else
   /* Get the Securable Memory Area protection */
   FLASH_OB_GetSecMem(&(pOBInit->BootEntryPoint), &(pOBInit->SecSize));
+#endif
 #endif
 }
 
@@ -432,7 +480,7 @@ void HAL_FLASHEx_DisableDebugger(void)
 #endif /* FLASH_ACR_DBG_SWEN */
 
 /**
-  * @brief  Flash Empy check
+  * @brief  Flash Empty check
   * @note   This API checks if first location in Flash is programmed or not.
   *         This check is done once by Option Byte Loader.
   * @retval 0 if 1st location is not programmed else
@@ -464,18 +512,35 @@ void HAL_FLASHEx_ForceFlashEmpty(uint32_t FlashEmpty)
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
 /**
   * @brief  Securable memory area protection enable
-  * @param  Bank Select Bank to be secured. On G0, there is only 1 bank so
-  *         parameter has to be set to 0.
+  * @param  Banks Select Bank to be secured.
+  *         This parameter can be a value of @ref FLASH_Banks
+  * @note   On some devices, there is only 1 bank so parameter has to be set FLASH_BANK_1.
   * @note   This API locks Securable memory area which is defined in SEC_SIZE option byte
   *         (that can be retrieved calling HAL_FLASHEx_OBGetConfig API and checking
   *         Secsize).
   * @note   SEC_PROT bit can only be set, it will be reset by system reset.
   * @retval None
   */
-void HAL_FLASHEx_EnableSecMemProtection(uint32_t Bank)
+void HAL_FLASHEx_EnableSecMemProtection(uint32_t Banks)
 {
-  assert_param(IS_FLASH_BANK(Bank));
-  FLASH->CR |= FLASH_CR_SEC_PROT;
+#if defined(FLASH_DBANK_SUPPORT)
+  assert_param(IS_FLASH_BANK(Banks));
+
+  if (Banks == (FLASH_BANK_2  | FLASH_BANK_1))
+  {
+    FLASH->CR |= (FLASH_CR_SEC_PROT2 | FLASH_CR_SEC_PROT);
+  }
+  else if (Banks == FLASH_BANK_2)
+  {
+    FLASH->CR |= FLASH_CR_SEC_PROT2;
+  }
+  else
+#else
+  UNUSED(Banks);
+#endif
+  {
+    FLASH->CR |= FLASH_CR_SEC_PROT;
+  }
 }
 #endif
 /**
@@ -493,29 +558,55 @@ void HAL_FLASHEx_EnableSecMemProtection(uint32_t Bank)
 
 /**
   * @brief  Mass erase of FLASH memory.
+  * @param  Banks: Banks to be erased
+  *         This parameter can be a combination of the following values:
+  *            @arg FLASH_BANK_1: Bank1 to be erased
+  *            @arg FLASH_BANK_2: Bank2 to be erased*
+  * @note (*) availability depends on devices
   * @retval None
   */
-static void FLASH_MassErase(void)
+static void FLASH_MassErase(uint32_t Banks)
 {
+  /* Check the parameters */
+  assert_param(IS_FLASH_BANK(Banks));
+
   /* Set the Mass Erase Bit and start bit */
-  FLASH->CR |= (FLASH_CR_STRT | FLASH_CR_MER1);
+  FLASH->CR |= (FLASH_CR_STRT | Banks);
 }
 
 /**
   * @brief  Erase the specified FLASH memory page.
+  * @param  Banks: Banks to be erased
+  *         This parameter can one of the following values:
+  *            @arg FLASH_BANK_1: Bank1 to be erased
+  *            @arg FLASH_BANK_2: Bank2 to be erased*
   * @param  Page FLASH page to erase
   *         This parameter must be a value between 0 and (max number of pages in Flash - 1)
+  * @note (*) availability depends on devices
   * @retval None
   */
-void FLASH_PageErase(uint32_t Page)
+void FLASH_PageErase(uint32_t Banks, uint32_t Page)
 {
   uint32_t tmp;
 
   /* Check the parameters */
+  assert_param(IS_FLASH_BANK(Banks));
   assert_param(IS_FLASH_PAGE(Page));
 
   /* Get configuration register, then clear page number */
   tmp = (FLASH->CR & ~FLASH_CR_PNB);
+
+#if defined(FLASH_DBANK_SUPPORT)
+  /* Check if page has to be erased in bank 1 or 2 */
+  if(Banks != FLASH_BANK_1)
+  {
+    tmp |= FLASH_CR_BKER;
+  }
+  else
+  {
+    tmp &= ~FLASH_CR_BKER;
+  }
+#endif
 
   /* Set page number, Page Erase bit & Start bit */
   FLASH->CR = (tmp | (FLASH_CR_STRT | (Page <<  FLASH_CR_PNB_Pos) | FLASH_CR_PER));
@@ -551,12 +642,15 @@ void FLASH_FlushCaches(void)
   *         executed from RAM or System flash, even if WRP is not activated.
   * @param  WRPArea  Specifies the area to be configured.
   *         This parameter can be one of the following values:
-  *            @arg  @ref OB_WRPAREA_ZONE_A Flash Zone A
-  *            @arg  @ref OB_WRPAREA_ZONE_B Flash Zone B
+  *           @arg @ref OB_WRPAREA_ZONE_A Flash Zone A
+  *           @arg @ref OB_WRPAREA_ZONE_B Flash Zone B
+  *           @arg @ref OB_WRPAREA_ZONE2_A Flash Bank 2 Zone A (*)
+  *           @arg @ref OB_WRPAREA_ZONE2_B Flash Bank 2 Zone B (*)
+  * @note  (*) availability depends on devices
   * @param  WRPStartOffset  Specifies the start page of the write protected area
-  *         This parameter can be page number between 0 and (max number of pages in the Flash - 1)
+  *         This parameter can be page number between 0 and (max number of pages in the Flash Bank - 1)
   * @param  WRDPEndOffset  Specifies the end page of the write protected area
-  *         This parameter can be page number between WRPStartOffset and (max number of pages in the Flash - 1)
+  *         This parameter can be page number between WRPStartOffset and (max number of pages in the Flash Bank - 1)
   * @retval None
   */
 static void FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32_t WRDPEndOffset)
@@ -567,13 +661,68 @@ static void FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32
   assert_param(IS_FLASH_PAGE(WRDPEndOffset));
 
   /* Configure the write protected area */
-  if (WRPArea != OB_WRPAREA_ZONE_A)
+  if (WRPArea == OB_WRPAREA_ZONE_A)
   {
-    FLASH->WRP1BR = ((WRDPEndOffset << FLASH_WRP1AR_WRP1A_END_Pos) | WRPStartOffset);
+    FLASH->WRP1AR = ((WRDPEndOffset << FLASH_WRP1AR_WRP1A_END_Pos) | WRPStartOffset);
   }
+#if defined(FLASH_DBANK_SUPPORT)
+  else if (WRPArea == OB_WRPAREA_ZONE2_A)
+  {
+    FLASH->WRP2AR = ((WRDPEndOffset << FLASH_WRP2AR_WRP2A_END_Pos) | WRPStartOffset);
+  }
+  else if (WRPArea == OB_WRPAREA_ZONE2_B)
+  {
+    FLASH->WRP2BR = ((WRDPEndOffset << FLASH_WRP2BR_WRP2B_END_Pos) | WRPStartOffset);
+  }
+#endif
   else
   {
-    FLASH->WRP1AR = ((WRDPEndOffset << FLASH_WRP1BR_WRP1B_END_Pos) | WRPStartOffset);
+    FLASH->WRP1BR = ((WRDPEndOffset << FLASH_WRP1BR_WRP1B_END_Pos) | WRPStartOffset);
+  }
+}
+
+/**
+  * @brief  Return the FLASH Write Protection Option Bytes value.
+  * @param[in]  WRPArea Specifies the area to be returned.
+  *             This parameter can be one of the following values:
+  *               @arg @ref OB_WRPAREA_ZONE_A Flash Zone A
+  *               @arg @ref OB_WRPAREA_ZONE_B Flash Zone B
+  *               @arg @ref OB_WRPAREA_ZONE2_A Flash Bank 2 Zone A (*)
+  *               @arg @ref OB_WRPAREA_ZONE2_B Flash Bank 2 Zone B (*)
+  * @note  (*) availability depends on devices
+  * @param[out]  WRPStartOffset  Specifies the address where to copied the start page
+  *                         of the write protected area
+  * @param[out]  WRDPEndOffset  Dpecifies the address where to copied the end page of
+  *                        the write protected area
+  * @retval None
+  */
+static void FLASH_OB_GetWRP(uint32_t WRPArea, uint32_t *WRPStartOffset, uint32_t *WRDPEndOffset)
+{
+  /* Check the parameters */
+  assert_param(IS_OB_WRPAREA(WRPArea));
+
+  /* Get the configuration of the write protected area */
+  if (WRPArea == OB_WRPAREA_ZONE_A)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP1AR, FLASH_WRP1AR_WRP1A_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP1AR, FLASH_WRP1AR_WRP1A_END) >> FLASH_WRP1AR_WRP1A_END_Pos);
+  }
+#if defined(FLASH_DBANK_SUPPORT)
+  else if (WRPArea == OB_WRPAREA_ZONE2_A)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP2AR, FLASH_WRP2AR_WRP2A_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP2AR, FLASH_WRP2AR_WRP2A_END) >> FLASH_WRP2AR_WRP2A_END_Pos);
+  }
+  else if (WRPArea == OB_WRPAREA_ZONE2_B)
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP2BR, FLASH_WRP2BR_WRP2B_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP2BR, FLASH_WRP2BR_WRP2B_END) >> FLASH_WRP2BR_WRP2B_END_Pos);
+  }
+#endif
+else
+  {
+    *WRPStartOffset = READ_BIT(FLASH->WRP1BR, FLASH_WRP1BR_WRP1B_STRT);
+    *WRDPEndOffset = (READ_BIT(FLASH->WRP1BR, FLASH_WRP1BR_WRP1B_END) >> FLASH_WRP1BR_WRP1B_END_Pos);
   }
 }
 
@@ -585,26 +734,28 @@ static void FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32
   *         This parameter can be a combination of @ref FLASH_OB_USER_Type
   * @param  UserConfig  The FLASH User Option Bytes values.
   *         This parameter can be a combination of:
-  *         @arg @ref FLASH_OB_USER_BOR_ENABLE(*),
-  *         @arg @ref FLASH_OB_USER_BOR_LEVEL(*),
-  *         @arg @ref FLASH_OB_USER_RESET_CONFIG(*),
-  *         @arg @ref FLASH_OB_USER_nRST_STOP,
-  *         @arg @ref FLASH_OB_USER_nRST_STANDBY,
-  *         @arg @ref FLASH_OB_USER_nRST_SHUTDOWN(*),
-  *         @arg @ref FLASH_OB_USER_IWDG_SW,
-  *         @arg @ref FLASH_OB_USER_IWDG_STOP,
-  *         @arg @ref FLASH_OB_USER_IWDG_STANDBY,
-  *         @arg @ref FLASH_OB_USER_WWDG_SW,
-  *         @arg @ref FLASH_OB_USER_SRAM_PARITY,
-  *         @arg @ref FLASH_OB_USER_nBOOT_SEL,
-  *         @arg @ref FLASH_OB_USER_nBOOT1,
-  *         @arg @ref FLASH_OB_USER_nBOOT0,
-  *         @arg @ref FLASH_OB_USER_INPUT_RESET_HOLDER(*)
+  *           @arg @ref FLASH_OB_USER_BOR_ENABLE(*)
+  *           @arg @ref FLASH_OB_USER_BOR_LEVEL(*)
+  *           @arg @ref FLASH_OB_USER_RESET_CONFIG(*)
+  *           @arg @ref FLASH_OB_USER_nRST_STOP
+  *           @arg @ref FLASH_OB_USER_nRST_STANDBY
+  *           @arg @ref FLASH_OB_USER_nRST_SHUTDOWN(*)
+  *           @arg @ref FLASH_OB_USER_IWDG_SW
+  *           @arg @ref FLASH_OB_USER_IWDG_STOP
+  *           @arg @ref FLASH_OB_USER_IWDG_STANDBY
+  *           @arg @ref FLASH_OB_USER_WWDG_SW
+  *           @arg @ref FLASH_OB_USER_SRAM_PARITY
+  *           @arg @ref FLASH_OB_USER_BANK_SWAP(*)
+  *           @arg @ref FLASH_OB_USER_DUAL_BANK(*)
+  *           @arg @ref FLASH_OB_USER_nBOOT_SEL
+  *           @arg @ref FLASH_OB_USER_nBOOT1
+  *           @arg @ref FLASH_OB_USER_nBOOT0
+  *           @arg @ref FLASH_OB_USER_INPUT_RESET_HOLDER(*)
   * @param  RDPLevel  specifies the read protection level.
   *         This parameter can be one of the following values:
-  *            @arg @ref OB_RDP_LEVEL_0 No protection
-  *            @arg @ref OB_RDP_LEVEL_1 Memory Read protection
-  *            @arg @ref OB_RDP_LEVEL_2 Full chip protection
+  *           @arg @ref OB_RDP_LEVEL_0 No protection
+  *           @arg @ref OB_RDP_LEVEL_1 Memory Read protection
+  *           @arg @ref OB_RDP_LEVEL_2 Full chip protection
   * @note  (*) availability depends on devices
   * @retval None
   */
@@ -621,6 +772,56 @@ static void FLASH_OB_OptrConfig(uint32_t UserType, uint32_t UserConfig, uint32_t
   optr = FLASH->OPTR;
   optr &= ~(UserType | FLASH_OPTR_RDP);
   FLASH->OPTR = (optr | UserConfig | RDPLevel);
+}
+
+/**
+  * @brief  Return the FLASH Read Protection level.
+  * @retval FLASH ReadOut Protection Status:
+  *         This return value can be one of the following values:
+  *           @arg @ref OB_RDP_LEVEL_0 No protection
+  *           @arg @ref OB_RDP_LEVEL_1 Read protection of the memory
+  *           @arg @ref OB_RDP_LEVEL_2 Full chip protection
+  */
+static uint32_t FLASH_OB_GetRDP(void)
+{
+  uint32_t rdplvl = READ_BIT(FLASH->OPTR, FLASH_OPTR_RDP);
+
+  if ((rdplvl != OB_RDP_LEVEL_0) && (rdplvl != OB_RDP_LEVEL_2))
+  {
+    return (OB_RDP_LEVEL_1);
+  }
+  else
+  {
+    return rdplvl;
+  }
+}
+
+/**
+  * @brief  Return the FLASH User Option Byte value.
+  * @retval The FLASH User Option Bytes values. It will be a combination of all the following values:
+  *           @arg @ref FLASH_OB_USER_BOR_ENABLE(*)
+  *           @arg @ref FLASH_OB_USER_BOR_LEVEL(*)
+  *           @arg @ref FLASH_OB_USER_RESET_CONFIG(*)
+  *           @arg @ref FLASH_OB_USER_nRST_STOP
+  *           @arg @ref FLASH_OB_USER_nRST_STANDBY
+  *           @arg @ref FLASH_OB_USER_nRST_SHUTDOWN(*)
+  *           @arg @ref FLASH_OB_USER_IWDG_SW
+  *           @arg @ref FLASH_OB_USER_IWDG_STOP
+  *           @arg @ref FLASH_OB_USER_IWDG_STANDBY
+  *           @arg @ref FLASH_OB_USER_WWDG_SW
+  *           @arg @ref FLASH_OB_USER_SRAM_PARITY
+  *           @arg @ref FLASH_OB_USER_BANK_SWAP(*)
+  *           @arg @ref FLASH_OB_USER_DUAL_BANK(*)
+  *           @arg @ref FLASH_OB_USER_nBOOT_SEL
+  *           @arg @ref FLASH_OB_USER_nBOOT1
+  *           @arg @ref FLASH_OB_USER_nBOOT0
+  *           @arg @ref FLASH_OB_USER_INPUT_RESET_HOLDER(*)
+  * @note  (*) availability depends on devices
+  */
+static uint32_t FLASH_OB_GetUser(void)
+{
+  uint32_t user = ((FLASH->OPTR & ~FLASH_OPTR_RDP) & OB_USER_ALL);
+  return user;
 }
 
 #if defined(FLASH_PCROP_SUPPORT)
@@ -644,11 +845,32 @@ static void FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAd
   uint32_t startoffset;
   uint32_t endoffset;
   uint32_t pcrop1aend;
+  uint32_t ropbase;
 
   /* Check the parameters */
   assert_param(IS_OB_PCROP_CONFIG(PCROPConfig));
-  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(PCROP1AStartAddr));
-  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(PCROP1AEndAddr));
+
+#if defined(FLASH_DBANK_SUPPORT)
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != FLASH_OPTR_nSWAP_BANK)
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP1AStartAddr));
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP1AEndAddr));
+
+    /* Bank swap, bank 1 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+#endif
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP1AStartAddr));
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP1AEndAddr));
+
+    /* No Bank swap, bank 1 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
 
   /* get pcrop 1A end register */
   pcrop1aend = FLASH->PCROP1AER;
@@ -657,8 +879,8 @@ static void FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAd
   if ((PCROPConfig & OB_PCROP_ZONE_A) != 0x00U)
   {
     /* Compute offset depending on pcrop granularity */
-    startoffset = ((PCROP1AStartAddr - FLASH_BASE) >> FLASH_PCROP_GRANULARITY_OFFSET);
-    endoffset = ((PCROP1AEndAddr - FLASH_BASE) >> FLASH_PCROP_GRANULARITY_OFFSET);
+    startoffset = ((PCROP1AStartAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
+    endoffset = ((PCROP1AEndAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
 
     /* Set Zone A start offset */
     FLASH->PCROP1ASR = startoffset;
@@ -682,7 +904,7 @@ static void FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAd
   * @brief  Configure the 1B Proprietary code readout protection.
   * @note   It is recommended to align PCROP zone with page granularity when using PCROP_RDP or avoid
   *         having some executable code in a page where PCROP zone starts or ends.
-  * @note   Minimum PCROP area size is 2 times the chosen granularity: PCROPA_STRT and PCROPA_END.
+  * @note   Minimum PCROP area size is 2 times the chosen granularity: PCROPB_STRT and PCROPB_END.
   *         So if the requirement is to be able to read-protect 1KB areas, the ROP granularity
   *         has to be set to 512 Bytes
   * @param  PCROP1BStartAddr  Specifies the Zone 1B Start address of the Proprietary code readout protection
@@ -695,23 +917,332 @@ static void FLASH_OB_PCROP1BConfig(uint32_t PCROP1BStartAddr, uint32_t PCROP1BEn
 {
   uint32_t startoffset;
   uint32_t endoffset;
+  uint32_t ropbase;
 
-  /* Check the parameters */
-  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(PCROP1BStartAddr));
-  assert_param(IS_FLASH_MAIN_MEM_ADDRESS(PCROP1BEndAddr));
+#if defined(FLASH_DBANK_SUPPORT)
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != FLASH_OPTR_nSWAP_BANK)
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP1BStartAddr));
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP1BEndAddr));
+
+    /* Bank swap, bank 1 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+#endif
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP1BStartAddr));
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP1BEndAddr));
+
+    /* No Bank swap, bank 1 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
 
   /* Configure the Proprietary code readout protection offset */
-  startoffset = ((PCROP1BStartAddr - FLASH_BASE) >> FLASH_PCROP_GRANULARITY_OFFSET);
-  endoffset = ((PCROP1BEndAddr - FLASH_BASE) >> FLASH_PCROP_GRANULARITY_OFFSET);
+  startoffset = ((PCROP1BStartAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
+  endoffset = ((PCROP1BEndAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
 
   /* Set Zone B start offset */
   FLASH->PCROP1BSR = startoffset;
   /* Set Zone B end offset */
   FLASH->PCROP1BER = endoffset;
 }
+
+/**
+  * @brief  Return the FLASH PCROP Protection Option Bytes value.
+  * @param  PCROPConfig [out]  specifies the configuration of PCROP_RDP option.
+  * @param  PCROP1AStartAddr [out]  Specifies the address where to copied the start address
+  *         of the 1A Proprietary code readout protection
+  * @param  PCROP1AEndAddr [out]  Specifies the address where to copied the end address of
+  *         the 1A Proprietary code readout protection
+  * @retval None
+  */
+static void FLASH_OB_GetPCROP1A(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr)
+{
+  uint32_t pcrop;
+  uint32_t ropbase;
+
+#if defined(FLASH_DBANK_SUPPORT)
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != FLASH_OPTR_nSWAP_BANK)
+  {
+    /* Bank swap, bank 1 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+#endif
+  {
+    /* No Bank swap, bank 1 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
+
+  pcrop = (FLASH->PCROP1ASR & FLASH_PCROP1ASR_PCROP1A_STRT);
+  *PCROP1AStartAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP1AStartAddr += ropbase;
+
+  pcrop = FLASH->PCROP1AER;
+  *PCROP1AEndAddr = ((pcrop & FLASH_PCROP1AER_PCROP1A_END) << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP1AEndAddr += (ropbase + FLASH_PCROP_GRANULARITY - 1U);
+
+  *PCROPConfig &= ~OB_PCROP_RDP_ERASE;
+  *PCROPConfig |= (pcrop & FLASH_PCROP1AER_PCROP_RDP);
+}
+
+/**
+  * @brief  Return the FLASH PCROP Protection Option Bytes value.
+  * @param  PCROP1BStartAddr [out]  Specifies the address where to copied the start address
+  *         of the 1B Proprietary code readout protection
+  * @param  PCROP1BEndAddr [out]  Specifies the address where to copied the end address of
+  *         the 1B Proprietary code readout protection
+  * @retval None
+  */
+static void FLASH_OB_GetPCROP1B(uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr)
+{
+  uint32_t pcrop;
+  uint32_t ropbase;
+
+#if defined(FLASH_DBANK_SUPPORT)
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != FLASH_OPTR_nSWAP_BANK)
+  {
+    /* Bank swap, bank 1 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+#endif
+  {
+    /* No Bank swap, bank 1 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
+
+  pcrop = (FLASH->PCROP1BSR & FLASH_PCROP1BSR_PCROP1B_STRT);
+  *PCROP1BStartAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP1BStartAddr += ropbase;
+
+  pcrop = (FLASH->PCROP1BER & FLASH_PCROP1BER_PCROP1B_END);
+  *PCROP1BEndAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP1BEndAddr += (ropbase + FLASH_PCROP_GRANULARITY - 1U);
+}
+
+#if defined(FLASH_DBANK_SUPPORT)
+/**
+  * @brief  Configure the 2A Proprietary code readout protection.
+  * @note   It is recommended to align PCROP zone with page granularity when using PCROP_RDP or avoid
+  *         having some executable code in a page where PCROP zone starts or ends.
+  * @note   Minimum PCROP area size is 2 times the chosen granularity: PCROPA_STRT and PCROPA_END.
+  *         So if the requirement is to be able to read-protect 1KB areas, the ROP granularity
+  *         has to be set to 512 Bytes
+  * @param  PCROP2AStartAddr  Specifies the Zone 2A Start address of the Proprietary code readout protection
+  *         This parameter can be an address between begin and end of the flash
+  * @param  PCROP2AEndAddr  Specifies the Zone 2A end address of the Proprietary code readout protection
+  *         This parameter can be an address between PCROP2AStartAddr and end of the flash
+  * @retval None
+  */
+static void FLASH_OB_PCROP2AConfig(uint32_t PCROP2AStartAddr, uint32_t PCROP2AEndAddr)
+{
+  uint32_t startoffset;
+  uint32_t endoffset;
+  uint32_t ropbase;
+
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != 0x00u)
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP2AStartAddr));
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP2AEndAddr));
+
+    /* No Bank swap, bank 2 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP2AStartAddr));
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP2AEndAddr));
+
+    /* Bank swap, bank 2 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
+
+  /* Configure the Proprietary code readout protection offset */
+  startoffset = ((PCROP2AStartAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
+  endoffset = ((PCROP2AEndAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
+
+  /* Set Zone A start offset */
+  FLASH->PCROP2ASR = startoffset;
+  /* Set Zone A end offset */
+  FLASH->PCROP2AER = endoffset;
+}
+
+/**
+  * @brief  Configure the 2B Proprietary code readout protection.
+  * @note   It is recommended to align PCROP zone with page granularity when using PCROP_RDP or avoid
+  *         having some executable code in a page where PCROP zone starts or ends.
+  * @note   Minimum PCROP area size is 2 times the chosen granularity: PCROP_STRT and PCROP_END.
+  *         So if the requirement is to be able to read-protect 1KB areas, the ROP granularity
+  *         has to be set to 512 Bytes
+  * @param  PCROP2BStartAddr  Specifies the Zone 2B Start address of the Proprietary code readout protection
+  *         This parameter can be an address between begin and end of the flash
+  * @param  PCROP2BEndAddr  Specifies the Zone 2B end address of the Proprietary code readout protection
+  *         This parameter can be an address between PCROP2BStartAddr and end of the flash
+  * @retval None
+  */
+static void FLASH_OB_PCROP2BConfig(uint32_t PCROP2BStartAddr, uint32_t PCROP2BEndAddr)
+{
+  uint32_t startoffset;
+  uint32_t endoffset;
+  uint32_t ropbase;
+
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != 0x00u)
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP2BStartAddr));
+    assert_param(IS_FLASH_MAIN_SECONDHALF_MEM_ADDRESS(PCROP2BEndAddr));
+
+    /* No Bank swap, bank 2 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+  {
+    /* Check the parameters */
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP2BStartAddr));
+    assert_param(IS_FLASH_MAIN_FIRSTHALF_MEM_ADDRESS(PCROP2BEndAddr));
+
+    /* Bank swap, bank 2 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
+
+  /* Configure the Proprietary code readout protection offset */
+  startoffset = ((PCROP2BStartAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
+  endoffset = ((PCROP2BEndAddr - ropbase) >> FLASH_PCROP_GRANULARITY_OFFSET);
+
+  /* Set Zone B start offset */
+  FLASH->PCROP2BSR = startoffset;
+  /* Set Zone B end offset */
+  FLASH->PCROP2BER = endoffset;
+}
+
+/**
+  * @brief  Return the FLASH PCROP Protection Option Bytes value.
+  * @param  PCROP2AStartAddr [out]  Specifies the address where to copied the start address
+  *         of the 2A Proprietary code readout protection
+  * @param  PCROP2AEndAddr [out]  Specifies the address where to copied the end address of
+  *         the 2A Proprietary code readout protection
+  * @retval None
+  */
+static void FLASH_OB_GetPCROP2A(uint32_t *PCROP2AStartAddr, uint32_t *PCROP2AEndAddr)
+{
+  uint32_t pcrop;
+  uint32_t ropbase;
+
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != 0x00u)
+  {
+    /* No Bank swap, bank 2 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+  {
+    /* Bank swap, bank 2 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
+
+  pcrop = (FLASH->PCROP2ASR & FLASH_PCROP2ASR_PCROP2A_STRT);
+  *PCROP2AStartAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP2AStartAddr += ropbase;
+
+  pcrop = (FLASH->PCROP2AER & FLASH_PCROP2AER_PCROP2A_END);
+  *PCROP2AEndAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP2AEndAddr += (ropbase + FLASH_PCROP_GRANULARITY - 1U);
+}
+
+/**
+  * @brief  Return the FLASH PCROP Protection Option Bytes value.
+  * @param  PCROP2BStartAddr [out]  Specifies the address where to copied the start address
+  *         of the 2B Proprietary code readout protection
+  * @param  PCROP2BEndAddr [out]  Specifies the address where to copied the end address of
+  *         the 2B Proprietary code readout protection
+  * @retval None
+  */
+static void FLASH_OB_GetPCROP2B(uint32_t *PCROP2BStartAddr, uint32_t *PCROP2BEndAddr)
+{
+  uint32_t pcrop;
+  uint32_t ropbase;
+
+  /* Check if banks are swapped */
+  if ((FLASH->OPTR & FLASH_OPTR_nSWAP_BANK) != 0x00u)
+  {
+    /* No Bank swap, bank 2 read only protection is on second half of Flash */
+    ropbase = (FLASH_BASE + FLASH_BANK_SIZE);
+  }
+  else
+  {
+    /* Bank swap, bank 2 read only protection is on first half of Flash */
+    ropbase = FLASH_BASE;
+  }
+
+  pcrop = (FLASH->PCROP2BSR & FLASH_PCROP2BSR_PCROP2B_STRT);
+  *PCROP2BStartAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP2BStartAddr += ropbase;
+
+  pcrop = (FLASH->PCROP2BER & FLASH_PCROP2BER_PCROP2B_END);
+  *PCROP2BEndAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
+  *PCROP2BEndAddr += (ropbase + FLASH_PCROP_GRANULARITY - 1U);
+}
+#endif
 #endif
 
 #if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
+#if defined(FLASH_DBANK_SUPPORT)
+/**
+  * @brief  Configure Securable Memory area feature.
+  * @param  BootEntry  specifies if boot scheme is forced to Flash (System or user) or not
+  *         This parameter can be one of the following values:
+  *           @arg @ref OB_BOOT_ENTRY_FORCED_NONE No boot entry forced
+  *           @arg @ref OB_BOOT_ENTRY_FORCED_FLASH Flash selected as unique entry boot
+  * @param  SecSize specifies number of pages to protect as securable memory area, starting from
+  *         beginning of Bank1 (page 0).
+  * @param  SecSize2 specifies number of pages to protect as securable memory area, starting from
+  *         beginning of Bank2 (page 0).
+  * @retval None
+  */
+static void FLASH_OB_SecMemConfig(uint32_t BootEntry, uint32_t SecSize, uint32_t SecSize2)
+{
+  uint32_t secmem;
+
+  /* Check the parameters */
+  assert_param(IS_OB_SEC_BOOT_LOCK(BootEntry));
+  assert_param(IS_OB_SEC_SIZE(SecSize));
+  assert_param(IS_OB_SEC_SIZE(SecSize2));
+
+  /* Set securable memory area configuration */
+  secmem = (FLASH->SECR & ~(FLASH_SECR_BOOT_LOCK | FLASH_SECR_SEC_SIZE | FLASH_SECR_SEC_SIZE2));
+  FLASH->SECR = (secmem | BootEntry | SecSize | (SecSize2 << FLASH_SECR_SEC_SIZE2_Pos));
+}
+
+/**
+  * @brief  Return the FLASH Securable memory area protection Option Bytes value.
+  * @param  BootEntry  specifies boot scheme configuration
+  * @param  SecSize specifies number of pages to protect as secure memory area, starting from
+  *         beginning of Bank1 (page 0).
+  * @param  SecSize2 specifies number of pages to protect as secure memory area, starting from
+  *         beginning of Bank2 (page 0).
+  * @retval None
+  */
+static void FLASH_OB_GetSecMem(uint32_t *BootEntry, uint32_t *SecSize, uint32_t *SecSize2)
+{
+  uint32_t secmem = FLASH->SECR;
+
+  *BootEntry = (secmem & FLASH_SECR_BOOT_LOCK);
+  *SecSize = (secmem & FLASH_SECR_SEC_SIZE);
+  *SecSize2 = (secmem & FLASH_SECR_SEC_SIZE2) >> FLASH_SECR_SEC_SIZE2_Pos;
+}
+
+#else
 /**
   * @brief  Configure Securable Memory area feature.
   * @param  BootEntry  specifies if boot scheme is forced to Flash (System or user) or not
@@ -734,137 +1265,7 @@ static void FLASH_OB_SecMemConfig(uint32_t BootEntry, uint32_t SecSize)
   secmem = (FLASH->SECR & ~(FLASH_SECR_BOOT_LOCK | FLASH_SECR_SEC_SIZE));
   FLASH->SECR = (secmem | BootEntry | SecSize);
 }
-#endif
 
-
-/**
-  * @brief  Return the FLASH Write Protection Option Bytes value.
-  * @param[in]  WRPArea Specifies the area to be returned.
-  *             This parameter can be one of the following values:
-  *               @arg @ref OB_WRPAREA_ZONE_A Flash Zone A
-  *               @arg @ref OB_WRPAREA_ZONE_B Flash Zone B
-  * @param[out]  WRPStartOffset  Specifies the address where to copied the start page
-  *                         of the write protected area
-  * @param[out]  WRDPEndOffset  Dpecifies the address where to copied the end page of
-  *                        the write protected area
-  * @retval None
-  */
-static void FLASH_OB_GetWRP(uint32_t WRPArea, uint32_t *WRPStartOffset, uint32_t *WRDPEndOffset)
-{
-  /* Check the parameters */
-  assert_param(IS_OB_WRPAREA(WRPArea));
-
-  /* Get the configuration of the write protected area */
-  if (WRPArea == OB_WRPAREA_ZONE_A)
-  {
-    *WRPStartOffset = READ_BIT(FLASH->WRP1AR, FLASH_WRP1AR_WRP1A_STRT);
-    *WRDPEndOffset = (READ_BIT(FLASH->WRP1AR, FLASH_WRP1AR_WRP1A_END) >> FLASH_WRP1AR_WRP1A_END_Pos);
-  }
-  else
-  {
-    *WRPStartOffset = READ_BIT(FLASH->WRP1BR, FLASH_WRP1BR_WRP1B_STRT);
-    *WRDPEndOffset = (READ_BIT(FLASH->WRP1BR, FLASH_WRP1BR_WRP1B_END) >> FLASH_WRP1BR_WRP1B_END_Pos);
-  }
-}
-
-/**
-  * @brief  Return the FLASH Read Protection level.
-  * @retval FLASH ReadOut Protection Status:
-  *         This return value can be one of the following values:
-  *            @arg @ref OB_RDP_LEVEL_0 No protection
-  *            @arg @ref OB_RDP_LEVEL_1 Read protection of the memory
-  *            @arg @ref OB_RDP_LEVEL_2 Full chip protection
-  */
-static uint32_t FLASH_OB_GetRDP(void)
-{
-  uint32_t rdplvl = READ_BIT(FLASH->OPTR, FLASH_OPTR_RDP);
-
-  if ((rdplvl != OB_RDP_LEVEL_0) && (rdplvl != OB_RDP_LEVEL_2))
-  {
-    return (OB_RDP_LEVEL_1);
-  }
-  else
-  {
-    return rdplvl;
-  }
-}
-
-/**
-  * @brief  Return the FLASH User Option Byte value.
-  * @retval The FLASH User Option Bytes values. It will be a combination of all the following values:
-  *         @ref FLASH_OB_USER_BOR_ENABLE(*),
-  *         @ref FLASH_OB_USER_BOR_LEVEL(*),
-  *         @ref FLASH_OB_USER_RESET_CONFIG(*),
-  *         @ref FLASH_OB_USER_nRST_STOP,
-  *         @ref FLASH_OB_USER_nRST_STANDBY,
-  *         @ref FLASH_OB_USER_nRST_SHUTDOWN(*),
-  *         @ref FLASH_OB_USER_IWDG_SW,
-  *         @ref FLASH_OB_USER_IWDG_STOP,
-  *         @ref FLASH_OB_USER_IWDG_STANDBY,
-  *         @ref FLASH_OB_USER_WWDG_SW,
-  *         @ref FLASH_OB_USER_SRAM_PARITY,
-  *         @ref FLASH_OB_USER_nBOOT_SEL,
-  *         @ref FLASH_OB_USER_nBOOT1,
-  *         @ref FLASH_OB_USER_nBOOT0,
-  *         @ref FLASH_OB_USER_INPUT_RESET_HOLDER(*)
-  * @note  (*) availability depends on devices
-  */
-static uint32_t FLASH_OB_GetUser(void)
-{
-  uint32_t user = ((FLASH->OPTR & ~FLASH_OPTR_RDP) & OB_USER_ALL);
-  return user;
-}
-
-#if defined(FLASH_PCROP_SUPPORT)
-/**
-  * @brief  Return the FLASH PCROP Protection Option Bytes value.
-  * @param  PCROPConfig [out]  specifies the configuration of PCROP_RDP option.
-  * @param  PCROP1AStartAddr [out]  Specifies the address where to copied the start address
-  *         of the 1A Proprietary code readout protection
-  * @param  PCROP1AEndAddr [out]  Specifies the address where to copied the end address of
-  *         the 1A Proprietary code readout protection
-  * @retval None
-  */
-static void FLASH_OB_GetPCROP1A(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr)
-{
-  uint32_t pcrop;
-
-  pcrop = (FLASH->PCROP1ASR & FLASH_PCROP1ASR_PCROP1A_STRT);
-  *PCROP1AStartAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
-  *PCROP1AStartAddr += FLASH_BASE;
-
-  pcrop = FLASH->PCROP1AER;
-  *PCROP1AEndAddr = ((pcrop & FLASH_PCROP1AER_PCROP1A_END) << FLASH_PCROP_GRANULARITY_OFFSET);
-  *PCROP1AEndAddr += (FLASH_BASE + FLASH_PCROP_GRANULARITY - 1U);
-
-  *PCROPConfig &= ~OB_PCROP_RDP_ERASE;
-  *PCROPConfig |= (pcrop & FLASH_PCROP1AER_PCROP_RDP);
-}
-
-
-/**
-  * @brief  Return the FLASH PCROP Protection Option Bytes value.
-  * @param  PCROP1BStartAddr [out]  Specifies the address where to copied the start address
-  *         of the 1B Proprietary code readout protection
-  * @param  PCROP1BEndAddr [out]  Specifies the address where to copied the end address of
-  *         the 1B Proprietary code readout protection
-  * @retval None
-  */
-static void FLASH_OB_GetPCROP1B(uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr)
-{
-  uint32_t pcrop;
-
-  pcrop = (FLASH->PCROP1BSR & FLASH_PCROP1BSR_PCROP1B_STRT);
-  *PCROP1BStartAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
-  *PCROP1BStartAddr += FLASH_BASE;
-
-  pcrop = (FLASH->PCROP1BER & FLASH_PCROP1BER_PCROP1B_END);
-  *PCROP1BEndAddr = (pcrop << FLASH_PCROP_GRANULARITY_OFFSET);
-  *PCROP1BEndAddr += (FLASH_BASE + FLASH_PCROP_GRANULARITY - 1U);
-}
-#endif
-
-#if defined(FLASH_SECURABLE_MEMORY_SUPPORT)
 /**
   * @brief  Return the FLASH Securable memory area protection Option Bytes value.
   * @param  BootEntry  specifies boot scheme configuration
@@ -879,6 +1280,7 @@ static void FLASH_OB_GetSecMem(uint32_t *BootEntry, uint32_t *SecSize)
   *BootEntry = (secmem & FLASH_SECR_BOOT_LOCK);
   *SecSize = (secmem & FLASH_SECR_SEC_SIZE);
 }
+#endif
 #endif
 
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_gpio.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_gpio.c
@@ -188,26 +188,6 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
     if (iocurrent != 0x00u)
     {
       /*--------------------- GPIO Mode Configuration ------------------------*/
-      /* In case of Alternate function mode selection */
-      if ((GPIO_Init->Mode == GPIO_MODE_AF_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
-      {
-        /* Check the Alternate function parameters */
-        assert_param(IS_GPIO_AF_INSTANCE(GPIOx));
-        assert_param(IS_GPIO_AF(GPIO_Init->Alternate));
-
-        /* Configure Alternate function mapped with the current IO */
-        temp = GPIOx->AFR[position >> 3u];
-        temp &= ~(0xFu << ((position & 0x07u) * 4u));
-        temp |= ((GPIO_Init->Alternate) << ((position & 0x07u) * 4u));
-        GPIOx->AFR[position >> 3u] = temp;
-      }
-
-      /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
-      temp = GPIOx->MODER;
-      temp &= ~(GPIO_MODER_MODE0 << (position * 2u));
-      temp |= ((GPIO_Init->Mode & GPIO_MODE) << (position * 2u));
-      GPIOx->MODER = temp;
-
       /* In case of Output or Alternate function mode selection */
       if ((GPIO_Init->Mode == GPIO_MODE_OUTPUT_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_PP) ||
           (GPIO_Init->Mode == GPIO_MODE_OUTPUT_OD) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
@@ -232,6 +212,26 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
       temp &= ~(GPIO_PUPDR_PUPD0 << (position * 2u));
       temp |= ((GPIO_Init->Pull) << (position * 2u));
       GPIOx->PUPDR = temp;
+
+      /* In case of Alternate function mode selection */
+      if ((GPIO_Init->Mode == GPIO_MODE_AF_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      {
+        /* Check the Alternate function parameters */
+        assert_param(IS_GPIO_AF_INSTANCE(GPIOx));
+        assert_param(IS_GPIO_AF(GPIO_Init->Alternate));
+
+        /* Configure Alternate function mapped with the current IO */
+        temp = GPIOx->AFR[position >> 3u];
+        temp &= ~(0xFu << ((position & 0x07u) * 4u));
+        temp |= ((GPIO_Init->Alternate) << ((position & 0x07u) * 4u));
+        GPIOx->AFR[position >> 3u] = temp;
+      }
+
+      /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
+      temp = GPIOx->MODER;
+      temp &= ~(GPIO_MODER_MODE0 << (position * 2u));
+      temp |= ((GPIO_Init->Mode & GPIO_MODE) << (position * 2u));
+      GPIOx->MODER = temp;
 
       /*--------------------- EXTI Mode Configuration ------------------------*/
       /* Configure the External Interrupt or event for the current IO */
@@ -429,17 +429,16 @@ void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState Pin
   */
 void HAL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
+  uint32_t odr;
+
   /* Check the parameters */
   assert_param(IS_GPIO_PIN(GPIO_Pin));
 
-  if ((GPIOx->ODR & GPIO_Pin) != 0x00u)
-  {
-    GPIOx->BRR = (uint32_t)GPIO_Pin;
-  }
-  else
-  {
-    GPIOx->BSRR = (uint32_t)GPIO_Pin;
-  }
+  /* get current Output Data Register value */
+  odr = GPIOx->ODR;
+
+  /* Set selected pins that were at low level, and reset ones that were high */
+  GPIOx->BSRR = ((odr & GPIO_Pin) << GPIO_NUMBER) | (~odr & GPIO_Pin);
 }
 
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_hcd.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_hcd.c
@@ -1,0 +1,2506 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_hcd.c
+  * @author  MCD Application Team
+  * @brief   HCD HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (#)Declare a HCD_HandleTypeDef handle structure, for example:
+       HCD_HandleTypeDef  hhcd;
+
+    (#)Fill parameters of Init structure in HCD handle
+
+    (#)Call HAL_HCD_Init() API to initialize the HCD peripheral (Core, Host core, ...)
+
+    (#)Initialize the HCD low level resources through the HAL_HCD_MspInit() API:
+        (##) Enable the HCD/USB Low Level interface clock using the following macros
+             (+++) __HAL_RCC_USB_CLK_ENABLE();
+        (##) Initialize the related GPIO clocks
+        (##) Configure HCD pin-out
+        (##) Configure HCD NVIC interrupt
+
+    (#)Associate the Upper USB Host stack to the HAL HCD Driver:
+        (##) hhcd.pData = phost;
+
+    (#)Enable HCD transmission and reception:
+        (##) HAL_HCD_Start();
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal.h"
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+#ifdef HAL_HCD_MODULE_ENABLED
+
+
+
+/** @defgroup HCD HCD
+  * @brief HCD HAL module driver
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function ----------------------------------------------------------*/
+/** @defgroup HCD_Private_Functions HCD Private Functions
+  * @{
+  */
+static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum);
+static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum);
+static void HCD_Port_IRQHandler(HCD_HandleTypeDef *hhcd);
+static void HAL_HCD_ClearPhyChannel(HCD_HandleTypeDef *hhcd);
+static uint8_t HAL_HCD_GetLogical_Channel(HCD_HandleTypeDef *hhcd, uint8_t phy_chnum, uint8_t dir);
+static uint8_t HAL_HCD_Check_usedChannel(HCD_HandleTypeDef *hhcd, uint8_t ch_num);
+static uint8_t HAL_HCD_Get_FreePhyChannel(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t epnum, uint8_t ep_type);
+
+static void HCD_HC_IN_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t phy_chnum, uint32_t regvalue);
+static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t phy_chnum, uint32_t regvalue);
+static uint16_t HAL_HCD_GetFreePMA(HCD_HandleTypeDef *hhcd, uint16_t mps);
+static HAL_StatusTypeDef  HAL_HCD_PMAFree(HCD_HandleTypeDef *hhcd, uint32_t pma_base, uint16_t mps);
+static void inline HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num, uint8_t phy_chnum, uint32_t regvalue);
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup HCD_Exported_Functions HCD Exported Functions
+  * @{
+  */
+
+/** @defgroup HCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+@verbatim
+===============================================================================
+##### Initialization and de-initialization functions #####
+===============================================================================
+[..]  This section provides functions allowing to:
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the host driver.
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
+{
+  /* Check the HCD handle allocation */
+  if (hhcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_HCD_ALL_INSTANCE(hhcd->Instance));
+
+  if (hhcd->State == HAL_HCD_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hhcd->Lock = HAL_UNLOCKED;
+
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+    hhcd->SOFCallback = HAL_HCD_SOF_Callback;
+    hhcd->ConnectCallback = HAL_HCD_Connect_Callback;
+    hhcd->DisconnectCallback = HAL_HCD_Disconnect_Callback;
+    hhcd->PortEnabledCallback = HAL_HCD_PortEnabled_Callback;
+    hhcd->PortDisabledCallback = HAL_HCD_PortDisabled_Callback;
+    hhcd->HC_NotifyURBChangeCallback = HAL_HCD_HC_NotifyURBChange_Callback;
+
+    if (hhcd->MspInitCallback == NULL)
+    {
+      hhcd->MspInitCallback = HAL_HCD_MspInit;
+    }
+
+    /* Init the low level hardware */
+    hhcd->MspInitCallback(hhcd);
+#else
+    /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+    HAL_HCD_MspInit(hhcd);
+#endif /* (USE_HAL_HCD_REGISTER_CALLBACKS) */
+  }
+  hhcd->State = HAL_HCD_STATE_BUSY;
+
+  /* Disable the Interrupts */
+  (void)__HAL_HCD_DISABLE(hhcd);
+
+  /*Init the Core (common init.) */
+  (void)USB_CoreInit(hhcd->Instance, hhcd->Init);
+
+  /* Force Host Mode*/
+  (void)USB_SetCurrentMode(hhcd->Instance, USB_HOST_MODE);
+
+  /* Init Host */
+  (void)USB_HostInit(hhcd->Instance, hhcd->Init);
+
+  /* Deactivate the power down*/
+  hhcd->Instance->CNTR  &= ~USB_CNTR_PDWN;
+
+  hhcd->State = HAL_HCD_STATE_READY;
+
+  /*Host Port State*/
+  hhcd->HostState = HCD_HCD_STATE_DISCONNECTED;
+
+  /*Init PMA Address */
+  (void)HAL_HCD_PMAReset(hhcd);
+
+  hhcd->State = HAL_HCD_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize a host channel.
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @param  epnum Endpoint number.
+  *          This parameter can be a value from 1 to 15
+  * @param  dev_address Current device address
+  *          This parameter can be a value from 0 to 255
+  * @param  speed Current device speed.
+  *          This parameter can be one of these values:
+  *            HCD_SPEED_HIGH High speed mode,
+  *            HCD_SPEED_FULL Full speed mode,
+  *            HCD_SPEED_LOW Low speed mode
+  * @param  ep_type Endpoint Type.
+  *          This parameter can be one of these values:
+  *            USBH_EP_CONTROL Control type,
+  *            USBH_EP_ISO Isochronous type,
+  *            USBH_EP_BULK Bulk type,
+  *            USBH_EP_INTERRUPT Interrupt type
+  * @param  mps Max Packet Size.
+  *          This parameter can be a value from 0 to32K
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_HC_Init(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                                  uint8_t epnum, uint8_t dev_address,
+                                  uint8_t speed, uint8_t ep_type, uint16_t mps)
+{
+  HAL_StatusTypeDef status;
+  uint8_t used_channel;
+
+  __HAL_LOCK(hhcd);
+
+  /* Check if the logical channel are already allocated */
+  used_channel = HAL_HCD_Check_usedChannel(hhcd, ch_num);
+
+  /*Check if the channel is not already opened */
+  if (used_channel == 0U)
+  {
+    /*Allocate New Physical channel */
+    hhcd->hc[ch_num & 0xFU].phy_ch_num = HAL_HCD_Get_FreePhyChannel(hhcd, ch_num, epnum, ep_type);
+
+    /*if it is not able to allocate channel  */
+    if (hhcd->hc[ch_num & 0xFU].phy_ch_num == HCD_FREE_CH_NOT_FOUND)
+    {
+      return HAL_ERROR;
+    }
+  }
+  /* Channel already opened */
+  else
+  {
+    /*Get Physical Channel number */
+    hhcd->hc[ch_num & 0xFU].phy_ch_num = (used_channel & 0xF0U) >> 4U;
+  }
+
+  if ((epnum & 0x80U) != 0U)
+  {
+    hhcd->hc[ch_num & 0xFU].ch_dir = CH_IN_DIR;
+  }
+  else
+  {
+    hhcd->hc[ch_num & 0xFU].ch_dir = CH_OUT_DIR;
+  }
+
+  hhcd->hc[ch_num & 0xFU].dev_addr   = dev_address;
+  hhcd->hc[ch_num & 0xFU].max_packet = mps;
+  hhcd->hc[ch_num & 0xFU].ep_type    = ep_type;
+  hhcd->hc[ch_num & 0xFU].ep_num     = epnum & 0x7FU;
+  hhcd->hc[ch_num & 0xFU].speed      = speed;
+
+  /*Check if the channel is not already opened */
+  if (used_channel == 0U)
+  {
+    if (((ep_type == EP_TYPE_ISOC) && (hhcd->Init.iso_singlebuffer_enable == 0U)) ||
+        ((ep_type == EP_TYPE_BULK) && (hhcd->Init.bulk_doublebuffer_enable == 1U)))
+    {
+      /* PMA Dynamic Allocation */
+      status = HAL_HCD_PMAlloc(hhcd, ch_num, HCD_DBL_BUF, mps);
+      if (status == HAL_ERROR)
+      {
+        return HAL_ERROR;
+      }
+    }
+    else
+    {
+      /* PMA Dynamic Allocation */
+      status = HAL_HCD_PMAlloc(hhcd, ch_num, HCD_SNG_BUF, mps);
+      if (status == HAL_ERROR)
+      {
+        return HAL_ERROR;
+      }
+    }
+  }
+
+  /* Init the USB Channel CHEPRx */
+  status =  USB_HC_Init(hhcd->Instance, hhcd->hc[ch_num & 0xFU].phy_ch_num,
+                        epnum, dev_address, speed, ep_type, mps);
+
+  /* check single buffer for isochronous channel */
+  if (ep_type == EP_TYPE_ISOC)
+  {
+    if (hhcd->Init.iso_singlebuffer_enable == 1U)
+    {
+      (void)USB_HC_DoubleBuffer(hhcd->Instance, hhcd->hc[ch_num & 0xFU].phy_ch_num, USB_DRD_DBUFF_ENBALE);
+    }
+    /*Init Buffer State */
+    hhcd->hc[ch_num & 0xFU].pmabuff0_state = USB_PMABUF_EMPTY;
+    hhcd->hc[ch_num & 0xFU].pmabuff1_state = USB_PMABUF_EMPTY;
+  }
+
+  /* Bulk double buffer check */
+  if (ep_type == EP_TYPE_BULK)
+  {
+    if (hhcd->Init.bulk_doublebuffer_enable == 1U)
+    {
+      (void)USB_HC_DoubleBuffer(hhcd->Instance, hhcd->hc[ch_num & 0xFU].phy_ch_num, USB_DRD_DBUFF_ENBALE);
+    }
+  }
+  __HAL_UNLOCK(hhcd);
+
+  return status;
+}
+
+/**
+  * @brief  HAL_HCD_HC_Close Pipe
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_HC_Close(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
+{
+  /* Stop the channel */
+  (void) HAL_HCD_HC_Halt(hhcd, ch_num);
+
+  HAL_Delay(3U);
+
+  if (hhcd->hc[ch_num & 0xFU].ch_dir == CH_IN_DIR)
+  {
+    /* Free Allocated Channel */
+    hhcd->phy_chin_state[hhcd->hc[ch_num & 0xFU].phy_ch_num] = 0U;
+  }
+  else
+  {
+    /* Free Allocated Channel */
+    hhcd->phy_chout_state[hhcd->hc[ch_num & 0xFU].phy_ch_num] = 0U;
+  }
+
+  /* Reset PMA Channel_Allocation */
+  (void)HAL_HCD_PMADeAlloc(hhcd, ch_num);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Halt a host channel.
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_HC_Halt(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  __HAL_LOCK(hhcd);
+  if (hhcd->hc[ch_num & 0xFU].ch_dir == CH_IN_DIR)
+  {
+    (void)USB_HC_IN_Halt(hhcd->Instance, (uint8_t) hhcd->hc[ch_num & 0xFU].phy_ch_num);
+  }
+  else
+  {
+    (void)USB_HC_OUT_Halt(hhcd->Instance, (uint8_t) hhcd->hc[ch_num & 0xFU].phy_ch_num);
+  }
+  __HAL_UNLOCK(hhcd);
+
+  return status;
+}
+
+/**
+  * @brief  DeInitialize the host driver.
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_DeInit(HCD_HandleTypeDef *hhcd)
+{
+  uint8_t idx;
+
+  /* Host Port State */
+  hhcd->HostState = HCD_HCD_STATE_DISCONNECTED;
+
+  /* Reset PMA Address */
+  (void)HAL_HCD_PMAReset(hhcd);
+
+  for (idx = 0U; idx < hhcd->Init.Host_channels; idx++)
+  {
+    hhcd->phy_chin_state[idx] = 0U;
+    hhcd->phy_chout_state[idx] = 0U;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize the HCD MSP.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void  HAL_HCD_MspInit(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_MspInit could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  DeInitialize the HCD MSP.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void  HAL_HCD_MspDeInit(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_MspDeInit could be implemented in the user file
+  */
+}
+
+__weak void HAL_HCD_SuspendCallback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_SuspendCallback could be implemented in the user file
+  */
+
+}
+
+__weak void HAL_HCD_ResumeCallback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_ResumeCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HCD_Exported_Functions_Group2 Input and Output operation functions
+  *  @brief   HCD IO operation functions
+  *
+@verbatim
+===============================================================================
+##### IO operation functions #####
+===============================================================================
+[..] This subsection provides a set of functions allowing to manage the USB Host Data
+Transfer
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Submit a new URB for processing.
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @param  direction Channel number.
+  *          This parameter can be one of these values:
+  *           0 : Output / 1 : Input
+  * @param  ep_type Endpoint Type.
+  *          This parameter can be one of these values:
+  *            USBH_EP_CONTROL   : Control type/
+  *            USBH_EP_ISO       : Isochronous type/
+  *            USBH_EP_BULK      : Bulk type/
+  *            USBH_EP_INTERRUPT : Interrupt type/
+  * @param  token Endpoint Type.
+  *          This parameter can be one of these values:
+  *            0: HC_PID_SETUP / 1: HC_PID_DATA1
+  * @param  pbuff pointer to URB data
+  * @param  length Length of URB data
+  * @param  do_ping activate do ping protocol (for high speed only).
+  *          This parameter can be one of these values:
+  *           0 : do ping inactive / 1 : do ping active
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_HC_SubmitRequest(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                                           uint8_t direction, uint8_t ep_type,
+                                           uint8_t token, uint8_t *pbuff,
+                                           uint16_t length, uint8_t do_ping)
+{
+  UNUSED(do_ping);
+
+  if (token == 0U)
+  {
+    hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_SETUP;
+  }
+  else
+  {
+    hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA1;
+  }
+
+  /* Manage Data Toggle */
+  switch (ep_type)
+  {
+    case EP_TYPE_CTRL:
+      if ((token == 1U) && (direction == 0U)) /* send data */
+      {
+        if (length == 0U)
+        {
+          /* For Status OUT stage, Length==0, Status Out PID = 1 */
+          hhcd->hc[ch_num & 0xFU].toggle_out = 1U;
+        }
+
+        /* Set the Data Toggle bit as per the Flag */
+        if (hhcd->hc[ch_num & 0xFU].toggle_out == 0U)
+        {
+          /* Put the PID 0 */
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA0;
+        }
+        else
+        {
+          /* Put the PID 1 */
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA1;
+        }
+      }
+      break;
+
+    case EP_TYPE_BULK:
+      if (direction == 0U)
+      {
+        /* Set the Data Toggle bit as per the Flag */
+        if (hhcd->hc[ch_num & 0xFU].toggle_out == 0U)
+        {
+          /* Put the PID 0 */
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA0;
+        }
+        else
+        {
+          /* Put the PID 1 */
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA1;
+        }
+      }
+      else
+      {
+        if (hhcd->hc[ch_num & 0xFU].toggle_in == 0U)
+        {
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA0;
+        }
+        else
+        {
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA1;
+        }
+      }
+      break;
+
+    case EP_TYPE_INTR:
+      if (direction == 0U)
+      {
+        /* Set the Data Toggle bit as per the Flag */
+        if (hhcd->hc[ch_num & 0xFU].toggle_out == 0U)
+        {
+          /* Put the PID 0 */
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA0;
+        }
+        else
+        {
+          /* Put the PID 1 */
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA1;
+        }
+      }
+      else
+      {
+        if (hhcd->hc[ch_num & 0xFU].toggle_in == 0U)
+        {
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA0;
+        }
+        else
+        {
+          hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA1;
+        }
+      }
+      break;
+
+    case EP_TYPE_ISOC:
+      hhcd->hc[ch_num & 0xFU].data_pid = HC_PID_DATA0;
+      break;
+
+    default:
+      break;
+  }
+
+  hhcd->hc[ch_num & 0xFU].xfer_buff = pbuff;
+  hhcd->hc[ch_num & 0xFU].xfer_len  = length;
+  hhcd->hc[ch_num & 0xFU].xfer_len_db  = length;
+  hhcd->hc[ch_num & 0xFU].urb_state = URB_IDLE;
+  hhcd->hc[ch_num & 0xFU].xfer_count = 0U;
+  hhcd->hc[ch_num & 0xFU].state = HC_IDLE;
+
+  return USB_HC_StartXfer(hhcd->Instance, &hhcd->hc[ch_num & 0xFU]);
+}
+/**
+  * @brief  Handle HCD interrupt request.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+void HAL_HCD_IRQHandler(HCD_HandleTypeDef *hhcd)
+{
+  uint8_t phy_chnum;
+  uint8_t chnum;
+  uint32_t epch_reg;
+
+  /* Port Change Detected (Connection/Disconnection) */
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_DCON))
+  {
+    /* Clear Flag */
+    __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_DCON);
+
+    /* Call Port IRQHandler */
+    HCD_Port_IRQHandler(hhcd);
+  }
+
+  /* Correct Transaction Detected -------*/
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_CTR))
+  {
+    /* Handle Host channel Interrupt */
+    for (phy_chnum = 0U; phy_chnum < hhcd->Init.Host_channels; phy_chnum++)
+    {
+      if ((HCD_GET_CHANNEL(hhcd->Instance, phy_chnum)  &USB_CH_VTRX) != 0U)
+      {
+        /* Get Logical channel to check if the channel is already opened */
+        chnum = HAL_HCD_GetLogical_Channel(hhcd, phy_chnum, 1U);
+
+        if (chnum != HCD_LOGICAL_CH_NOT_OPENED)
+        {
+          /* Call Channel_IN_IRQ() */
+          HCD_HC_IN_IRQHandler(hhcd, chnum);
+        }
+        else
+        {
+          /*Channel was not closed correctly still have interrupt */
+          epch_reg = HCD_GET_CHANNEL(hhcd->Instance, phy_chnum);
+          epch_reg = (epch_reg & (USB_CHEP_REG_MASK & (~USB_CH_ERRRX) & (~USB_CH_VTRX))) |
+                     (USB_CH_VTTX | USB_CH_ERRTX);
+
+          HCD_SET_CHANNEL(hhcd->Instance, phy_chnum, epch_reg);
+        }
+      }
+
+      if ((HCD_GET_CHANNEL(hhcd->Instance, phy_chnum)  &USB_CH_VTTX) != 0U)
+      {
+        /*Get Logical channel to check if the channel is already opened*/
+        chnum = HAL_HCD_GetLogical_Channel(hhcd, phy_chnum, 0U);
+
+        if (chnum != HCD_LOGICAL_CH_NOT_OPENED)
+        {
+          /*Call Channel_OUT_IRQ()*/
+          HCD_HC_OUT_IRQHandler(hhcd, chnum);
+        }
+        else
+        {
+          /*Clear Error & unwanted VTTX or Channel was not closed correctly */
+          epch_reg = HCD_GET_CHANNEL(hhcd->Instance, phy_chnum);
+          epch_reg = (epch_reg & (USB_CHEP_REG_MASK & (~USB_CH_ERRTX) & (~USB_CH_VTTX))) |
+                     (USB_CH_VTRX | USB_CH_ERRRX);
+
+          HCD_SET_CHANNEL(hhcd->Instance, phy_chnum, epch_reg);
+        }
+      }
+    }
+
+    /* Clear Correct Transfer */
+    __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_CTR);
+
+  }
+
+  /* Wakeup Flag Detected */
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_WKUP))
+  {
+    if (hhcd->HostState == HCD_HCD_STATE_SUSPEND)
+    {
+      /* Set The L2Resume bit */
+      hhcd->Instance->CNTR |= USB_CNTR_L2RES;
+
+      /* Clear the wake-up flag */
+      __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_WKUP);
+
+      /* Update the USB Software state machine */
+      HAL_HCD_ResumeCallback(hhcd);
+      hhcd->HostState = HCD_HCD_STATE_RESUME;
+    }
+    else
+    {
+      /*Clear the wake-up flag*/
+      __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_WKUP);
+    }
+  }
+
+  /*Global Error Flag Detected */
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_ERR))
+  {
+    __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_ERR);
+  }
+
+  /* PMA Overrun detected */
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_PMAOVR))
+  {
+    __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_PMAOVR);
+  }
+
+  /* Suspend Detected */
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_SUSP))
+  {
+    /*Set HAL State to Suspend */
+    hhcd->HostState = HCD_HCD_STATE_SUSPEND;
+
+    /* Force low-power mode in the macrocell */
+    hhcd->Instance->CNTR |= USB_CNTR_SUSPEN;
+
+    /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
+    __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_SUSP);
+
+    /*Call suspend Callback*/
+    HAL_HCD_SuspendCallback(hhcd);
+  }
+
+  /*Start Of Frame Detected */
+  if (__HAL_HCD_GET_FLAG(hhcd, USB_ISTR_SOF))
+  {
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+    hhcd->SOFCallback(hhcd);
+#else
+    HAL_HCD_SOF_Callback(hhcd);
+#endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
+
+    __HAL_HCD_CLEAR_FLAG(hhcd, USB_ISTR_SOF);
+
+    /* when first SOF is detected after USB_RESET is asserted */
+    if (hhcd->HostState == HCD_HCD_STATE_RESETED)
+    {
+      /* HAL State */
+      hhcd->HostState = HCD_HCD_STATE_RUN;
+      HAL_HCD_PortEnabled_Callback(hhcd);
+    }
+  }
+}
+
+/**
+  * @brief  SOF callback.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void HAL_HCD_SOF_Callback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_SOF_Callback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief Connection Event callback.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void HAL_HCD_Connect_Callback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_Connect_Callback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Disconnection Event callback.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void HAL_HCD_Disconnect_Callback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_Disconnect_Callback could be implemented in the user file
+  */
+}
+/**
+  * @brief  Port Enabled  Event callback.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void HAL_HCD_PortEnabled_Callback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_HCD_Disconnect_Callback could be implemented in the user file
+   */
+}
+/**
+  * @brief  Port Disabled  Event callback.
+  * @param  hhcd HCD handle
+  * @retval None
+  */
+__weak void HAL_HCD_PortDisabled_Callback(HCD_HandleTypeDef *hhcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_HCD_Disconnect_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Notify URB state change callback.
+  * @param  hhcd HCD handle
+  * @param  chnum Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @param  urb_state
+  *          This parameter can be one of these values:
+  *            URB_IDLE/
+  *            URB_DONE/
+  *            URB_NOTREADY/
+  *            URB_NYET/
+  *            URB_ERROR/
+  *            URB_STALL/
+  * @retval None
+  */
+__weak void HAL_HCD_HC_NotifyURBChange_Callback(HCD_HandleTypeDef *hhcd,
+                                                uint8_t chnum, HCD_URBStateTypeDef urb_state)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hhcd);
+  UNUSED(chnum);
+  UNUSED(urb_state);
+
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_HCD_HC_NotifyURBChange_Callback could be implemented in the user file
+  */
+}
+#if (USE_HAL_HCD_REGISTER_CALLBACKS == 1U)
+/**
+  * @brief  Register a User USB HCD Callback
+  *         To be used instead of the weak predefined callback
+  * @param  hhcd USB HCD handle
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_HCD_SOF_CB_ID USB HCD SOF callback ID
+  *          @arg @ref HAL_HCD_CONNECT_CB_ID USB HCD Connect callback ID
+  *          @arg @ref HAL_HCD_DISCONNECT_CB_ID HCD Disconnect callback ID
+  *          @arg @ref HAL_HCD_PORT_ENABLED_CB_ID USB HCD Port Enable callback ID
+  *          @arg @ref HAL_HCD_PORT_DISABLED_CB_ID USB HCD Port Disable callback ID
+  *          @arg @ref HAL_HCD_MSPINIT_CB_ID MspDeInit callback ID
+  *          @arg @ref HAL_HCD_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @param  pCallback pointer to the Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_RegisterCallback(HCD_HandleTypeDef *hhcd,
+                                           HAL_HCD_CallbackIDTypeDef CallbackID,
+                                           pHCD_CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+  /* Process locked */
+  __HAL_LOCK(hhcd);
+
+  if (hhcd->State == HAL_HCD_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_HCD_SOF_CB_ID :
+        hhcd->SOFCallback = pCallback;
+        break;
+
+      case HAL_HCD_CONNECT_CB_ID :
+        hhcd->ConnectCallback = pCallback;
+        break;
+
+      case HAL_HCD_DISCONNECT_CB_ID :
+        hhcd->DisconnectCallback = pCallback;
+        break;
+
+      case HAL_HCD_PORT_ENABLED_CB_ID :
+        hhcd->PortEnabledCallback = pCallback;
+        break;
+
+      case HAL_HCD_PORT_DISABLED_CB_ID :
+        hhcd->PortDisabledCallback = pCallback;
+        break;
+
+      case HAL_HCD_MSPINIT_CB_ID :
+        hhcd->MspInitCallback = pCallback;
+        break;
+
+      case HAL_HCD_MSPDEINIT_CB_ID :
+        hhcd->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hhcd->State == HAL_HCD_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_HCD_MSPINIT_CB_ID :
+        hhcd->MspInitCallback = pCallback;
+        break;
+
+      case HAL_HCD_MSPDEINIT_CB_ID :
+        hhcd->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hhcd);
+  return status;
+}
+
+/**
+  * @brief  Unregister an USB HCD Callback
+  *         USB HCD callback is redirected to the weak predefined callback
+  * @param  hhcd USB HCD handle
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_HCD_SOF_CB_ID USB HCD SOF callback ID
+  *          @arg @ref HAL_HCD_CONNECT_CB_ID USB HCD Connect callback ID
+  *          @arg @ref HAL_HCD_DISCONNECT_CB_ID DRD HCD Disconnect callback ID
+  *          @arg @ref HAL_HCD_PORT_ENABLED_CB_ID USB HCD Port Enabled callback ID
+  *          @arg @ref HAL_HCD_PORT_DISABLED_CB_ID USB HCD Port Disabled callback ID
+  *          @arg @ref HAL_HCD_MSPINIT_CB_ID MspDeInit callback ID
+  *          @arg @ref HAL_HCD_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_UnRegisterCallback(HCD_HandleTypeDef *hhcd,
+                                             HAL_HCD_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hhcd);
+
+  /* Setup Legacy weak Callbacks  */
+  if (hhcd->State == HAL_HCD_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_HCD_SOF_CB_ID :
+        hhcd->SOFCallback = HAL_HCD_SOF_Callback;
+        break;
+
+      case HAL_HCD_CONNECT_CB_ID :
+        hhcd->ConnectCallback = HAL_HCD_Connect_Callback;
+        break;
+
+      case HAL_HCD_DISCONNECT_CB_ID :
+        hhcd->DisconnectCallback = HAL_HCD_Disconnect_Callback;
+        break;
+
+      case HAL_HCD_PORT_ENABLED_CB_ID :
+        hhcd->PortEnabledCallback = HAL_HCD_PortEnabled_Callback;
+        break;
+
+      case HAL_HCD_PORT_DISABLED_CB_ID :
+        hhcd->PortDisabledCallback = HAL_HCD_PortDisabled_Callback;
+        break;
+
+      case HAL_HCD_MSPINIT_CB_ID :
+        hhcd->MspInitCallback = HAL_HCD_MspInit;
+        break;
+
+      case HAL_HCD_MSPDEINIT_CB_ID :
+        hhcd->MspDeInitCallback = HAL_HCD_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hhcd->State == HAL_HCD_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_HCD_MSPINIT_CB_ID :
+        hhcd->MspInitCallback = HAL_HCD_MspInit;
+        break;
+
+      case HAL_HCD_MSPDEINIT_CB_ID :
+        hhcd->MspDeInitCallback = HAL_HCD_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hhcd);
+  return status;
+}
+
+/**
+  * @brief  Register USB HCD Host Channel Notify URB Change Callback
+  *         To be used instead of the weak HAL_HCD_HC_NotifyURBChange_Callback() predefined callback
+  * @param  hhcd HCD handle
+  * @param  pCallback pointer to the USB HCD Host Channel Notify URB Change Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_RegisterHC_NotifyURBChangeCallback(HCD_HandleTypeDef *hhcd,
+                                                             pHCD_HC_NotifyURBChangeCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hhcd);
+
+  if (hhcd->State == HAL_HCD_STATE_READY)
+  {
+    hhcd->HC_NotifyURBChangeCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status = HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hhcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB HCD Host Channel Notify URB Change Callback
+  *         USB HCD Host Channel Notify URB Change Callback is redirected
+  *         to the weak HAL_HCD_HC_NotifyURBChange_Callback() predefined callback
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_UnRegisterHC_NotifyURBChangeCallback(HCD_HandleTypeDef *hhcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hhcd);
+
+  if (hhcd->State == HAL_HCD_STATE_READY)
+  {
+    hhcd->HC_NotifyURBChangeCallback = HAL_HCD_HC_NotifyURBChange_Callback; /* Legacy weak DataOutStageCallback */
+  }
+  else
+  {
+    /* Update the error code */
+    hhcd->ErrorCode |= HAL_HCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hhcd);
+
+  return status;
+}
+#endif /* USE_HAL_HCD_REGISTER_CALLBACKS */
+
+
+/**
+  * @}
+  */
+
+/** @defgroup HCD_Exported_Functions_Group3 Peripheral Control functions
+  *  @brief   Management functions
+  *
+@verbatim
+===============================================================================
+##### Peripheral Control functions #####
+===============================================================================
+[..]
+This subsection provides a set of functions allowing to control the HCD data
+transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start the host driver.
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_Start(HCD_HandleTypeDef *hhcd)
+{
+  __HAL_LOCK(hhcd);
+
+  /*Set the PullDown on the PHY */
+  hhcd->Instance->BCDR |= USB_BCDR_DPPD;
+
+  /* Clear Reset  */
+  hhcd->Instance->CNTR &= ~USB_CNTR_USBRST;
+
+  /*Remove PowerDown */
+  hhcd->Instance->CNTR &= ~USB_CNTR_PDWN;
+
+  __HAL_UNLOCK(hhcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop the host driver.
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_Stop(HCD_HandleTypeDef *hhcd)
+{
+  __HAL_LOCK(hhcd);
+  /*Stop the Host IP: setting powerdown  */
+  (void)USB_StopHost(hhcd->Instance);
+
+  /* clear all allocated virtual channel */
+  HAL_HCD_ClearPhyChannel(hhcd);
+
+  /* Reset the PMA current pointer */
+  (void)HAL_HCD_PMAReset(hhcd);
+
+  __HAL_UNLOCK(hhcd);
+  return HAL_OK;
+}
+
+/**
+  * @brief  Put the Device in suspend mode
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_Suspend(HCD_HandleTypeDef *hhcd)
+{
+  uint32_t count = 0U;
+
+  /* Set Suspend Mode */
+  hhcd->Instance->CNTR |= USB_CNTR_SUSPEN;
+
+  /* wait for Suspend Ready */
+  while ((hhcd->Instance->CNTR & USB_CNTR_SUSPRDY) == 0U)
+  {
+    if (++count > 0xFFFFFFU)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Resume host port
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_Resume(HCD_HandleTypeDef *hhcd)
+{
+  /* Set Resume bit */
+  hhcd->Instance->CNTR |= USB_CNTR_L2RES;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Reset the host port.
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_ResetPort(HCD_HandleTypeDef *hhcd)
+{
+  __HAL_LOCK(hhcd);
+
+  /* Reset the USB Port by inserting an SE0 on the bus */
+  (void)USB_ResetPort(hhcd->Instance);
+
+  if (hhcd->HostState == HCD_HCD_STATE_CONNECTED)
+  {
+    hhcd->HostState = HCD_HCD_STATE_RESETED;
+  }
+  __HAL_UNLOCK(hhcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Resme the host port.
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HCD_ResumePort(HCD_HandleTypeDef *hhcd)
+{
+  /* Set Resume bit */
+  hhcd->Instance->CNTR |= USB_CNTR_L2RES;
+  HAL_Delay(30U);
+
+  /* Clear Resume bit */
+  hhcd->Instance->CNTR &= ~USB_CNTR_L2RES;
+
+  return HAL_OK;
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup HCD_Exported_Functions_Group4 Peripheral State functions
+  *  @brief   Peripheral State functions
+  *
+@verbatim
+===============================================================================
+##### Peripheral State functions #####
+===============================================================================
+[..]
+This subsection permits to get in run-time the status of the peripheral
+and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the HCD handle state.
+  * @param  hhcd HCD handle
+  * @retval HAL state
+  */
+HCD_StateTypeDef HAL_HCD_GetState(HCD_HandleTypeDef *hhcd)
+{
+  return hhcd->State;
+}
+
+/**
+  * @brief  Return  URB state for a channel.
+  * @param  hhcd HCD handle
+  * @param  chnum Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @retval URB state.
+  *          This parameter can be one of these values:
+  *            URB_IDLE/
+  *            URB_DONE/
+  *            URB_NOTREADY/
+  *            URB_NYET/
+  *            URB_ERROR/
+  *            URB_STALL
+  */
+HCD_URBStateTypeDef HAL_HCD_HC_GetURBState(HCD_HandleTypeDef *hhcd, uint8_t chnum)
+{
+  return hhcd->hc[chnum].urb_state;
+}
+
+
+/**
+  * @brief  Return the last host transfer size.
+  * @param  hhcd HCD handle
+  * @param  chnum Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @retval last transfer size in byte
+  */
+uint32_t HAL_HCD_HC_GetXferCount(HCD_HandleTypeDef *hhcd, uint8_t chnum)
+{
+  return hhcd->hc[chnum].xfer_count;
+}
+
+/**
+  * @brief  Return the Host Channel state.
+  * @param  hhcd HCD handle
+  * @param  chnum Channel number.
+  *         This parameter can be a value from 1 to 15
+  * @retval Host channel state
+  *          This parameter can be one of these values:
+  *            HC_IDLE/
+  *            HC_XFRC/
+  *            HC_HALTED/
+  *            HC_NYET/
+  *            HC_NAK/
+  *            HC_STALL/
+  *            HC_XACTERR/
+  *            HC_BBLERR/
+  *            HC_DATATGLERR
+  */
+HCD_HCStateTypeDef  HAL_HCD_HC_GetState(HCD_HandleTypeDef *hhcd, uint8_t chnum)
+{
+  return hhcd->hc[chnum].state;
+}
+
+/**
+  * @brief  Return the current Host frame number.
+  * @param  hhcd HCD handle
+  * @retval Current Host frame number
+  */
+uint32_t HAL_HCD_GetCurrentFrame(HCD_HandleTypeDef *hhcd)
+{
+  return (USB_GetCurrentFrame(hhcd->Instance));
+}
+
+/**
+  * @brief  Return the Host enumeration speed.
+  * @param  hhcd HCD handle
+  * @retval Enumeration speed
+  */
+uint32_t HAL_HCD_GetCurrentSpeed(HCD_HandleTypeDef *hhcd)
+{
+  return (USB_GetHostSpeed(hhcd->Instance));
+}
+
+/**
+  * @brief  Handle Host Channel OUT Double Buffer Bulk requests.
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number This parameter can be a value from 1 to 15
+  * @param  phy_chnum Physical Channel number [0..7]
+  * @param  regvalue contain Snapshot of the EPCHn register when ISR is detected
+  * @retval none
+  */
+static void HCD_HC_OUT_BulkDb(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                              uint8_t phy_chnum, uint32_t regvalue)
+{
+  uint16_t data_xfr;
+  uint16_t len;
+
+  /* Send Buffer0 */
+  if ((regvalue & USB_CH_DTOG_TX) != 0U)
+  {
+    data_xfr = (uint16_t)(((USB_DRD_PMA_BUFF + phy_chnum)->TXBD & 0x03FF0000U) >> 16U);
+
+    if (hhcd->hc[ch_num & 0xFU].xfer_len >= data_xfr)
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len -= data_xfr;
+    }
+    else
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len = 0U;
+    }
+
+    /* Transfer no yet finished only one packet of mps is transferred and ACKed from device */
+    if (hhcd->hc[ch_num & 0xFU].xfer_len != 0U)
+    {
+      /* manage multiple Xfer */
+      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+
+      /* check if we need to free user buffer */
+      if ((regvalue & USB_CH_DTOG_RX) != 0U)
+      {
+        /* Toggle SwBuff */
+        HCD_FreeUserBuffer(hhcd->Instance, phy_chnum, 1U);
+      }
+
+      /* hhcd->hc[ch_num&0xFU].xfer_len_db==0 ==> when all data are written in the PMA to yet transferred */
+      if (hhcd->hc[ch_num & 0xFU].xfer_len_db > 0U) /* Still data to fill in the buffer */
+      {
+        hhcd->hc[ch_num & 0xFU].xfer_buff += data_xfr;
+
+        /* calculate len of new buffer to fill */
+        if (hhcd->hc[ch_num & 0xFU].xfer_len_db > hhcd->hc[ch_num & 0xFU].max_packet)
+        {
+          len = (uint16_t)hhcd->hc[ch_num & 0xFU].max_packet;
+          hhcd->hc[ch_num & 0xFU].xfer_len_db -= len;
+        }
+        else
+        {
+          len = (uint16_t)hhcd->hc[ch_num & 0xFU].xfer_len_db;
+          hhcd->hc[ch_num & 0xFU].xfer_len_db = 0U; /* end of fill buffer */
+        }
+
+        /* Write remaining data to Buffer0 */
+        HCD_SET_CH_TX_CNT(hhcd->Instance, phy_chnum, (uint16_t)len);
+        USB_WritePMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                     hhcd->hc[ch_num & 0xFU].pmaaddr0, (uint16_t)len);
+      }
+      /* start a new transfer */
+      HCD_SET_CH_TX_STATUS(hhcd->Instance, phy_chnum, USB_CH_TX_VALID);
+    }
+    else
+    {
+      /* Transfer complete state */
+      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+      hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
+      hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
+      hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
+      /* Close the Channel */
+      HCD_SET_CH_TX_STATUS(hhcd->Instance, phy_chnum, USB_CH_TX_DIS);
+    }
+  }
+  else
+  {
+    /* Send Buffer1 */
+    data_xfr = (uint16_t)(((USB_DRD_PMA_BUFF + phy_chnum)->RXBD & 0x03FF0000U) >> 16U);
+
+    if (hhcd->hc[ch_num & 0xFU].xfer_len >= data_xfr) /* updated */
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len -= data_xfr;
+    }
+
+    /* Transfer no yet finished only one packet of mps is transferred and ACKed from device */
+    if (hhcd->hc[ch_num & 0xFU].xfer_len != 0U)
+    {
+      /* manage multiple Xfer */
+      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+
+      /* check if we need to free user buffer */
+      if ((regvalue & USB_CH_DTOG_RX) == 0U)
+      {
+        /* Toggle SwBuff */
+        HCD_FreeUserBuffer(hhcd->Instance, phy_chnum, 1U);
+      }
+
+      /* hhcd->hc[ch_num&0xFU].xfer_len_db==0 ==> when all data are written in the PMA to yet transferred */
+      if (hhcd->hc[ch_num & 0xFU].xfer_len_db > 0U) /* Still data to fill in the buffer */
+      {
+        hhcd->hc[ch_num & 0xFU].xfer_buff += data_xfr;
+
+        /* calculate len of new buffer to fill */
+        if (hhcd->hc[ch_num & 0xFU].xfer_len_db > hhcd->hc[ch_num & 0xFU].max_packet)
+        {
+          len = hhcd->hc[ch_num & 0xFU].max_packet;
+          hhcd->hc[ch_num & 0xFU].xfer_len_db -= len;
+        }
+        else
+        {
+          len = (uint16_t)hhcd->hc[ch_num & 0xFU].xfer_len_db;
+          hhcd->hc[ch_num & 0xFU].xfer_len_db = 0U; /* end of fill buffer */
+        }
+
+        /* Write remaining data to Buffer0 */
+        HCD_SET_CH_DBUF1_CNT(hhcd->Instance, phy_chnum, 0U, (uint16_t)len);
+
+        USB_WritePMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                     hhcd->hc[ch_num & 0xFU].pmaaddr1, (uint16_t)len);
+      }
+      /* start a new transfer */
+      HCD_SET_CH_TX_STATUS(hhcd->Instance, phy_chnum, USB_CH_TX_VALID);
+    }
+    else
+    {
+      /* Transfer complete state */
+      hhcd->hc[ch_num & 0xFU].xfer_count  += data_xfr;
+      hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
+      hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
+      hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
+      /* Close the channel */
+      HCD_SET_CH_TX_STATUS(hhcd->Instance, phy_chnum, USB_CH_TX_DIS);
+    }
+  }
+}
+
+
+/**
+  * @brief  Handle Host Channel IN Isochronous Transaction
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number: This parameter can be a value from 1 to 15
+  * @param  phy_chnum Physical Channel number [0..7]
+  * @param  regvalue contain Snapshot of the EPCHn register when ISR is detected
+  * @retval none
+  */
+static void inline HCD_HC_IN_ISO(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                                 uint8_t phy_chnum, uint32_t regvalue)
+{
+  /* Check if Double buffer isochronous */
+  if ((regvalue & USB_CH_KIND) == 0U)
+  {
+    /* Read from Buffer0 */
+    if ((regvalue & USB_CH_DTOG_RX) != 0U)
+    {
+      /* Get number of Received byte in buffer0 */
+      hhcd->hc[ch_num & 0xFU].xfer_count = HCD_GET_CH_DBUF0_CNT(hhcd->Instance, phy_chnum);
+
+      if (hhcd->hc[ch_num & 0xFU].xfer_count != 0U)
+      {
+        /* Read from Buffer0 */
+        USB_ReadPMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                    hhcd->hc[ch_num & 0xFU].pmaaddr0,
+                    (uint16_t)hhcd->hc[ch_num & 0xFU].xfer_count);
+
+        hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
+      }
+    }
+    else
+    {
+      /* Get number of Received byte in buffer1 */
+      hhcd->hc[ch_num & 0xFU].xfer_count = HCD_GET_CH_DBUF1_CNT(hhcd->Instance, phy_chnum);
+
+      if (hhcd->hc[ch_num & 0xFU].xfer_count != 0U)
+      {
+        /* Read from Buffer1 */
+        USB_ReadPMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                    hhcd->hc[ch_num & 0xFU].pmaaddr1,
+                    (uint16_t)hhcd->hc[ch_num & 0xFU].xfer_count);
+
+        hhcd->hc[ch_num & 0xFU].urb_state = URB_DONE;
+      }
+    }
+  }
+  else  /* single buffer isochronous */
+  {
+    /* Get Control Data OUT Packet*/
+    hhcd->hc[ch_num & 0xFU].xfer_count = HCD_GET_CH_RX_CNT(hhcd->Instance, phy_chnum);
+    if (hhcd->hc[ch_num & 0xFU].xfer_count != 0U)
+    {
+      USB_ReadPMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                  hhcd->hc[ch_num & 0xFU].pmaadress,
+                  (uint16_t)hhcd->hc[ch_num & 0xFU].xfer_count);
+
+      hhcd->hc[ch_num & 0xFU].urb_state = URB_DONE;
+    }
+  }
+
+  /* Transfer complete state */
+  hhcd->hc[ch_num & 0xFU].state = HC_XFRC;
+
+  /* Clear VTRX */
+  HCD_CLEAR_RX_CH_CTR(hhcd->Instance, phy_chnum);
+
+}
+/**
+  * @brief  Handle Host Channel IN Double Buffer Bulk requests.
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number: This parameter can be a value from 1 to 15
+  * @param  phy_chnum Physical Channel number [0..7]
+  * @param  regvalue contain Snapshot of the EPCHn register when ISR is detected
+  * @retval none
+  */
+static void HCD_HC_IN_BulkDb(HCD_HandleTypeDef *hhcd,
+                             uint8_t ch_num, uint8_t phy_chnum, uint32_t regvalue)
+{
+  uint16_t received_bytes;
+
+  /* Read from Buffer 0 */
+  if ((regvalue & USB_CH_DTOG_RX) != 0U)
+  {
+    received_bytes = (uint16_t)HCD_GET_CH_DBUF0_CNT(hhcd->Instance, phy_chnum);
+
+    if (hhcd->hc[ch_num & 0xFU].xfer_len <= received_bytes)
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len = 0U;
+    }
+    else
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len -= received_bytes;
+    }
+    /* Check if we Need to free the other buffer for the IP */
+    if ((hhcd->hc[ch_num & 0xFU].xfer_len != 0U) && ((regvalue & USB_CH_DTOG_TX) != 0U))
+    {
+      /* Toggle SwBuff */
+      HCD_FreeUserBuffer(hhcd->Instance, phy_chnum, 0U);/* Allow the IP to submit a new IN */
+    }
+    /* Read the byte from PMA to user Buffer(System Memory) */
+    USB_ReadPMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                hhcd->hc[ch_num & 0xFU].pmaaddr0, (uint16_t)received_bytes);
+  }
+  else
+  {
+    /* Read from Buffer 1 */
+    received_bytes = (uint16_t) HCD_GET_CH_DBUF1_CNT(hhcd->Instance, phy_chnum);
+
+    if (hhcd->hc[ch_num & 0xFU].xfer_len <= received_bytes)
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len = 0U;
+    }
+    else
+    {
+      hhcd->hc[ch_num & 0xFU].xfer_len -= received_bytes;
+    }
+
+    /* Check if we Need to free the other buffer for the IP */
+    if ((hhcd->hc[ch_num & 0xFU].xfer_len != 0U) && ((regvalue & USB_CH_DTOG_TX) == 0U))
+    {
+      /* Toggle SwBuff */
+      HCD_FreeUserBuffer(hhcd->Instance, phy_chnum, 0U);
+    }
+
+    /* Read the byte from PMA to user Buffer(System Memory) */
+    USB_ReadPMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                hhcd->hc[ch_num & 0xFU].pmaaddr1, (uint16_t)received_bytes);
+  }
+
+  /* update the global number of all received bytes */
+  hhcd->hc[ch_num & 0xFU].xfer_count += received_bytes;
+
+  /* Transfer complete state */
+  hhcd->hc[ch_num & 0xFU].state = HC_ACK;
+  hhcd->hc[ch_num & 0xFU].ErrCnt = 0U;
+
+  if ((hhcd->hc[ch_num & 0xFU].xfer_len == 0U) ||
+      ((received_bytes < hhcd->hc[ch_num & 0xFU].max_packet)))
+  {
+    hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
+    hhcd->hc[ch_num & 0xFU].state  = HC_XFRC;
+
+    /* disable channel */
+    HCD_SET_CH_RX_STATUS(hhcd->Instance, phy_chnum, USB_CH_RX_DIS);
+  }
+  else
+  {
+    hhcd->hc[ch_num & 0xFU].xfer_buff += received_bytes;
+
+    /* Reactivate the Channel Submit an other URB since the Transfer is not yet completed */
+    HCD_SET_CH_RX_STATUS(hhcd->Instance, phy_chnum, USB_CH_RX_STRX);
+  }
+}
+
+/**
+  * @brief  Handle Host Channel IN interrupt requests.
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval none
+  */
+static void HCD_HC_IN_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
+{
+  uint16_t received_bytes;
+  uint8_t phy_chnum = (uint8_t)__HAL_HCD_GET_CHNUM(hhcd);
+
+  /*Take a Flag snapshot from the CHEP register, due to STRX bits are used for both control and status */
+  uint32_t ch_reg =  HCD_GET_CHANNEL(hhcd->Instance, phy_chnum);
+
+  /* Manage Correct Transaction */
+  if ((ch_reg & USB_CH_ERRRX) == 0U)
+  {
+    /* Isochronous Channel */
+    if ((ch_reg & USB_CH_UTYPE) == USB_EP_ISOCHRONOUS)
+    {
+      HCD_HC_IN_ISO(hhcd, ch_num, phy_chnum, ch_reg);
+    }
+    else
+    {
+      /* manage ACK response single buffer */
+      if (((ch_reg) & USB_CH_RX_STRX) == USB_CH_RX_ACK_SBUF)
+      {
+        /* Get Control Data OUT Packet */
+        received_bytes = (uint16_t)HCD_GET_CH_RX_CNT(hhcd->Instance, phy_chnum);
+
+        /* Read the byte from PMA to user Buffer(System Memory) */
+        USB_ReadPMA(hhcd->Instance, hhcd->hc[ch_num & 0xFU].xfer_buff,
+                    hhcd->hc[ch_num & 0xFU].pmaadress, (uint16_t)received_bytes);
+
+        /* update the global number of all received bytes */
+        hhcd->hc[ch_num & 0xFU].xfer_count += received_bytes;
+
+        /* Transfer complete state */
+        hhcd->hc[ch_num & 0xFU].state = HC_ACK;
+        hhcd->hc[ch_num & 0xFU].ErrCnt = 0U;
+        if (hhcd->hc[ch_num & 0xFU].xfer_len <= received_bytes)
+        {
+          hhcd->hc[ch_num & 0xFU].xfer_len = 0U;
+        }
+        else
+        {
+          hhcd->hc[ch_num & 0xFU].xfer_len -= received_bytes;
+        }
+        if ((hhcd->hc[ch_num & 0xFU].xfer_len == 0U) ||
+            ((received_bytes < hhcd->hc[ch_num & 0xFU].max_packet)))
+        {
+          hhcd->hc[ch_num & 0xFU].urb_state  = URB_DONE;
+          hhcd->hc[ch_num & 0xFU].state  = HC_XFRC;
+        }
+        else
+        {
+          hhcd->hc[ch_num & 0xFU].xfer_buff += received_bytes;
+
+          /* Reactivate the Channel to Submit another URB since the Transfer is not yet completed */
+          HCD_SET_CH_RX_STATUS(hhcd->Instance, phy_chnum, USB_CH_RX_STRX);
+        }
+        if ((hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_BULK) ||
+            (hhcd->hc[ch_num & 0xFU].ep_type == EP_TYPE_INTR))
+        {
+          hhcd->hc[ch_num & 0xFU].toggle_out ^= 1U;
+        }
+      }
+
+      /* manage NACK Response */
+      else if (((ch_reg & USB_CH_RX_STRX) == USB_CH_RX_NAK)
+               && (hhcd->hc[ch_num & 0xFU].urb_state != URB_DONE))
+      {
+        hhcd->hc[ch_num & 0xFU].urb_state = URB_NOTREADY;
+        hhcd->hc[ch_num & 0xFU].ErrCnt = 0U;
+        hhcd->hc[ch_num & 0xFU].state = HC_NAK;
+      }
+
+      /* manage STALL Response */
+      else if ((ch_reg & USB_CH_RX_STRX) == USB_CH_RX_STALL)
+      {
+        (void)HAL_HCD_HC_Halt(hhcd, (uint8_t)ch_num);
+        hhcd->hc[ch_num & 0xFU].state = HC_STALL;
+        hhcd->hc[ch_num & 0xFU].urb_state = URB_STALL;
+
+        /* Close the channel */
+        HCD_SET_CH_RX_STATUS(hhcd->Instance, phy_chnum, USB_CH_RX_DIS);
+      }
+
+      /* Double Buffer Management in case of Bulk Transaction */
+      else  if (((ch_reg & USB_CH_RX_STRX) == USB_CH_RX_ACK_DBUF)
+                && ((ch_reg & USB_CH_KIND) != 0U))
+      {
+        /* Bulk IN Double Buffer ISR */
+        HCD_HC_IN_BulkDb(hhcd, ch_num, phy_chnum, ch_reg);
+      }
+      else
+      {
+        /*....*/
+        /* not defined state: STRX=11 in single buffer no iso is not defined */
+      }
+      HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)ch_num,
+                                          hhcd->hc[ch_num & 0xFU].urb_state);
+
+      /*Clear VTRX */
+      HCD_CLEAR_RX_CH_CTR(hhcd->Instance, phy_chnum);
+    }
+  }
+  else   /* Error detected during last transaction */
+  {
+    /* Set URB Error State */
+    hhcd->hc[ch_num & 0xFU].urb_state = URB_NOTREADY;
+    hhcd->hc[ch_num & 0xFU].ErrCnt++;
+    hhcd->hc[ch_num & 0xFU].state = HC_XACTERR;
+
+    /* Clear VTTRX & ERR_RX */
+    HCD_CLEAR_RX_CH_ERR(hhcd->Instance, phy_chnum);
+
+    /* Check Error number */
+    if (hhcd->hc[ch_num & 0xFU].ErrCnt > 3U)
+    {
+      hhcd->hc[ch_num & 0xFU].urb_state = URB_ERROR;
+      HCD_SET_CH_RX_STATUS(hhcd->Instance, phy_chnum, USB_CH_RX_DIS);
+
+      /* Clear pending err_tx */
+      HCD_CLEAR_RX_CH_ERR(hhcd->Instance, phy_chnum);
+    }
+    HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)ch_num,
+                                        hhcd->hc[ch_num & 0xFU].urb_state);
+  }
+}
+
+
+/**
+  * @brief  Handle Host Channel OUT interrupt requests.
+  * @param  hhcd  HCD handle
+  * @param  chnum Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval none
+  */
+static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
+{
+  uint16_t data_xfr;
+
+  /* Get Physical Channel number */
+  uint32_t phy_chnum = (uint8_t)__HAL_HCD_GET_CHNUM(hhcd);
+
+  /* Take a Flag snapshot from the CHEP register, due to STRX bits are used for both control &status */
+  __IO uint32_t ch_reg =  *(__IO uint32_t *)(&(hhcd->Instance->CHEP0R) + phy_chnum);
+
+  /*------ Manage Correct Transaction ------*/
+  if ((ch_reg & USB_CH_ERRTX) == 0U)
+  {
+    /* Handle Isochronous channel */
+    if ((ch_reg & USB_CH_UTYPE) == USB_EP_ISOCHRONOUS)
+    {
+      /* correct transaction */
+      if ((hhcd->Instance->ISTR & USB_ISTR_ERR) == 0U)
+      {
+        /* Double buffer isochronous out*/
+        if ((ch_reg & USB_CH_KIND) == 0U)
+        {
+          /* Odd Transaction */
+          if ((ch_reg & USB_CH_DTOG_TX) != 0U)
+          {
+            hhcd->hc[chnum & 0xFU].pmabuff0_state = USB_PMABUF_EMPTY;
+          }
+          /* Even Transaction */
+          else
+          {
+            hhcd->hc[chnum & 0xFU].pmabuff1_state = USB_PMABUF_EMPTY;
+          }
+        }
+        else /* single buffer isochronous out */
+        {
+          HCD_SET_CH_TX_CNT(hhcd->Instance, phy_chnum, (uint16_t)0U);
+        }
+
+        /* Transfer complete state */
+        hhcd->hc[chnum & 0xFU].state = HC_XFRC;
+        hhcd->hc[chnum & 0xFU].urb_state = URB_DONE;
+      }
+
+      /*Clear Correct Transfer */
+      HCD_CLEAR_TX_CH_CTR(hhcd->Instance, phy_chnum);
+    }
+    else /* Manage all Non Isochronous Transaction */
+    {
+      /* Check ACK response */
+      if ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_ACK_SBUF)
+      {
+        data_xfr = (uint16_t)(((USB_DRD_PMA_BUFF + phy_chnum)->TXBD & 0x03FF0000U) >> 16U);
+
+        if (hhcd->hc[chnum & 0xFU].xfer_len >= data_xfr)
+        {
+          hhcd->hc[chnum & 0xFU].xfer_len -= data_xfr;
+        }
+        else
+        {
+          hhcd->hc[chnum & 0xFU].xfer_len = 0U;
+        }
+
+        /* Transfer no yet finished only one packet of mps is transferred and ACKed from device */
+        if (hhcd->hc[chnum & 0xFU].xfer_len != 0U)
+        {
+          /* manage multiple Xfer */
+          hhcd->hc[chnum & 0xFU].xfer_buff += data_xfr;
+          hhcd->hc[chnum & 0xFU].xfer_count  += data_xfr;
+
+          /* start a new transfer */
+          (void) USB_HC_StartXfer(hhcd->Instance, &hhcd->hc[chnum & 0xFU]);
+        }
+        else
+        {
+          /* Transfer complete */
+          hhcd->hc[chnum & 0xFU].xfer_count += data_xfr;
+          hhcd->hc[chnum & 0xFU].state = HC_XFRC;
+          hhcd->hc[chnum & 0xFU].urb_state = URB_DONE;
+          if ((hhcd->hc[chnum & 0xFU].ep_type == EP_TYPE_BULK) ||
+              (hhcd->hc[chnum & 0xFU].ep_type == EP_TYPE_INTR))
+          {
+            hhcd->hc[chnum & 0xFU].toggle_out ^= 1U;
+          }
+        }
+      }
+
+      /* Check NACK Response */
+      else if ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_NAK)
+      {
+        hhcd->hc[chnum & 0xFU].urb_state = URB_NOTREADY;
+        hhcd->hc[chnum & 0xFU].ErrCnt = 0U;
+        hhcd->hc[chnum & 0xFU].state = HC_NAK;
+      }
+
+      /*Check STALL Response*/
+      else if ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_STALL)
+      {
+        (void) HAL_HCD_HC_Halt(hhcd, (uint8_t)chnum);
+        hhcd->hc[chnum & 0xFU].state = HC_STALL;
+        hhcd->hc[chnum & 0xFU].urb_state = URB_STALL;
+      }
+
+      /*Check double buffer ACK in case of bulk transaction */
+      else if ((ch_reg & USB_CH_TX_STTX) == USB_CH_TX_ACK_DBUF)
+      {
+        /*Double buffer management Bulk Out*/
+        (void) HCD_HC_OUT_BulkDb(hhcd, chnum, (uint8_t)phy_chnum, ch_reg);
+      }
+      else
+      {
+        /*...*/
+      }
+
+      HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)chnum,
+                                          hhcd->hc[chnum & 0xFU].urb_state);
+      HCD_CLEAR_TX_CH_CTR(hhcd->Instance, phy_chnum);
+    }  /* end no isochronous */
+  }
+
+  /*------ Manage Transaction Error------*/
+  else
+  {
+    hhcd->hc[chnum & 0xFU].ErrCnt++;
+    if (hhcd->hc[chnum & 0xFU].ErrCnt > 3U)
+    {
+      HCD_SET_CH_TX_STATUS(hhcd->Instance, phy_chnum, USB_CH_TX_DIS);
+      hhcd->hc[chnum & 0xFU].urb_state = URB_ERROR;
+    }
+    else
+    {
+      hhcd->hc[chnum & 0xFU].urb_state = URB_NOTREADY;
+    }
+
+    hhcd->hc[chnum & 0xFU].state = HC_XACTERR;
+
+    /*Clear ERR_TX*/
+    HCD_CLEAR_TX_CH_ERR(hhcd->Instance, phy_chnum);
+    HAL_HCD_HC_NotifyURBChange_Callback(hhcd, (uint8_t)chnum,
+                                        hhcd->hc[chnum & 0xFU].urb_state);
+  }
+}
+
+
+/**
+  * @brief  Handle Host Port interrupt requests.
+  * @param  hhcd  HCD handle
+  * @retval None
+  */
+static void HCD_Port_IRQHandler(HCD_HandleTypeDef *hhcd)
+{
+  /* J-state detected & LastState=Disconnected   */
+  if (((hhcd->Instance->FNR & USB_FNR_RXDP) != 0U) &&
+      ((hhcd->HostState == HCD_HCD_STATE_DISCONNECTED) != 0U))
+  {
+    HAL_HCD_Connect_Callback(hhcd);
+    hhcd->HostState = HCD_HCD_STATE_CONNECTED;
+  }
+  /* K-state detected & LastState=Disconnected  */
+  else  if (((hhcd->Instance->ISTR & USB_ISTR_LS_DCONN) != 0U)
+            && ((hhcd->HostState == HCD_HCD_STATE_DISCONNECTED) != 0U))
+  {
+    HAL_HCD_Connect_Callback(hhcd);
+    hhcd->HostState = HCD_HCD_STATE_CONNECTED;
+  }
+  /* SE0 detected USB Disconnected state */
+  else if ((hhcd->Instance->FNR & (USB_FNR_RXDP | USB_FNR_RXDM)) == 0U)
+  {
+    /*Host Port State*/
+    hhcd->HostState = HCD_HCD_STATE_DISCONNECTED;
+    /*Disconnection Callback */
+    HAL_HCD_Disconnect_Callback(hhcd);
+  }
+  /* J-state detected & lastState=Connected: a Missing disconnection is detected */
+  else if (((hhcd->Instance->FNR & USB_FNR_RXDP) != 0U) &&
+           ((hhcd->HostState == HCD_HCD_STATE_CONNECTED) != 0U))
+  {
+    /*Disconnection Callback */
+    HAL_HCD_Disconnect_Callback(hhcd);
+    /*Host Port State*/
+    hhcd->HostState = HCD_HCD_STATE_DISCONNECTED;
+  }
+  /* K-state detected & LastState=Disconnected: a Missing disconnection is detected */
+  else if (((hhcd->Instance->ISTR & USB_ISTR_LS_DCONN) != 0U)
+           && ((hhcd->HostState == HCD_HCD_STATE_CONNECTED) != 0U))
+  {
+    /*Disconnection Callback */
+    HAL_HCD_Disconnect_Callback(hhcd);
+    /*Host Port State*/
+    hhcd->HostState = HCD_HCD_STATE_DISCONNECTED;
+  }
+  else
+  {
+    /* should not be here */
+  }
+}
+
+/**
+  * @brief  Check if the ch_num are already reserved to a physical channel
+  * @param  hhcd  HCD handle
+  * @param  ch_num  Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL status
+  */
+static uint8_t HAL_HCD_Check_usedChannel(HCD_HandleTypeDef *hhcd, uint8_t ch_num)
+{
+  uint8_t idx;
+
+  /* Check if the logical channel are already opened  */
+  for (idx = 0U; idx < hhcd->Init.Host_channels; idx++)
+  {
+    if ((((hhcd->phy_chin_state[idx] & 0x00F0U) >> 4U) == ((uint16_t)ch_num + 1U)) && (hhcd->phy_chin_state[idx] != 0U))
+    {
+      return (1U | (idx << 4U));
+    }
+    if ((((hhcd->phy_chout_state[idx] & 0x00F0U) >> 4U) == ((uint16_t)ch_num + 1U)) && (hhcd->phy_chout_state[idx] != 0U))
+    {
+      return (1U | (idx << 4U));
+    }
+  }
+
+  return 0U;
+}
+
+/**
+  * @brief  Get a Logical Channel number from  physical Channel
+  * @param  hhcd  HCD handle
+  * @param  phy_chnum
+  *         This parameter can be a value from 1 to 15
+  * @param  dir  Channel direction
+  *         -0 OUT_Channel
+  *         -1 IN_Channel
+  * @retval HAL status
+  */
+static uint8_t HAL_HCD_GetLogical_Channel(HCD_HandleTypeDef *hhcd,
+                                          uint8_t phy_chnum, uint8_t dir)
+{
+  /* Out Channel Direction */
+  if (dir == 0U)
+  {
+    if (((hhcd->phy_chout_state[phy_chnum & 0x7U] & 0x00F0U) >> 4U) != 0U)
+    {
+      return ((uint8_t)((hhcd->phy_chout_state[phy_chnum & 0x7U] & 0x00F0U) >> 4U) - 1U);
+    }
+    else
+    {
+      /*Channel not registered Error*/
+      return HCD_LOGICAL_CH_NOT_OPENED;
+    }
+  }
+  /* IN Channel Direction */
+  else
+  {
+    if (((hhcd->phy_chin_state[phy_chnum & 0x7U] & 0x00F0U) >> 4U) != 0U)
+    {
+      return ((uint8_t)((hhcd->phy_chin_state[phy_chnum & 0x7U] & 0x00F0U) >> 4U) - 1U);
+    }
+    else
+    {
+      /*Channel not registered Error*/
+      return HCD_LOGICAL_CH_NOT_OPENED;
+    }
+  }
+}
+/**
+  * @brief  Get a free physical Channel number according to the direction
+  * @param  hhcd HCD handle
+  * @param  ch_num Channel number
+  *         This parameter can be a value from 1 to 15
+  * @param  epnum Endpoint number
+  *          This parameter can be a value from 1 to 15
+  * @param  ep_type Endpoint Type
+  *          This parameter can be one of these values:
+  *            EP_TYPE_CTRL Control type,
+  *            EP_TYPE_ISOC Isochronous type,
+  *            EP_TYPE_BULK Bulk type,
+  *            EP_TYPE_INTR Interrupt type
+  * @retval if physical channel is available return Phy_channel number
+         else return HCD_FREE_CH_NOT_FOUND
+  */
+static uint8_t HAL_HCD_Get_FreePhyChannel(HCD_HandleTypeDef *hhcd, uint8_t ch_num,
+                                          uint8_t epnum, uint8_t ep_type)
+{
+  uint8_t idx;
+
+  if ((epnum & 0x80U) != 0U)
+  {
+    /* Find a new available physical in channel */
+    for (idx = 0U; idx < hhcd->Init.Host_channels; idx++)
+    {
+      if ((hhcd->phy_chin_state[idx] == 0U) &&   /* if PhysicalChannelx(EPCHidx) IN is Free */
+          ((((hhcd->phy_chout_state[idx] & 0x000FU) == ((uint16_t)ep_type + 1U)) && /* if  the same (EPCHidx) Channelx OUT is already opened check if the same type is allocated */
+            (((hhcd->phy_chout_state[idx] & 0x0F00U) == ((uint16_t)epnum & 0x0FU)))) || /* Check if the same Epnum is allocated then allocate the same physical channelOUT for IN Logical Channel */
+           (hhcd->phy_chout_state[idx] == 0U))) /* OR if  physical Channel OUT (EPCHidx)is free */
+      {
+        /* chin_state will store the ep_type to be used for the same channel in out direction */
+        hhcd->phy_chin_state[idx] = (((uint16_t)ch_num + 1U) << 4U) |
+                                    ((uint16_t)ep_type + 1U) | /* ep_type(0/1/2/3) so adding + 1 to avoid having a 0 value */
+                                    (((uint16_t)epnum & 0x0FU) << 8U);
+
+        return idx;
+      }
+    }
+  }
+  else
+  {
+    /* Find a new available physical out channel */
+    for (idx = 0U; idx < hhcd->Init.Host_channels; idx++)
+    {
+      /* if there is a free out channel and the same channel is used for the in direction then check if same ep_type used */
+      if ((hhcd->phy_chout_state[idx] == 0U) &&
+          ((((hhcd->phy_chin_state[idx] & 0x0FU) == ((uint16_t)ep_type + 1U)) &&
+            ((hhcd->phy_chin_state[idx] & 0x0F00U) == ((uint16_t)epnum & 0x0FU))) ||
+           (hhcd->phy_chin_state[idx] == 0U)))
+      {
+        /* chin_state will store the ep_type to be used for the same channel in out direction */
+        hhcd->phy_chout_state[idx] = (((uint16_t)ch_num + 1U) << 4U) |
+                                     ((uint16_t)ep_type + 1U) |  /* ep_type(0/1/2/3) so adding +1 to avoid having a 0 value */
+                                     (((uint16_t)epnum & 0x0FU) << 8U);
+
+        return idx;
+      }
+    }
+  }
+
+  /*in case of Error */
+  return HCD_FREE_CH_NOT_FOUND;
+}
+
+/**
+  * @brief  Free All Channel allocation
+  * @param  hhcd HCD handle
+  * @retval HAL status
+  */
+static void  HAL_HCD_ClearPhyChannel(HCD_HandleTypeDef *hhcd)
+{
+  uint8_t idx;
+
+  for (idx = 0U; idx < hhcd->Init.Host_channels; idx++)
+  {
+    /*Reset channel allocation value */
+    hhcd->phy_chout_state[idx] = 0U;
+    hhcd->phy_chin_state[idx] = 0U;
+  }
+}
+
+/*----------------------  PMA Allocation Section --------------------- */
+/*
+                __col31________________col0__   Column-- >
+          lin0 | entry31.|.......  | entry0 |   Line
+               |---------|---------|--------|    |
+          line1| entry63.|.......  | entry32|    |
+               |---------|---------|--------|   \|/
+               | entry127|.......  | entry64|
+               |---------|---------|--------|
+               | entry256|......   |entry128|
+                ----------------------------
+           an allocation space of 64byte need 8 Free contiguous Entry in the Matrix
+           - a Free Entry is a bit with 0 Value/  a busy entry is a bit with 1 value. */
+
+/**
+  * @brief  Fetch in the PMA_LockupTable free space of number of mps byte
+  * @param  hhcd  Host instance
+  * @param  mps  Channel Max Packet Size
+  * @retval PMA_Address of the first free block containing mps byte
+            0xFFFF in case of no space available
+  */
+static uint16_t HAL_HCD_GetFreePMA(HCD_HandleTypeDef *hhcd, uint16_t mps)
+{
+  uint32_t Entry, FreeBlocks = 0U;
+  uint8_t FirstFreeBlock_col = 0U, FirstFreeBlock_line = 0U;
+  uint8_t ColIndex;
+  uint16_t NbrReqBlocks;
+  uint16_t mps_t = mps;
+
+  /* since PMA buffer descriptor RXBD allocate address according to BLSIZE, BLSIZE=1==> mps>64
+    allocation in PMA is done in 32Bytes each entry */
+  if ((mps_t > 64U) && ((mps_t % 32U) != 0U))
+  {
+    /* Align the mps to 32byte block to match the allocation in PMA,
+      check Definition of allocation buffer memory in usb user spec */
+    mps_t = (uint16_t)(((mps_t / 32U) + 1U) * 32U);
+  }
+
+  /* calculate the number of block(8byte) to allocate */
+  NbrReqBlocks = mps_t / 8U;
+
+  /* check if we need remaining Block */
+  if ((mps_t % 8U) != 0U)
+  {
+    NbrReqBlocks++;
+  }
+
+  /* Look For NbrReqBlocks * Empty Block */
+  for (uint8_t i = 0U; ((i < PMA_BLOCKS) && (FreeBlocks != NbrReqBlocks)); i++)
+  {
+    Entry = hhcd->PMALookupTable[i];
+
+    /* when parse is in progress, check the first col to look for a contiguous block */
+    if ((FreeBlocks != 0U) && ((Entry & (uint32_t)1U) != 0U))
+    {
+      FreeBlocks = 0U;
+    }
+    uint8_t j = 0U;
+    while ((j <= 31U) && (FreeBlocks != NbrReqBlocks))
+    {
+      /* check if block j is free */
+      if ((Entry & ((uint32_t)1U << j)) == 0U)
+      {
+        if (FreeBlocks == 0U)
+        {
+          FirstFreeBlock_col = j;
+          FirstFreeBlock_line = i;
+          FreeBlocks++;
+        }
+        j++;
+
+        /* Parse Column PMALockTable */
+        while ((j <= 31U) && ((Entry & ((uint32_t)1U << j)) == 0U) && (FreeBlocks < NbrReqBlocks))
+        {
+          FreeBlocks++;
+          j++;
+        }
+
+        /* Free contiguous Blocks not found */
+        if (((FreeBlocks < NbrReqBlocks) && (j < 31U)) ||
+            ((j == 31U) && ((Entry & ((uint32_t)1U << j)) != 0U)))
+        {
+          FreeBlocks = 0U;
+        }
+      }
+      j++;
+    } /* end for j */
+  } /* end for i */
+
+  /* Free block found */
+  if (FreeBlocks >= NbrReqBlocks)
+  {
+    ColIndex = FirstFreeBlock_col;
+
+    for (uint8_t i = FirstFreeBlock_line; ((i < PMA_BLOCKS) && (FreeBlocks > 0U)); i++)
+    {
+      for (uint8_t j = ColIndex; j <= 31U; j++)
+      {
+        hhcd->PMALookupTable[i] |= ((uint32_t)1U << j);
+        if (--FreeBlocks == 0U)
+        {
+          break;
+        }
+      }
+      ColIndex = 0U;
+    }
+
+    return (uint16_t)((FirstFreeBlock_line * (uint16_t)256U) + (FirstFreeBlock_col * (uint16_t)8U));
+  }
+  else
+  {
+    return 0xFFFFU;
+  }
+}
+
+/**
+  * @brief  Allocate PMA buffer for Channel
+  *         This API will fetch a free space
+  * @param  hhcd    Host instance
+  * @param  ch_num  Channel number
+  * @param  ch_kind endpoint Kind
+  *                  USB_SNG_BUF Single Buffer used
+  *                  USB_DBL_BUF Double Buffer used
+  * @param  mps Channel Max Packet Size
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_HCD_PMAlloc(HCD_HandleTypeDef *hhcd, uint8_t  ch_num,
+                                   uint16_t ch_kind, uint16_t mps)
+{
+  uint16_t pma_addr0;
+  uint16_t pma_addr1; /* used for double buffer mode if enabled */
+
+  /* Host Channel */
+  HCD_HCTypeDef *hc = &(hhcd->hc[ch_num]);
+
+  /* Get a FreePMA Address */
+  pma_addr0 = HAL_HCD_GetFreePMA(hhcd, mps);
+
+  /* if there is no free space to allocate */
+  if (pma_addr0 == 0xFFFFU)
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Here we check if the endpoint is single or double Buffer */
+    if (ch_kind == HCD_SNG_BUF)
+    {
+      /* Single Buffer */
+      hc->doublebuffer = 0U;
+
+      /* Configure the PMA */
+      if (hc->ch_dir == CH_IN_DIR)
+      {
+        (USB_DRD_PMA_BUFF + hc->phy_ch_num)->RXBD = pma_addr0;
+      }
+      else
+      {
+        (USB_DRD_PMA_BUFF + hc->phy_ch_num)->TXBD = pma_addr0;
+      }
+
+      /* Set the Pmaaddress */
+      hc->pmaadress = pma_addr0;
+    }
+    else /* USB_DBL_BUF */
+    {
+      /* Double Buffer Endpoint */
+      hc->doublebuffer = 1U;
+
+      /* Get a FreePMA Address for buffer 2 */
+      pma_addr1 = HAL_HCD_GetFreePMA(hhcd, mps);
+
+      if (pma_addr1 == 0xFFFFU)
+      {
+        /* Free the first buffer */
+        (void)HAL_HCD_PMAFree(hhcd, pma_addr0, mps);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Configure the PMA */
+        hc->pmaaddr0 = (uint16_t)(pma_addr0);
+        hc->pmaaddr1 = (uint16_t)(pma_addr1);
+
+        /* Set Buffer0 pma address */
+        (USB_DRD_PMA_BUFF + hc->phy_ch_num)->TXBD = pma_addr0;
+
+        /* Set Buffer1 pma address */
+        (USB_DRD_PMA_BUFF + hc->phy_ch_num)->RXBD = pma_addr1;
+
+        /* Used for Bulk DB MPS < 64bytes */
+        if (hc->ch_dir == CH_IN_DIR)
+        {
+          hc->pmaadress = hc->pmaaddr1;
+        }
+        else
+        {
+          hc->pmaadress = hc->pmaaddr0;
+        }
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  PMA De-Allocation for Channel Free the reserved block in the PMA-LookupTable
+  * @param  hhcd  Host instance
+  * @param  ch_num Channel number
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_HCD_PMADeAlloc(HCD_HandleTypeDef *hhcd, uint8_t  ch_num)
+{
+  HAL_StatusTypeDef status;
+  uint8_t Err = 0U;
+
+  /* Host Channel */
+  HCD_HCTypeDef *hc = &(hhcd->hc[ch_num]);
+
+  /* Single Buffer */
+  if (hc->doublebuffer == 0U)
+  {
+    status = HAL_HCD_PMAFree(hhcd, hc->pmaadress, hc->max_packet);
+  }
+  else   /* Double buffer */
+  {
+    status = HAL_HCD_PMAFree(hhcd, hc->pmaaddr0, hc->max_packet);
+    if (status != HAL_OK)
+    {
+      Err++;
+    }
+
+    status = HAL_HCD_PMAFree(hhcd, hc->pmaaddr1, hc->max_packet);
+    if (status != HAL_OK)
+    {
+      Err++;
+    }
+
+    if (Err != 0U)
+    {
+      return HAL_ERROR;
+    }
+  }
+
+  return status;
+}
+
+
+/**
+  * @brief  PMA Reset
+  * @param  hhcd  Host instance
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_HCD_PMAReset(HCD_HandleTypeDef *hhcd)
+{
+  /* Reset All PMA Entry */
+  for (uint8_t i = 0U; i < PMA_BLOCKS; i++)
+  {
+    hhcd->PMALookupTable[i] = 0U;
+  }
+
+  /* Allocate a Space for buffer descriptor table depending on the Host channel number */
+  for (uint8_t i = 0U; i < hhcd->Init.Host_channels; i++)
+  {
+    hhcd->PMALookupTable[0] |= ((uint32_t)1U << i);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  PMA FRee
+  * @param  hhcd   Host instance
+  * @param  pma_base PMA base offset stored in hhcd->hc.pmaaddr
+  * @param  mps  Max Packet Size
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef  HAL_HCD_PMAFree(HCD_HandleTypeDef *hhcd, uint32_t pma_base, uint16_t mps)
+{
+  uint32_t block_nbr;
+  uint8_t ColIndex;
+  uint8_t LineIndex;
+  uint16_t mps_t = mps;
+
+  /* since PMA buffer descriptor RXBD allocate address according to BLSIZE, BLSIZE=1==> mps>64
+    allocation in PMA is done in 32Bytes each entry */
+  if ((mps_t > 64U) && ((mps_t % 32U) != 0U))
+  {
+    /* Align the mps to 32byte block to match the allocation in PMA,
+      check Definition of allocation buffer memory in usb user spec */
+    mps_t = (uint16_t)(((mps_t / 32U) + 1U) * 32U);
+  }
+
+  /* Calculate the number of needed block to Free */
+  if ((mps_t / 8U) != 0U)
+  {
+    block_nbr = ((uint32_t)mps_t / 8U);
+
+    if ((mps_t % 8U) != 0U)
+    {
+      block_nbr++;
+    }
+  }
+  else
+  {
+    block_nbr = 1U;
+  }
+
+  /* Decode Col/Line of PMA_Base position in the PMA_LookupTable */
+  if (pma_base > 256U)
+  {
+    LineIndex = (uint8_t)(pma_base / 256U);
+    ColIndex = (uint8_t)((pma_base - ((uint32_t)LineIndex * 256U)) / 8U);
+  }
+  else
+  {
+    LineIndex = 0U;
+    ColIndex = (uint8_t)(pma_base / 8U);
+  }
+
+  /* Reset the corresponding bit in the lookupTable */
+  for (uint8_t i = LineIndex; ((i < PMA_BLOCKS) && (block_nbr > 0U)); i++)
+  {
+    for (uint8_t j = ColIndex; j <= 31U; j++)
+    {
+      /* Check if the block is not already reserved or it was already closed */
+      if ((hhcd->PMALookupTable[i] & ((uint32_t)1U << j)) == 0U)
+      {
+        return HAL_ERROR;
+      }
+      /* Free the reserved block by resetting the corresponding bit */
+      hhcd->PMALookupTable[i] &= ~(1U << j);
+
+      if (--block_nbr == 0U)
+      {
+        break;
+      }
+    }
+    ColIndex = 0U;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_HCD_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_i2c_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_i2c_ex.c
@@ -272,6 +272,8 @@ HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp(I2C_HandleTypeDef *hi2c)
   *        can be enabled only by using I2C_FASTMODEPLUS_I2C1 parameter.
   * @note  For all I2C2 pins fast mode plus driving capability can be enabled
   *        only by using I2C_FASTMODEPLUS_I2C2 parameter.
+  * @note  For all I2C3 pins fast mode plus driving capability can be enabled
+  *        only by using I2C_FASTMODEPLUS_I2C3 parameter.
   * @retval None
   */
 void HAL_I2CEx_EnableFastModePlus(uint32_t ConfigFastModePlus)
@@ -297,6 +299,8 @@ void HAL_I2CEx_EnableFastModePlus(uint32_t ConfigFastModePlus)
   *        can be disabled only by using I2C_FASTMODEPLUS_I2C1 parameter.
   * @note  For all I2C2 pins fast mode plus driving capability can be disabled
   *        only by using I2C_FASTMODEPLUS_I2C2 parameter.
+  * @note  For all I2C3 pins fast mode plus driving capability can be disabled
+  *        only by using I2C_FASTMODEPLUS_I2C3 parameter.
   * @retval None
   */
 void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus)

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_i2s.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_i2s.c
@@ -90,6 +90,10 @@
      (+) Pause the DMA Transfer using HAL_I2S_DMAPause()
      (+) Resume the DMA Transfer using HAL_I2S_DMAResume()
      (+) Stop the DMA Transfer using HAL_I2S_DMAStop()
+         In Slave mode, if HAL_I2S_DMAStop is used to stop the communication, an error
+         HAL_I2S_ERROR_BUSY_LINE_RX is raised as the master continue to transmit data.
+         In this case __HAL_I2S_FLUSH_RX_DR macro must be used to flush the remaining data
+         inside DR register and avoid using DeInit/Init process for the next transfer.
 
    *** I2S HAL driver macros list ***
    ===================================
@@ -101,6 +105,7 @@
       (+) __HAL_I2S_ENABLE_IT : Enable the specified I2S interrupts
       (+) __HAL_I2S_DISABLE_IT : Disable the specified I2S interrupts
       (+) __HAL_I2S_GET_FLAG: Check whether the specified I2S flag is set or not
+      (+) __HAL_I2S_FLUSH_RX_DR: Read DR Register to Flush RX Data
 
     [..]
       (@) You can refer to the I2S HAL driver header file for more useful macros
@@ -115,13 +120,13 @@
           Use Functions HAL_I2S_RegisterCallback() to register an interrupt callback.
 
           Function HAL_I2S_RegisterCallback() allows to register following callbacks:
-            (+) TxCpltCallback        : I2S Tx Completed callback
-            (+) RxCpltCallback        : I2S Rx Completed callback
-            (+) TxHalfCpltCallback    : I2S Tx Half Completed callback
-            (+) RxHalfCpltCallback    : I2S Rx Half Completed callback
-            (+) ErrorCallback         : I2S Error callback
-            (+) MspInitCallback       : I2S Msp Init callback
-            (+) MspDeInitCallback     : I2S Msp DeInit callback
+            (++) TxCpltCallback        : I2S Tx Completed callback
+            (++) RxCpltCallback        : I2S Rx Completed callback
+            (++) TxHalfCpltCallback    : I2S Tx Half Completed callback
+            (++) RxHalfCpltCallback    : I2S Rx Half Completed callback
+            (++) ErrorCallback         : I2S Error callback
+            (++) MspInitCallback       : I2S Msp Init callback
+            (++) MspDeInitCallback     : I2S Msp DeInit callback
           This function takes as parameters the HAL peripheral handle, the Callback ID
           and a pointer to the user callback function.
 
@@ -131,14 +136,15 @@
           HAL_I2S_UnRegisterCallback takes as parameters the HAL peripheral handle,
           and the Callback ID.
           This function allows to reset following callbacks:
-            (+) TxCpltCallback        : I2S Tx Completed callback
-            (+) RxCpltCallback        : I2S Rx Completed callback
-            (+) TxHalfCpltCallback    : I2S Tx Half Completed callback
-            (+) RxHalfCpltCallback    : I2S Rx Half Completed callback
-            (+) ErrorCallback         : I2S Error callback
-            (+) MspInitCallback       : I2S Msp Init callback
-            (+) MspDeInitCallback     : I2S Msp DeInit callback
+            (++) TxCpltCallback        : I2S Tx Completed callback
+            (++) RxCpltCallback        : I2S Rx Completed callback
+            (++) TxHalfCpltCallback    : I2S Tx Half Completed callback
+            (++) RxHalfCpltCallback    : I2S Rx Half Completed callback
+            (++) ErrorCallback         : I2S Error callback
+            (++) MspInitCallback       : I2S Msp Init callback
+            (++) MspDeInitCallback     : I2S Msp DeInit callback
 
+       [..]
        By default, after the HAL_I2S_Init() and when the state is HAL_I2S_STATE_RESET
        all callbacks are set to the corresponding weak functions:
        examples HAL_I2S_MasterTxCpltCallback(), HAL_I2S_MasterRxCpltCallback().
@@ -148,6 +154,7 @@
        If MspInit or MspDeInit are not null, the HAL_I2S_Init()/ HAL_I2S_DeInit()
        keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
 
+       [..]
        Callbacks can be registered/unregistered in HAL_I2S_STATE_READY state only.
        Exception done MspInit/MspDeInit functions that can be registered/unregistered
        in HAL_I2S_STATE_READY or HAL_I2S_STATE_RESET state,
@@ -156,7 +163,8 @@
        using HAL_I2S_RegisterCallback() before calling HAL_I2S_DeInit()
        or HAL_I2S_Init() function.
 
-       When The compilation define USE_HAL_I2S_REGISTER_CALLBACKS is set to 0 or
+       [..]
+       When the compilation define USE_HAL_I2S_REGISTER_CALLBACKS is set to 0 or
        not defined, the callback registering feature is not available
        and weak (surcharged) callbacks are used.
 
@@ -192,6 +200,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+#define I2S_TIMEOUT_FLAG          100U         /*!< Timeout 100 ms            */
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
@@ -329,13 +338,25 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
     /* I2S standard */
     if (hi2s->Init.Standard <= I2S_STANDARD_LSB)
     {
-      /* In I2S standard packet lenght is multiplied by 2 */
+      /* In I2S standard packet length is multiplied by 2 */
       packetlength = packetlength * 2U;
     }
 
+#if defined (RCC_PERIPHCLK_I2S2)
+    if (hi2s->Instance == SPI1)
+    {
+      /* Get the source clock value: based on System Clock value */
+      i2sclk = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2S1);
+    }
+    else /* SPI2 case */
+    {
+      /* Get the source clock value: based on System Clock value */
+      i2sclk = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2S2);
+    }
+#else
     /* Get the source clock value: based on System Clock value */
     i2sclk = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2S1);
-
+#endif
     /* Compute the Real divider depending on the MCLK output state, with a floating point */
     if (hi2s->Init.MCLKOutput == I2S_MCLKOUTPUT_ENABLE)
     {
@@ -403,7 +424,7 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
     /* Write to SPIx I2SCFGR */
     SET_BIT(hi2s->Instance->I2SCFGR, SPI_I2SCFGR_ASTRTEN);
   }
-#endif
+#endif /* SPI_I2SCFGR_ASTRTEN */
 
   hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
   hi2s->State     = HAL_I2S_STATE_READY;
@@ -497,7 +518,8 @@ __weak void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID, pI2S_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_I2S_RegisterCallback(I2S_HandleTypeDef *hi2s, HAL_I2S_CallbackIDTypeDef CallbackID,
+                                           pI2S_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -822,7 +844,8 @@ HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uin
   }
 
   /* Check if Slave mode is selected */
-  if (((tmpreg_cfgr & SPI_I2SCFGR_I2SCFG) == I2S_MODE_SLAVE_TX) || ((tmpreg_cfgr & SPI_I2SCFGR_I2SCFG) == I2S_MODE_SLAVE_RX))
+  if (((tmpreg_cfgr & SPI_I2SCFGR_I2SCFG) == I2S_MODE_SLAVE_TX)
+      || ((tmpreg_cfgr & SPI_I2SCFGR_I2SCFG) == I2S_MODE_SLAVE_RX))
   {
     /* Wait until Busy flag is reset */
     if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_BSY, RESET, Timeout) != HAL_OK)
@@ -1131,7 +1154,10 @@ HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData,
   hi2s->hdmatx->XferErrorCallback = I2S_DMAError;
 
   /* Enable the Tx DMA Stream/Channel */
-  if (HAL_OK != HAL_DMA_Start_IT(hi2s->hdmatx, (uint32_t)hi2s->pTxBuffPtr, (uint32_t)&hi2s->Instance->DR, hi2s->TxXferSize))
+  if (HAL_OK != HAL_DMA_Start_IT(hi2s->hdmatx,
+                                 (uint32_t)hi2s->pTxBuffPtr,
+                                 (uint32_t)&hi2s->Instance->DR,
+                                 hi2s->TxXferSize))
   {
     /* Update SPI error code */
     SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_DMA);
@@ -1227,7 +1253,8 @@ HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
   }
 
   /* Enable the Rx DMA Stream/Channel */
-  if (HAL_OK != HAL_DMA_Start_IT(hi2s->hdmarx, (uint32_t)&hi2s->Instance->DR, (uint32_t)hi2s->pRxBuffPtr, hi2s->RxXferSize))
+  if (HAL_OK != HAL_DMA_Start_IT(hi2s->hdmarx, (uint32_t)&hi2s->Instance->DR, (uint32_t)hi2s->pRxBuffPtr,
+                                 hi2s->RxXferSize))
   {
     /* Update SPI error code */
     SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_DMA);
@@ -1341,34 +1368,85 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
      and the correspond call back is executed HAL_I2S_TxCpltCallback() or HAL_I2S_RxCpltCallback()
      */
 
-  /* Disable the I2S Tx/Rx DMA requests */
-  CLEAR_BIT(hi2s->Instance->CR2, SPI_CR2_TXDMAEN);
-  CLEAR_BIT(hi2s->Instance->CR2, SPI_CR2_RXDMAEN);
-
-  /* Abort the I2S DMA tx Stream/Channel */
-  if (hi2s->hdmatx != NULL)
+  if ((hi2s->Init.Mode == I2S_MODE_MASTER_TX) || (hi2s->Init.Mode == I2S_MODE_SLAVE_TX))
   {
-    /* Disable the I2S DMA tx Stream/Channel */
-    if (HAL_OK != HAL_DMA_Abort(hi2s->hdmatx))
+    /* Abort the I2S DMA tx Stream/Channel */
+    if (hi2s->hdmatx != NULL)
     {
-      SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_DMA);
-      errorcode = HAL_ERROR;
+      /* Disable the I2S DMA tx Stream/Channel */
+      if (HAL_OK != HAL_DMA_Abort(hi2s->hdmatx))
+      {
+        SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_DMA);
+        errorcode = HAL_ERROR;
+      }
     }
+
+    /* Wait until TXE flag is set */
+    if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_TXE, SET, I2S_TIMEOUT_FLAG) != HAL_OK)
+    {
+      /* Set the error code */
+      SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_TIMEOUT);
+      hi2s->State = HAL_I2S_STATE_READY;
+      errorcode   = HAL_ERROR;
+    }
+
+    /* Wait until BSY flag is Reset */
+    if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_BSY, RESET, I2S_TIMEOUT_FLAG) != HAL_OK)
+    {
+      /* Set the error code */
+      SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_TIMEOUT);
+      hi2s->State = HAL_I2S_STATE_READY;
+      errorcode   = HAL_ERROR;
+    }
+
+    /* Disable I2S peripheral */
+    __HAL_I2S_DISABLE(hi2s);
+
+    /* Clear UDR flag */
+    __HAL_I2S_CLEAR_UDRFLAG(hi2s);
+
+    /* Disable the I2S Tx DMA requests */
+    CLEAR_BIT(hi2s->Instance->CR2, SPI_CR2_TXDMAEN);
+
   }
 
-  /* Abort the I2S DMA rx Stream/Channel */
-  if (hi2s->hdmarx != NULL)
+  else if ((hi2s->Init.Mode == I2S_MODE_MASTER_RX) || (hi2s->Init.Mode == I2S_MODE_SLAVE_RX))
   {
-    /* Disable the I2S DMA rx Stream/Channel */
-    if (HAL_OK != HAL_DMA_Abort(hi2s->hdmarx))
+    /* Abort the I2S DMA rx Stream/Channel */
+    if (hi2s->hdmarx != NULL)
     {
-      SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_DMA);
+      /* Disable the I2S DMA rx Stream/Channel */
+      if (HAL_OK != HAL_DMA_Abort(hi2s->hdmarx))
+      {
+        SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_DMA);
+        errorcode = HAL_ERROR;
+      }
+    }
+
+    /* Disable I2S peripheral */
+    __HAL_I2S_DISABLE(hi2s);
+
+    /* Clear OVR flag */
+    __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+
+    /* Disable the I2S Rx DMA request */
+    CLEAR_BIT(hi2s->Instance->CR2, SPI_CR2_RXDMAEN);
+
+    if (hi2s->Init.Mode == I2S_MODE_SLAVE_RX)
+    {
+      /* Set the error code */
+      SET_BIT(hi2s->ErrorCode, HAL_I2S_ERROR_BUSY_LINE_RX);
+
+      /* Set the I2S State ready */
+      hi2s->State = HAL_I2S_STATE_READY;
       errorcode = HAL_ERROR;
     }
+    else
+    {
+      /* Read DR to Flush RX Data */
+      READ_REG((hi2s->Instance)->DR);
+    }
   }
-
-  /* Disable I2S peripheral */
-  __HAL_I2S_DISABLE(hi2s);
 
   hi2s->State = HAL_I2S_STATE_READY;
 
@@ -1748,7 +1826,8 @@ static void I2S_Receive_IT(I2S_HandleTypeDef *hi2s)
   * @param  Timeout Duration of the timeout
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, FlagStatus State, uint32_t Timeout)
+static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, FlagStatus State,
+                                                       uint32_t Timeout)
 {
   uint32_t tickstart;
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_irda.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_irda.c
@@ -815,7 +815,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, u
       return  HAL_ERROR;
     }
 
-    /* In case of 9bits/No Parity transfer, pData buffer provided as input paramter
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
        should be aligned on a u16 frontier, as data to be filled into TDR will be
        handled through a u16 cast. */
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
@@ -832,7 +832,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, u
     hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
     hirda->gState = HAL_IRDA_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     hirda->TxXferSize = Size;
@@ -922,7 +922,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, ui
       return  HAL_ERROR;
     }
 
-    /* In case of 9bits/No Parity transfer, pData buffer provided as input paramter
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
        should be aligned on a u16 frontier, as data to be received from RDR will be
        handled through a u16 cast. */
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
@@ -939,7 +939,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, ui
     hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
     hirda->RxState = HAL_IRDA_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     hirda->RxXferSize = Size;
@@ -1024,7 +1024,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData
       return HAL_ERROR;
     }
 
-    /* In case of 9bits/No Parity transfer, pData buffer provided as input paramter
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
        should be aligned on a u16 frontier, as data to be filled into TDR will be
        handled through a u16 cast. */
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
@@ -1086,7 +1086,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData,
       return HAL_ERROR;
     }
 
-    /* In case of 9bits/No Parity transfer, pData buffer provided as input paramter
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
        should be aligned on a u16 frontier, as data to be received from RDR will be
        handled through a u16 cast. */
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
@@ -1155,7 +1155,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pDat
       return HAL_ERROR;
     }
 
-    /* In case of 9bits/No Parity transfer, pData buffer provided as input paramter
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
        should be aligned on a u16 frontier, as data copy into TDR will be
        handled by DMA from a u16 frontier. */
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
@@ -1252,7 +1252,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData
       return HAL_ERROR;
     }
 
-    /* In case of 9bits/No Parity transfer, pData buffer provided as input paramter
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
        should be aligned on a u16 frontier, as data copy from RDR will be
        handled by DMA from a u16 frontier. */
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
@@ -1382,7 +1382,7 @@ HAL_StatusTypeDef HAL_IRDA_DMAResume(IRDA_HandleTypeDef *hirda)
     /* Clear the Overrun flag before resuming the Rx transfer*/
     __HAL_IRDA_CLEAR_OREFLAG(hirda);
 
-    /* Reenable PE and ERR (Frame error, noise error, overrun error) interrupts */
+    /* Re-enable PE and ERR (Frame error, noise error, overrun error) interrupts */
     SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE);
     SET_BIT(hirda->Instance->CR3, USART_CR3_EIE);
 
@@ -2420,7 +2420,7 @@ static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda)
   /* Initialize the IRDA ErrorCode */
   hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Check if the Transmitter is enabled */

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_iwdg.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_iwdg.c
@@ -16,33 +16,43 @@
     (+) The IWDG can be started by either software or hardware (configurable
         through option byte).
 
-    (+) The IWDG is clocked by Low-Speed clock (LSI) and thus stays active even
-        if the main clock fails.
+    (+) The IWDG is clocked by the Low-Speed Internal clock (LSI) and thus stays
+        active even if the main clock fails.
 
-    (+) Once the IWDG is started, the LSI is forced ON and both can not be
+    (+) Once the IWDG is started, the LSI is forced ON and both cannot be
         disabled. The counter starts counting down from the reset value (0xFFF).
         When it reaches the end of count value (0x000) a reset signal is
         generated (IWDG reset).
 
     (+) Whenever the key value 0x0000 AAAA is written in the IWDG_KR register,
-        the IWDG_RLR value is reloaded in the counter and the watchdog reset is
-        prevented.
+        the IWDG_RLR value is reloaded into the counter and the watchdog reset
+        is prevented.
 
     (+) The IWDG is implemented in the VDD voltage domain that is still functional
-        in STOP and STANDBY mode (IWDG reset can wake-up from STANDBY).
+        in STOP and STANDBY mode (IWDG reset can wake up the CPU from STANDBY).
         IWDGRST flag in RCC_CSR register can be used to inform when an IWDG
         reset occurs.
 
-    (+) Debug mode : When the microcontroller enters debug mode (core halted),
+    (+) Debug mode: When the microcontroller enters debug mode (core halted),
         the IWDG counter either continues to work normally or stops, depending
         on DBG_IWDG_STOP configuration bit in DBG module, accessible through
         __HAL_DBGMCU_FREEZE_IWDG() and __HAL_DBGMCU_UNFREEZE_IWDG() macros.
 
     [..] Min-max timeout value @32KHz (LSI): ~125us / ~32.7s
-         The IWDG timeout may vary due to LSI frequency dispersion. STM32G0xx
-         devices provide the capability to measure the LSI frequency (LSI clock
-         connected internally to TIM16 CH1 input capture). The measured value
-         can be used to have an IWDG timeout with an acceptable accuracy.
+         The IWDG timeout may vary due to LSI clock frequency dispersion.
+         STM32G0xx devices provide the capability to measure the LSI clock
+         frequency (LSI clock is internally connected to TIM16 CH1 input capture).
+         The measured value can be used to have an IWDG timeout with an
+         acceptable accuracy.
+
+    [..] Default timeout value (necessary for IWDG_SR status register update):
+         Constant LSI_VALUE is defined based on the nominal LSI clock frequency.
+         This frequency being subject to variations as mentioned above, the
+         default timeout value (defined through constant HAL_IWDG_DEFAULT_TIMEOUT
+         below) may become too short or too long.
+         In such cases, this default timeout value can be tuned by redefining
+         the constant LSI_VALUE at user-application level (based, for instance,
+         on the measured LSI clock frequency as explained above).
 
                      ##### How to use this driver #####
   ==============================================================================
@@ -108,10 +118,14 @@
 /** @defgroup IWDG_Private_Defines IWDG Private Defines
   * @{
   */
-/* Status register need 5 RC LSI divided by prescaler clock to be updated. With
-   higher prescaler (256), and according to LSI variation, we need to wait at
-   least 6 cycles so 48 ms. */
-#define HAL_IWDG_DEFAULT_TIMEOUT            48u
+/* Status register needs up to 5 LSI clock periods divided by the clock
+   prescaler to be updated. The number of LSI clock periods is upper-rounded to
+   6 for the timeout value calculation.
+   The timeout value is also calculated using the highest prescaler (256) and
+   the LSI_VALUE constant. The value of this constant can be changed by the user
+   to take into account possible LSI clock period variations.
+   The timeout value is multiplied by 1000 to be converted in milliseconds. */
+#define HAL_IWDG_DEFAULT_TIMEOUT ((6UL * 256UL * 1000UL) / LSI_VALUE)
 /**
   * @}
   */
@@ -126,8 +140,8 @@
   */
 
 /** @addtogroup IWDG_Exported_Functions_Group1
- *  @brief    Initialization and Start functions.
- *
+  *  @brief    Initialization and Start functions.
+  *
 @verbatim
  ===============================================================================
           ##### Initialization and Start functions #####
@@ -215,8 +229,8 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
 
 
 /** @addtogroup IWDG_Exported_Functions_Group2
- *  @brief   IO operation functions
- *
+  *  @brief   IO operation functions
+  *
 @verbatim
  ===============================================================================
                       ##### IO operation functions #####

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_lptim.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_lptim.c
@@ -31,7 +31,7 @@
          (++) The instance: LPTIM1 or LPTIM2.
          (++) Clock: the counter clock.
              (+++) Source   : it can be either the ULPTIM input (IN1) or one of
-                              the internal clock; (APB, LSE, LSI or HSI).
+                              the internal clock; (APB, LSE, LSI or MSI).
              (+++) Prescaler: select the clock divider.
          (++)  UltraLowPowerClock : To be used only if the ULPTIM is selected
                as counter clock source.
@@ -152,6 +152,7 @@
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
   *                        opensource.org/licenses/BSD-3-Clause
+  *
   ******************************************************************************
   */
 
@@ -173,12 +174,39 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @addtogroup LPTIM_Private_Constants
+  * @{
+  */
+#define TIMEOUT                                     1000UL /* Timeout is 1s */
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
+/** @addtogroup LPTIM_Private_Macros
+  * @{
+  */
+#if defined(LPTIM2)
+#define __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(__INSTANCE__) \
+     (((__INSTANCE__) == LPTIM1) ? __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT() : __HAL_LPTIM_LPTIM2_EXTI_ENABLE_IT())
+
+#define __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(__INSTANCE__) \
+     (((__INSTANCE__) == LPTIM1) ? __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT() : __HAL_LPTIM_LPTIM2_EXTI_DISABLE_IT())
+#else
+#define __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(__INSTANCE__) __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT()
+
+#define __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(__INSTANCE__) __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT()
+#endif /* LPTIM2 */
+/**
+  * @}
+  */
+
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
 static void LPTIM_ResetCallback(LPTIM_HandleTypeDef *lptim);
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
+static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t flag);
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -215,7 +243,7 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
   uint32_t tmpcfgr;
 
   /* Check the LPTIM handle allocation */
-  if(hlptim == NULL)
+  if (hlptim == NULL)
   {
     return HAL_ERROR;
   }
@@ -225,22 +253,25 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
 
   assert_param(IS_LPTIM_CLOCK_SOURCE(hlptim->Init.Clock.Source));
   assert_param(IS_LPTIM_CLOCK_PRESCALER(hlptim->Init.Clock.Prescaler));
-  if ((hlptim->Init.Clock.Source) ==  LPTIM_CLOCKSOURCE_ULPTIM)
+  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
   {
     assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
-    assert_param(IS_LPTIM_CLOCK_SAMPLE_TIME(hlptim->Init.UltraLowPowerClock.SampleTime));
   }
   assert_param(IS_LPTIM_TRG_SOURCE(hlptim->Init.Trigger.Source));
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if (hlptim->Init.Trigger.Source != LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    assert_param(IS_LPTIM_EXT_TRG_POLARITY(hlptim->Init.Trigger.ActiveEdge));
+  }
+  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC)
   {
     assert_param(IS_LPTIM_TRIG_SAMPLE_TIME(hlptim->Init.Trigger.SampleTime));
-    assert_param(IS_LPTIM_EXT_TRG_POLARITY(hlptim->Init.Trigger.ActiveEdge));
+    assert_param(IS_LPTIM_CLOCK_SAMPLE_TIME(hlptim->Init.UltraLowPowerClock.SampleTime));
   }
   assert_param(IS_LPTIM_OUTPUT_POLARITY(hlptim->Init.OutputPolarity));
   assert_param(IS_LPTIM_UPDATE_MODE(hlptim->Init.UpdateMode));
   assert_param(IS_LPTIM_COUNTER_SOURCE(hlptim->Init.CounterSource));
 
-  if(hlptim->State == HAL_LPTIM_STATE_RESET)
+  if (hlptim->State == HAL_LPTIM_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
     hlptim->Lock = HAL_UNLOCKED;
@@ -249,7 +280,7 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
     /* Reset interrupt callbacks to legacy weak callbacks */
     LPTIM_ResetCallback(hlptim);
 
-    if(hlptim->MspInitCallback == NULL)
+    if (hlptim->MspInitCallback == NULL)
     {
       hlptim->MspInitCallback = HAL_LPTIM_MspInit;
     }
@@ -268,18 +299,22 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
   /* Get the LPTIMx CFGR value */
   tmpcfgr = hlptim->Instance->CFGR;
 
-  if (((hlptim->Init.Clock.Source) == LPTIM_CLOCKSOURCE_ULPTIM) || ((hlptim->Init.CounterSource) == LPTIM_COUNTERSOURCE_EXTERNAL))
+  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
   {
-    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKPOL | LPTIM_CFGR_CKFLT));
+    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKPOL));
   }
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if (hlptim->Init.Trigger.Source != LPTIM_TRIGSOURCE_SOFTWARE)
   {
-    tmpcfgr &= (uint32_t)(~ (LPTIM_CFGR_TRGFLT | LPTIM_CFGR_TRIGSEL));
+    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_TRIGSEL));
+  }
+  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC)
+  {
+    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_TRGFLT | LPTIM_CFGR_CKFLT));
   }
 
   /* Clear CKSEL, CKPOL, PRESC, TRIGEN, TRGFLT, WAVPOL, PRELOAD & COUNTMODE bits */
   tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKSEL | LPTIM_CFGR_CKPOL | LPTIM_CFGR_TRIGEN | LPTIM_CFGR_PRELOAD |
-                          LPTIM_CFGR_WAVPOL | LPTIM_CFGR_PRESC | LPTIM_CFGR_COUNTMODE ));
+                          LPTIM_CFGR_WAVPOL | LPTIM_CFGR_PRESC | LPTIM_CFGR_COUNTMODE));
 
   /* Set initialization parameters */
   tmpcfgr |= (hlptim->Init.Clock.Source    |
@@ -288,29 +323,39 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
               hlptim->Init.UpdateMode      |
               hlptim->Init.CounterSource);
 
-  if (((hlptim->Init.Clock.Source) == LPTIM_CLOCKSOURCE_ULPTIM) || ((hlptim->Init.CounterSource) == LPTIM_COUNTERSOURCE_EXTERNAL))
+  /* Glitch filters for internal triggers and  external inputs are configured
+   * only if an internal clock source is provided to the LPTIM
+   */
+  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC)
   {
-    tmpcfgr |=  (hlptim->Init.UltraLowPowerClock.Polarity |
+    tmpcfgr |= (hlptim->Init.Trigger.SampleTime |
                 hlptim->Init.UltraLowPowerClock.SampleTime);
   }
 
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  /* Configure the active edge or edges used by the counter only if LPTIM is
+   * clocked by an external clock source
+   */
+  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+  {
+    tmpcfgr |= (hlptim->Init.UltraLowPowerClock.Polarity);
+  }
+
+  if (hlptim->Init.Trigger.Source != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Enable External trigger and set the trigger source */
-    tmpcfgr |= (hlptim->Init.Trigger.Source     |
-                hlptim->Init.Trigger.ActiveEdge |
-                hlptim->Init.Trigger.SampleTime);
+    tmpcfgr |= (hlptim->Init.Trigger.Source |
+                hlptim->Init.Trigger.ActiveEdge);
   }
 
   /* Write to LPTIMx CFGR */
   hlptim->Instance->CFGR = tmpcfgr;
 
   /* Configure LPTIM input sources */
-  if(hlptim->Instance == LPTIM1)
+  if (hlptim->Instance == LPTIM1)
   {
     /* Check LPTIM Input1 and Input2 sources */
-    assert_param(IS_LPTIM_INPUT1_SOURCE(hlptim->Instance,hlptim->Init.Input1Source));
-    assert_param(IS_LPTIM_INPUT2_SOURCE(hlptim->Instance,hlptim->Init.Input2Source));
+    assert_param(IS_LPTIM_INPUT1_SOURCE(hlptim->Instance, hlptim->Init.Input1Source));
+    assert_param(IS_LPTIM_INPUT2_SOURCE(hlptim->Instance, hlptim->Init.Input2Source));
 
     /* Configure LPTIM Input1 and Input2 sources */
     hlptim->Instance->CFGR2 = (hlptim->Init.Input1Source | hlptim->Init.Input2Source);
@@ -318,7 +363,7 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
   else
   {
     /* Check LPTIM2 Input1 source */
-    assert_param(IS_LPTIM_INPUT1_SOURCE(hlptim->Instance,hlptim->Init.Input1Source));
+    assert_param(IS_LPTIM_INPUT1_SOURCE(hlptim->Instance, hlptim->Init.Input1Source));
 
     /* Configure LPTIM2 Input1 source */
     hlptim->Instance->CFGR2 = hlptim->Init.Input1Source;
@@ -339,7 +384,7 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
 HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim)
 {
   /* Check the LPTIM handle allocation */
-  if(hlptim == NULL)
+  if (hlptim == NULL)
   {
     return HAL_ERROR;
   }
@@ -350,8 +395,13 @@ HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim)
   /* Disable the LPTIM Peripheral Clock */
   __HAL_LPTIM_DISABLE(hlptim);
 
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
-  if(hlptim->MspDeInitCallback == NULL)
+  if (hlptim->MspDeInitCallback == NULL)
   {
     hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;
   }
@@ -450,7 +500,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Peri
   assert_param(IS_LPTIM_PULSE(Pulse));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Reset WAVE bit to set PWM mode */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
@@ -458,17 +508,35 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Peri
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
   /* Load the period value in the autoreload register */
   __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
 
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
   /* Load the pulse value in the compare register */
   __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -485,13 +553,18 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
 
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -514,10 +587,45 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t P
   assert_param(IS_LPTIM_PULSE(Pulse));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Reset WAVE bit to set PWM mode */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Enable Autoreload write complete interrupt */
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_ARROK);
@@ -532,7 +640,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t P
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* If external trigger source is used, then enable external trigger interrupt */
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if ((hlptim->Init.Trigger.Source) != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Enable external trigger interrupt */
     __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
@@ -541,17 +649,11 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t P
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
-  /* Load the period value in the autoreload register */
-  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
-
-  /* Load the pulse value in the compare register */
-  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
-
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -568,12 +670,17 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
 
-    /* Disable Autoreload write complete interrupt */
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Disable Autoreload write complete interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_ARROK);
 
   /* Disable Compare write complete interrupt */
@@ -586,14 +693,14 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* If external trigger source is used, then disable external trigger interrupt */
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if ((hlptim->Init.Trigger.Source) != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Disable external trigger interrupt */
     __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
   }
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -616,7 +723,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start(LPTIM_HandleTypeDef *hlptim, uint32_t
   assert_param(IS_LPTIM_PULSE(Pulse));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Reset WAVE bit to set one pulse mode */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
@@ -624,17 +731,35 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start(LPTIM_HandleTypeDef *hlptim, uint32_t
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
   /* Load the period value in the autoreload register */
   __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
 
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
   /* Load the pulse value in the compare register */
   __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -651,13 +776,18 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
 
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -680,10 +810,45 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start_IT(LPTIM_HandleTypeDef *hlptim, uint3
   assert_param(IS_LPTIM_PULSE(Pulse));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Reset WAVE bit to set one pulse mode */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Enable Autoreload write complete interrupt */
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_ARROK);
@@ -698,7 +863,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start_IT(LPTIM_HandleTypeDef *hlptim, uint3
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* If external trigger source is used, then enable external trigger interrupt */
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if ((hlptim->Init.Trigger.Source) != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Enable external trigger interrupt */
     __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
@@ -707,17 +872,11 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start_IT(LPTIM_HandleTypeDef *hlptim, uint3
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
-  /* Load the period value in the autoreload register */
-  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
-
-  /* Load the pulse value in the compare register */
-  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
-
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -734,10 +893,15 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Disable Autoreload write complete interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_ARROK);
@@ -752,14 +916,14 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* If external trigger source is used, then disable external trigger interrupt */
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if ((hlptim->Init.Trigger.Source) != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Disable external trigger interrupt */
     __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
   }
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -782,7 +946,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   assert_param(IS_LPTIM_PULSE(Pulse));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Set WAVE bit to enable the set once mode */
   hlptim->Instance->CFGR |= LPTIM_CFGR_WAVE;
@@ -790,17 +954,35 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
   /* Load the period value in the autoreload register */
   __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
 
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
   /* Load the pulse value in the compare register */
   __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -817,13 +999,18 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
 
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -846,10 +1033,45 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   assert_param(IS_LPTIM_PULSE(Pulse));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Set WAVE bit to enable the set once mode */
   hlptim->Instance->CFGR |= LPTIM_CFGR_WAVE;
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Enable Autoreload write complete interrupt */
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_ARROK);
@@ -864,7 +1086,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* If external trigger source is used, then enable external trigger interrupt */
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if ((hlptim->Init.Trigger.Source) != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Enable external trigger interrupt */
     __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
@@ -873,17 +1095,11 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
-  /* Load the period value in the autoreload register */
-  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
-
-  /* Load the pulse value in the compare register */
-  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
-
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -900,10 +1116,15 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Disable Autoreload write complete interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_ARROK);
@@ -918,14 +1139,14 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* If external trigger source is used, then disable external trigger interrupt */
-  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  if ((hlptim->Init.Trigger.Source) != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Disable external trigger interrupt */
     __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
   }
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -949,35 +1170,44 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   assert_param(hlptim->Init.Clock.Prescaler == LPTIM_PRESCALER_DIV1);
   assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
 
-    /* Set the LPTIM state */
-    hlptim->State= HAL_LPTIM_STATE_BUSY;
+  /* Set the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
-    /* Get the LPTIMx CFGR value */
-    tmpcfgr = hlptim->Instance->CFGR;
+  /* Get the LPTIMx CFGR value */
+  tmpcfgr = hlptim->Instance->CFGR;
 
-    /* Clear CKPOL bits */
-    tmpcfgr &= (uint32_t)(~LPTIM_CFGR_CKPOL);
+  /* Clear CKPOL bits */
+  tmpcfgr &= (uint32_t)(~LPTIM_CFGR_CKPOL);
 
-    /* Set Input polarity */
-    tmpcfgr |=  hlptim->Init.UltraLowPowerClock.Polarity;
+  /* Set Input polarity */
+  tmpcfgr |=  hlptim->Init.UltraLowPowerClock.Polarity;
 
-    /* Write to LPTIMx CFGR */
-    hlptim->Instance->CFGR = tmpcfgr;
+  /* Write to LPTIMx CFGR */
+  hlptim->Instance->CFGR = tmpcfgr;
 
-    /* Set ENC bit to enable the encoder interface */
-    hlptim->Instance->CFGR |= LPTIM_CFGR_ENC;
+  /* Set ENC bit to enable the encoder interface */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_ENC;
 
-    /* Enable the Peripheral */
-    __HAL_LPTIM_ENABLE(hlptim);
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
 
-    /* Load the period value in the autoreload register */
-    __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
 
-    /* Start timer in continuous mode */
-    __HAL_LPTIM_START_CONTINUOUS(hlptim);
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
 
-    /* Change the TIM state*/
-    hlptim->State= HAL_LPTIM_STATE_READY;
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+
+  /* Change the TIM state*/
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -994,16 +1224,21 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_ENCODER_INTERFACE_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Reset ENC bit to disable the encoder interface */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_ENC;
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1027,42 +1262,62 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   assert_param(hlptim->Init.Clock.Prescaler == LPTIM_PRESCALER_DIV1);
   assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
 
-    /* Set the LPTIM state */
-    hlptim->State= HAL_LPTIM_STATE_BUSY;
+  /* Set the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
-    /* Configure edge sensitivity for encoder mode */
-    /* Get the LPTIMx CFGR value */
-    tmpcfgr = hlptim->Instance->CFGR;
+  /* Configure edge sensitivity for encoder mode */
+  /* Get the LPTIMx CFGR value */
+  tmpcfgr = hlptim->Instance->CFGR;
 
-    /* Clear CKPOL bits */
-    tmpcfgr &= (uint32_t)(~LPTIM_CFGR_CKPOL);
+  /* Clear CKPOL bits */
+  tmpcfgr &= (uint32_t)(~LPTIM_CFGR_CKPOL);
 
-    /* Set Input polarity */
-    tmpcfgr |=  hlptim->Init.UltraLowPowerClock.Polarity;
+  /* Set Input polarity */
+  tmpcfgr |=  hlptim->Init.UltraLowPowerClock.Polarity;
 
-    /* Write to LPTIMx CFGR */
-    hlptim->Instance->CFGR = tmpcfgr;
+  /* Write to LPTIMx CFGR */
+  hlptim->Instance->CFGR = tmpcfgr;
 
-    /* Set ENC bit to enable the encoder interface */
-    hlptim->Instance->CFGR |= LPTIM_CFGR_ENC;
+  /* Set ENC bit to enable the encoder interface */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_ENC;
 
-    /* Enable "switch to down direction" interrupt */
-    __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_DOWN);
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
 
-    /* Enable "switch to up direction" interrupt */
-    __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_UP);
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
 
-    /* Enable the Peripheral */
-    __HAL_LPTIM_ENABLE(hlptim);
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
 
-    /* Load the period value in the autoreload register */
-    __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
-    /* Start timer in continuous mode */
-    __HAL_LPTIM_START_CONTINUOUS(hlptim);
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
 
-    /* Change the TIM state*/
-    hlptim->State= HAL_LPTIM_STATE_READY;
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Enable "switch to down direction" interrupt */
+  __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_DOWN);
+
+  /* Enable "switch to up direction" interrupt */
+  __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_UP);
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+
+  /* Change the TIM state*/
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1079,10 +1334,15 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_ENCODER_INTERFACE_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Reset ENC bit to disable the encoder interface */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_ENC;
@@ -1094,7 +1354,7 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_UP);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1119,7 +1379,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   assert_param(IS_LPTIM_PULSE(Timeout));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Set TIMOUT bit to enable the timeout function */
   hlptim->Instance->CFGR |= LPTIM_CFGR_TIMOUT;
@@ -1127,17 +1387,35 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
   /* Load the period value in the autoreload register */
   __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
 
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
   /* Load the Timeout value in the compare register */
   __HAL_LPTIM_COMPARE_SET(hlptim, Timeout);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1154,16 +1432,21 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Reset TIMOUT bit to enable the timeout function */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_TIMOUT;
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1188,10 +1471,48 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   assert_param(IS_LPTIM_PULSE(Timeout));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
+
+  /* Enable EXTI Line interrupt on the LPTIM Wake-up Timer */
+  __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(hlptim->Instance);
 
   /* Set TIMOUT bit to enable the timeout function */
   hlptim->Instance->CFGR |= LPTIM_CFGR_TIMOUT;
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+
+  /* Load the Timeout value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Timeout);
+
+  /* Wait for the completion of the write operation to the LPTIM_CMP register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Enable Compare match interrupt */
   __HAL_LPTIM_ENABLE_IT(hlptim, LPTIM_IT_CMPM);
@@ -1199,17 +1520,11 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
-  /* Load the period value in the autoreload register */
-  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
-
-  /* Load the Timeout value in the compare register */
-  __HAL_LPTIM_COMPARE_SET(hlptim, Timeout);
-
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1226,10 +1541,18 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
+
+  /* Disable EXTI Line interrupt on the LPTIM Wake-up Timer */
+  __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(hlptim->Instance);
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Reset TIMOUT bit to enable the timeout function */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_TIMOUT;
@@ -1238,7 +1561,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_CMPM);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1258,10 +1581,10 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   assert_param(IS_LPTIM_PERIOD(Period));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* If clock source is not ULPTIM clock and counter source is external, then it must not be prescaled */
-  if((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
+  if ((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
     /* Check if clock is prescaled */
     assert_param(IS_LPTIM_CLOCK_PRESCALERDIV1(hlptim->Init.Clock.Prescaler));
@@ -1272,14 +1595,23 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
   /* Load the period value in the autoreload register */
   __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1296,13 +1628,18 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
 
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1322,15 +1659,41 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   assert_param(IS_LPTIM_PERIOD(Period));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
+
+  /* Enable EXTI Line interrupt on the LPTIM Wake-up Timer */
+  __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(hlptim->Instance);
 
   /* If clock source is not ULPTIM clock and counter source is external, then it must not be prescaled */
-  if((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
+  if ((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
     /* Check if clock is prescaled */
     assert_param(IS_LPTIM_CLOCK_PRESCALERDIV1(hlptim->Init.Clock.Prescaler));
     /* Set clock prescaler to 0 */
     hlptim->Instance->CFGR &= ~LPTIM_CFGR_PRESC;
+  }
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+
+  /* Clear flag */
+  __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+
+  /* Wait for the completion of the write operation to the LPTIM_ARR register */
+  if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
   }
 
   /* Enable Autoreload write complete interrupt */
@@ -1342,14 +1705,11 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Enable the Peripheral */
   __HAL_LPTIM_ENABLE(hlptim);
 
-  /* Load the period value in the autoreload register */
-  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
-
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1366,19 +1726,26 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   /* Set the LPTIM state */
-  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
+
+  /* Disable EXTI Line interrupt on the LPTIM Wake-up Timer */
+  __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(hlptim->Instance);
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
+
+  if (HAL_LPTIM_GetState(hlptim) == HAL_LPTIM_STATE_TIMEOUT)
+  {
+    return HAL_TIMEOUT;
+  }
 
   /* Disable Autoreload write complete interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_ARROK);
 
   /* Disable Autoreload match interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_ARRM);
-
   /* Change the TIM state*/
-  hlptim->State= HAL_LPTIM_STATE_READY;
+  hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -1410,7 +1777,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   */
 uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim)
 {
-    /* Check the parameters */
+  /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   return (hlptim->Instance->CNT);
@@ -1423,7 +1790,7 @@ uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim)
   */
 uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim)
 {
-    /* Check the parameters */
+  /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   return (hlptim->Instance->ARR);
@@ -1436,7 +1803,7 @@ uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim)
   */
 uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim)
 {
-    /* Check the parameters */
+  /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
   return (hlptim->Instance->CMP);
@@ -1445,8 +1812,6 @@ uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim)
 /**
   * @}
   */
-
-
 
 /** @defgroup LPTIM_Exported_Functions_Group4 LPTIM IRQ handler and callbacks
  *  @brief  LPTIM  IRQ handler.
@@ -1478,16 +1843,16 @@ uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim)
 void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
 {
   /* Compare match interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_CMPM) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_CMPM) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_CMPM) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_CMPM) != RESET)
     {
       /* Clear Compare match flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPM);
 
       /* Compare match Callback */
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
-          hlptim->CompareMatchCallback(hlptim);
+      hlptim->CompareMatchCallback(hlptim);
 #else
       HAL_LPTIM_CompareMatchCallback(hlptim);
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
@@ -1495,9 +1860,9 @@ void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
   }
 
   /* Autoreload match interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_ARRM) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_ARRM) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_ARRM) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_ARRM) != RESET)
     {
       /* Clear Autoreload match flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARRM);
@@ -1512,9 +1877,9 @@ void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
   }
 
   /* Trigger detected interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_EXTTRIG) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_EXTTRIG) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_EXTTRIG) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_EXTTRIG) != RESET)
     {
       /* Clear Trigger detected flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_EXTTRIG);
@@ -1529,9 +1894,9 @@ void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
   }
 
   /* Compare write interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_CMPOK) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_CMPOK) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_CMPOK) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_CMPOK) != RESET)
     {
       /* Clear Compare write flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
@@ -1546,9 +1911,9 @@ void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
   }
 
   /* Autoreload write interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_ARROK) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_ARROK) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_ARROK) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_ARROK) != RESET)
     {
       /* Clear Autoreload write flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
@@ -1563,9 +1928,9 @@ void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
   }
 
   /* Direction counter changed from Down to Up interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_UP) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_UP) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_UP) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_UP) != RESET)
     {
       /* Clear Direction counter changed from Down to Up flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_UP);
@@ -1580,9 +1945,9 @@ void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
   }
 
   /* Direction counter changed from Up to Down interrupt */
-  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_DOWN) != RESET)
+  if (__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_DOWN) != RESET)
   {
-    if(__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_DOWN) != RESET)
+    if (__HAL_LPTIM_GET_IT_SOURCE(hlptim, LPTIM_IT_DOWN) != RESET)
     {
       /* Clear Direction counter changed from Up to Down flag */
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_DOWN);
@@ -1720,13 +2085,13 @@ __weak void HAL_LPTIM_DirectionDownCallback(LPTIM_HandleTypeDef *hlptim)
   * @param pCallback pointer to the callback function
   * @retval status
   */
-HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef *       hlptim,
+HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef        *hlptim,
                                              HAL_LPTIM_CallbackIDTypeDef CallbackID,
                                              pLPTIM_CallbackTypeDef      pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if(pCallback == NULL)
+  if (pCallback == NULL)
   {
     return HAL_ERROR;
   }
@@ -1734,68 +2099,68 @@ HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef *       hlptim,
   /* Process locked */
   __HAL_LOCK(hlptim);
 
-  if(hlptim->State == HAL_LPTIM_STATE_READY)
+  if (hlptim->State == HAL_LPTIM_STATE_READY)
   {
     switch (CallbackID)
     {
-    case HAL_LPTIM_MSPINIT_CB_ID :
-      hlptim->MspInitCallback = pCallback;
-      break;
+      case HAL_LPTIM_MSPINIT_CB_ID :
+        hlptim->MspInitCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_MSPDEINIT_CB_ID :
-      hlptim->MspDeInitCallback = pCallback;
-      break;
+      case HAL_LPTIM_MSPDEINIT_CB_ID :
+        hlptim->MspDeInitCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_COMPARE_MATCH_CB_ID :
-      hlptim->CompareMatchCallback = pCallback;
-      break;
+      case HAL_LPTIM_COMPARE_MATCH_CB_ID :
+        hlptim->CompareMatchCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_AUTORELOAD_MATCH_CB_ID :
-      hlptim->AutoReloadMatchCallback = pCallback;
-      break;
+      case HAL_LPTIM_AUTORELOAD_MATCH_CB_ID :
+        hlptim->AutoReloadMatchCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_TRIGGER_CB_ID :
-      hlptim->TriggerCallback = pCallback;
-      break;
+      case HAL_LPTIM_TRIGGER_CB_ID :
+        hlptim->TriggerCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_COMPARE_WRITE_CB_ID :
-      hlptim->CompareWriteCallback = pCallback;
-      break;
+      case HAL_LPTIM_COMPARE_WRITE_CB_ID :
+        hlptim->CompareWriteCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_AUTORELOAD_WRITE_CB_ID :
-      hlptim->AutoReloadWriteCallback = pCallback;
-      break;
+      case HAL_LPTIM_AUTORELOAD_WRITE_CB_ID :
+        hlptim->AutoReloadWriteCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_DIRECTION_UP_CB_ID :
-      hlptim->DirectionUpCallback = pCallback;
-      break;
+      case HAL_LPTIM_DIRECTION_UP_CB_ID :
+        hlptim->DirectionUpCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_DIRECTION_DOWN_CB_ID :
-      hlptim->DirectionDownCallback = pCallback;
-      break;
+      case HAL_LPTIM_DIRECTION_DOWN_CB_ID :
+        hlptim->DirectionDownCallback = pCallback;
+        break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(hlptim->State == HAL_LPTIM_STATE_RESET)
+  else if (hlptim->State == HAL_LPTIM_STATE_RESET)
   {
     switch (CallbackID)
     {
-    case HAL_LPTIM_MSPINIT_CB_ID :
-      hlptim->MspInitCallback = pCallback;
-      break;
+      case HAL_LPTIM_MSPINIT_CB_ID :
+        hlptim->MspInitCallback = pCallback;
+        break;
 
-    case HAL_LPTIM_MSPDEINIT_CB_ID :
-      hlptim->MspDeInitCallback = pCallback;
-      break;
+      case HAL_LPTIM_MSPDEINIT_CB_ID :
+        hlptim->MspDeInitCallback = pCallback;
+        break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
@@ -1827,7 +2192,7 @@ HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef *       hlptim,
   *          @arg @ref HAL_LPTIM_DIRECTION_DOWN_CB_ID   Down-counting direction change Callback ID
   * @retval status
   */
-HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef *       hlptim,
+HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef        *hlptim,
                                                HAL_LPTIM_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
@@ -1835,68 +2200,68 @@ HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef *       hlpti
   /* Process locked */
   __HAL_LOCK(hlptim);
 
-  if(hlptim->State == HAL_LPTIM_STATE_READY)
+  if (hlptim->State == HAL_LPTIM_STATE_READY)
   {
     switch (CallbackID)
     {
-    case HAL_LPTIM_MSPINIT_CB_ID :
-      hlptim->MspInitCallback = HAL_LPTIM_MspInit;                          /* Legacy weak MspInit Callback */
-      break;
+      case HAL_LPTIM_MSPINIT_CB_ID :
+        hlptim->MspInitCallback = HAL_LPTIM_MspInit;                          /* Legacy weak MspInit Callback */
+        break;
 
-    case HAL_LPTIM_MSPDEINIT_CB_ID :
-      hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;                       /* Legacy weak Msp DeInit Callback */
-      break;
+      case HAL_LPTIM_MSPDEINIT_CB_ID :
+        hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;                       /* Legacy weak Msp DeInit Callback */
+        break;
 
-    case HAL_LPTIM_COMPARE_MATCH_CB_ID :
-      hlptim->CompareMatchCallback = HAL_LPTIM_CompareMatchCallback;         /* Legacy weak IC Msp Init Callback */
-      break;
+      case HAL_LPTIM_COMPARE_MATCH_CB_ID :
+        hlptim->CompareMatchCallback = HAL_LPTIM_CompareMatchCallback;         /* Legacy weak Compare match Callback */
+        break;
 
-    case HAL_LPTIM_AUTORELOAD_MATCH_CB_ID :
-      hlptim->AutoReloadMatchCallback = HAL_LPTIM_AutoReloadMatchCallback;   /* Legacy weak IC Msp DeInit Callback */
-      break;
+      case HAL_LPTIM_AUTORELOAD_MATCH_CB_ID :
+        hlptim->AutoReloadMatchCallback = HAL_LPTIM_AutoReloadMatchCallback;   /* Legacy weak Auto-reload match Callback */
+        break;
 
-    case HAL_LPTIM_TRIGGER_CB_ID :
-      hlptim->TriggerCallback = HAL_LPTIM_TriggerCallback;                   /* Legacy weak OC Msp Init Callback */
-      break;
+      case HAL_LPTIM_TRIGGER_CB_ID :
+        hlptim->TriggerCallback = HAL_LPTIM_TriggerCallback;                   /* Legacy weak External trigger event detection Callback */
+        break;
 
-    case HAL_LPTIM_COMPARE_WRITE_CB_ID :
-      hlptim->CompareWriteCallback = HAL_LPTIM_CompareWriteCallback;         /* Legacy weak OC Msp DeInit Callback */
-      break;
+      case HAL_LPTIM_COMPARE_WRITE_CB_ID :
+        hlptim->CompareWriteCallback = HAL_LPTIM_CompareWriteCallback;         /* Legacy weak Compare register write complete Callback */
+        break;
 
-    case HAL_LPTIM_AUTORELOAD_WRITE_CB_ID :
-      hlptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback;   /* Legacy weak PWM Msp Init Callback */
-      break;
+      case HAL_LPTIM_AUTORELOAD_WRITE_CB_ID :
+        hlptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback;   /* Legacy weak Auto-reload register write complete Callback */
+        break;
 
-    case HAL_LPTIM_DIRECTION_UP_CB_ID :
-      hlptim->DirectionUpCallback = HAL_LPTIM_DirectionUpCallback;           /* Legacy weak PWM Msp DeInit Callback */
-      break;
+      case HAL_LPTIM_DIRECTION_UP_CB_ID :
+        hlptim->DirectionUpCallback = HAL_LPTIM_DirectionUpCallback;           /* Legacy weak Up-counting direction change Callback */
+        break;
 
-    case HAL_LPTIM_DIRECTION_DOWN_CB_ID :
-      hlptim->DirectionDownCallback = HAL_LPTIM_DirectionDownCallback;       /* Legacy weak One Pulse Msp Init Callback */
-      break;
+      case HAL_LPTIM_DIRECTION_DOWN_CB_ID :
+        hlptim->DirectionDownCallback = HAL_LPTIM_DirectionDownCallback;       /* Legacy weak Down-counting direction change Callback */
+        break;
 
-    default :
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(hlptim->State == HAL_LPTIM_STATE_RESET)
+  else if (hlptim->State == HAL_LPTIM_STATE_RESET)
   {
     switch (CallbackID)
     {
-    case HAL_LPTIM_MSPINIT_CB_ID :
-      hlptim->MspInitCallback = HAL_LPTIM_MspInit;                           /* Legacy weak MspInit Callback */
-      break;
+      case HAL_LPTIM_MSPINIT_CB_ID :
+        hlptim->MspInitCallback = HAL_LPTIM_MspInit;                           /* Legacy weak MspInit Callback */
+        break;
 
-    case HAL_LPTIM_MSPDEINIT_CB_ID :
-      hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;                        /* Legacy weak Msp DeInit Callback */
-      break;
+      case HAL_LPTIM_MSPDEINIT_CB_ID :
+        hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;                        /* Legacy weak Msp DeInit Callback */
+        break;
 
-    default :
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
@@ -1971,14 +2336,168 @@ static void LPTIM_ResetCallback(LPTIM_HandleTypeDef *lptim)
   lptim->CompareWriteCallback    = HAL_LPTIM_CompareWriteCallback;    /* Compare register write complete Callback     */
   lptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback; /* Auto-reload register write complete Callback */
   lptim->DirectionUpCallback     = HAL_LPTIM_DirectionUpCallback;     /* Up-counting direction change Callback        */
-  lptim->DirectionDownCallback   = HAL_LPTIM_DirectionDownCallback;   /* Down-counting direction change Callback       */
+  lptim->DirectionDownCallback   = HAL_LPTIM_DirectionDownCallback;   /* Down-counting direction change Callback      */
 }
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
 
 /**
+  * @brief  LPTimer Wait for flag set
+  * @param  hlptim pointer to a LPTIM_HandleTypeDef structure that contains
+  *                the configuration information for LPTIM module.
+  * @param  flag   The lptim flag
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t flag)
+{
+  HAL_StatusTypeDef result = HAL_OK;
+  uint32_t count = TIMEOUT * (SystemCoreClock / 20UL / 1000UL);
+  do
+  {
+    count--;
+    if (count == 0UL)
+    {
+      result = HAL_TIMEOUT;
+    }
+  }
+  while ((!(__HAL_LPTIM_GET_FLAG((hlptim), (flag)))) && (count != 0UL));
+
+  return result;
+}
+
+/**
+  * @brief  Disable LPTIM HW instance.
+  * @param  hlptim pointer to a LPTIM_HandleTypeDef structure that contains
+  *                the configuration information for LPTIM module.
+  * @note   The following sequence is required to solve LPTIM disable HW limitation.
+  *         Please check Errata Sheet ES0335 for more details under "MCU may remain
+  *         stuck in LPTIM interrupt when entering Stop mode" section.
+  * @retval None
+  */
+void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim)
+{
+  uint32_t tmpclksource = 0;
+  uint32_t tmpIER;
+  uint32_t tmpCFGR;
+  uint32_t tmpCMP;
+  uint32_t tmpARR;
+  uint32_t tmpCFGR2;
+
+  __disable_irq();
+
+  /*********** Save LPTIM Config ***********/
+  /* Save LPTIM source clock */
+  switch ((uint32_t)hlptim->Instance)
+  {
+    case LPTIM1_BASE:
+      tmpclksource = __HAL_RCC_GET_LPTIM1_SOURCE();
+      break;
+#if defined(LPTIM2)
+    case LPTIM2_BASE:
+      tmpclksource = __HAL_RCC_GET_LPTIM2_SOURCE();
+      break;
+#endif /* LPTIM2 */
+    default:
+      break;
+  }
+
+  /* Save LPTIM configuration registers */
+  tmpIER = hlptim->Instance->IER;
+  tmpCFGR = hlptim->Instance->CFGR;
+  tmpCMP = hlptim->Instance->CMP;
+  tmpARR = hlptim->Instance->ARR;
+  tmpCFGR2 = hlptim->Instance->CFGR2;
+
+  /*********** Reset LPTIM ***********/
+  switch ((uint32_t)hlptim->Instance)
+  {
+    case LPTIM1_BASE:
+      __HAL_RCC_LPTIM1_FORCE_RESET();
+      __HAL_RCC_LPTIM1_RELEASE_RESET();
+      break;
+#if defined(LPTIM2)
+    case LPTIM2_BASE:
+      __HAL_RCC_LPTIM2_FORCE_RESET();
+      __HAL_RCC_LPTIM2_RELEASE_RESET();
+      break;
+#endif /* LPTIM2 */
+    default:
+      break;
+  }
+
+  /*********** Restore LPTIM Config ***********/
+  if ((tmpCMP != 0UL) || (tmpARR != 0UL))
+  {
+    /* Force LPTIM source kernel clock from APB */
+    switch ((uint32_t)hlptim->Instance)
+    {
+      case LPTIM1_BASE:
+        __HAL_RCC_LPTIM1_CONFIG(RCC_LPTIM1CLKSOURCE_PCLK1);
+        break;
+#if defined(LPTIM2)
+      case LPTIM2_BASE:
+        __HAL_RCC_LPTIM2_CONFIG(RCC_LPTIM2CLKSOURCE_PCLK1);
+        break;
+#endif /* LPTIM2 */
+      default:
+        break;
+    }
+
+    if (tmpCMP != 0UL)
+    {
+      /* Restore CMP register (LPTIM should be enabled first) */
+      hlptim->Instance->CR |= LPTIM_CR_ENABLE;
+      hlptim->Instance->CMP = tmpCMP;
+
+      /* Wait for the completion of the write operation to the LPTIM_CMP register */
+      if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_CMPOK) == HAL_TIMEOUT)
+      {
+        hlptim->State = HAL_LPTIM_STATE_TIMEOUT;
+      }
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+    }
+
+    if (tmpARR != 0UL)
+    {
+      /* Restore ARR register (LPTIM should be enabled first) */
+      hlptim->Instance->CR |= LPTIM_CR_ENABLE;
+      hlptim->Instance->ARR = tmpARR;
+
+      /* Wait for the completion of the write operation to the LPTIM_ARR register */
+      if (LPTIM_WaitForFlag(hlptim, LPTIM_FLAG_ARROK) == HAL_TIMEOUT)
+      {
+        hlptim->State = HAL_LPTIM_STATE_TIMEOUT;
+      }
+
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+    }
+
+    /* Restore LPTIM source kernel clock */
+    switch ((uint32_t)hlptim->Instance)
+    {
+      case LPTIM1_BASE:
+        __HAL_RCC_LPTIM1_CONFIG(tmpclksource);
+        break;
+#if defined(LPTIM2)
+      case LPTIM2_BASE:
+        __HAL_RCC_LPTIM2_CONFIG(tmpclksource);
+        break;
+#endif /* LPTIM2 */
+      default:
+        break;
+    }
+  }
+
+  /* Restore configuration registers (LPTIM should be disabled first) */
+  hlptim->Instance->CR &= ~(LPTIM_CR_ENABLE);
+  hlptim->Instance->IER = tmpIER;
+  hlptim->Instance->CFGR = tmpCFGR;
+  hlptim->Instance->CFGR2 = tmpCFGR2;
+
+  __enable_irq();
+}
+/**
   * @}
   */
-
 #endif /* LPTIM1 || LPTIM2 */
 
 #endif /* HAL_LPTIM_MODULE_ENABLED */

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pcd.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pcd.c
@@ -1,0 +1,2154 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_pcd.c
+  * @author  MCD Application Team
+  * @brief   PCD HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The PCD HAL driver can be used as follows:
+
+     (#) Declare a PCD_HandleTypeDef handle structure, for example:
+         PCD_HandleTypeDef  hpcd;
+
+     (#) Fill parameters of Init structure in HCD handle
+
+     (#) Call HAL_PCD_Init() API to initialize the PCD peripheral (Core, Device core, ...)
+
+     (#) Initialize the PCD low level resources through the HAL_PCD_MspInit() API:
+         (##) Enable the PCD/USB Low Level interface clock using
+              (+++) __HAL_RCC_USB_CLK_ENABLE(); For USB Device only FS peripheral
+
+         (##) Initialize the related GPIO clocks
+         (##) Configure PCD pin-out
+         (##) Configure PCD NVIC interrupt
+
+     (#)Associate the Upper USB device stack to the HAL PCD Driver:
+         (##) hpcd.pData = pdev;
+
+     (#)Enable PCD transmission and reception:
+         (##) HAL_PCD_Start();
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal.h"
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCD PCD
+  * @brief PCD HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+
+#if defined (USB_DRD_FS)
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup PCD_Private_Macros PCD Private Macros
+  * @{
+  */
+#define PCD_MIN(a, b)  (((a) < (b)) ? (a) : (b))
+#define PCD_MAX(a, b)  (((a) > (b)) ? (a) : (b))
+/**
+  * @}
+  */
+
+/* Private functions prototypes ----------------------------------------------*/
+/** @defgroup PCD_Private_Functions PCD Private Functions
+  * @{
+  */
+
+static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd);
+static HAL_StatusTypeDef HAL_PCD_EP_DB_Transmit(PCD_HandleTypeDef *hpcd, PCD_EPTypeDef *ep, uint16_t wEPVal);
+static uint16_t HAL_PCD_EP_DB_Receive(PCD_HandleTypeDef *hpcd, PCD_EPTypeDef *ep, uint16_t wEPVal);
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Functions PCD Exported Functions
+  * @{
+  */
+
+/** @defgroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions
+  *
+@verbatim
+ ===============================================================================
+            ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the PCD according to the specified
+  *         parameters in the PCD_InitTypeDef and initialize the associated handle.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
+{
+  uint8_t i;
+
+  /* Check the PCD handle allocation */
+  if (hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_PCD_ALL_INSTANCE(hpcd->Instance));
+
+  if (hpcd->State == HAL_PCD_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hpcd->Lock = HAL_UNLOCKED;
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->SOFCallback = HAL_PCD_SOFCallback;
+    hpcd->SetupStageCallback = HAL_PCD_SetupStageCallback;
+    hpcd->ResetCallback = HAL_PCD_ResetCallback;
+    hpcd->SuspendCallback = HAL_PCD_SuspendCallback;
+    hpcd->ResumeCallback = HAL_PCD_ResumeCallback;
+    hpcd->ConnectCallback = HAL_PCD_ConnectCallback;
+    hpcd->DisconnectCallback = HAL_PCD_DisconnectCallback;
+    hpcd->DataOutStageCallback = HAL_PCD_DataOutStageCallback;
+    hpcd->DataInStageCallback = HAL_PCD_DataInStageCallback;
+    hpcd->ISOOUTIncompleteCallback = HAL_PCD_ISOOUTIncompleteCallback;
+    hpcd->ISOINIncompleteCallback = HAL_PCD_ISOINIncompleteCallback;
+    hpcd->LPMCallback = HAL_PCDEx_LPM_Callback;
+    hpcd->BCDCallback = HAL_PCDEx_BCD_Callback;
+
+    if (hpcd->MspInitCallback == NULL)
+    {
+      hpcd->MspInitCallback = HAL_PCD_MspInit;
+    }
+
+    /* Init the low level hardware */
+    hpcd->MspInitCallback(hpcd);
+#else
+    /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+    HAL_PCD_MspInit(hpcd);
+#endif /* (USE_HAL_PCD_REGISTER_CALLBACKS) */
+  }
+
+  hpcd->State = HAL_PCD_STATE_BUSY;
+
+  /* Disable the Interrupts */
+  __HAL_PCD_DISABLE(hpcd);
+
+  /* Init endpoints structures */
+  for (i = 0U; i < hpcd->Init.dev_endpoints; i++)
+  {
+    /* Init ep structure */
+    hpcd->IN_ep[i].is_in = 1U;
+    hpcd->IN_ep[i].num = i;
+    hpcd->IN_ep[i].tx_fifo_num = i;
+    /* Control until ep is activated */
+    hpcd->IN_ep[i].type = EP_TYPE_CTRL;
+    hpcd->IN_ep[i].maxpacket = 0U;
+    hpcd->IN_ep[i].xfer_buff = 0U;
+    hpcd->IN_ep[i].xfer_len = 0U;
+  }
+
+  for (i = 0U; i < hpcd->Init.dev_endpoints; i++)
+  {
+    hpcd->OUT_ep[i].is_in = 0U;
+    hpcd->OUT_ep[i].num = i;
+    /* Control until ep is activated */
+    hpcd->OUT_ep[i].type = EP_TYPE_CTRL;
+    hpcd->OUT_ep[i].maxpacket = 0U;
+    hpcd->OUT_ep[i].xfer_buff = 0U;
+    hpcd->OUT_ep[i].xfer_len = 0U;
+  }
+
+  /* Init Device */
+  (void)USB_DevInit(hpcd->Instance, hpcd->Init);
+
+  hpcd->USB_Address = 0U;
+  hpcd->State = HAL_PCD_STATE_READY;
+
+  /* Activate LPM */
+  if (hpcd->Init.lpm_enable == 1U)
+  {
+    (void)HAL_PCDEx_ActivateLPM(hpcd);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the PCD peripheral.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Check the PCD handle allocation */
+  if (hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  hpcd->State = HAL_PCD_STATE_BUSY;
+
+  /* Stop Device */
+  if (USB_StopDevice(hpcd->Instance) != HAL_OK)
+  {
+    return HAL_ERROR;
+  }
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+  if (hpcd->MspDeInitCallback == NULL)
+  {
+    hpcd->MspDeInitCallback = HAL_PCD_MspDeInit; /* Legacy weak MspDeInit  */
+  }
+
+  /* DeInit the low level hardware */
+  hpcd->MspDeInitCallback(hpcd);
+#else
+  /* DeInit the low level hardware: CLOCK, NVIC.*/
+  HAL_PCD_MspDeInit(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+  hpcd->State = HAL_PCD_STATE_RESET;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the PCD MSP.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes PCD MSP.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_MspDeInit could be implemented in the user file
+   */
+}
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+/**
+  * @brief  Register a User USB PCD Callback
+  *         To be used instead of the weak predefined callback
+  * @param  hpcd USB PCD handle
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_PCD_SOF_CB_ID USB PCD SOF callback ID
+  *          @arg @ref HAL_PCD_SETUPSTAGE_CB_ID USB PCD Setup callback ID
+  *          @arg @ref HAL_PCD_RESET_CB_ID USB PCD Reset callback ID
+  *          @arg @ref HAL_PCD_SUSPEND_CB_ID USB PCD Suspend callback ID
+  *          @arg @ref HAL_PCD_RESUME_CB_ID USB PCD Resume callback ID
+  *          @arg @ref HAL_PCD_CONNECT_CB_ID USB PCD Connect callback ID
+  *          @arg @ref HAL_PCD_DISCONNECT_CB_ID OTG PCD Disconnect callback ID
+  *          @arg @ref HAL_PCD_MSPINIT_CB_ID MspDeInit callback ID
+  *          @arg @ref HAL_PCD_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @param  pCallback pointer to the Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd,
+                                           HAL_PCD_CallbackIDTypeDef CallbackID,
+                                           pPCD_CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+    return HAL_ERROR;
+  }
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_PCD_SOF_CB_ID :
+        hpcd->SOFCallback = pCallback;
+        break;
+
+      case HAL_PCD_SETUPSTAGE_CB_ID :
+        hpcd->SetupStageCallback = pCallback;
+        break;
+
+      case HAL_PCD_RESET_CB_ID :
+        hpcd->ResetCallback = pCallback;
+        break;
+
+      case HAL_PCD_SUSPEND_CB_ID :
+        hpcd->SuspendCallback = pCallback;
+        break;
+
+      case HAL_PCD_RESUME_CB_ID :
+        hpcd->ResumeCallback = pCallback;
+        break;
+
+      case HAL_PCD_CONNECT_CB_ID :
+        hpcd->ConnectCallback = pCallback;
+        break;
+
+      case HAL_PCD_DISCONNECT_CB_ID :
+        hpcd->DisconnectCallback = pCallback;
+        break;
+
+      case HAL_PCD_MSPINIT_CB_ID :
+        hpcd->MspInitCallback = pCallback;
+        break;
+
+      case HAL_PCD_MSPDEINIT_CB_ID :
+        hpcd->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hpcd->State == HAL_PCD_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_PCD_MSPINIT_CB_ID :
+        hpcd->MspInitCallback = pCallback;
+        break;
+
+      case HAL_PCD_MSPDEINIT_CB_ID :
+        hpcd->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+  return status;
+}
+
+/**
+  * @brief  Unregister an USB PCD Callback
+  *         USB PCD callabck is redirected to the weak predefined callback
+  * @param  hpcd USB PCD handle
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_PCD_SOF_CB_ID USB PCD SOF callback ID
+  *          @arg @ref HAL_PCD_SETUPSTAGE_CB_ID USB PCD Setup callback ID
+  *          @arg @ref HAL_PCD_RESET_CB_ID USB PCD Reset callback ID
+  *          @arg @ref HAL_PCD_SUSPEND_CB_ID USB PCD Suspend callback ID
+  *          @arg @ref HAL_PCD_RESUME_CB_ID USB PCD Resume callback ID
+  *          @arg @ref HAL_PCD_CONNECT_CB_ID USB PCD Connect callback ID
+  *          @arg @ref HAL_PCD_DISCONNECT_CB_ID OTG PCD Disconnect callback ID
+  *          @arg @ref HAL_PCD_MSPINIT_CB_ID MspDeInit callback ID
+  *          @arg @ref HAL_PCD_MSPDEINIT_CB_ID MspDeInit callback ID
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  /* Setup Legacy weak Callbacks  */
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    switch (CallbackID)
+    {
+      case HAL_PCD_SOF_CB_ID :
+        hpcd->SOFCallback = HAL_PCD_SOFCallback;
+        break;
+
+      case HAL_PCD_SETUPSTAGE_CB_ID :
+        hpcd->SetupStageCallback = HAL_PCD_SetupStageCallback;
+        break;
+
+      case HAL_PCD_RESET_CB_ID :
+        hpcd->ResetCallback = HAL_PCD_ResetCallback;
+        break;
+
+      case HAL_PCD_SUSPEND_CB_ID :
+        hpcd->SuspendCallback = HAL_PCD_SuspendCallback;
+        break;
+
+      case HAL_PCD_RESUME_CB_ID :
+        hpcd->ResumeCallback = HAL_PCD_ResumeCallback;
+        break;
+
+      case HAL_PCD_CONNECT_CB_ID :
+        hpcd->ConnectCallback = HAL_PCD_ConnectCallback;
+        break;
+
+      case HAL_PCD_DISCONNECT_CB_ID :
+        hpcd->DisconnectCallback = HAL_PCD_DisconnectCallback;
+        break;
+
+      case HAL_PCD_MSPINIT_CB_ID :
+        hpcd->MspInitCallback = HAL_PCD_MspInit;
+        break;
+
+      case HAL_PCD_MSPDEINIT_CB_ID :
+        hpcd->MspDeInitCallback = HAL_PCD_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (hpcd->State == HAL_PCD_STATE_RESET)
+  {
+    switch (CallbackID)
+    {
+      case HAL_PCD_MSPINIT_CB_ID :
+        hpcd->MspInitCallback = HAL_PCD_MspInit;
+        break;
+
+      case HAL_PCD_MSPDEINIT_CB_ID :
+        hpcd->MspDeInitCallback = HAL_PCD_MspDeInit;
+        break;
+
+      default :
+        /* Update the error code */
+        hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+  return status;
+}
+
+/**
+  * @brief  Register USB PCD Data OUT Stage Callback
+  *         To be used instead of the weak HAL_PCD_DataOutStageCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @param  pCallback pointer to the USB PCD Data OUT Stage Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_DataOutStageCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->DataOutStageCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB PCD Data OUT Stage Callback
+  *         USB PCD Data OUT Stage Callback is redirected to the weak HAL_PCD_DataOutStageCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->DataOutStageCallback = HAL_PCD_DataOutStageCallback; /* Legacy weak DataOutStageCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Register USB PCD Data IN Stage Callback
+  *         To be used instead of the weak HAL_PCD_DataInStageCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @param  pCallback pointer to the USB PCD Data IN Stage Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_DataInStageCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->DataInStageCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB PCD Data IN Stage Callback
+  *         USB PCD Data OUT Stage Callback is redirected to the weak HAL_PCD_DataInStageCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterDataInStageCallback(PCD_HandleTypeDef *hpcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->DataInStageCallback = HAL_PCD_DataInStageCallback; /* Legacy weak DataInStageCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Register USB PCD Iso OUT incomplete Callback
+  *         To be used instead of the weak HAL_PCD_ISOOUTIncompleteCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @param  pCallback pointer to the USB PCD Iso OUT incomplete Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_IsoOutIncpltCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->ISOOUTIncompleteCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB PCD Iso OUT incomplete Callback
+  *         USB PCD Iso OUT incomplete Callback is redirected to the weak HAL_PCD_ISOOUTIncompleteCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->ISOOUTIncompleteCallback = HAL_PCD_ISOOUTIncompleteCallback; /* Legacy weak ISOOUTIncompleteCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Register USB PCD Iso IN incomplete Callback
+  *         To be used instead of the weak HAL_PCD_ISOINIncompleteCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @param  pCallback pointer to the USB PCD Iso IN incomplete Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_IsoInIncpltCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->ISOINIncompleteCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB PCD Iso IN incomplete Callback
+  *         USB PCD Iso IN incomplete Callback is redirected to the weak HAL_PCD_ISOINIncompleteCallback() predefined callback
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->ISOINIncompleteCallback = HAL_PCD_ISOINIncompleteCallback; /* Legacy weak ISOINIncompleteCallback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Register USB PCD BCD Callback
+  *         To be used instead of the weak HAL_PCDEx_BCD_Callback() predefined callback
+  * @param  hpcd PCD handle
+  * @param  pCallback pointer to the USB PCD BCD Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterBcdCallback(PCD_HandleTypeDef *hpcd, pPCD_BcdCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->BCDCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB PCD BCD Callback
+  *         USB BCD Callback is redirected to the weak HAL_PCDEx_BCD_Callback() predefined callback
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterBcdCallback(PCD_HandleTypeDef *hpcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->BCDCallback = HAL_PCDEx_BCD_Callback; /* Legacy weak HAL_PCDEx_BCD_Callback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Register USB PCD LPM Callback
+  *         To be used instead of the weak HAL_PCDEx_LPM_Callback() predefined callback
+  * @param  hpcd PCD handle
+  * @param  pCallback pointer to the USB PCD LPM Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_RegisterLpmCallback(PCD_HandleTypeDef *hpcd, pPCD_LpmCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->LPMCallback = pCallback;
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+
+/**
+  * @brief  Unregister the USB PCD LPM Callback
+  *         USB LPM Callback is redirected to the weak HAL_PCDEx_LPM_Callback() predefined callback
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_UnRegisterLpmCallback(PCD_HandleTypeDef *hpcd)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hpcd);
+
+  if (hpcd->State == HAL_PCD_STATE_READY)
+  {
+    hpcd->LPMCallback = HAL_PCDEx_LPM_Callback; /* Legacy weak HAL_PCDEx_LPM_Callback  */
+  }
+  else
+  {
+    /* Update the error code */
+    hpcd->ErrorCode |= HAL_PCD_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpcd);
+
+  return status;
+}
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group2 Input and Output operation functions
+  *  @brief   Data transfers functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the PCD data
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start the USB device
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  __HAL_PCD_ENABLE(hpcd);
+  (void)USB_DevConnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop the USB device.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  __HAL_PCD_DISABLE(hpcd);
+  (void)USB_DevDisconnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  This function handles PCD interrupt request.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
+{
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_CTR))
+  {
+    /* servicing of the endpoint correct transfer interrupt */
+    /* clear of the CTR flag into the sub */
+    (void)PCD_EP_ISR_Handler(hpcd);
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_RESET))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_RESET);
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->ResetCallback(hpcd);
+#else
+    HAL_PCD_ResetCallback(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+    (void)HAL_PCD_SetAddress(hpcd, 0U);
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_PMAOVR))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_PMAOVR);
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_ERR))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ERR);
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_WKUP))
+  {
+    hpcd->Instance->CNTR &= ~(USB_CNTR_SUSPRDY);
+    hpcd->Instance->CNTR &= ~(USB_CNTR_SUSPEN);
+
+    if (hpcd->LPM_State == LPM_L1)
+    {
+      hpcd->LPM_State = LPM_L0;
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->LPMCallback(hpcd, PCD_LPM_L0_ACTIVE);
+#else
+      HAL_PCDEx_LPM_Callback(hpcd, PCD_LPM_L0_ACTIVE);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+    }
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->ResumeCallback(hpcd);
+#else
+    HAL_PCD_ResumeCallback(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_WKUP);
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_SUSP))
+  {
+    /* Force low-power mode in the macrocell */
+    hpcd->Instance->CNTR |= USB_CNTR_SUSPEN;
+
+    /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SUSP);
+
+    hpcd->Instance->CNTR |= USB_CNTR_SUSPRDY;
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->SuspendCallback(hpcd);
+#else
+    HAL_PCD_SuspendCallback(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+  }
+
+  /* Handle LPM Interrupt */
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_L1REQ))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_L1REQ);
+    if (hpcd->LPM_State == LPM_L0)
+    {
+      /* Force suspend and low-power mode before going to L1 state*/
+      hpcd->Instance->CNTR |= USB_CNTR_SUSPRDY;
+      hpcd->Instance->CNTR |= USB_CNTR_SUSPEN;
+
+      hpcd->LPM_State = LPM_L1;
+      hpcd->BESL = ((uint32_t)hpcd->Instance->LPMCSR & USB_LPMCSR_BESL) >> 2;
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->LPMCallback(hpcd, PCD_LPM_L1_ACTIVE);
+#else
+      HAL_PCDEx_LPM_Callback(hpcd, PCD_LPM_L1_ACTIVE);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+    }
+    else
+    {
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->SuspendCallback(hpcd);
+#else
+      HAL_PCD_SuspendCallback(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+    }
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_SOF))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SOF);
+
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->SOFCallback(hpcd);
+#else
+    HAL_PCD_SOFCallback(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+  }
+
+  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_ESOF))
+  {
+    /* clear ESOF flag in ISTR */
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ESOF);
+  }
+}
+
+
+/**
+  * @brief  Data OUT stage callback.
+  * @param  hpcd PCD handle
+  * @param  epnum endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Data IN stage callback
+  * @param  hpcd PCD handle
+  * @param  epnum endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_DataInStageCallback could be implemented in the user file
+   */
+}
+/**
+  * @brief  Setup stage callback
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_SetupStageCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  USB Start Of Frame callback.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_SOFCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  USB Reset callback.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ResetCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Suspend event callback.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_SuspendCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Resume event callback.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ResumeCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Incomplete ISO OUT callback.
+  * @param  hpcd PCD handle
+  * @param  epnum endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ISOOUTIncompleteCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Incomplete ISO IN callback.
+  * @param  hpcd PCD handle
+  * @param  epnum endpoint number
+  * @retval None
+  */
+__weak void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(epnum);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ISOINIncompleteCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Connection event callback.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_ConnectCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Disconnection event callback.
+  * @param  hpcd PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCD_DisconnectCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group3 Peripheral Control functions
+  *  @brief   management functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the PCD data
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Connect the USB device
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  (void)USB_DevConnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disconnect the USB device.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd);
+  (void)USB_DevDisconnect(hpcd->Instance);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the USB Device address.
+  * @param  hpcd PCD handle
+  * @param  address new device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address)
+{
+  __HAL_LOCK(hpcd);
+  hpcd->USB_Address = address;
+  (void)USB_SetDevAddress(hpcd->Instance, address);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+/**
+  * @brief  Open and configure an endpoint.
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @param  ep_mps endpoint max packet size
+  * @param  ep_type endpoint type
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr,
+                                  uint16_t ep_mps, uint8_t ep_type)
+{
+  HAL_StatusTypeDef  ret = HAL_OK;
+  PCD_EPTypeDef *ep;
+
+  if ((ep_addr & 0x80U) == 0x80U)
+  {
+    ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 1U;
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 0U;
+  }
+
+  ep->num = ep_addr & EP_ADDR_MSK;
+  ep->maxpacket = ep_mps;
+  ep->type = ep_type;
+
+  if (ep->is_in != 0U)
+  {
+    /* Assign a Tx FIFO */
+    ep->tx_fifo_num = ep->num;
+  }
+  /* Set initial data PID. */
+  if (ep_type == EP_TYPE_BULK)
+  {
+    ep->data_pid_start = 0U;
+  }
+
+  __HAL_LOCK(hpcd);
+  (void)USB_ActivateEndpoint(hpcd->Instance, ep);
+  __HAL_UNLOCK(hpcd);
+
+  return ret;
+}
+
+/**
+  * @brief  Deactivate an endpoint.
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  PCD_EPTypeDef *ep;
+
+  if ((ep_addr & 0x80U) == 0x80U)
+  {
+    ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 1U;
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 0U;
+  }
+  ep->num   = ep_addr & EP_ADDR_MSK;
+
+  __HAL_LOCK(hpcd);
+  (void)USB_DeactivateEndpoint(hpcd->Instance, ep);
+  __HAL_UNLOCK(hpcd);
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Receive an amount of data.
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @param  pBuf pointer to the reception buffer
+  * @param  len amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  PCD_EPTypeDef *ep;
+
+  ep = &hpcd->OUT_ep[ep_addr & EP_ADDR_MSK];
+
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;
+  ep->xfer_len = len;
+  ep->xfer_count = 0U;
+  ep->is_in = 0U;
+  ep->num = ep_addr & EP_ADDR_MSK;
+
+  if ((ep_addr & EP_ADDR_MSK) == 0U)
+  {
+    (void)USB_EP0StartXfer(hpcd->Instance, ep);
+  }
+  else
+  {
+    (void)USB_EPStartXfer(hpcd->Instance, ep);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get Received Data Size
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @retval Data Size
+  */
+uint32_t HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  return hpcd->OUT_ep[ep_addr & EP_ADDR_MSK].xfer_count;
+}
+/**
+  * @brief  Send an amount of data
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @param  pBuf pointer to the transmission buffer
+  * @param  len amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  PCD_EPTypeDef *ep;
+
+  ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;
+  ep->xfer_len = len;
+  ep->xfer_fill_db = 1U;
+  ep->xfer_len_db = len;
+  ep->xfer_count = 0U;
+  ep->is_in = 1U;
+  ep->num = ep_addr & EP_ADDR_MSK;
+
+  if ((ep_addr & EP_ADDR_MSK) == 0U)
+  {
+    (void)USB_EP0StartXfer(hpcd->Instance, ep);
+  }
+  else
+  {
+    (void)USB_EPStartXfer(hpcd->Instance, ep);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set a STALL condition over an endpoint
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  PCD_EPTypeDef *ep;
+
+  if (((uint32_t)ep_addr & EP_ADDR_MSK) > hpcd->Init.dev_endpoints)
+  {
+    return HAL_ERROR;
+  }
+
+  if ((0x80U & ep_addr) == 0x80U)
+  {
+    ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 1U;
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+    ep->is_in = 0U;
+  }
+
+  ep->is_stall = 1U;
+  ep->num = ep_addr & EP_ADDR_MSK;
+
+  __HAL_LOCK(hpcd);
+
+  (void)USB_EPSetStall(hpcd->Instance, ep);
+
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Clear a STALL condition over in an endpoint
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  PCD_EPTypeDef *ep;
+
+  if (((uint32_t)ep_addr & 0x0FU) > hpcd->Init.dev_endpoints)
+  {
+    return HAL_ERROR;
+  }
+
+  if ((0x80U & ep_addr) == 0x80U)
+  {
+    ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 1U;
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & EP_ADDR_MSK];
+    ep->is_in = 0U;
+  }
+
+  ep->is_stall = 0U;
+  ep->num = ep_addr & EP_ADDR_MSK;
+
+  __HAL_LOCK(hpcd);
+  (void)USB_EPClearStall(hpcd->Instance, ep);
+  __HAL_UNLOCK(hpcd);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Flush an endpoint
+  * @param  hpcd PCD handle
+  * @param  ep_addr endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(ep_addr);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Activate remote wakeup signalling
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  return (USB_ActivateRemoteWakeup(hpcd->Instance));
+}
+
+/**
+  * @brief  De-activate remote wakeup signalling.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  return (USB_DeActivateRemoteWakeup(hpcd->Instance));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Exported_Functions_Group4 Peripheral State functions
+  *  @brief   Peripheral State functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the PCD handle state.
+  * @param  hpcd PCD handle
+  * @retval HAL state
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd)
+{
+  return hpcd->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+/** @addtogroup PCD_Private_Functions
+  * @{
+  */
+
+
+/**
+  * @brief  This function handles PCD Endpoint interrupt request.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
+{
+  PCD_EPTypeDef *ep;
+  uint16_t count, wIstr, wEPVal, TxByteNbre;
+  uint8_t epindex;
+
+  /* stay in loop while pending interrupts */
+  while ((hpcd->Instance->ISTR & USB_ISTR_CTR) != 0U)
+  {
+    wIstr = (uint16_t)hpcd->Instance->ISTR;
+
+    /* extract highest priority endpoint number */
+    epindex = (uint8_t)(wIstr & USB_ISTR_IDN);
+
+    if (epindex == 0U)
+    {
+      /* Decode and service control endpoint interrupt */
+
+      /* DIR bit = origin of the interrupt */
+      if ((wIstr & USB_ISTR_DIR) == 0U)
+      {
+        /* DIR = 0 */
+
+        /* DIR = 0 => IN  int */
+        /* DIR = 0 implies that (EP_CTR_TX = 1) always */
+        PCD_CLEAR_TX_EP_CTR(hpcd->Instance, PCD_ENDP0);
+        ep = &hpcd->IN_ep[0];
+
+        ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
+        ep->xfer_buff += ep->xfer_count;
+
+        /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+        hpcd->DataInStageCallback(hpcd, 0U);
+#else
+        HAL_PCD_DataInStageCallback(hpcd, 0U);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+        if ((hpcd->USB_Address > 0U) && (ep->xfer_len == 0U))
+        {
+          hpcd->Instance->DADDR = ((uint16_t)hpcd->USB_Address | USB_DADDR_EF);
+          hpcd->USB_Address = 0U;
+        }
+      }
+      else
+      {
+        /* DIR = 1 */
+
+        /* DIR = 1 & CTR_RX => SETUP or OUT int */
+        /* DIR = 1 & (CTR_TX | CTR_RX) => 2 int pending */
+        ep = &hpcd->OUT_ep[0];
+        wEPVal = (uint16_t)PCD_GET_ENDPOINT(hpcd->Instance, PCD_ENDP0);
+
+        if ((wEPVal & USB_EP_SETUP) != 0U)
+        {
+          /* Get SETUP Packet */
+          ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+
+          USB_ReadPMA(hpcd->Instance, (uint8_t *)hpcd->Setup,
+                      ep->pmaadress, (uint16_t)ep->xfer_count);
+
+          /* SETUP bit kept frozen while CTR_RX = 1 */
+          PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
+
+          /* Process SETUP Packet*/
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+          hpcd->SetupStageCallback(hpcd);
+#else
+          HAL_PCD_SetupStageCallback(hpcd);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+        }
+        else if ((wEPVal & USB_EP_VTRX) != 0U)
+        {
+          PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
+
+          /* Get Control Data OUT Packet */
+          ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+
+          if ((ep->xfer_count != 0U) && (ep->xfer_buff != 0U))
+          {
+            USB_ReadPMA(hpcd->Instance, ep->xfer_buff,
+                        ep->pmaadress, (uint16_t)ep->xfer_count);
+
+            ep->xfer_buff += ep->xfer_count;
+
+            /* Process Control Data OUT Packet */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+            hpcd->DataOutStageCallback(hpcd, 0U);
+#else
+            HAL_PCD_DataOutStageCallback(hpcd, 0U);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+          }
+
+          PCD_SET_EP_RX_CNT(hpcd->Instance, PCD_ENDP0, ep->maxpacket);
+          PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID);
+        }
+      }
+    }
+    else
+    {
+      /* Decode and service non control endpoints interrupt */
+      /* process related endpoint register */
+      wEPVal = (uint16_t)PCD_GET_ENDPOINT(hpcd->Instance, epindex);
+
+      if ((wEPVal & USB_EP_VTRX) != 0U)
+      {
+        /* clear int flag */
+        PCD_CLEAR_RX_EP_CTR(hpcd->Instance, epindex);
+        ep = &hpcd->OUT_ep[epindex];
+
+        /* OUT Single Buffering */
+        if (ep->doublebuffer == 0U)
+        {
+          count = (uint16_t)PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+
+          if (count != 0U)
+          {
+            USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, count);
+          }
+        }
+        else
+        {
+          /* manage double buffer bulk out */
+          if (ep->type == EP_TYPE_BULK)
+          {
+            count = HAL_PCD_EP_DB_Receive(hpcd, ep, wEPVal);
+          }
+          else /* manage double buffer iso out */
+          {
+            /* free EP OUT Buffer */
+            PCD_FreeUserBuffer(hpcd->Instance, ep->num, 0U);
+
+            if ((PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_RX) != 0U)
+            {
+              /* read from endpoint BUF0Addr buffer */
+              count = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+
+              if (count != 0U)
+              {
+                USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, count);
+              }
+            }
+            else
+            {
+              /* read from endpoint BUF1Addr buffer */
+              count = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+
+              if (count != 0U)
+              {
+                USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
+              }
+            }
+          }
+        }
+        /* multi-packet on the NON control OUT endpoint */
+        ep->xfer_count += count;
+        ep->xfer_buff += count;
+
+        if ((ep->xfer_len == 0U) || (count < ep->maxpacket))
+        {
+          /* RX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+          hpcd->DataOutStageCallback(hpcd, ep->num);
+#else
+          HAL_PCD_DataOutStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+        }
+        else
+        {
+          (void) USB_EPStartXfer(hpcd->Instance, ep);
+        }
+
+      }
+
+      if ((wEPVal & USB_EP_VTTX) != 0U)
+      {
+        ep = &hpcd->IN_ep[epindex];
+
+        /* clear int flag */
+        PCD_CLEAR_TX_EP_CTR(hpcd->Instance, epindex);
+
+        /* Manage all non bulk transaction or Bulk Single Buffer Transaction */
+        if ((ep->type != EP_TYPE_BULK) ||
+            ((ep->type == EP_TYPE_BULK) && ((wEPVal & USB_EP_KIND) == 0U)))
+        {
+          /* multi-packet on the NON control IN endpoint */
+          TxByteNbre = (uint16_t)PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
+
+          if (ep->xfer_len > TxByteNbre)
+          {
+            ep->xfer_len -= TxByteNbre;
+          }
+          else
+          {
+            ep->xfer_len = 0U;
+          }
+
+          /* Zero Length Packet? */
+          if (ep->xfer_len == 0U)
+          {
+            /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+            hpcd->DataInStageCallback(hpcd, ep->num);
+#else
+            HAL_PCD_DataInStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+          }
+          else
+          {
+            /* Transfer is not yet Done */
+            ep->xfer_buff += TxByteNbre;
+            ep->xfer_count += TxByteNbre;
+            (void)USB_EPStartXfer(hpcd->Instance, ep);
+          }
+        }
+        /* bulk in double buffer enable in case of transferLen> Ep_Mps */
+        else
+        {
+          (void)HAL_PCD_EP_DB_Transmit(hpcd, ep, wEPVal);
+        }
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Manage double buffer bulk out transaction from ISR
+  * @param  hpcd PCD handle
+  * @param  ep current endpoint handle
+  * @param  wEPVal Last snapshot of EPRx register value taken in ISR
+  * @retval HAL status
+  */
+static uint16_t HAL_PCD_EP_DB_Receive(PCD_HandleTypeDef *hpcd,
+                                      PCD_EPTypeDef *ep, uint16_t wEPVal)
+{
+  uint16_t count;
+
+  /* Manage Buffer0 OUT */
+  if ((wEPVal & USB_EP_DTOG_RX) != 0U)
+  {
+    /* Get count of received Data on buffer0 */
+    count = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len >= count)
+    {
+      ep->xfer_len -= count;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    if (ep->xfer_len == 0U)
+    {
+      /* set NAK to OUT endpoint since double buffer is enabled */
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_NAK);
+    }
+
+    /* Check if Buffer1 is in blocked state which requires to toggle */
+    if ((wEPVal & USB_EP_DTOG_TX) != 0U)
+    {
+      PCD_FreeUserBuffer(hpcd->Instance, ep->num, 0U);
+    }
+
+    if (count != 0U)
+    {
+      USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, count);
+    }
+  }
+  /* Manage Buffer 1 DTOG_RX=0 */
+  else
+  {
+    /* Get count of received data */
+    count = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len >= count)
+    {
+      ep->xfer_len -= count;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    if (ep->xfer_len == 0U)
+    {
+      /* set NAK on the current endpoint */
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_NAK);
+    }
+
+    /*Need to FreeUser Buffer*/
+    if ((wEPVal & USB_EP_DTOG_TX) == 0U)
+    {
+      PCD_FreeUserBuffer(hpcd->Instance, ep->num, 0U);
+    }
+
+    if (count != 0U)
+    {
+      USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
+    }
+  }
+
+  return count;
+}
+
+
+/**
+  * @brief  Manage double buffer bulk IN transaction from ISR
+  * @param  hpcd PCD handle
+  * @param  ep current endpoint handle
+  * @param  wEPVal Last snapshot of EPRx register value taken in ISR
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef HAL_PCD_EP_DB_Transmit(PCD_HandleTypeDef *hpcd,
+                                                PCD_EPTypeDef *ep, uint16_t wEPVal)
+{
+  uint32_t len;
+  uint16_t TxByteNbre;
+
+  /* Data Buffer0 ACK received */
+  if ((wEPVal & USB_EP_DTOG_TX) != 0U)
+  {
+    /* multi-packet on the NON control IN endpoint */
+    TxByteNbre = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len > TxByteNbre)
+    {
+      ep->xfer_len -= TxByteNbre;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+    /* Transfer is completed */
+    if (ep->xfer_len == 0U)
+    {
+      /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->DataInStageCallback(hpcd, ep->num);
+#else
+      HAL_PCD_DataInStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+      if ((wEPVal & USB_EP_DTOG_RX) != 0U)
+      {
+        PCD_FreeUserBuffer(hpcd->Instance, ep->num, 1U);
+      }
+    }
+    else /* Transfer is not yet Done */
+    {
+      /* need to Free USB Buff */
+      if ((wEPVal & USB_EP_DTOG_RX) != 0U)
+      {
+        PCD_FreeUserBuffer(hpcd->Instance, ep->num, 1U);
+      }
+
+      /* Still there is data to Fill in the next Buffer */
+      if (ep->xfer_fill_db == 1U)
+      {
+        ep->xfer_buff += TxByteNbre;
+        ep->xfer_count += TxByteNbre;
+
+        /* Calculate the len of the new buffer to fill */
+        if (ep->xfer_len_db >= ep->maxpacket)
+        {
+          len = ep->maxpacket;
+          ep->xfer_len_db -= len;
+        }
+        else if (ep->xfer_len_db == 0U)
+        {
+          len = TxByteNbre;
+          ep->xfer_fill_db = 0U;
+        }
+        else
+        {
+          ep->xfer_fill_db = 0U;
+          len = ep->xfer_len_db;
+          ep->xfer_len_db = 0U;
+        }
+
+        /* Write remaining Data to Buffer */
+        /* Set the Double buffer counter for pma buffer1 */
+        PCD_SET_EP_DBUF0_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+
+        /* Copy user buffer to USB PMA */
+        USB_WritePMA(hpcd->Instance, ep->xfer_buff,  ep->pmaaddr0, (uint16_t)len);
+      }
+    }
+  }
+  else /* Data Buffer1 ACK received */
+  {
+    /* multi-packet on the NON control IN endpoint */
+    TxByteNbre = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len >= TxByteNbre)
+    {
+      ep->xfer_len -= TxByteNbre;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    /* Transfer is completed */
+    if (ep->xfer_len == 0U)
+    {
+      /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->DataInStageCallback(hpcd, ep->num);
+#else
+      HAL_PCD_DataInStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+      /*need to Free USB Buff*/
+      if ((wEPVal & USB_EP_DTOG_RX) == 0U)
+      {
+        PCD_FreeUserBuffer(hpcd->Instance, ep->num, 1U);
+      }
+    }
+    else /* Transfer is not yet Done */
+    {
+      /* need to Free USB Buff */
+      if ((wEPVal & USB_EP_DTOG_RX) == 0U)
+      {
+        PCD_FreeUserBuffer(hpcd->Instance, ep->num, 1U);
+      }
+
+      /* Still there is data to Fill in the next Buffer */
+      if (ep->xfer_fill_db == 1U)
+      {
+        ep->xfer_buff += TxByteNbre;
+        ep->xfer_count += TxByteNbre;
+
+        /* Calculate the len of the new buffer to fill */
+        if (ep->xfer_len_db >= ep->maxpacket)
+        {
+          len = ep->maxpacket;
+          ep->xfer_len_db -= len;
+        }
+        else if (ep->xfer_len_db == 0U)
+        {
+          len = TxByteNbre;
+          ep->xfer_fill_db = 0U;
+        }
+        else
+        {
+          len = ep->xfer_len_db;
+          ep->xfer_len_db = 0U;
+          ep->xfer_fill_db = 0;
+        }
+
+        /* Set the Double buffer counter for pmabuffer1 */
+        PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+
+        /* Copy the user buffer to USB PMA */
+        USB_WritePMA(hpcd->Instance, ep->xfer_buff,  ep->pmaaddr1, (uint16_t)len);
+      }
+    }
+  }
+
+  /*enable endpoint IN*/
+  PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID);
+
+  return HAL_OK;
+}
+
+
+
+/**
+  * @}
+  */
+#endif /* defined (USB_DRD_FS) */
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pcd_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pcd_ex.c
@@ -1,0 +1,336 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_hal_pcd_ex.c
+  * @author  MCD Application Team
+  * @brief   PCD Extended HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Extended features functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal.h"
+
+/** @addtogroup STM32G0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCDEx PCDEx
+  * @brief PCD Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+
+#if defined (USB_DRD_FS)
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup PCDEx_Exported_Functions PCDEx Exported Functions
+  * @{
+  */
+
+/** @defgroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
+  * @brief    PCDEx control functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Update FIFO configuration
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure PMA for EP
+  * @param  hpcd  Device instance
+  * @param  ep_addr endpoint address
+  * @param  ep_kind endpoint Kind
+  *                  USB_SNG_BUF: Single Buffer used
+  *                  USB_DBL_BUF: Double Buffer used
+  * @param  pmaadress: EP address in The PMA: In case of single buffer endpoint
+  *                   this parameter is 16-bit value providing the address
+  *                   in PMA allocated to endpoint.
+  *                   In case of double buffer endpoint this parameter
+  *                   is a 32-bit value providing the endpoint buffer 0 address
+  *                   in the LSB part of 32-bit value and endpoint buffer 1 address
+  *                   in the MSB part of 32-bit value.
+  * @retval HAL status
+  */
+
+HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, uint16_t ep_addr,
+                                       uint16_t ep_kind, uint32_t pmaadress)
+{
+  PCD_EPTypeDef *ep;
+
+  /* initialize ep structure*/
+  if ((0x80U & ep_addr) == 0x80U)
+  {
+    ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+
+  /* Here we check if the endpoint is single or double Buffer*/
+  if (ep_kind == PCD_SNG_BUF)
+  {
+    /* Single Buffer */
+    ep->doublebuffer = 0U;
+    /* Configure the PMA */
+    ep->pmaadress = (uint16_t)pmaadress;
+  }
+  else /* USB_DBL_BUF */
+  {
+    /* Double Buffer Endpoint */
+    ep->doublebuffer = 1U;
+    /* Configure the PMA */
+    ep->pmaaddr0 = (uint16_t)(pmaadress & 0xFFFFU);
+    ep->pmaaddr1 = (uint16_t)((pmaadress & 0xFFFF0000U) >> 16);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Activate BatteryCharging feature.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_ActivateBCD(PCD_HandleTypeDef *hpcd)
+{
+  USB_DRD_TypeDef *USBx = hpcd->Instance;
+  hpcd->battery_charging_active = 1U;
+
+  /* Enable BCD feature */
+  USBx->BCDR |= USB_BCDR_BCDEN;
+
+  /* Enable DCD : Data Contact Detect */
+  USBx->BCDR &= ~(USB_BCDR_PDEN);
+  USBx->BCDR &= ~(USB_BCDR_SDEN);
+  USBx->BCDR |= USB_BCDR_DCDEN;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate BatteryCharging feature.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_DeActivateBCD(PCD_HandleTypeDef *hpcd)
+{
+  USB_DRD_TypeDef *USBx = hpcd->Instance;
+  hpcd->battery_charging_active = 0U;
+
+  /* Disable BCD feature */
+  USBx->BCDR &= ~(USB_BCDR_BCDEN);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle BatteryCharging Process.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd)
+{
+  USB_DRD_TypeDef *USBx = hpcd->Instance;
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Wait Detect flag or a timeout is happen*/
+  while ((USBx->BCDR & USB_BCDR_DCDET) == 0U)
+  {
+    /* Check for the Timeout */
+    if ((HAL_GetTick() - tickstart) > 1000U)
+    {
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->BCDCallback(hpcd, PCD_BCD_ERROR);
+#else
+      HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_ERROR);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+      return;
+    }
+  }
+
+  HAL_Delay(200U);
+
+  /* Data Pin Contact ? Check Detect flag */
+  if ((USBx->BCDR & USB_BCDR_DCDET) == USB_BCDR_DCDET)
+  {
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->BCDCallback(hpcd, PCD_BCD_CONTACT_DETECTION);
+#else
+    HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_CONTACT_DETECTION);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+  }
+  /* Primary detection: checks if connected to Standard Downstream Port
+  (without charging capability) */
+  USBx->BCDR &= ~(USB_BCDR_DCDEN);
+  HAL_Delay(50U);
+  USBx->BCDR |= (USB_BCDR_PDEN);
+  HAL_Delay(50U);
+
+  /* If Charger detect ? */
+  if ((USBx->BCDR & USB_BCDR_PDET) == USB_BCDR_PDET)
+  {
+    /* Start secondary detection to check connection to Charging Downstream
+    Port or Dedicated Charging Port */
+    USBx->BCDR &= ~(USB_BCDR_PDEN);
+    HAL_Delay(50U);
+    USBx->BCDR |= (USB_BCDR_SDEN);
+    HAL_Delay(50U);
+
+    /* If CDP ? */
+    if ((USBx->BCDR & USB_BCDR_SDET) == USB_BCDR_SDET)
+    {
+      /* Dedicated Downstream Port DCP */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->BCDCallback(hpcd, PCD_BCD_DEDICATED_CHARGING_PORT);
+#else
+      HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_DEDICATED_CHARGING_PORT);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+    }
+    else
+    {
+      /* Charging Downstream Port CDP */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->BCDCallback(hpcd, PCD_BCD_CHARGING_DOWNSTREAM_PORT);
+#else
+      HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_CHARGING_DOWNSTREAM_PORT);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+    }
+  }
+  else /* NO */
+  {
+    /* Standard Downstream Port */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->BCDCallback(hpcd, PCD_BCD_STD_DOWNSTREAM_PORT);
+#else
+    HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_STD_DOWNSTREAM_PORT);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+  }
+
+  /* Battery Charging capability discovery finished Start Enumeration */
+  (void)HAL_PCDEx_DeActivateBCD(hpcd);
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+  hpcd->BCDCallback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
+#else
+  HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+}
+
+
+/**
+  * @brief  Activate LPM feature.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd)
+{
+
+  USB_DRD_TypeDef *USBx = hpcd->Instance;
+  hpcd->lpm_active = 1U;
+  hpcd->LPM_State = LPM_L0;
+
+  USBx->LPMCSR |= USB_LPMCSR_LMPEN;
+  USBx->LPMCSR |= USB_LPMCSR_LPMACK;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivate LPM feature.
+  * @param  hpcd PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd)
+{
+  USB_DRD_TypeDef *USBx = hpcd->Instance;
+
+  hpcd->lpm_active = 0U;
+
+  USBx->LPMCSR &= ~(USB_LPMCSR_LMPEN);
+  USBx->LPMCSR &= ~(USB_LPMCSR_LPMACK);
+
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief  Send LPM message to user layer callback.
+  * @param  hpcd PCD handle
+  * @param  msg LPM message
+  * @retval HAL status
+  */
+__weak void HAL_PCDEx_LPM_Callback(PCD_HandleTypeDef *hpcd, PCD_LPM_MsgTypeDef msg)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(msg);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCDEx_LPM_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Send BatteryCharging message to user layer callback.
+  * @param  hpcd PCD handle
+  * @param  msg LPM message
+  * @retval HAL status
+  */
+__weak void HAL_PCDEx_BCD_Callback(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hpcd);
+  UNUSED(msg);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_PCDEx_BCD_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* defined (USB_DRD_FS) */
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pwr.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pwr.c
@@ -41,23 +41,6 @@
   * @{
   */
 
-#if defined(PWR_PVD_SUPPORT)
-/** @defgroup PWR_PVD_Mode_Mask PWR PVD Mode Mask
-  * @{
-  */
-#define PVD_MODE_IT           0x00010000U  /*!< Mask for interruption yielded
-                                                by PVD threshold crossing     */
-#define PVD_MODE_EVT          0x00020000U  /*!< Mask for event yielded
-                                                by PVD threshold crossing     */
-#define PVD_RISING_EDGE       0x00000001U  /*!< Mask for rising edge set as
-                                                PVD trigger                   */
-#define PVD_FALLING_EDGE      0x00000002U  /*!< Mask for falling edge set as
-                                                PVD trigger                   */
-/**
-  * @}
-  */
-#endif
-
 /**
   * @}
   */
@@ -108,17 +91,6 @@ void HAL_PWR_DeInit(void)
  ===============================================================================
 
     [..]
-     *** PVD configuration ***
-    =========================
-    [..]
-      (+) The PVD is used to monitor the VDD power supply by comparing it to a
-          threshold selected by the PVD Level (PVDRT[2:0] & PVDFT[2:0] bits in
-          PWR CR2 register).
-      (+) PVDO flag is available to indicate if VDD/VDDA is higher or lower
-          than the PVD threshold. This event is internally connected to the EXTI
-          line 16 and can generate an interrupt if enabled.
-      (+) The PVD is stopped in Standby & Shutdown mode.
-
     *** WakeUp pin configuration ***
     ================================
     [..]
@@ -232,7 +204,7 @@ void HAL_PWR_DeInit(void)
         cleared. SRAM and registers contents are lost except for backup domain
         registers.
       (+) Entry:
-          (++) The Shutdown mode is entered thru HAL_PWREx_EnterSHUTDOWNMode() API,
+          (++) The Shutdown mode is entered through HAL_PWREx_EnterSHUTDOWNMode() API,
                by setting SLEEPDEEP in Cortex control register.
       (+) Exit:
           (++) WKUP pin edge detection, RTC event (wakeup, alarm, timestamp),
@@ -269,96 +241,23 @@ void HAL_PWR_DisableBkUpAccess(void)
   CLEAR_BIT(PWR->CR1, PWR_CR1_DBP);
 }
 
-
-#if defined(PWR_PVD_SUPPORT)
-/**
-  * @brief  Configure the Power Voltage Detector (PVD).
-  * @param  sConfigPVD pointer to a PWR_PVDTypeDef structure that contains the
-            PVD configuration information: threshold levels, operating mode.
-  * @note   Refer to the electrical characteristics of your device datasheet for
-  *         more details about the voltage thresholds corresponding to each
-  *         detection level.
-  * @note   User should take care that rising threshold is higher than falling
-  *         one in order to avoid having always PVDO output set.
-  * @retval HAL_OK
-  */
-HAL_StatusTypeDef HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD)
-{
-  /* Check the parameters */
-  assert_param(IS_PWR_PVD_LEVEL(sConfigPVD->PVDLevel));
-  assert_param(IS_PWR_PVD_MODE(sConfigPVD->Mode));
-
-  /* Set PVD level bits only according to PVDLevel value */
-  MODIFY_REG(PWR->CR2, (PWR_CR2_PVDFT | PWR_CR2_PVDRT), sConfigPVD->PVDLevel);
-
-  /* Clear any previous config, in case no event or IT mode is selected */
-  __HAL_PWR_PVD_EXTI_DISABLE_EVENT();
-  __HAL_PWR_PVD_EXTI_DISABLE_IT();
-  __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();
-  __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();
-
-  /* Configure interrupt mode */
-  if((sConfigPVD->Mode & PVD_MODE_IT) == PVD_MODE_IT)
-  {
-    __HAL_PWR_PVD_EXTI_ENABLE_IT();
-  }
-
-  /* Configure event mode */
-  if((sConfigPVD->Mode & PVD_MODE_EVT) == PVD_MODE_EVT)
-  {
-    __HAL_PWR_PVD_EXTI_ENABLE_EVENT();
-  }
-
-  /* Configure the edge */
-  if((sConfigPVD->Mode & PVD_RISING_EDGE) == PVD_RISING_EDGE)
-  {
-    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();
-  }
-
-  if((sConfigPVD->Mode & PVD_FALLING_EDGE) == PVD_FALLING_EDGE)
-  {
-    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();
-  }
-
-  return HAL_OK;
-}
-
-
-/**
-  * @brief  Enable the Power Voltage Detector (PVD).
-  * @retval None
-  */
-void HAL_PWR_EnablePVD(void)
-{
-  SET_BIT(PWR->CR2, PWR_CR2_PVDE);
-}
-
-
-/**
-  * @brief  Disable the Power Voltage Detector (PVD).
-  * @retval None
-  */
-void HAL_PWR_DisablePVD(void)
-{
-  CLEAR_BIT(PWR->CR2, PWR_CR2_PVDE);
-}
-#endif
-
 /**
   * @brief  Enable the WakeUp PINx functionality.
   * @param  WakeUpPinPolarity Specifies which Wake-Up pin to enable.
   *         This parameter can be one of the following legacy values which set
   *         the default polarity i.e. detection on high level (rising edge):
-  *           @arg @ref PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2, PWR_WAKEUP_PIN4,
-  *                PWR_WAKEUP_PIN5,PWR_WAKEUP_PIN6
+  *           @arg @ref PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2, PWR_WAKEUP_PIN3(*),
+  *                     PWR_WAKEUP_PIN4, PWR_WAKEUP_PIN5(*),PWR_WAKEUP_PIN6
   *         or one of the following value where the user can explicitly specify
   *         the enabled pin and the chosen polarity:
   *           @arg @ref PWR_WAKEUP_PIN1_HIGH or PWR_WAKEUP_PIN1_LOW
   *           @arg @ref PWR_WAKEUP_PIN2_HIGH or PWR_WAKEUP_PIN2_LOW
+  *           @arg @ref PWR_WAKEUP_PIN3_HIGH or PWR_WAKEUP_PIN3_LOW (*)
   *           @arg @ref PWR_WAKEUP_PIN4_HIGH or PWR_WAKEUP_PIN4_LOW
-  *           @arg @ref PWR_WAKEUP_PIN5_HIGH or PWR_WAKEUP_PIN5_LOW
+  *           @arg @ref PWR_WAKEUP_PIN5_HIGH or PWR_WAKEUP_PIN5_LOW (*)
   *           @arg @ref PWR_WAKEUP_PIN6_HIGH or PWR_WAKEUP_PIN6_LOW
   * @note  PWR_WAKEUP_PINx and PWR_WAKEUP_PINx_HIGH are equivalent.
+  * @note (*) availability depends on devices
   * @retval None
   */
 void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity)
@@ -378,8 +277,9 @@ void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinPolarity)
   * @brief  Disable the WakeUp PINx functionality.
   * @param  WakeUpPinx Specifies the Power Wake-Up pin to disable.
   *         This parameter can be one of the following values:
-  *           @arg @ref PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2, PWR_WAKEUP_PIN4,
-  *                PWR_WAKEUP_PIN5,PWR_WAKEUP_PIN6
+  *           @arg @ref PWR_WAKEUP_PIN1, PWR_WAKEUP_PIN2,PWR_WAKEUP_PIN3(*),
+  *                     PWR_WAKEUP_PIN4,PWR_WAKEUP_PIN5(*),PWR_WAKEUP_PIN6
+  * @note (*) availability depends on devices
   * @retval None
   */
 void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx)
@@ -624,59 +524,6 @@ void HAL_PWR_DisableSEVOnPend(void)
   /* Clear SEVONPEND bit of Cortex System Control Register */
   CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SEVONPEND_Msk));
 }
-
-#if defined(PWR_PVD_SUPPORT)
-/**
-  * @brief  This function handles the PWR PVD interrupt request.
-  * @note   This API should be called under the PVD_IRQHandler().
-  * @retval None
-  */
-void HAL_PWR_PVD_IRQHandler(void)
-{
-  /* Check PWR exti Rising flag */
-  if(__HAL_PWR_PVD_EXTI_GET_RISING_FLAG() != 0x0U)
-  {
-    /* Clear PVD exti pending bit */
-    __HAL_PWR_PVD_EXTI_CLEAR_RISING_FLAG();
-
-    /* PWR PVD interrupt rising user callback */
-    HAL_PWR_PVD_Rising_Callback();
-  }
-
-  /* Check PWR exti fallling flag */
-  if(__HAL_PWR_PVD_EXTI_GET_FALLING_FLAG() != 0x0U)
-  {
-    /* Clear PVD exti pending bit */
-    __HAL_PWR_PVD_EXTI_CLEAR_FALLING_FLAG();
-
-    /* PWR PVD interrupt falling user callback */
-    HAL_PWR_PVD_Falling_Callback();
-  }
-}
-
-/**
-  * @brief  PWR PVD interrupt rising callback
-  * @retval None
-  */
-__weak void HAL_PWR_PVD_Rising_Callback(void)
-{
-  /* NOTE : This function should not be modified; when the callback is needed,
-            the HAL_PWR_PVD_Rising_Callback can be implemented in the user file
-  */
-}
-
-/**
-  * @brief  PWR PVD interrupt Falling callback
-  * @retval None
-  */
-__weak void HAL_PWR_PVD_Falling_Callback(void)
-{
-  /* NOTE : This function should not be modified; when the callback is needed,
-            the HAL_PWR_PVD_Falling_Callback can be implemented in the user file
-  */
-}
-
-#endif
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pwr_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_pwr_ex.c
@@ -41,6 +41,23 @@
   * @{
   */
 
+#if defined(PWR_PVD_SUPPORT)
+/** @defgroup PWR_PVD_Mode_Mask PWR PVD Mode Mask
+  * @{
+  */
+#define PVD_MODE_IT           0x00010000U  /*!< Mask for interruption yielded
+                                                by PVD threshold crossing     */
+#define PVD_MODE_EVT          0x00020000U  /*!< Mask for event yielded
+                                                by PVD threshold crossing     */
+#define PVD_RISING_EDGE       0x00000001U  /*!< Mask for rising edge set as
+                                                PVD trigger                   */
+#define PVD_FALLING_EDGE      0x00000002U  /*!< Mask for falling edge set as
+                                                PVD trigger                   */
+/**
+  * @}
+  */
+#endif
+
 /** @defgroup PWREx_TimeOut_Value  PWREx Flag Setting Time Out Value
   * @{
   */
@@ -83,6 +100,20 @@
   ##### Extended Peripheral Initialization and de-initialization functions #####
  ===============================================================================
     [..]
+     *** PVD configuration ***
+    =========================
+    [..]
+      (+) The PVD is used to monitor the VDD power supply by comparing it to a
+          threshold selected by the PVD Level (PVDRT[2:0] & PVDFT[2:0] bits in
+          PWR CR2 register).
+      (+) PVDO flag is available to indicate if VDD/VDDA is higher or lower
+          than the PVD threshold. This event is internally connected to the EXTI
+          line 16 and can generate an interrupt if enabled.
+      (+) The PVD is stopped in Standby & Shutdown mode.
+
+     *** PVM configuration ***
+    =========================
+    [..]
 
 @endverbatim
   * @{
@@ -90,7 +121,7 @@
 
 /**
   * @brief  Enable battery charging.
-  * @note   When VDD is present, charge the external battery on VBAT thru an
+  * @note   When VDD is present, charge the external battery on VBAT through an
   *         internal resistor.
   * @param  ResistorSelection specifies the resistor impedance.
   *         This parameter can be one of the following values:
@@ -142,7 +173,208 @@ void HAL_PWREx_DisablePORMonitorSampling(void)
 }
 #endif
 
+#if defined(PWR_PVD_SUPPORT)
+/**
+  * @brief  Configure the Power Voltage Detector (PVD).
+  * @param  sConfigPVD pointer to a PWR_PVDTypeDef structure that contains the
+            PVD configuration information: threshold levels, operating mode.
+  * @note   Refer to the electrical characteristics of your device datasheet for
+  *         more details about the voltage thresholds corresponding to each
+  *         detection level.
+  * @note   User should take care that rising threshold is higher than falling
+  *         one in order to avoid having always PVDO output set.
+  * @retval HAL_OK
+  */
+HAL_StatusTypeDef HAL_PWREx_ConfigPVD(PWR_PVDTypeDef *sConfigPVD)
+{
+  /* Check the parameters */
+  assert_param(IS_PWR_PVD_LEVEL(sConfigPVD->PVDLevel));
+  assert_param(IS_PWR_PVD_MODE(sConfigPVD->Mode));
 
+  /* Set PVD level bits only according to PVDLevel value */
+  MODIFY_REG(PWR->CR2, (PWR_CR2_PVDFT | PWR_CR2_PVDRT), sConfigPVD->PVDLevel);
+
+  /* Clear any previous config, in case no event or IT mode is selected */
+  __HAL_PWR_PVD_EXTI_DISABLE_EVENT();
+  __HAL_PWR_PVD_EXTI_DISABLE_IT();
+  __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();
+  __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();
+
+  /* Configure interrupt mode */
+  if((sConfigPVD->Mode & PVD_MODE_IT) == PVD_MODE_IT)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_IT();
+  }
+
+  /* Configure event mode */
+  if((sConfigPVD->Mode & PVD_MODE_EVT) == PVD_MODE_EVT)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_EVENT();
+  }
+
+  /* Configure the edge */
+  if((sConfigPVD->Mode & PVD_RISING_EDGE) == PVD_RISING_EDGE)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();
+  }
+
+  if((sConfigPVD->Mode & PVD_FALLING_EDGE) == PVD_FALLING_EDGE)
+  {
+    __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Enable the Power Voltage Detector (PVD).
+  * @retval None
+  */
+void HAL_PWREx_EnablePVD(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_PVDE);
+}
+
+
+/**
+  * @brief  Disable the Power Voltage Detector (PVD).
+  * @retval None
+  */
+void HAL_PWREx_DisablePVD(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_PVDE);
+}
+#endif
+
+#if defined(PWR_PVM_SUPPORT)
+/**
+  * @brief Enable VDDUSB supply.
+  * @note  Remove VDDUSB electrical and logical isolation, once VDDUSB supply is present.
+  * @retval None
+  */
+void HAL_PWREx_EnableVddUSB(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_USV);
+}
+
+/**
+  * @brief Disable VDDUSB supply.
+  * @retval None
+  */
+void HAL_PWREx_DisableVddUSB(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_USV);
+}
+#endif
+
+#if defined(PWR_CR2_IOSV)
+/**
+  * @brief Enable VDDIO2 supply.
+  * @note  Remove VDDIO2 electrical and logical isolation, once VDDIO2 supply is present.
+  * @retval None
+  */
+void HAL_PWREx_EnableVddIO2(void)
+{
+  SET_BIT(PWR->CR2, PWR_CR2_IOSV);
+}
+
+
+/**
+  * @brief Disable VDDIO2 supply.
+  * @retval None
+  */
+void HAL_PWREx_DisableVddIO2(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_CR2_IOSV);
+}
+#endif /* PWR_CR2_IOSV */
+
+#if defined (PWR_PVM_SUPPORT)
+/**
+  * @brief Enable the Power Voltage Monitoring for USB peripheral (power domain Vddio2)
+  * @retval None
+  */
+void HAL_PWREx_EnablePVMUSB(void)
+{
+  SET_BIT(PWR->CR2, PWR_PVM_USB);
+}
+
+/**
+  * @brief Disable the Power Voltage Monitoring for USB peripheral (power domain Vddio2)
+  * @retval None
+  */
+void HAL_PWREx_DisablePVMUSB(void)
+{
+  CLEAR_BIT(PWR->CR2, PWR_PVM_USB);
+}
+#endif
+
+#if defined(PWR_PVM_SUPPORT)
+/**
+  * @brief Configure the Peripheral Voltage Monitoring (PVM).
+  * @param sConfigPVM: pointer to a PWR_PVMTypeDef structure that contains the
+  *        PVM configuration information.
+  * @note The API configures a single PVM according to the information contained
+  *       in the input structure. To configure several PVMs, the API must be singly
+  *       called for each PVM used.
+  * @note Refer to the electrical characteristics of your device datasheet for
+  *         more details about the voltage thresholds corresponding to each
+  *         detection level and to each monitored supply.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the parameters */
+  assert_param(IS_PWR_PVM_TYPE(sConfigPVM->PVMType));
+  assert_param(IS_PWR_PVM_MODE(sConfigPVM->Mode));
+
+  /* Configure EXTI 34 interrupts if so required:
+     scan through PVMType to detect which PVMx is set and
+     configure the corresponding EXTI line accordingly. */
+  switch (sConfigPVM->PVMType)
+  {
+    case PWR_PVM_USB:
+      /* Clear any previous config. Keep it clear if no event or IT mode is selected */
+      __HAL_PWR_PVM_EXTI_DISABLE_EVENT();
+      __HAL_PWR_PVM_EXTI_DISABLE_IT();
+      __HAL_PWR_PVM_EXTI_DISABLE_FALLING_EDGE();
+      __HAL_PWR_PVM_EXTI_DISABLE_RISING_EDGE();
+
+      /* Configure interrupt mode */
+      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      {
+        __HAL_PWR_PVM_EXTI_ENABLE_IT();
+      }
+
+      /* Configure event mode */
+      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      {
+        __HAL_PWR_PVM_EXTI_ENABLE_EVENT();
+      }
+
+      /* Configure the edge */
+      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      {
+        __HAL_PWR_PVM_EXTI_ENABLE_RISING_EDGE();
+      }
+
+      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      {
+        __HAL_PWR_PVM_EXTI_ENABLE_FALLING_EDGE();
+      }
+      break;
+
+    default:
+      status = HAL_ERROR;
+      break;
+  }
+
+  return status;
+}
+#endif
 /**
   * @brief  Enable Internal Wake-up Line.
   * @retval None
@@ -152,7 +384,6 @@ void HAL_PWREx_EnableInternalWakeUpLine(void)
   SET_BIT(PWR->CR3, PWR_CR3_EIWUL);
 }
 
-
 /**
   * @brief  Disable Internal Wake-up Line.
   * @retval None
@@ -161,7 +392,6 @@ void HAL_PWREx_DisableInternalWakeUpLine(void)
 {
   CLEAR_BIT(PWR->CR3, PWR_CR3_EIWUL);
 }
-
 
 /**
   * @brief  Enable GPIO pull-up state in Standby and Shutdown modes.
@@ -211,6 +441,12 @@ HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber)
        CLEAR_BIT(PWR->PDCRD, GPIONumber);
        break;
 
+#if defined(GPI0E)
+    case PWR_GPIO_E:
+       SET_BIT(PWR->PUCRE, GPIONumber);
+       CLEAR_BIT(PWR->PDCRE, GPIONumber);
+       break;
+#endif
     case PWR_GPIO_F:
        SET_BIT(PWR->PUCRF, GPIONumber);
        CLEAR_BIT(PWR->PDCRF, GPIONumber);
@@ -263,6 +499,11 @@ HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber
       CLEAR_BIT(PWR->PUCRD, GPIONumber);
       break;
 
+#if defined(GPI0E)
+    case PWR_GPIO_E:
+      CLEAR_BIT(PWR->PUCRE, GPIONumber);
+      break;
+#endif
     case PWR_GPIO_F:
       CLEAR_BIT(PWR->PUCRF, GPIONumber);
       break;
@@ -324,6 +565,12 @@ HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumbe
        CLEAR_BIT(PWR->PUCRD, GPIONumber);
        break;
 
+#if defined(GPIOE)
+    case PWR_GPIO_E:
+       SET_BIT(PWR->PDCRE, GPIONumber);
+       CLEAR_BIT(PWR->PUCRE, GPIONumber);
+       break;
+#endif
     case PWR_GPIO_F:
        SET_BIT(PWR->PDCRF, GPIONumber);
        CLEAR_BIT(PWR->PUCRF, GPIONumber);
@@ -376,6 +623,11 @@ HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumb
       CLEAR_BIT(PWR->PDCRD, GPIONumber);
       break;
 
+#if defined(GPIOE)
+    case PWR_GPIO_E:
+      CLEAR_BIT(PWR->PDCRE, GPIONumber);
+      break;
+#endif
     case PWR_GPIO_F:
       CLEAR_BIT(PWR->PDCRF, GPIONumber);
       break;
@@ -478,7 +730,9 @@ void HAL_PWREx_DisableFlashPowerDown(uint32_t PowerMode)
 
 /**
   * @brief   Return Voltage Scaling Range.
-  * @retval  VOS bit field : PWR_REGULATOR_VOLTAGE_RANGE1 or PWR_REGULATOR_VOLTAGE_RANGE2
+  * @retval  VOS bit field:
+  *         @arg @ref PWR_REGULATOR_VOLTAGE_SCALE1
+  *         @arg @ref PWR_REGULATOR_VOLTAGE_SCALE2
   */
 uint32_t HAL_PWREx_GetVoltageRange(void)
 {
@@ -620,6 +874,129 @@ void HAL_PWREx_EnterSHUTDOWNMode(void)
   /* Request Wait For Interrupt */
   __WFI();
 }
+#endif
+
+#if defined(PWR_PVD_SUPPORT) && defined(PWR_PVM_SUPPORT)
+/**
+  * @brief  This function handles the PWR PVD interrupt request.
+  * @note   This API should be called under the PVD_IRQHandler().
+  * @retval None
+  */
+void HAL_PWREx_PVD_PVM_IRQHandler(void)
+{
+  /* Check PWR PVD exti Rising flag */
+  if(__HAL_PWR_PVD_EXTI_GET_RISING_FLAG() != 0x0U)
+  {
+    /* Clear PVD exti pending bit */
+    __HAL_PWR_PVD_EXTI_CLEAR_RISING_FLAG();
+
+    /* PWR PVD interrupt rising user callback */
+    HAL_PWREx_PVD_PVM_Rising_Callback();
+  }
+
+  /* Check PWR exti fallling flag */
+  if(__HAL_PWR_PVD_EXTI_GET_FALLING_FLAG() != 0x0U)
+  {
+    /* Clear PVD exti pending bit */
+    __HAL_PWR_PVD_EXTI_CLEAR_FALLING_FLAG();
+
+    /* PWR PVD interrupt falling user callback */
+    HAL_PWREx_PVD_PVM_Falling_Callback();
+  }
+
+  /* Check PWR PVM exti Rising flag */
+  if(__HAL_PWR_PVM_EXTI_GET_RISING_FLAG() != 0x0U)
+  {
+    /* Clear PVM exti pending bit */
+    __HAL_PWR_PVM_EXTI_CLEAR_RISING_FLAG();
+
+    /* PWR PVD PVM interrupt rising user callback */
+    HAL_PWREx_PVD_PVM_Rising_Callback();
+  }
+
+  /* Check PWR PVM exti fallling flag */
+  if(__HAL_PWR_PVM_EXTI_GET_FALLING_FLAG() != 0x0U)
+  {
+    /* Clear PVM exti pending bit */
+    __HAL_PWR_PVM_EXTI_CLEAR_FALLING_FLAG();
+
+    /* PWR PVM interrupt falling user callback */
+    HAL_PWREx_PVD_PVM_Falling_Callback();
+  }
+}
+
+/**
+  * @brief  PWR PVD interrupt rising callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVD_PVM_Rising_Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_PWR_PVD_Rising_Callback can be implemented in the user file
+  */
+}
+
+/**
+  * @brief  PWR PVD interrupt Falling callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVD_PVM_Falling_Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_PWR_PVD_Falling_Callback can be implemented in the user file
+  */
+}
+#elif defined(PWR_PVD_SUPPORT)
+/**
+  * @brief  This function handles the PWR PVD interrupt request.
+  * @note   This API should be called under the PVD_IRQHandler().
+  * @retval None
+  */
+void HAL_PWREx_PVD_IRQHandler(void)
+{
+  /* Check PWR exti Rising flag */
+  if(__HAL_PWR_PVD_EXTI_GET_RISING_FLAG() != 0x0U)
+  {
+    /* Clear PVD exti pending bit */
+    __HAL_PWR_PVD_EXTI_CLEAR_RISING_FLAG();
+
+    /* PWR PVD interrupt rising user callback */
+    HAL_PWREx_PVD_Rising_Callback();
+  }
+
+  /* Check PWR exti fallling flag */
+  if(__HAL_PWR_PVD_EXTI_GET_FALLING_FLAG() != 0x0U)
+  {
+    /* Clear PVD exti pending bit */
+    __HAL_PWR_PVD_EXTI_CLEAR_FALLING_FLAG();
+
+    /* PWR PVD interrupt falling user callback */
+    HAL_PWREx_PVD_Falling_Callback();
+  }
+}
+
+/**
+  * @brief  PWR PVD interrupt rising callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVD_Rising_Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_PWR_PVD_Rising_Callback can be implemented in the user file
+  */
+}
+
+/**
+  * @brief  PWR PVD interrupt Falling callback
+  * @retval None
+  */
+__weak void HAL_PWREx_PVD_Falling_Callback(void)
+{
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_PWR_PVD_Falling_Callback can be implemented in the user file
+  */
+}
+
 #endif
 
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rcc.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rcc.c
@@ -18,8 +18,8 @@
       D-Cache and I-Cache are disabled, and all peripherals are off except internal
       SRAM, Flash and JTAG.
 
-      (+) There is no prescaler on High speed (AHB) and Low speed (APB) busses:
-          all peripherals mapped on these busses are running at HSI speed.
+      (+) There is no prescaler on High speed (AHB) and Low speed (APB) buses:
+          all peripherals mapped on these buses are running at HSI speed.
       (+) The clock for all peripherals is switched off, except the SRAM and FLASH.
       (+) All GPIOs are in analog mode, except the JTAG pins which
           are assigned to be used for debug purpose.
@@ -29,7 +29,7 @@
       (+) Configure the clock source to be used to drive the System clock
           (if the application needs higher frequency/performance)
       (+) Configure the System clock frequency and Flash settings
-      (+) Configure the AHB and APB busses prescalers
+      (+) Configure the AHB and APB buses prescalers
       (+) Enable the clock for the peripheral(s) to be used
       (+) Configure the clock source(s) for peripherals which clocks are not
           derived from the System clock (RTC, ADC, RNG, HSTIM)
@@ -66,12 +66,16 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /** @defgroup RCC_Private_Constants RCC Private Constants
- * @{
- */
+  * @{
+  */
 #define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
 #define HSI_TIMEOUT_VALUE          (2U)    /* 2 ms (minimum Tick + 1) */
 #define LSI_TIMEOUT_VALUE          (2U)    /* 2 ms (minimum Tick + 1) */
 #define PLL_TIMEOUT_VALUE          (2U)    /* 2 ms (minimum Tick + 1) */
+
+#if defined(RCC_HSI48_SUPPORT)
+#define HSI48_TIMEOUT_VALUE        (2U)    /* 2 ms (minimum Tick + 1) */
+#endif /* RCC_HSI48_SUPPORT */
 #define CLOCKSWITCH_TIMEOUT_VALUE  (5000U) /* 5 s    */
 
 #define PLLSOURCE_NONE             (0U)
@@ -86,6 +90,12 @@
 #define MCO1_CLK_ENABLE()     __HAL_RCC_GPIOA_CLK_ENABLE()
 #define MCO1_GPIO_PORT        GPIOA
 #define MCO1_PIN              GPIO_PIN_8
+
+#if defined(RCC_MCO2_SUPPORT)
+#define MCO2_CLK_ENABLE()    __HAL_RCC_GPIOA_CLK_ENABLE()
+#define MCO2_GPIO_PORT        GPIOA
+#define MCO2_PIN              GPIO_PIN_10
+#endif /* RCC_MCO2_SUPPORT */
 
 #define RCC_PLL_OSCSOURCE_CONFIG(__HAL_RCC_PLLSOURCE__) \
             (MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (uint32_t)(__HAL_RCC_PLLSOURCE__)))
@@ -118,7 +128,7 @@
  ===============================================================================
     [..]
       This section provides functions allowing to configure the internal and external oscillators
-      (HSE, HSI, LSE, LSI, PLL, CSS and MCO) and the System busses clocks (SYSCLK, AHB, APB)
+      (HSE, HSI, LSE, LSI, PLL, CSS and MCO) and the System buses clocks (SYSCLK, AHB, APB)
 
     [..] Internal/external clock and PLL configuration
          (+) HSI (high-speed internal): 16 MHz factory-trimmed RC used directly or through
@@ -143,17 +153,19 @@
              if enabled. The interrupt is linked to the Cortex-M0+ NMI (Non-Maskable Interrupt)
              exception vector.
 
-         (+) MCO (microcontroller clock output): used to output LSI, HSI, LSE, HSE or
-             main PLL clock (through a configurable prescaler) on PA8 pin.
+         (+) MCOx (microcontroller clock output):
+             (++) MCO1 used to output LSI, HSI48(*), HSI, LSE, HSE or main PLL clock (through a configurable prescaler) on PA8 pin.
+             (++) MCO2(*) used to output LSI, HSI48(*), HSI, LSE, HSE, main PLLR clock, PLLQ clock, PLLP clock, RTC clock or RTC_Wakeup (through a configurable prescaler) on PA10 pin.
+                 (*) available on certain devices only
 
-    [..] System, AHB and APB busses clocks configuration
+    [..] System, AHB and APB buses clocks configuration
          (+) Several clock sources can be used to drive the System clock (SYSCLK): HSI,
              HSE, LSI, LSE and main PLL.
              The AHB clock (HCLK) is derived from System clock through configurable
              prescaler and used to clock the CPU, memory and peripherals mapped
              on AHB bus (DMA, GPIO...).and APB (PCLK1) clock is derived
              from AHB clock through configurable prescalers and used to clock
-             the peripherals mapped on these busses. You can use
+             the peripherals mapped on these buses. You can use
              "@ref HAL_RCC_GetSysClockFreq()" function to retrieve the frequencies of these clocks.
 
          -@- All the peripheral clocks are derived from the System clock (SYSCLK) except:
@@ -322,7 +334,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     temp_pllckcfg = __HAL_RCC_GET_PLL_OSCSOURCE();
 
     /* When the HSE is used as system clock or clock source for PLL in these cases it is not allowed to be disabled */
-    if (((temp_sysclksrc == RCC_CFGR_SWS_PLL) && (temp_pllckcfg == RCC_PLLSOURCE_HSE)) || (temp_sysclksrc == RCC_CFGR_SWS_HSE))
+    if (((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (temp_pllckcfg == RCC_PLLSOURCE_HSE)) || (temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_HSE))
     {
       if ((READ_BIT(RCC->CR, RCC_CR_HSERDY) != 0U) && (RCC_OscInitStruct->HSEState == RCC_HSE_OFF))
       {
@@ -376,7 +388,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     /* Check if HSI16 is used as system clock or as PLL source when PLL is selected as system clock */
     temp_sysclksrc = __HAL_RCC_GET_SYSCLK_SOURCE();
     temp_pllckcfg = __HAL_RCC_GET_PLL_OSCSOURCE();
-    if (((temp_sysclksrc == RCC_CFGR_SWS_PLL) && (temp_pllckcfg == RCC_PLLSOURCE_HSI)) || (temp_sysclksrc == RCC_CFGR_SWS_HSI))
+    if (((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (temp_pllckcfg == RCC_PLLSOURCE_HSI)) || (temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_HSI))
     {
       /* When HSI is used as system clock or as PLL input clock it can not be disabled */
       if ((READ_BIT(RCC->CR, RCC_CR_HSIRDY) != 0U) && (RCC_OscInitStruct->HSIState == RCC_HSI_OFF))
@@ -389,7 +401,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
         __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
 
-        if (temp_sysclksrc == RCC_CFGR_SWS_HSI)
+        if (temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_HSI)
         {
           /* Adjust the HSI16 division factor */
           __HAL_RCC_HSI_CONFIG(RCC_OscInitStruct->HSIDiv);
@@ -457,7 +469,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     assert_param(IS_RCC_LSI(RCC_OscInitStruct->LSIState));
 
     /* Check if LSI is used as system clock */
-    if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_LSI)
+    if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_LSI)
     {
       /* When LSI is used as system clock it will not be disabled */
       if ((((RCC->CSR) & RCC_CSR_LSIRDY) != 0U) && (RCC_OscInitStruct->LSIState == RCC_LSI_OFF))
@@ -513,7 +525,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     assert_param(IS_RCC_LSE(RCC_OscInitStruct->LSEState));
 
     /* When the LSE is used as system clock, it is not allowed disable it */
-    if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_LSE)
+    if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_LSE)
     {
       if ((((RCC->BDCR) & RCC_BDCR_LSERDY) != 0U) && (RCC_OscInitStruct->LSEState == RCC_LSE_OFF))
       {
@@ -587,6 +599,50 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       }
     }
   }
+#if defined(RCC_HSI48_SUPPORT)
+  /*------------------------------ HSI48 Configuration -----------------------*/
+  if (((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI48) == RCC_OSCILLATORTYPE_HSI48)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSI48(RCC_OscInitStruct->HSI48State));
+
+    /* Check the LSI State */
+    if (RCC_OscInitStruct->HSI48State != RCC_HSI48_OFF)
+    {
+      /* Enable the Internal Low Speed oscillator (HSI48). */
+      __HAL_RCC_HSI48_ENABLE();
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till HSI48 is ready */
+      while (READ_BIT(RCC->CR, RCC_CR_HSI48RDY) == 0U)
+      {
+        if ((HAL_GetTick() - tickstart) > HSI48_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Disable the Internal Low Speed oscillator (HSI48). */
+      __HAL_RCC_HSI48_DISABLE();
+
+      /* Get Start Tick*/
+      tickstart = HAL_GetTick();
+
+      /* Wait till HSI48 is disabled */
+      while (READ_BIT(RCC->CR, RCC_CR_HSI48RDY) != 0U)
+      {
+        if ((HAL_GetTick() - tickstart) > HSI48_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+#endif /* RCC_HSI48_SUPPORT */
   /*-------------------------------- PLL Configuration -----------------------*/
   /* Check the parameters */
   assert_param(IS_RCC_PLL(RCC_OscInitStruct->PLL.PLLState));
@@ -594,7 +650,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
   if (RCC_OscInitStruct->PLL.PLLState != RCC_PLL_NONE)
   {
     /* Check if the PLL is used as system clock or not */
-    if (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+    if (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_PLLCLK)
     {
       if (RCC_OscInitStruct->PLL.PLLState == RCC_PLL_ON)
       {
@@ -605,7 +661,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         assert_param(IS_RCC_PLLP_VALUE(RCC_OscInitStruct->PLL.PLLP));
 #if defined(RCC_PLLQ_SUPPORT)
         assert_param(IS_RCC_PLLQ_VALUE(RCC_OscInitStruct->PLL.PLLQ));
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
         assert_param(IS_RCC_PLLR_VALUE(RCC_OscInitStruct->PLL.PLLR));
 
         /* Disable the main PLL. */
@@ -630,7 +686,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
                              RCC_OscInitStruct->PLL.PLLP,
 #if defined(RCC_PLLQ_SUPPORT)
                              RCC_OscInitStruct->PLL.PLLQ,
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
                              RCC_OscInitStruct->PLL.PLLR);
 
         /* Enable the main PLL. */
@@ -663,7 +719,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         __HAL_RCC_PLLCLKOUT_DISABLE(RCC_PLLCFGR_PLLPEN | RCC_PLLCFGR_PLLQEN | RCC_PLLCFGR_PLLREN);
 #else
         __HAL_RCC_PLLCLKOUT_DISABLE(RCC_PLLCFGR_PLLPEN | RCC_PLLCFGR_PLLREN);
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
 
         /* Get Start Tick*/
         tickstart = HAL_GetTick();
@@ -681,7 +737,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     else
     {
       /* Check if there is a request to disable the PLL used as System clock source */
-      if((RCC_OscInitStruct->PLL.PLLState) == RCC_PLL_OFF)
+      if ((RCC_OscInitStruct->PLL.PLLState) == RCC_PLL_OFF)
       {
         return HAL_ERROR;
       }
@@ -689,14 +745,14 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       {
         /* Do not return HAL_ERROR if request repeats the current configuration */
         temp_pllckcfg = RCC->PLLCFGR;
-        if((READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLSRC) != RCC_OscInitStruct->PLL.PLLSource) ||
-           (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLM) != RCC_OscInitStruct->PLL.PLLM) ||
-           (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLN) != (RCC_OscInitStruct->PLL.PLLN << RCC_PLLCFGR_PLLN_Pos)) ||
-           (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLP) != RCC_OscInitStruct->PLL.PLLP) ||
+        if ((READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLSRC) != RCC_OscInitStruct->PLL.PLLSource) ||
+            (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLM) != RCC_OscInitStruct->PLL.PLLM) ||
+            (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLN) != (RCC_OscInitStruct->PLL.PLLN << RCC_PLLCFGR_PLLN_Pos)) ||
+            (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLP) != RCC_OscInitStruct->PLL.PLLP) ||
 #if defined (RCC_PLLQ_SUPPORT)
-           (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLQ) != RCC_OscInitStruct->PLL.PLLQ) ||
-#endif
-           (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLR) != RCC_OscInitStruct->PLL.PLLR))
+            (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLQ) != RCC_OscInitStruct->PLL.PLLQ) ||
+#endif /* RCC_PLLQ_SUPPORT */
+            (READ_BIT(temp_pllckcfg, RCC_PLLCFGR_PLLR) != RCC_OscInitStruct->PLL.PLLR))
         {
           return HAL_ERROR;
         }
@@ -707,7 +763,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
 }
 
 /**
-  * @brief  Initialize the CPU, AHB and APB busses clocks according to the specified
+  * @brief  Initialize the CPU, AHB and APB buses clocks according to the specified
   *         parameters in the RCC_ClkInitStruct.
   * @param  RCC_ClkInitStruct  pointer to a @ref RCC_ClkInitTypeDef structure that
   *         contains the configuration information for the RCC peripheral.
@@ -898,8 +954,8 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   */
 
 /** @defgroup RCC_Exported_Functions_Group2 Peripheral Control functions
- *  @brief   RCC clocks control functions
- *
+  *  @brief   RCC clocks control functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral Control functions #####
@@ -907,7 +963,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
     [..]
     This subsection provides a set of functions allowing to:
 
-    (+) Ouput clock to MCO pin.
+    (+) Output clock to MCO pin.
     (+) Retrieve current clock frequencies.
     (+) Enable the Clock Security System.
 
@@ -916,30 +972,61 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   */
 
 /**
-  * @brief  Select the clock source to output on MCO pin(PA8).
-  * @note   PA8 should be configured in alternate function mode.
+  * @brief  Select the clock source to output on MCO1 pin(PA8) or MC02 pin (PA10)(*).
+  * @note   PA8, PA10(*) should be configured in alternate function mode.
   * @param  RCC_MCOx  specifies the output direction for the clock source.
   *          For STM32G0xx family this parameter can have only one value:
   *            @arg @ref RCC_MCO1  Clock source to output on MCO1 pin(PA8).
+  *            @arg @ref RCC_MCO2  Clock source to output on MCO2 pin(PA10)(*).
   * @param  RCC_MCOSource  specifies the clock source to output.
   *          This parameter can be one of the following values:
   *            @arg @ref RCC_MCO1SOURCE_NOCLOCK  MCO output disabled, no clock on MCO
-  *            @arg @ref RCC_MCO1SOURCE_SYSCLK  system  clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_HSI  HSI clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_HSE  HSE clock selected as MCO sourcee
-  *            @arg @ref RCC_MCO1SOURCE_PLLCLK  main PLL clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_LSI  LSI clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_LSE  LSE clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_SYSCLK   system  clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSI48    HSI48 clock selected as MCO source for devices with HSI48(*)
+  *            @arg @ref RCC_MCO1SOURCE_HSI      HSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSE      HSE clock selected as MCO sourcee
+  *            @arg @ref RCC_MCO1SOURCE_PLLCLK   main PLLR clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSI      LSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSE      LSE clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_PLLPCLK  PLLP clock selected as MCO1 source(*)
+  *            @arg @ref RCC_MCO1SOURCE_PLLQCLK  PLLQ clock selected as MCO1 source(*)
+  *            @arg @ref RCC_MCO1SOURCE_RTCCLK   RTC clock selected as MCO1 source(*)
+  *            @arg @ref RCC_MCO1SOURCE_RTC_WKUP RTC_Wakeup selected as MCO1 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_NOCLOCK  MCO2 output disabled, no clock on MCO2(*)
+  *            @arg @ref RCC_MCO2SOURCE_SYSCLK   system  clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_HSI48    HSI48 clock selected as MCO2 source for devices with HSI48(*)
+  *            @arg @ref RCC_MCO2SOURCE_HSI      HSI clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_HSE      HSE clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_PLLCLK   main PLLR clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_LSI      LSI clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_LSE      LSE clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_PLLPCLK  PLLP clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_PLLQCLK  PLLQ clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_RTCCLK   RTC clock selected as MCO2 source(*)
+  *            @arg @ref RCC_MCO2SOURCE_RTC_WKUP RTC_Wakeup selected as MCO2 source(*)
   * @param  RCC_MCODiv  specifies the MCO prescaler.
   *          This parameter can be one of the following values:
-  *            @arg @ref RCC_MCODIV_1  no division applied to MCO clock
-  *            @arg @ref RCC_MCODIV_2  division by 2 applied to MCO clock
-  *            @arg @ref RCC_MCODIV_4  division by 4 applied to MCO clock
-  *            @arg @ref RCC_MCODIV_8  division by 8 applied to MCO clock
-  *            @arg @ref RCC_MCODIV_16  division by 16 applied to MCO clock
-  *            @arg @ref RCC_MCODIV_32  division by 32 applied to MCO clock
-  *            @arg @ref RCC_MCODIV_64  division by 64 applied to MCO clock
-  *            @arg @ref RCC_MCODIV_128  division by 128 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_1     no division applied to MCO clock
+  *            @arg @ref RCC_MCODIV_2     division by 2 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_4     division by 4 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_8     division by 8 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_16    division by 16 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_32    division by 32 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_64    division by 64 applied to MCO clock
+  *            @arg @ref RCC_MCODIV_128   division by 128 applied to MCO clock
+  *            @arg @ref RCC_MCO2DIV_1    no division applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_2    division by 2 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_4    division by 4 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_8    division by 8 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_16   division by 16 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_32   division by 32 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_64   division by 64 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_128  division by 128 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_256  division by 256 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_512  division by 512 applied to MCO2 clock(*)
+  *            @arg @ref RCC_MCO2DIV_1024 division by 1024 applied to MCO2 clock(*)
+  *
+  * (*) Feature not available on all devices of the family
   * @retval None
   */
 void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
@@ -948,25 +1035,40 @@ void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_M
 
   /* Check the parameters */
   assert_param(IS_RCC_MCO(RCC_MCOx));
-  assert_param(IS_RCC_MCODIV(RCC_MCODiv));
-  assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
 
-  /* Prevent unused argument(s) compilation warning if no assert_param check */
-  UNUSED(RCC_MCOx);
+  /* Common GPIO init parameters */
+  GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+  GPIO_InitStruct.Pull      = GPIO_NOPULL;
 
-  /* MCO Clock Enable */
-  MCO1_CLK_ENABLE();
-
-  /* Configue the MCO1 pin in alternate function mode */
-  GPIO_InitStruct.Pin = MCO1_PIN;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
-  HAL_GPIO_Init(MCO1_GPIO_PORT, &GPIO_InitStruct);
-
-  /* Mask MCOSEL[] and MCOPRE[] bits then set MCO1 clock source and prescaler */
-  MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE), (RCC_MCOSource | RCC_MCODiv));
+  if (RCC_MCOx == RCC_MCO1)
+  {
+    assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+    assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
+    /* MCO1 Clock Enable */
+    MCO1_CLK_ENABLE();
+    /* Configure the MCO1 pin in alternate function mode */
+    GPIO_InitStruct.Pin = MCO1_PIN;
+    GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
+    HAL_GPIO_Init(MCO1_GPIO_PORT, &GPIO_InitStruct);
+    /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
+    MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCOPRE), (RCC_MCOSource | RCC_MCODiv));
+  }
+#if defined(RCC_MCO2_SUPPORT)
+  else if (RCC_MCOx == RCC_MCO2)
+  {
+    assert_param(IS_RCC_MCO2DIV(RCC_MCODiv));
+    assert_param(IS_RCC_MCO2SOURCE(RCC_MCOSource));
+    /* MCO2 Clock Enable */
+    MCO2_CLK_ENABLE();
+    /* Configure the MCO2 pin in alternate function mode */
+    GPIO_InitStruct.Pin       = MCO2_PIN;
+    GPIO_InitStruct.Alternate = GPIO_AF3_MCO2;
+    HAL_GPIO_Init(MCO2_GPIO_PORT, &GPIO_InitStruct);
+    /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
+    MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCO2SEL | RCC_CFGR_MCO2PRE), (RCC_MCOSource | RCC_MCODiv));
+  }
+#endif /* RCC_MCO2_SUPPORT */
 }
 
 /**
@@ -1010,7 +1112,7 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
   uint32_t pllvco, pllsource, pllr, pllm, hsidiv;
   uint32_t sysclockfreq;
 
-  if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSI)
+  if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_HSI)
   {
     /* HSISYS can be derived for HSI16 */
     hsidiv = (1UL << ((READ_BIT(RCC->CR, RCC_CR_HSIDIV)) >> RCC_CR_HSIDIV_Pos));
@@ -1018,12 +1120,12 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
     /* HSI used as system clock source */
     sysclockfreq = (HSI_VALUE / hsidiv);
   }
-  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSE)
+  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_HSE)
   {
     /* HSE used as system clock source */
     sysclockfreq = HSE_VALUE;
   }
-  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL)
+  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_PLLCLK)
   {
     /* PLL used as system clock  source */
 
@@ -1036,7 +1138,7 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
     switch (pllsource)
     {
       case RCC_PLLSOURCE_HSE:  /* HSE used as PLL clock source */
-        pllvco =  (HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos);
+        pllvco = (HSE_VALUE / pllm) * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos);
         break;
 
       case RCC_PLLSOURCE_HSI:  /* HSI16 used as PLL clock source */
@@ -1047,12 +1149,12 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
     pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> RCC_PLLCFGR_PLLR_Pos) + 1U);
     sysclockfreq = pllvco / pllr;
   }
-  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_LSE)
+  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_LSE)
   {
     /* LSE used as system clock source */
     sysclockfreq = LSE_VALUE;
   }
-  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_LSI)
+  else if (__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_LSI)
   {
     /* LSI used as system clock source */
     sysclockfreq = LSI_VALUE;
@@ -1103,8 +1205,13 @@ void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
   assert_param(RCC_OscInitStruct != (void *)NULL);
 
   /* Set all possible values for the Oscillator type parameter ---------------*/
+#if defined(RCC_HSI48_SUPPORT)
+  RCC_OscInitStruct->OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | \
+                                      RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_HSI48;
+#else
   RCC_OscInitStruct->OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | \
                                       RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_LSI;
+#endif /* RCC_HSI48_SUPPORT */
 
   /* Get the HSE configuration -----------------------------------------------*/
   if ((RCC->CR & RCC_CR_HSEBYP) == RCC_CR_HSEBYP)
@@ -1157,6 +1264,17 @@ void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     RCC_OscInitStruct->LSIState = RCC_LSI_OFF;
   }
 
+#if defined(RCC_HSI48_SUPPORT)
+  /* Get the HSI48 configuration ---------------------------------------------*/
+  if (READ_BIT(RCC->CR, RCC_CR_HSI48ON) == RCC_CR_HSI48ON)
+  {
+    RCC_OscInitStruct->HSI48State = RCC_HSI48_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSI48State = RCC_HSI48_OFF;
+  }
+#endif /* RCC_HSI48_SUPPORT */
 
   /* Get the PLL configuration -----------------------------------------------*/
   if ((RCC->CR & RCC_CR_PLLON) == RCC_CR_PLLON)
@@ -1173,7 +1291,7 @@ void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
   RCC_OscInitStruct->PLL.PLLP = (RCC->PLLCFGR & RCC_PLLCFGR_PLLP);
 #if defined(RCC_PLLQ_SUPPORT)
   RCC_OscInitStruct->PLL.PLLQ = (RCC->PLLCFGR & RCC_PLLCFGR_PLLQ);
-#endif
+#endif /* RCC_PLLQ_SUPPORT */
   RCC_OscInitStruct->PLL.PLLR = (RCC->PLLCFGR & RCC_PLLCFGR_PLLR);
 }
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rcc_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rcc_ex.c
@@ -7,6 +7,7 @@
   *          functionalities RCC extended peripheral:
   *           + Extended Peripheral Control functions
   *           + Extended Clock management functions
+  *           + Extended Clock Recovery System Control functions
   *
   ******************************************************************************
   * @attention
@@ -39,8 +40,8 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private defines -----------------------------------------------------------*/
 /** @defgroup RCCEx_Private_Constants RCCEx Private Constants
- * @{
- */
+  * @{
+  */
 #define PLL_TIMEOUT_VALUE        100U /* 100 ms (minimum Tick + 1)  */
 
 #define LSCO_CLK_ENABLE()     __HAL_RCC_GPIOA_CLK_ENABLE()
@@ -60,8 +61,8 @@
   */
 
 /** @defgroup RCCEx_Exported_Functions_Group1 Extended Peripheral Control functions
- *  @brief  Extended Peripheral Control functions
- *
+  * @brief  Extended Peripheral Control functions
+  *
 @verbatim
  ===============================================================================
                 ##### Extended Peripheral Control functions  #####
@@ -83,19 +84,25 @@
   *         parameters in the @ref RCC_PeriphCLKInitTypeDef.
   * @param  PeriphClkInit  pointer to a @ref RCC_PeriphCLKInitTypeDef structure that
   *         contains a field PeriphClockSelection which can be a combination of the following values:
-  *            @arg @ref RCC_PERIPHCLK_RTC  RTC peripheral clock
-  *            @arg @ref RCC_PERIPHCLK_ADC    ADC peripheral clock
-  *            @arg @ref RCC_PERIPHCLK_I2C1   I2C1 peripheral clock
-  *            @arg @ref RCC_PERIPHCLK_I2S1   I2S1 peripheral clock
-  *            @arg @ref RCC_PERIPHCLK_USART1 USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_RTC     RTC peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_ADC     ADC peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C1    I2C1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C2    I2C2 peripheral clock (2)
+  *            @arg @ref RCC_PERIPHCLK_I2S1    I2S1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2S2    I2S2 peripheral clock (1)
+  *            @arg @ref RCC_PERIPHCLK_USART1  USART1 peripheral clock
   *            @arg @ref RCC_PERIPHCLK_CEC     CEC peripheral clock     (1)
   *            @arg @ref RCC_PERIPHCLK_LPTIM1  LPTIM1 peripheral clock  (1)
   *            @arg @ref RCC_PERIPHCLK_LPTIM2  LPTIM2 peripheral clock  (1)
   *            @arg @ref RCC_PERIPHCLK_LPUART1 LPUART1 peripheral clock (1)
+  *            @arg @ref RCC_PERIPHCLK_LPUART2 LPUART2 peripheral clock (1)
   *            @arg @ref RCC_PERIPHCLK_RNG     RNG peripheral clock     (1)
   *            @arg @ref RCC_PERIPHCLK_TIM1    TIM1 peripheral clock    (1)(2)
   *            @arg @ref RCC_PERIPHCLK_TIM15   TIM15 peripheral clock   (1)(2)
   *            @arg @ref RCC_PERIPHCLK_USART2  USART2 peripheral clock     (2)
+  *            @arg @ref RCC_PERIPHCLK_USART3  USART3 peripheral clock     (2)
+  *            @arg @ref RCC_PERIPHCLK_FDCAN   FDCAN peripheral clock   (1)
+  *            @arg @ref RCC_PERIPHCLK_USB     USB peripheral clock     (1)
   *
   * @note   (1) Peripherals are not available on all devices
   * @note   (2) Peripherals clock selection is not available on all devices
@@ -224,17 +231,41 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
   }
 #endif /* RCC_CCIPR_USART2SEL */
 
-#if defined(RCC_CCIPR_LPUART1SEL)
+#if defined(RCC_CCIPR_USART3SEL)
+  /*-------------------------- USART3 clock source configuration -------------------*/
+  if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART3) == RCC_PERIPHCLK_USART3)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART3CLKSOURCE(PeriphClkInit->Usart3ClockSelection));
+
+    /* Configure the USART3 clock source */
+    __HAL_RCC_USART3_CONFIG(PeriphClkInit->Usart3ClockSelection);
+  }
+#endif /* RCC_CCIPR_USART3SEL */
+
+#if defined(LPUART1)
   /*-------------------------- LPUART1 clock source configuration ------------------*/
   if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1)
   {
     /* Check the parameters */
     assert_param(IS_RCC_LPUART1CLKSOURCE(PeriphClkInit->Lpuart1ClockSelection));
 
-    /* Configure the LPUAR1 clock source */
+    /* Configure the LPUART1 clock source */
     __HAL_RCC_LPUART1_CONFIG(PeriphClkInit->Lpuart1ClockSelection);
   }
-#endif /* RCC_CCIPR_LPUART1SEL */
+#endif /* LPUART1 */
+
+#if defined(LPUART2)
+  /*-------------------------- LPUART2 clock source configuration ------------------*/
+  if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPUART2) == RCC_PERIPHCLK_LPUART2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LPUART2CLKSOURCE(PeriphClkInit->Lpuart2ClockSelection));
+
+    /* Configure the LPUART clock source */
+    __HAL_RCC_LPUART2_CONFIG(PeriphClkInit->Lpuart2ClockSelection);
+  }
+#endif /* LPUART2 */
 
 #if defined(RCC_CCIPR_LPTIM1SEL)
   /*-------------------------- LPTIM1 clock source configuration -------------------*/
@@ -264,7 +295,19 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_I2C1_CONFIG(PeriphClkInit->I2c1ClockSelection);
   }
 
-#if defined(RCC_CCIPR_RNGSEL)
+#if defined(RCC_CCIPR_I2C2SEL)
+  /*-------------------------- I2C2 clock source configuration ---------------------*/
+  if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C2) == RCC_PERIPHCLK_I2C2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C2CLKSOURCE(PeriphClkInit->I2c2ClockSelection));
+
+    /* Configure the I2C2 clock source */
+    __HAL_RCC_I2C2_CONFIG(PeriphClkInit->I2c2ClockSelection);
+  }
+#endif /* (RCC_CCIPR_I2C2SEL */
+
+#if defined(RNG)
   /*-------------------------- RNG clock source configuration ----------------------*/
   if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RNG) == (RCC_PERIPHCLK_RNG))
   {
@@ -277,7 +320,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
       __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLLQCLK);
     }
   }
-#endif /* RCC_CCIPR_RNGSEL */
+#endif /* RNG */
   /*-------------------------- ADC clock source configuration ----------------------*/
   if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_ADC) == RCC_PERIPHCLK_ADC)
   {
@@ -294,7 +337,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     }
   }
 
-#if defined(RCC_CCIPR_CECSEL)
+#if defined(CEC)
   /*-------------------------- CEC clock source configuration ---------------------*/
   if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_CEC) == RCC_PERIPHCLK_CEC)
   {
@@ -304,7 +347,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* Configure the CEC clock source */
     __HAL_RCC_CEC_CONFIG(PeriphClkInit->CecClockSelection);
   }
-#endif /* RCC_CCIPR_CECSEL */
+#endif /* CEC */
 
 #if defined(RCC_CCIPR_TIM1SEL)
   /*-------------------------- TIM1 clock source configuration ---------------------*/
@@ -358,6 +401,60 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     }
   }
 
+#if defined(RCC_CCIPR2_I2S2SEL)
+  /*-------------------------- I2S2 clock source configuration ---------------------*/
+  if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2S2) == RCC_PERIPHCLK_I2S2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2S2CLKSOURCE(PeriphClkInit->I2s2ClockSelection));
+
+    /* Configure the I2S2 clock source */
+    __HAL_RCC_I2S2_CONFIG(PeriphClkInit->I2s2ClockSelection);
+
+    if (PeriphClkInit->I2s2ClockSelection == RCC_I2S2CLKSOURCE_PLL)
+    {
+      /* Enable PLLPCLK output */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLLPCLK);
+    }
+  }
+#endif /* RCC_CCIPR2_I2S2SEL */
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)  || defined(STM32G0B0xx)
+  /*-------------------------- USB clock source configuration ---------------------*/
+  if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USB) == RCC_PERIPHCLK_USB)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USBCLKSOURCE(PeriphClkInit->UsbClockSelection));
+
+    /* Configure the USB clock source */
+    __HAL_RCC_USB_CONFIG(PeriphClkInit->UsbClockSelection);
+
+    if (PeriphClkInit->UsbClockSelection == RCC_USBCLKSOURCE_PLL)
+    {
+      /* Enable PLLQCLK output */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLLQCLK);
+    }
+  }
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+  /*-------------------------- FDCAN clock source configuration ---------------------*/
+  if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_FDCAN) == RCC_PERIPHCLK_FDCAN)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_FDCANCLKSOURCE(PeriphClkInit->FdcanClockSelection));
+
+    /* Configure the FDCAN clock source */
+    __HAL_RCC_FDCAN_CONFIG(PeriphClkInit->FdcanClockSelection);
+
+    if (PeriphClkInit->FdcanClockSelection == RCC_FDCANCLKSOURCE_PLL)
+    {
+      /* Enable PLLQCLK output */
+      __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLLQCLK);
+    }
+  }
+#endif /* FDCAN1 || FDCAN2 */
+
   return status;
 }
 
@@ -386,6 +483,9 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 #if defined(RCC_CCIPR_LPUART1SEL)
   PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_LPUART1;
 #endif /* RCC_CCIPR_LPUART1SEL */
+#if defined(RCC_CCIPR_LPUART2SEL)
+  PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_LPUART2;
+#endif /* RCC_CCIPR_LPUART2SEL */
 #if defined(RCC_CCIPR_CECSEL)
   PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_CEC;
 #endif /* RCC_CCIPR_CECSEL */
@@ -398,19 +498,45 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 #if defined(RCC_CCIPR_USART2SEL)
   PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_USART2;
 #endif /* RCC_CCIPR_USART2SEL */
-
+#if defined(RCC_CCIPR_USART3SEL)
+  PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_USART3;
+#endif /* RCC_CCIPR_USART3SEL */
+#if defined(RCC_CCIPR_I2C2SEL)
+  PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_I2C2;
+#endif /* RCC_CCIPR_I2C2SEL */
+#if defined(RCC_CCIPR2_I2S2SEL)
+  PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_I2S2;
+#endif /* RCC_CCIPR2_I2S2SEL */
+#if defined(RCC_CCIPR2_USBSEL)
+  PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_USB;
+#endif /* RCC_CCIPR2_USBSEL */
+#if defined(RCC_CCIPR2_FDCANSEL)
+  PeriphClkInit->PeriphClockSelection |=  RCC_PERIPHCLK_FDCAN;
+#endif /* RCC_CCIPR_FDCANSEL */
   /* Get the USART1 clock source ---------------------------------------------*/
   PeriphClkInit->Usart1ClockSelection  = __HAL_RCC_GET_USART1_SOURCE();
 #if defined(RCC_CCIPR_USART2SEL)
   /* Get the USART2 clock source ---------------------------------------------*/
   PeriphClkInit->Usart2ClockSelection  = __HAL_RCC_GET_USART2_SOURCE();
 #endif /* RCC_CCIPR_USART2SEL */
+#if defined(RCC_CCIPR_USART3SEL)
+  /* Get the USART3 clock source ---------------------------------------------*/
+  PeriphClkInit->Usart3ClockSelection  = __HAL_RCC_GET_USART3_SOURCE();
+#endif /* RCC_CCIPR_USART3SEL */
 #if defined(RCC_CCIPR_LPUART1SEL)
   /* Get the LPUART1 clock source --------------------------------------------*/
   PeriphClkInit->Lpuart1ClockSelection = __HAL_RCC_GET_LPUART1_SOURCE();
 #endif /* RCC_CCIPR_LPUART1SEL */
+#if defined(RCC_CCIPR_LPUART2SEL)
+  /* Get the LPUART2 clock source --------------------------------------------*/
+  PeriphClkInit->Lpuart2ClockSelection = __HAL_RCC_GET_LPUART2_SOURCE();
+#endif /* RCC_CCIPR_LPUART2SEL */
   /* Get the I2C1 clock source -----------------------------------------------*/
   PeriphClkInit->I2c1ClockSelection    = __HAL_RCC_GET_I2C1_SOURCE();
+#if defined(RCC_CCIPR_I2C2SEL)
+  /* Get the I2C2 clock source -----------------------------------------------*/
+  PeriphClkInit->I2c2ClockSelection    = __HAL_RCC_GET_I2C2_SOURCE();
+#endif /* RCC_CCIPR_I2C2SEL */
 #if defined(RCC_CCIPR_LPTIM1SEL)
   /* Get the LPTIM1 clock source ---------------------------------------------*/
   PeriphClkInit->Lptim1ClockSelection  = __HAL_RCC_GET_LPTIM1_SOURCE();
@@ -439,8 +565,20 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   /* Get the CEC clock source -----------------------------------------------*/
   PeriphClkInit->CecClockSelection     = __HAL_RCC_GET_CEC_SOURCE();
 #endif  /* RCC_CCIPR_CECSEL */
+#if defined(RCC_CCIPR2_USBSEL)
+  /* Get the USB clock source -----------------------------------------------*/
+  PeriphClkInit->UsbClockSelection     = __HAL_RCC_GET_USB_SOURCE();
+#endif  /* RCC_CCIPR2_USBSEL */
+#if defined(RCC_CCIPR2_FDCANSEL)
+  /* Get the FDCAN clock source -----------------------------------------------*/
+  PeriphClkInit->FdcanClockSelection     = __HAL_RCC_GET_FDCAN_SOURCE();
+#endif  /* RCC_CCIPR2_FDCANSEL */
   /* Get the I2S1 clock source -----------------------------------------------*/
   PeriphClkInit->I2s1ClockSelection    = __HAL_RCC_GET_I2S1_SOURCE();
+#if defined(RCC_CCIPR2_I2S2SEL)
+  /* Get the I2S2 clock source -----------------------------------------------*/
+  PeriphClkInit->I2s2ClockSelection    = __HAL_RCC_GET_I2S2_SOURCE();
+#endif /* RCC_CCIPR2_I2S2SEL */
 }
 
 /**
@@ -451,16 +589,22 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   *            @arg @ref RCC_PERIPHCLK_RTC     RTC peripheral clock
   *            @arg @ref RCC_PERIPHCLK_ADC     ADC peripheral clock
   *            @arg @ref RCC_PERIPHCLK_I2C1    I2C1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2C2    I2C2 peripheral clock (1)
   *            @arg @ref RCC_PERIPHCLK_I2S1    I2S1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_I2S2    I2S2 peripheral clock (1)
   *            @arg @ref RCC_PERIPHCLK_USART1  USART1 peripheral clock
+  *            @arg @ref RCC_PERIPHCLK_USART2  USART2 peripheral clock (1)(2)
+  *            @arg @ref RCC_PERIPHCLK_USART3  USART3 peripheral clock (1)
   *            @arg @ref RCC_PERIPHCLK_RNG     RNG peripheral clock    (1)
   *            @arg @ref RCC_PERIPHCLK_TIM15   TIM15 peripheral clock  (1)(2)
   *            @arg @ref RCC_PERIPHCLK_TIM1    TIM1 peripheral clock   (1)(2)
   *            @arg @ref RCC_PERIPHCLK_LPTIM1  LPTIM1 peripheral clock (1)
   *            @arg @ref RCC_PERIPHCLK_LPTIM2  LPTIM2 peripheral clock (1)
   *            @arg @ref RCC_PERIPHCLK_LPUART1 LPUART1 peripheral clock(1)
+  *            @arg @ref RCC_PERIPHCLK_LPUART2 LPUART2 peripheral clock(1)
   *            @arg @ref RCC_PERIPHCLK_CEC     CEC peripheral clock    (1)
-  *            @arg @ref RCC_PERIPHCLK_USART2  USART2 peripheral clock (1)(2)
+  *            @arg @ref RCC_PERIPHCLK_FDCAN    FDCAN peripheral clock (1)
+  *            @arg @ref RCC_PERIPHCLK_USB      USB peripheral clock   (1)
   * @note   (1) Peripheral not available on all devices
   * @note   (2) Peripheral Clock configuration not available on all devices
   * @retval Frequency in Hz
@@ -474,7 +618,7 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
 #if defined(RCC_CCIPR_RNGSEL)
   uint32_t rngclk;
   uint32_t rngdiv;
-#endif
+#endif /* RCC_CCIPR_RNGSEL */
   /* Check the parameters */
   assert_param(IS_RCC_PERIPHCLOCK(PeriphClk));
 
@@ -494,7 +638,7 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
       frequency = LSI_VALUE;
     }
     /* Check if HSE is ready  and if RTC clock selection is HSI_DIV32*/
-    else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSERDY)) &&(srcclk == RCC_RTCCLKSOURCE_HSE_DIV32))
+    else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSERDY)) && (srcclk == RCC_RTCCLKSOURCE_HSE_DIV32))
     {
       frequency = HSE_VALUE / 32U;
     }
@@ -609,6 +753,36 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
         }
         break;
 #endif /* RCC_CCIPR_USART2SEL */
+
+#if defined(RCC_CCIPR_USART3SEL)
+      case RCC_PERIPHCLK_USART3:
+        /* Get the current USART3 source */
+        srcclk = __HAL_RCC_GET_USART3_SOURCE();
+
+        if (srcclk == RCC_USART3CLKSOURCE_PCLK1)
+        {
+          frequency = HAL_RCC_GetPCLK1Freq();
+        }
+        else if (srcclk == RCC_USART3CLKSOURCE_SYSCLK)
+        {
+          frequency = HAL_RCC_GetSysClockFreq();
+        }
+        else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)) && (srcclk == RCC_USART3CLKSOURCE_HSI))
+        {
+          frequency = HSI_VALUE;
+        }
+        else if ((HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)) && (srcclk == RCC_USART3CLKSOURCE_LSE))
+        {
+          frequency = LSE_VALUE;
+        }
+        /* Clock not enabled for USART3 */
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* RCC_CCIPR_USART3SEL */
+
 #if defined(RCC_CCIPR_CECSEL)
       case RCC_PERIPHCLK_CEC:
         /* Get the current CEC source */
@@ -658,6 +832,35 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
         }
         break;
 #endif /* RCC_CCIPR_LPUART1SEL */
+
+#if defined(RCC_CCIPR_LPUART2SEL)
+      case RCC_PERIPHCLK_LPUART2:
+        /* Get the current LPUART2 source */
+        srcclk = __HAL_RCC_GET_LPUART2_SOURCE();
+
+        if (srcclk == RCC_LPUART2CLKSOURCE_PCLK1)
+        {
+          frequency = HAL_RCC_GetPCLK1Freq();
+        }
+        else if (srcclk == RCC_LPUART2CLKSOURCE_SYSCLK)
+        {
+          frequency = HAL_RCC_GetSysClockFreq();
+        }
+        else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)) && (srcclk == RCC_LPUART2CLKSOURCE_HSI))
+        {
+          frequency = HSI_VALUE;
+        }
+        else if ((HAL_IS_BIT_SET(RCC->BDCR, RCC_BDCR_LSERDY)) && (srcclk == RCC_LPUART2CLKSOURCE_LSE))
+        {
+          frequency = LSE_VALUE;
+        }
+        /* Clock not enabled for LPUART2 */
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* RCC_CCIPR_LPUART2SEL */
 
       case RCC_PERIPHCLK_ADC:
 
@@ -710,6 +913,31 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
         }
         break;
 
+#if defined(RCC_CCIPR_I2C2SEL)
+      case RCC_PERIPHCLK_I2C2:
+        /* Get the current I2C2 source */
+        srcclk = __HAL_RCC_GET_I2C2_SOURCE();
+
+        if (srcclk == RCC_I2C2CLKSOURCE_PCLK1)
+        {
+          frequency = HAL_RCC_GetPCLK1Freq();
+        }
+        else if (srcclk == RCC_I2C2CLKSOURCE_SYSCLK)
+        {
+          frequency = HAL_RCC_GetSysClockFreq();
+        }
+        else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)) && (srcclk == RCC_I2C2CLKSOURCE_HSI))
+        {
+          frequency = HSI_VALUE;
+        }
+        /* Clock not enabled for I2C2 */
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* RCC_CCIPR_I2C2SEL */
+
       case RCC_PERIPHCLK_I2S1:
         /* Get the current I2S1 source */
         srcclk = __HAL_RCC_GET_I2S1_SOURCE();
@@ -742,6 +970,41 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
           /* Nothing to do as frequency already initialized to 0U */
         }
         break;
+
+#if defined(RCC_CCIPR2_I2S2SEL)
+      case RCC_PERIPHCLK_I2S2:
+        /* Get the current I2S2 source */
+        srcclk = __HAL_RCC_GET_I2S2_SOURCE();
+
+        if (srcclk == RCC_I2S2CLKSOURCE_PLL)
+        {
+          if (__HAL_RCC_GET_PLLCLKOUT_CONFIG(RCC_PLLPCLK) != 0U)
+          {
+            /* f(PLLP) = f(VCO input) * PLLN / PLLP */
+            plln = READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos;
+            frequency = (pllvco * plln) / ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLP) >> RCC_PLLCFGR_PLLP_Pos) + 1U);
+          }
+        }
+        else if (srcclk == RCC_I2S2CLKSOURCE_SYSCLK)
+        {
+          frequency = HAL_RCC_GetSysClockFreq();
+        }
+        else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSIRDY)) && (srcclk == RCC_I2S2CLKSOURCE_HSI))
+        {
+          frequency = HSI_VALUE;
+        }
+        else if (srcclk == RCC_I2S2CLKSOURCE_EXT)
+        {
+          /* External clock used.*/
+          frequency = EXTERNAL_I2S2_CLOCK_VALUE;
+        }
+        /* Clock not enabled for I2S2 */
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* RCC_CCIPR2_I2S2SEL */
 
 #if defined(RCC_CCIPR_LPTIM1SEL)
       case RCC_PERIPHCLK_LPTIM1:
@@ -851,6 +1114,72 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
         break;
 #endif /* RCC_CCIPR_TIM15SEL */
 
+#if defined(RCC_CCIPR2_USBSEL)
+      case RCC_PERIPHCLK_USB:
+
+        srcclk = READ_BIT(RCC->CCIPR2, RCC_CCIPR2_USBSEL);
+
+        if (srcclk == RCC_USBCLKSOURCE_PLL) /* PLL ? */
+        {
+          if (__HAL_RCC_GET_PLLCLKOUT_CONFIG(RCC_PLLQCLK) != 0U)
+          {
+            /* f(PLLQ) = f(VCO input) * PLLN / PLLQ */
+            plln = READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos;
+            frequency = (pllvco * plln) / ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ) >> RCC_PLLCFGR_PLLQ_Pos) + 1U);
+          }
+        }
+#if defined(RCC_HSI48_SUPPORT)
+        else if (srcclk == RCC_USBCLKSOURCE_HSI48) /* HSI48 ? */
+        {
+          if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSI48RDY)) && (srcclk == RCC_USBCLKSOURCE_HSI48))
+          {
+            frequency = HSI48_VALUE;
+          }
+        }
+#endif /* RCC_HSI48_SUPPORT */
+        else if (srcclk == RCC_USBCLKSOURCE_HSE)
+        {
+          if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSERDY)) && (srcclk == RCC_USBCLKSOURCE_HSE))
+          {
+            frequency = HSE_VALUE;
+          }
+        }
+        else /* No clock source */
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* RCC_CCIPR2_USBSEL */
+
+#if defined(RCC_CCIPR2_FDCANSEL)
+      case RCC_PERIPHCLK_FDCAN:
+
+        srcclk = READ_BIT(RCC->CCIPR2, RCC_CCIPR2_FDCANSEL);
+
+        if (srcclk == RCC_FDCANCLKSOURCE_PLL) /* PLL ? */
+        {
+          if (__HAL_RCC_GET_PLLCLKOUT_CONFIG(RCC_PLLQCLK) != 0U)
+          {
+            /* f(PLLQ) = f(VCO input) * PLLN / PLLQ */
+            plln = READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos;
+            frequency = (pllvco * plln) / ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ) >> RCC_PLLCFGR_PLLQ_Pos) + 1U);
+          }
+        }
+        else if (srcclk == RCC_FDCANCLKSOURCE_PCLK1) /* PCLK1 ? */
+        {
+          frequency = HAL_RCC_GetPCLK1Freq();
+        }
+        else if ((HAL_IS_BIT_SET(RCC->CR, RCC_CR_HSERDY)) && (srcclk == RCC_FDCANCLKSOURCE_HSE))
+        {
+          frequency = HSE_VALUE;
+        }
+        else /* No clock source */
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* RCC_CCIPR2_FDCANSEL */
+
       default:
         break;
     }
@@ -864,8 +1193,8 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
   */
 
 /** @defgroup RCCEx_Exported_Functions_Group2 Extended Clock management functions
- *  @brief  Extended Clock management functions
- *
+  *  @brief  Extended Clock management functions
+  *
 @verbatim
  ===============================================================================
                 ##### Extended clock management functions  #####
@@ -898,7 +1227,7 @@ void HAL_RCCEx_EnableLSCO(uint32_t LSCOSource)
   /* LSCO Pin Clock Enable */
   LSCO_CLK_ENABLE();
 
-  /* Configue the LSCO pin in analog mode */
+  /* Configure the LSCO pin in analog mode */
   GPIO_InitStruct.Pin = LSCO_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
@@ -964,6 +1293,369 @@ void HAL_RCCEx_DisableLSCO(void)
     __HAL_RCC_PWR_CLK_DISABLE();
   }
 }
+
+/**
+  * @}
+  */
+
+#if defined(CRS)
+
+/** @defgroup RCCEx_Exported_Functions_Group3 Extended Clock Recovery System Control functions
+  * @brief  Extended Clock Recovery System Control functions
+  *
+@verbatim
+ ===============================================================================
+                ##### Extended Clock Recovery System Control functions  #####
+ ===============================================================================
+    [..]
+      For devices with Clock Recovery System feature (CRS), RCC Extension HAL driver can be used as follows:
+
+      (#) In System clock config, HSI48 needs to be enabled
+
+      (#) Enable CRS clock in IP MSP init which will use CRS functions
+
+      (#) Call CRS functions as follows:
+          (##) Prepare synchronization configuration necessary for HSI48 calibration
+              (+++) Default values can be set for frequency Error Measurement (reload and error limit)
+                        and also HSI48 oscillator smooth trimming.
+              (+++) Macro __HAL_RCC_CRS_RELOADVALUE_CALCULATE can be also used to calculate
+                        directly reload value with target and sychronization frequencies values
+          (##) Call function HAL_RCCEx_CRSConfig which
+              (+++) Resets CRS registers to their default values.
+              (+++) Configures CRS registers with synchronization configuration
+              (+++) Enables automatic calibration and frequency error counter feature
+           Note: When using USB LPM (Link Power Management) and the device is in Sleep mode, the
+           periodic USB SOF will not be generated by the host. No SYNC signal will therefore be
+           provided to the CRS to calibrate the HSI48 on the run. To guarantee the required clock
+           precision after waking up from Sleep mode, the LSE or reference clock on the GPIOs
+           should be used as SYNC signal.
+
+          (##) A polling function is provided to wait for complete synchronization
+              (+++) Call function HAL_RCCEx_CRSWaitSynchronization()
+              (+++) According to CRS status, user can decide to adjust again the calibration or continue
+                        application if synchronization is OK
+
+      (#) User can retrieve information related to synchronization in calling function
+            HAL_RCCEx_CRSGetSynchronizationInfo()
+
+      (#) Regarding synchronization status and synchronization information, user can try a new calibration
+           in changing synchronization configuration and call again HAL_RCCEx_CRSConfig.
+           Note: When the SYNC event is detected during the downcounting phase (before reaching the zero value),
+           it means that the actual frequency is lower than the target (and so, that the TRIM value should be
+           incremented), while when it is detected during the upcounting phase it means that the actual frequency
+           is higher (and that the TRIM value should be decremented).
+
+      (#) In interrupt mode, user can resort to the available macros (__HAL_RCC_CRS_XXX_IT). Interrupts will go
+          through CRS Handler (CRS_IRQn/CRS_IRQHandler)
+              (++) Call function HAL_RCCEx_CRSConfig()
+              (++) Enable CRS_IRQn (thanks to NVIC functions)
+              (++) Enable CRS interrupt (__HAL_RCC_CRS_ENABLE_IT)
+              (++) Implement CRS status management in the following user callbacks called from
+                   HAL_RCCEx_CRS_IRQHandler():
+                   (+++) HAL_RCCEx_CRS_SyncOkCallback()
+                   (+++) HAL_RCCEx_CRS_SyncWarnCallback()
+                   (+++) HAL_RCCEx_CRS_ExpectedSyncCallback()
+                   (+++) HAL_RCCEx_CRS_ErrorCallback()
+
+      (#) To force a SYNC EVENT, user can use the function HAL_RCCEx_CRSSoftwareSynchronizationGenerate().
+          This function can be called before calling HAL_RCCEx_CRSConfig (for instance in Systick handler)
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start automatic synchronization for polling mode
+  * @param  pInit Pointer on RCC_CRSInitTypeDef structure
+  * @retval None
+  */
+void HAL_RCCEx_CRSConfig(RCC_CRSInitTypeDef *pInit)
+{
+  uint32_t value;  /* no init needed */
+
+  /* Check the parameters */
+  assert_param(IS_RCC_CRS_SYNC_DIV(pInit->Prescaler));
+  assert_param(IS_RCC_CRS_SYNC_SOURCE(pInit->Source));
+  assert_param(IS_RCC_CRS_SYNC_POLARITY(pInit->Polarity));
+  assert_param(IS_RCC_CRS_RELOADVALUE(pInit->ReloadValue));
+  assert_param(IS_RCC_CRS_ERRORLIMIT(pInit->ErrorLimitValue));
+  assert_param(IS_RCC_CRS_HSI48CALIBRATION(pInit->HSI48CalibrationValue));
+
+  /* CONFIGURATION */
+
+  /* Before configuration, reset CRS registers to their default values*/
+  __HAL_RCC_CRS_FORCE_RESET();
+  __HAL_RCC_CRS_RELEASE_RESET();
+
+  /* Set the SYNCDIV[2:0] bits according to Prescaler value */
+  /* Set the SYNCSRC[1:0] bits according to Source value */
+  /* Set the SYNCSPOL bit according to Polarity value */
+  value = (pInit->Prescaler | pInit->Source | pInit->Polarity);
+  /* Set the RELOAD[15:0] bits according to ReloadValue value */
+  value |= pInit->ReloadValue;
+  /* Set the FELIM[7:0] bits according to ErrorLimitValue value */
+  value |= (pInit->ErrorLimitValue << CRS_CFGR_FELIM_Pos);
+  WRITE_REG(CRS->CFGR, value);
+
+  /* Adjust HSI48 oscillator smooth trimming */
+  /* Set the TRIM[6:0] bits according to RCC_CRS_HSI48CalibrationValue value */
+  MODIFY_REG(CRS->CR, CRS_CR_TRIM, (pInit->HSI48CalibrationValue << CRS_CR_TRIM_Pos));
+
+  /* START AUTOMATIC SYNCHRONIZATION*/
+
+  /* Enable Automatic trimming & Frequency error counter */
+  SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN | CRS_CR_CEN);
+}
+
+/**
+  * @brief  Generate the software synchronization event
+  * @retval None
+  */
+void HAL_RCCEx_CRSSoftwareSynchronizationGenerate(void)
+{
+  SET_BIT(CRS->CR, CRS_CR_SWSYNC);
+}
+
+/**
+  * @brief  Return synchronization info
+  * @param  pSynchroInfo Pointer on RCC_CRSSynchroInfoTypeDef structure
+  * @retval None
+  */
+void HAL_RCCEx_CRSGetSynchronizationInfo(RCC_CRSSynchroInfoTypeDef *pSynchroInfo)
+{
+  /* Check the parameter */
+  assert_param(pSynchroInfo != (void *)NULL);
+
+  /* Get the reload value */
+  pSynchroInfo->ReloadValue = (READ_BIT(CRS->CFGR, CRS_CFGR_RELOAD));
+
+  /* Get HSI48 oscillator smooth trimming */
+  pSynchroInfo->HSI48CalibrationValue = (READ_BIT(CRS->CR, CRS_CR_TRIM) >> CRS_CR_TRIM_Pos);
+
+  /* Get Frequency error capture */
+  pSynchroInfo->FreqErrorCapture = (READ_BIT(CRS->ISR, CRS_ISR_FECAP) >> CRS_ISR_FECAP_Pos);
+
+  /* Get Frequency error direction */
+  pSynchroInfo->FreqErrorDirection = (READ_BIT(CRS->ISR, CRS_ISR_FEDIR));
+}
+
+/**
+  * @brief Wait for CRS Synchronization status.
+  * @param Timeout  Duration of the timeout
+  * @note  Timeout is based on the maximum time to receive a SYNC event based on synchronization
+  *        frequency.
+  * @note    If Timeout set to HAL_MAX_DELAY, HAL_TIMEOUT will be never returned.
+  * @retval Combination of Synchronization status
+  *          This parameter can be a combination of the following values:
+  *            @arg @ref RCC_CRS_TIMEOUT
+  *            @arg @ref RCC_CRS_SYNCOK
+  *            @arg @ref RCC_CRS_SYNCWARN
+  *            @arg @ref RCC_CRS_SYNCERR
+  *            @arg @ref RCC_CRS_SYNCMISS
+  *            @arg @ref RCC_CRS_TRIMOVF
+  */
+uint32_t HAL_RCCEx_CRSWaitSynchronization(uint32_t Timeout)
+{
+  uint32_t crsstatus = RCC_CRS_NONE;
+  uint32_t tickstart;
+
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+
+  /* Wait for CRS flag or timeout detection */
+  do
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
+      {
+        crsstatus = RCC_CRS_TIMEOUT;
+      }
+    }
+    /* Check CRS SYNCOK flag  */
+    if (__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCOK))
+    {
+      /* CRS SYNC event OK */
+      crsstatus |= RCC_CRS_SYNCOK;
+
+      /* Clear CRS SYNC event OK bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCOK);
+    }
+
+    /* Check CRS SYNCWARN flag  */
+    if (__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCWARN))
+    {
+      /* CRS SYNC warning */
+      crsstatus |= RCC_CRS_SYNCWARN;
+
+      /* Clear CRS SYNCWARN bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCWARN);
+    }
+
+    /* Check CRS TRIM overflow flag  */
+    if (__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_TRIMOVF))
+    {
+      /* CRS SYNC Error */
+      crsstatus |= RCC_CRS_TRIMOVF;
+
+      /* Clear CRS Error bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_TRIMOVF);
+    }
+
+    /* Check CRS Error flag  */
+    if (__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCERR))
+    {
+      /* CRS SYNC Error */
+      crsstatus |= RCC_CRS_SYNCERR;
+
+      /* Clear CRS Error bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCERR);
+    }
+
+    /* Check CRS SYNC Missed flag  */
+    if (__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCMISS))
+    {
+      /* CRS SYNC Missed */
+      crsstatus |= RCC_CRS_SYNCMISS;
+
+      /* Clear CRS SYNC Missed bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCMISS);
+    }
+
+    /* Check CRS Expected SYNC flag  */
+    if (__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_ESYNC))
+    {
+      /* frequency error counter reached a zero value */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_ESYNC);
+    }
+  }
+  while (RCC_CRS_NONE == crsstatus);
+
+  return crsstatus;
+}
+
+/**
+  * @brief Handle the Clock Recovery System interrupt request.
+  * @retval None
+  */
+void HAL_RCCEx_CRS_IRQHandler(void)
+{
+  uint32_t crserror = RCC_CRS_NONE;
+  /* Get current IT flags and IT sources values */
+  uint32_t itflags = READ_REG(CRS->ISR);
+  uint32_t itsources = READ_REG(CRS->CR);
+
+  /* Check CRS SYNCOK flag  */
+  if (((itflags & RCC_CRS_FLAG_SYNCOK) != 0U) && ((itsources & RCC_CRS_IT_SYNCOK) != 0U))
+  {
+    /* Clear CRS SYNC event OK flag */
+    WRITE_REG(CRS->ICR, CRS_ICR_SYNCOKC);
+
+    /* user callback */
+    HAL_RCCEx_CRS_SyncOkCallback();
+  }
+  /* Check CRS SYNCWARN flag  */
+  else if (((itflags & RCC_CRS_FLAG_SYNCWARN) != 0U) && ((itsources & RCC_CRS_IT_SYNCWARN) != 0U))
+  {
+    /* Clear CRS SYNCWARN flag */
+    WRITE_REG(CRS->ICR, CRS_ICR_SYNCWARNC);
+
+    /* user callback */
+    HAL_RCCEx_CRS_SyncWarnCallback();
+  }
+  /* Check CRS Expected SYNC flag  */
+  else if (((itflags & RCC_CRS_FLAG_ESYNC) != 0U) && ((itsources & RCC_CRS_IT_ESYNC) != 0U))
+  {
+    /* frequency error counter reached a zero value */
+    WRITE_REG(CRS->ICR, CRS_ICR_ESYNCC);
+
+    /* user callback */
+    HAL_RCCEx_CRS_ExpectedSyncCallback();
+  }
+  /* Check CRS Error flags  */
+  else
+  {
+    if (((itflags & RCC_CRS_FLAG_ERR) != 0U) && ((itsources & RCC_CRS_IT_ERR) != 0U))
+    {
+      if ((itflags & RCC_CRS_FLAG_SYNCERR) != 0U)
+      {
+        crserror |= RCC_CRS_SYNCERR;
+      }
+      if ((itflags & RCC_CRS_FLAG_SYNCMISS) != 0U)
+      {
+        crserror |= RCC_CRS_SYNCMISS;
+      }
+      if ((itflags & RCC_CRS_FLAG_TRIMOVF) != 0U)
+      {
+        crserror |= RCC_CRS_TRIMOVF;
+      }
+
+      /* Clear CRS Error flags */
+      WRITE_REG(CRS->ICR, CRS_ICR_ERRC);
+
+      /* user error callback */
+      HAL_RCCEx_CRS_ErrorCallback(crserror);
+    }
+  }
+}
+
+/**
+  * @brief  RCCEx Clock Recovery System SYNCOK interrupt callback.
+  * @retval none
+  */
+__weak void HAL_RCCEx_CRS_SyncOkCallback(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the @ref HAL_RCCEx_CRS_SyncOkCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief  RCCEx Clock Recovery System SYNCWARN interrupt callback.
+  * @retval none
+  */
+__weak void HAL_RCCEx_CRS_SyncWarnCallback(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the @ref HAL_RCCEx_CRS_SyncWarnCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief  RCCEx Clock Recovery System Expected SYNC interrupt callback.
+  * @retval none
+  */
+__weak void HAL_RCCEx_CRS_ExpectedSyncCallback(void)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the @ref HAL_RCCEx_CRS_ExpectedSyncCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @brief  RCCEx Clock Recovery System Error interrupt callback.
+  * @param  Error Combination of Error status.
+  *         This parameter can be a combination of the following values:
+  *           @arg @ref RCC_CRS_SYNCERR
+  *           @arg @ref RCC_CRS_SYNCMISS
+  *           @arg @ref RCC_CRS_TRIMOVF
+  * @retval none
+  */
+__weak void HAL_RCCEx_CRS_ErrorCallback(uint32_t Error)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Error);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the @ref HAL_RCCEx_CRS_ErrorCallback should be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+#endif /* CRS */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rtc.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rtc.c
@@ -105,12 +105,11 @@
     (+) WakeUpTimerEventCallback     :  RTC WakeUpTimer Event callback.
     (+) Tamper1EventCallback         :  RTC Tamper1Event callback.
     (+) Tamper2EventCallback         :  RTC Tamper2Event callback.
-    (+) InternalTamper1EventCallback :  RTC Internal Tamper 1 Event callback.
+    (+) Tamper3EventCallback         :  RTC Tamper3Event callback. (*)
     (+) InternalTamper3EventCallback :  RTC Internal Tamper 3 Event callback.
     (+) InternalTamper4EventCallback :  RTC Internal Tamper 4 Event callback.
     (+) InternalTamper5EventCallback :  RTC Internal Tamper 5 Event callback.
     (+) InternalTamper6EventCallback :  RTC Internal Tamper 6 Event callback.
-    (+) InternalTamper7EventCallback :  RTC Internal Tamper 7 Event callback.
     (+) MspInitCallback              :  RTC MspInit.
     (+) MspDeInitCallback            :  RTC MspDeInit.
   This function takes as parameters the HAL peripheral handle, the Callback ID
@@ -127,12 +126,11 @@
     (+) WakeUpTimerEventCallback     : RTC WakeUpTimer Event callback.
     (+) Tamper1EventCallback         : RTC Tamper 1 Event callback.
     (+) Tamper2EventCallback         : RTC Tamper 2 Event callback.
-    (+) InternalTamper1EventCallback : RTC Internal Tamper 1 Event callback.
+    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback.(*)
     (+) InternalTamper3EventCallback : RTC Internal Tamper 3 Event callback.
     (+) InternalTamper4EventCallback : RTC Internal Tamper 4 Event callback.
     (+) InternalTamper5EventCallback : RTC Internal Tamper 5 Event callback.
     (+) InternalTamper6EventCallback : RTC Internal Tamper 6 Event callback.
-    (+) InternalTamper7EventCallback : RTC Internal Tamper 7 Event callback.
     (+) MspInitCallback              : RTC MspInit callback.
     (+) MspDeInitCallback            : RTC MspDeInit callback.
 
@@ -274,6 +272,9 @@ HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
     hrtc->WakeUpTimerEventCallback     =  HAL_RTCEx_WakeUpTimerEventCallback; /* Legacy weak WakeUpTimerEventCallback */
     hrtc->Tamper1EventCallback         =  HAL_RTCEx_Tamper1EventCallback;     /* Legacy weak Tamper1EventCallback     */
     hrtc->Tamper2EventCallback         =  HAL_RTCEx_Tamper2EventCallback;     /* Legacy weak Tamper2EventCallback     */
+#if defined(TAMP_CR1_TAMP3E)
+    hrtc->Tamper3EventCallback         =  HAL_RTCEx_Tamper3EventCallback;     /* Legacy weak Tamper3EventCallback     */
+#endif
     hrtc->InternalTamper3EventCallback =  HAL_RTCEx_InternalTamper3EventCallback;   /*!< Legacy weak InternalTamper3EventCallback */
     hrtc->InternalTamper4EventCallback =  HAL_RTCEx_InternalTamper4EventCallback;   /*!< Legacy weak InternalTamper4EventCallback */
     hrtc->InternalTamper5EventCallback =  HAL_RTCEx_InternalTamper5EventCallback;   /*!< Legacy weak InternalTamper5EventCallback */
@@ -439,6 +440,7 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
   *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      WakeUp Timer Event Callback ID
   *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Callback ID
   *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Callback ID
+  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Callback ID (*)
   *          @arg @ref HAL_RTC_INTERNAL_TAMPER3_EVENT_CB_ID Internal Tamper 3 Callback ID
   *          @arg @ref HAL_RTC_INTERNAL_TAMPER4_EVENT_CB_ID Internal Tamper 4 Callback ID
   *          @arg @ref HAL_RTC_INTERNAL_TAMPER5_EVENT_CB_ID Internal Tamper 5 Callback ID
@@ -488,6 +490,11 @@ HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Call
       hrtc->Tamper2EventCallback = pCallback;
       break;
 
+#if defined(TAMP_CR1_TAMP3E)
+    case HAL_RTC_TAMPER3_EVENT_CB_ID :
+      hrtc->Tamper3EventCallback = pCallback;
+      break;
+#endif
 
     case HAL_RTC_INTERNAL_TAMPER3_EVENT_CB_ID :
       hrtc->InternalTamper3EventCallback = pCallback;
@@ -504,7 +511,6 @@ HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Call
     case HAL_RTC_INTERNAL_TAMPER6_EVENT_CB_ID :
        hrtc->InternalTamper6EventCallback = pCallback;
       break;
-
 
    case HAL_RTC_MSPINIT_CB_ID :
       hrtc->MspInitCallback = pCallback;
@@ -562,6 +568,7 @@ HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Call
   *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      WakeUp Timer Event Callback ID
   *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Callback ID
   *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Callback ID
+  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Callback ID (*)
   *          @arg @ref HAL_RTC_INTERNAL_TAMPER3_EVENT_CB_ID Internal Tamper 3 Callback ID
   *          @arg @ref HAL_RTC_INTERNAL_TAMPER4_EVENT_CB_ID Internal Tamper 4 Callback ID
   *          @arg @ref HAL_RTC_INTERNAL_TAMPER5_EVENT_CB_ID Internal Tamper 5 Callback ID
@@ -605,6 +612,11 @@ HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Ca
       hrtc->Tamper2EventCallback = HAL_RTCEx_Tamper2EventCallback;         /* Legacy weak Tamper2EventCallback         */
       break;
 
+#if defined(TAMP_CR1_TAMP3E)
+    case HAL_RTC_TAMPER3_EVENT_CB_ID :
+      hrtc->Tamper3EventCallback = HAL_RTCEx_Tamper3EventCallback;         /* Legacy weak Tamper3EventCallback         */
+      break;
+#endif
 
     case HAL_RTC_INTERNAL_TAMPER3_EVENT_CB_ID :
       hrtc->InternalTamper3EventCallback = HAL_RTCEx_InternalTamper3EventCallback;        /* Legacy weak InternalTamper3EventCallback         */
@@ -1496,7 +1508,7 @@ HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     sAlarm->AlarmTime.Hours = (uint8_t)((tmpreg & (RTC_ALRMAR_HT | RTC_ALRMAR_HU)) >> RTC_ALRMAR_HU_Pos);
     sAlarm->AlarmTime.Minutes = (uint8_t)((tmpreg & (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU)) >> RTC_ALRMAR_MNU_Pos);
     sAlarm->AlarmTime.Seconds = (uint8_t)((tmpreg & (RTC_ALRMAR_ST | RTC_ALRMAR_SU)) >> RTC_ALRMAR_SU_Pos);
-    sAlarm->AlarmTime.TimeFormat = (uint8_t)((tmpreg & RTC_ALRMAR_PM) >> RTC_ALRMAR_SU_Pos);
+    sAlarm->AlarmTime.TimeFormat = (uint8_t)((tmpreg & RTC_ALRMAR_PM) >> RTC_ALRMAR_PM_Pos);
     sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
     sAlarm->AlarmDateWeekDay = (uint8_t)((tmpreg & (RTC_ALRMAR_DT | RTC_ALRMAR_DU)) >> RTC_ALRMAR_DU_Pos);
     sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMAR_WDSEL);

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rtc_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_rtc_ex.c
@@ -90,7 +90,7 @@
          function.
      (+) To read the RTC Backup Data registers, use the HAL_RTCEx_BKUPRead()
          function.
-     (+) Befoer callingthose fucntion you have to call HAL_RTC_Init() in order to
+     (+) Before calling those functions you have to call HAL_RTC_Init() in order to
          perform TAMP base address offset calculation.
 
    @endverbatim
@@ -442,22 +442,18 @@ __weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
 void HAL_RTCEx_TimeStampIRQHandler(RTC_HandleTypeDef *hrtc)
 {
   /* Get the TimeStamp interrupt source enable status */
-  if(__HAL_RTC_TIMESTAMP_GET_IT_SOURCE(hrtc, RTC_IT_TS) != 0U)
+  if (READ_BIT(RTC->MISR, RTC_MISR_TSMF) != 0U)
   {
-    /* Get the pending status of the TIMESTAMP Interrupt */
-    if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) != 0U)
-    {
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
-      /* Call TimeStampEvent registered Callback */
-      hrtc->TimeStampEventCallback(hrtc);
+    /* Call TimeStampEvent registered Callback */
+    hrtc->TimeStampEventCallback(hrtc);
 #else
-      /* TIMESTAMP callback */
-      HAL_RTCEx_TimeStampEventCallback(hrtc);
+    /* TIMESTAMP callback */
+    HAL_RTCEx_TimeStampEventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
-      /* Clear the TIMESTAMP interrupt pending bit */
-      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
-    }
+    /* Clearing flags after the Callback because the content of RTC_TSTR and RTC_TSDR are cleared when TSF bit is reset.*/
+    WRITE_REG(RTC->SCR, RTC_SCR_CITSF | RTC_SCR_CTSF);
   }
 
   /* Change RTC state */
@@ -1500,6 +1496,7 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t T
   *         This parameter can be a combination of the following values:
   *         @arg RTC_TAMPER_1
   *         @arg RTC_TAMPER_2
+  *         @arg RTC_TAMPER_3 (*)
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
@@ -1676,7 +1673,7 @@ void HAL_RTCEx_TamperIRQHandler(RTC_HandleTypeDef *hrtc)
   /* Get interrupt status */
   tmp = tamp->MISR;
 
-  /* Immediatly clear flags */
+  /* Immediately clear flags */
   tamp->SCR = tmp;
 
   /* Check Tamper1 status */
@@ -1703,6 +1700,19 @@ void HAL_RTCEx_TamperIRQHandler(RTC_HandleTypeDef *hrtc)
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
   }
 
+#if defined(TAMP_CR1_TAMP3E)
+  /* Check Tamper3 status */
+  if((tmp & RTC_TAMPER_3) == RTC_TAMPER_3)
+  {
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      /* Call Tamper 3 Event registered Callback */
+      hrtc->Tamper3EventCallback(hrtc);
+#else
+    /* Tamper3 callback */
+    HAL_RTCEx_Tamper3EventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+  }
+#endif
 
   /* Check Internal Tamper3 status */
   if((tmp & RTC_INT_TAMPER_3) == RTC_INT_TAMPER_3)
@@ -1786,8 +1796,22 @@ __weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
    */
 }
 
+#if defined(TAMP_CR1_TAMP3E)
+/**
+  * @brief  Tamper 3 callback.
+  * @param  hrtc RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
 
-
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_RTCEx_Tamper2EventCallback could be implemented in the user file
+   */
+}
+#endif
 
 /**
   * @brief  Internal Tamper 3 callback.

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_smartcard.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_smartcard.c
@@ -757,29 +757,30 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
         (++) HAL_SMARTCARD_RxCpltCallback()
         (++) HAL_SMARTCARD_ErrorCallback()
 
+  [..]
     (#) Non-Blocking mode transfers could be aborted using Abort API's :
-        (+) HAL_SMARTCARD_Abort()
-        (+) HAL_SMARTCARD_AbortTransmit()
-        (+) HAL_SMARTCARD_AbortReceive()
-        (+) HAL_SMARTCARD_Abort_IT()
-        (+) HAL_SMARTCARD_AbortTransmit_IT()
-        (+) HAL_SMARTCARD_AbortReceive_IT()
+        (++) HAL_SMARTCARD_Abort()
+        (++) HAL_SMARTCARD_AbortTransmit()
+        (++) HAL_SMARTCARD_AbortReceive()
+        (++) HAL_SMARTCARD_Abort_IT()
+        (++) HAL_SMARTCARD_AbortTransmit_IT()
+        (++) HAL_SMARTCARD_AbortReceive_IT()
 
     (#) For Abort services based on interrupts (HAL_SMARTCARD_Abortxxx_IT), a set of Abort Complete Callbacks are provided:
-        (+) HAL_SMARTCARD_AbortCpltCallback()
-        (+) HAL_SMARTCARD_AbortTransmitCpltCallback()
-        (+) HAL_SMARTCARD_AbortReceiveCpltCallback()
+        (++) HAL_SMARTCARD_AbortCpltCallback()
+        (++) HAL_SMARTCARD_AbortTransmitCpltCallback()
+        (++) HAL_SMARTCARD_AbortReceiveCpltCallback()
 
     (#) In Non-Blocking mode transfers, possible errors are split into 2 categories.
         Errors are handled as follows :
-       (+) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
-           to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
-           Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
-           and HAL_SMARTCARD_ErrorCallback() user callback is executed. Transfer is kept ongoing on SMARTCARD side.
-           If user wants to abort it, Abort services should be called by user.
-       (+) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
-           This concerns Frame Error in Interrupt mode tranmission, Overrun Error in Interrupt mode reception and all errors in DMA mode.
-           Error code is set to allow user to identify error type, and HAL_SMARTCARD_ErrorCallback() user callback is executed.
+       (++) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
+            to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
+            Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
+            and HAL_SMARTCARD_ErrorCallback() user callback is executed. Transfer is kept ongoing on SMARTCARD side.
+            If user wants to abort it, Abort services should be called by user.
+       (++) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
+            This concerns Frame Error in Interrupt mode transmission, Overrun Error in Interrupt mode reception and all errors in DMA mode.
+            Error code is set to allow user to identify error type, and HAL_SMARTCARD_ErrorCallback() user callback is executed.
 
 @endverbatim
   * @{
@@ -823,13 +824,22 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, ui
     /* Disable the Peripheral first to update mode for TX master */
     CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
 
-    /* Disable Rx, enable Tx */
-    CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
-    SET_BIT(hsmartcard->Instance->RQR, (uint16_t)SMARTCARD_RXDATA_FLUSH_REQUEST);
+    /* In case of TX only mode, if NACK is enabled, the USART must be able to monitor
+       the bidirectional line to detect a NACK signal in case of parity error.
+       Therefore, the receiver block must be enabled as well (RE bit must be set). */
+    if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
+     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+    {
+      SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
+    }
+    /* Enable Tx */
     SET_BIT(hsmartcard->Instance->CR1, USART_CR1_TE);
 
     /* Enable the Peripheral */
     SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+
+    /* Perform a TX/RX FIFO Flush */
+    __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
 
     hsmartcard->ErrorCode = HAL_SMARTCARD_ERROR_NONE;
     hsmartcard->TxXferSize = Size;
@@ -850,15 +860,23 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, ui
     {
       return HAL_TIMEOUT;
     }
-    /* Re-enable Rx at end of transmission if initial mode is Rx/Tx */
-    if (hsmartcard->Init.Mode == SMARTCARD_MODE_TX_RX)
+
+    /* Disable the Peripheral first to update mode */
+    CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+    if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
+     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
     {
-      /* Disable the Peripheral first to update modes */
-      CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
-      SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
-      /* Enable the Peripheral */
-      SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+      /* In case of TX only mode, if NACK is enabled, receiver block has been enabled
+         for Transmit phase. Disable this receiver block. */
+      CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
     }
+    if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX_RX)
+     || (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+    {
+      /* Perform a TX FIFO Flush at end of Tx phase, as all sent bytes are appearing in Rx Data register */
+      __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
+    }
+    SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
 
     /* At end of Tx process, restore hsmartcard->gState to Ready */
     hsmartcard->gState = HAL_SMARTCARD_STATE_READY;
@@ -979,13 +997,22 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsmartcard,
     /* Disable the Peripheral first to update mode for TX master */
     CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
 
-    /* Disable Rx, enable Tx */
-    CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
-    SET_BIT(hsmartcard->Instance->RQR, (uint16_t)SMARTCARD_RXDATA_FLUSH_REQUEST);
+    /* In case of TX only mode, if NACK is enabled, the USART must be able to monitor
+       the bidirectional line to detect a NACK signal in case of parity error.
+       Therefore, the receiver block must be enabled as well (RE bit must be set). */
+    if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
+     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+    {
+      SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
+    }
+    /* Enable Tx */
     SET_BIT(hsmartcard->Instance->CR1, USART_CR1_TE);
 
     /* Enable the Peripheral */
     SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+
+    /* Perform a TX/RX FIFO Flush */
+    __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
 
     /* Configure Tx interrupt processing */
     if (hsmartcard->FifoMode == SMARTCARD_FIFOMODE_ENABLE)
@@ -1127,13 +1154,22 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsmartcard
     /* Disable the Peripheral first to update mode for TX master */
     CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
 
-    /* Disable Rx, enable Tx */
-    CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
-    SET_BIT(hsmartcard->Instance->RQR, (uint16_t)SMARTCARD_RXDATA_FLUSH_REQUEST);
+    /* In case of TX only mode, if NACK is enabled, the USART must be able to monitor
+       the bidirectional line to detect a NACK signal in case of parity error.
+       Therefore, the receiver block must be enabled as well (RE bit must be set). */
+    if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
+     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+    {
+      SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
+    }
+    /* Enable Tx */
     SET_BIT(hsmartcard->Instance->CR1, USART_CR1_TE);
 
     /* Enable the Peripheral */
     SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+
+    /* Perform a TX/RX FIFO Flush */
+    __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
 
     /* Set the SMARTCARD DMA transfer complete callback */
     hsmartcard->hdmatx->XferCpltCallback = SMARTCARD_DMATransmitCplt;
@@ -2945,15 +2981,22 @@ static void SMARTCARD_EndTransmit_IT(SMARTCARD_HandleTypeDef *hsmartcard)
     CLEAR_BIT(hsmartcard->Instance->CR3, USART_CR3_EIE);
   }
 
-  /* Re-enable Rx at end of transmission if initial mode is Rx/Tx */
-  if (hsmartcard->Init.Mode == SMARTCARD_MODE_TX_RX)
+  /* Disable the Peripheral first to update mode */
+  CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+  if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
+   && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
   {
-    /* Disable the Peripheral first to update modes */
-    CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
-    SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
-    /* Enable the Peripheral */
-    SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
+    /* In case of TX only mode, if NACK is enabled, receiver block has been enabled
+       for Transmit phase. Disable this receiver block. */
+    CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
   }
+  if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX_RX)
+   || (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+  {
+    /* Perform a TX FIFO Flush at end of Tx phase, as all sent bytes are appearing in Rx Data register */
+    __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
+  }
+  SET_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
 
   /* Tx process is ended, restore hsmartcard->gState to Ready */
   hsmartcard->gState = HAL_SMARTCARD_STATE_READY;

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_smartcard_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_smartcard_ex.c
@@ -55,11 +55,17 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup SMARTCARDEx_Private_Constants SMARTCARD Extended Private Constants
+  * @{
+  */
 /* UART RX FIFO depth */
 #define RX_FIFO_DEPTH 8U
 
 /* UART TX FIFO depth */
 #define TX_FIFO_DEPTH 8U
+/**
+  * @}
+  */
 
 /* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
@@ -188,8 +194,8 @@ HAL_StatusTypeDef HAL_SMARTCARDEx_DisableReceiverTimeOut(SMARTCARD_HandleTypeDef
     This subsection provides a set of FIFO mode related callback functions.
 
     (#) TX/RX Fifos Callbacks:
-        (+) HAL_SMARTCARDEx_RxFifoFullCallback()
-        (+) HAL_SMARTCARDEx_TxFifoEmptyCallback()
+        (++) HAL_SMARTCARDEx_RxFifoFullCallback()
+        (++) HAL_SMARTCARDEx_TxFifoEmptyCallback()
 
 @endverbatim
   * @{
@@ -231,15 +237,16 @@ __weak void HAL_SMARTCARDEx_TxFifoEmptyCallback(SMARTCARD_HandleTypeDef *hsmartc
   * @}
   */
 
-/** @defgroup SMARTCARD_Exported_Functions_Group3 Extended Peripheral Peripheral Control functions
+/** @defgroup SMARTCARDEx_Exported_Functions_Group3 Extended Peripheral FIFO Control functions
   *  @brief   SMARTCARD control functions
   *
 @verbatim
  ===============================================================================
-                      ##### Peripheral Control functions #####
+                  ##### Peripheral FIFO Control functions #####
  ===============================================================================
     [..]
-    This subsection provides a set of functions allowing to control the SMARTCARD.
+    This subsection provides a set of functions allowing to control the SMARTCARD
+    FIFO feature.
      (+) HAL_SMARTCARDEx_EnableFifoMode() API enables the FIFO mode
      (+) HAL_SMARTCARDEx_DisableFifoMode() API disables the FIFO mode
      (+) HAL_SMARTCARDEx_SetTxFifoThreshold() API sets the TX FIFO threshold
@@ -433,7 +440,7 @@ HAL_StatusTypeDef HAL_SMARTCARDEx_SetRxFifoThreshold(SMARTCARD_HandleTypeDef *hs
   * @}
   */
 
-/** @defgroup SMARTCARDEx_Private_Functions  SMARTCARD Extended private Functions
+/** @defgroup SMARTCARDEx_Private_Functions  SMARTCARD Extended Private Functions
   * @{
   */
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_smbus.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_smbus.c
@@ -203,18 +203,18 @@
 /** @addtogroup SMBUS_Private_Functions SMBUS Private Functions
   * @{
   */
-static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
 
-static void SMBUS_Enable_IRQ(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
-static void SMBUS_Disable_IRQ(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
-static HAL_StatusTypeDef SMBUS_Master_ISR(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags);
-static HAL_StatusTypeDef SMBUS_Slave_ISR(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags);
+static void SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
+static void SMBUS_Disable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
+static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags);
+static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags);
 
-static void SMBUS_ConvertOtherXferOptions(struct __SMBUS_HandleTypeDef *hsmbus);
+static void SMBUS_ConvertOtherXferOptions(SMBUS_HandleTypeDef *hsmbus);
 
-static void SMBUS_ITErrorHandler(struct __SMBUS_HandleTypeDef *hsmbus);
+static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus);
 
-static void SMBUS_TransferConfig(struct __SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
 /**
   * @}
   */
@@ -1801,7 +1801,7 @@ uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus)
   * @param  StatusFlags Value of Interrupt Flags.
   * @retval HAL status
   */
-static HAL_StatusTypeDef SMBUS_Master_ISR(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags)
+static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags)
 {
   uint16_t DevAddress;
 
@@ -1854,7 +1854,7 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(struct __SMBUS_HandleTypeDef *hsmbus, 
       /* Process Unlocked */
       __HAL_UNLOCK(hsmbus);
 
-      /* REenable the selected SMBUS peripheral */
+      /* Re-enable the selected SMBUS peripheral */
       __HAL_SMBUS_ENABLE(hsmbus);
 
       /* Call the corresponding callback to inform upper layer of End of Transfer */
@@ -2085,7 +2085,7 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(struct __SMBUS_HandleTypeDef *hsmbus, 
   * @param  StatusFlags Value of Interrupt Flags.
   * @retval HAL status
   */
-static HAL_StatusTypeDef SMBUS_Slave_ISR(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags)
+static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags)
 {
   uint8_t TransferDirection;
   uint16_t SlaveAddrCode;
@@ -2341,7 +2341,7 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(struct __SMBUS_HandleTypeDef *hsmbus, u
   * @param  InterruptRequest Value of @ref SMBUS_Interrupt_configuration_definition.
   * @retval HAL status
   */
-static void SMBUS_Enable_IRQ(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest)
+static void SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest)
 {
   uint32_t tmpisr = 0UL;
 
@@ -2381,7 +2381,7 @@ static void SMBUS_Enable_IRQ(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t Inte
   * @param  InterruptRequest Value of @ref SMBUS_Interrupt_configuration_definition.
   * @retval HAL status
   */
-static void SMBUS_Disable_IRQ(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest)
+static void SMBUS_Disable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest)
 {
   uint32_t tmpisr = 0UL;
   uint32_t tmpstate = hsmbus->State;
@@ -2453,7 +2453,7 @@ static void SMBUS_Disable_IRQ(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t Int
   * @param  hsmbus SMBUS handle.
   * @retval None
   */
-static void SMBUS_ITErrorHandler(struct __SMBUS_HandleTypeDef *hsmbus)
+static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
 {
   uint32_t itflags   = READ_REG(hsmbus->Instance->ISR);
   uint32_t itsources = READ_REG(hsmbus->Instance->CR1);
@@ -2554,7 +2554,7 @@ static void SMBUS_ITErrorHandler(struct __SMBUS_HandleTypeDef *hsmbus)
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(struct __SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
+static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
 {
   uint32_t tickstart = HAL_GetTick();
 
@@ -2603,7 +2603,7 @@ static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(struct __SMBUS_HandleTypeD
   *     @arg @ref SMBUS_GENERATE_START_WRITE Generate Restart for write request.
   * @retval None
   */
-static void SMBUS_TransferConfig(struct __SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
 {
   /* Check the parameters */
   assert_param(IS_SMBUS_ALL_INSTANCE(hsmbus->Instance));
@@ -2616,11 +2616,11 @@ static void SMBUS_TransferConfig(struct __SMBUS_HandleTypeDef *hsmbus,  uint16_t
 }
 
 /**
-  * @brief  Convert SMBUSx OTHER_xxx XferOptions to functionnal XferOptions.
+  * @brief  Convert SMBUSx OTHER_xxx XferOptions to functional XferOptions.
   * @param  hsmbus SMBUS handle.
   * @retval None
   */
-static void SMBUS_ConvertOtherXferOptions(struct __SMBUS_HandleTypeDef *hsmbus)
+static void SMBUS_ConvertOtherXferOptions(SMBUS_HandleTypeDef *hsmbus)
 {
   /* if user set XferOptions to SMBUS_OTHER_FRAME_NO_PEC   */
   /* it request implicitly to generate a restart condition */

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_spi.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_spi.c
@@ -65,16 +65,16 @@
           Use Functions HAL_SPI_RegisterCallback() to register an interrupt callback.
 
           Function HAL_SPI_RegisterCallback() allows to register following callbacks:
-            (+) TxCpltCallback        : SPI Tx Completed callback
-            (+) RxCpltCallback        : SPI Rx Completed callback
-            (+) TxRxCpltCallback      : SPI TxRx Completed callback
-            (+) TxHalfCpltCallback    : SPI Tx Half Completed callback
-            (+) RxHalfCpltCallback    : SPI Rx Half Completed callback
-            (+) TxRxHalfCpltCallback  : SPI TxRx Half Completed callback
-            (+) ErrorCallback         : SPI Error callback
-            (+) AbortCpltCallback     : SPI Abort callback
-            (+) MspInitCallback       : SPI Msp Init callback
-            (+) MspDeInitCallback     : SPI Msp DeInit callback
+            (++) TxCpltCallback        : SPI Tx Completed callback
+            (++) RxCpltCallback        : SPI Rx Completed callback
+            (++) TxRxCpltCallback      : SPI TxRx Completed callback
+            (++) TxHalfCpltCallback    : SPI Tx Half Completed callback
+            (++) RxHalfCpltCallback    : SPI Rx Half Completed callback
+            (++) TxRxHalfCpltCallback  : SPI TxRx Half Completed callback
+            (++) ErrorCallback         : SPI Error callback
+            (++) AbortCpltCallback     : SPI Abort callback
+            (++) MspInitCallback       : SPI Msp Init callback
+            (++) MspDeInitCallback     : SPI Msp DeInit callback
           This function takes as parameters the HAL peripheral handle, the Callback ID
           and a pointer to the user callback function.
 
@@ -84,17 +84,18 @@
           HAL_SPI_UnRegisterCallback takes as parameters the HAL peripheral handle,
           and the Callback ID.
           This function allows to reset following callbacks:
-            (+) TxCpltCallback        : SPI Tx Completed callback
-            (+) RxCpltCallback        : SPI Rx Completed callback
-            (+) TxRxCpltCallback      : SPI TxRx Completed callback
-            (+) TxHalfCpltCallback    : SPI Tx Half Completed callback
-            (+) RxHalfCpltCallback    : SPI Rx Half Completed callback
-            (+) TxRxHalfCpltCallback  : SPI TxRx Half Completed callback
-            (+) ErrorCallback         : SPI Error callback
-            (+) AbortCpltCallback     : SPI Abort callback
-            (+) MspInitCallback       : SPI Msp Init callback
-            (+) MspDeInitCallback     : SPI Msp DeInit callback
+            (++) TxCpltCallback        : SPI Tx Completed callback
+            (++) RxCpltCallback        : SPI Rx Completed callback
+            (++) TxRxCpltCallback      : SPI TxRx Completed callback
+            (++) TxHalfCpltCallback    : SPI Tx Half Completed callback
+            (++) RxHalfCpltCallback    : SPI Rx Half Completed callback
+            (++) TxRxHalfCpltCallback  : SPI TxRx Half Completed callback
+            (++) ErrorCallback         : SPI Error callback
+            (++) AbortCpltCallback     : SPI Abort callback
+            (++) MspInitCallback       : SPI Msp Init callback
+            (++) MspDeInitCallback     : SPI Msp DeInit callback
 
+       [..]
        By default, after the HAL_SPI_Init() and when the state is HAL_SPI_STATE_RESET
        all callbacks are set to the corresponding weak functions:
        examples HAL_SPI_MasterTxCpltCallback(), HAL_SPI_MasterRxCpltCallback().
@@ -104,6 +105,7 @@
        If MspInit or MspDeInit are not null, the HAL_SPI_Init()/ HAL_SPI_DeInit()
        keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
 
+       [..]
        Callbacks can be registered/unregistered in HAL_SPI_STATE_READY state only.
        Exception done MspInit/MspDeInit functions that can be registered/unregistered
        in HAL_SPI_STATE_READY or HAL_SPI_STATE_RESET state,
@@ -112,7 +114,8 @@
        using HAL_SPI_RegisterCallback() before calling HAL_SPI_DeInit()
        or HAL_SPI_Init() function.
 
-       When The compilation define USE_HAL_PPP_REGISTER_CALLBACKS is set to 0 or
+       [..]
+       When the compilation define USE_HAL_PPP_REGISTER_CALLBACKS is set to 0 or
        not defined, the callback registering feature is not available
        and weak (surcharged) callbacks are used.
 
@@ -128,7 +131,7 @@
        DataSize = SPI_DATASIZE_8BIT:
        +----------------------------------------------------------------------------------------------+
        |         |                | 2Lines Fullduplex   |     2Lines RxOnly    |         1Line        |
-       | Process | Tranfert mode  |---------------------|----------------------|----------------------|
+       | Process | Transfer mode  |---------------------|----------------------|----------------------|
        |         |                |  Master  |  Slave   |  Master   |  Slave   |  Master   |  Slave   |
        |==============================================================================================|
        |    T    |     Polling    | Fpclk/4  | Fpclk/8  |    NA     |    NA    |    NA     |   NA     |
@@ -153,7 +156,7 @@
        DataSize = SPI_DATASIZE_16BIT:
        +----------------------------------------------------------------------------------------------+
        |         |                | 2Lines Fullduplex   |     2Lines RxOnly    |         1Line        |
-       | Process | Tranfert mode  |---------------------|----------------------|----------------------|
+       | Process | Transfer mode  |---------------------|----------------------|----------------------|
        |         |                |  Master  |  Slave   |  Master   |  Slave   |  Master   |  Slave   |
        |==============================================================================================|
        |    T    |     Polling    | Fpclk/4  | Fpclk/8  |    NA     |    NA    |    NA     |   NA     |
@@ -269,8 +272,8 @@ static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_
   */
 
 /** @defgroup SPI_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
@@ -334,6 +337,24 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
   {
     assert_param(IS_SPI_CPOL(hspi->Init.CLKPolarity));
     assert_param(IS_SPI_CPHA(hspi->Init.CLKPhase));
+
+    if (hspi->Init.Mode == SPI_MODE_MASTER)
+    {
+      assert_param(IS_SPI_BAUDRATE_PRESCALER(hspi->Init.BaudRatePrescaler));
+    }
+    else
+    {
+      /* Baudrate prescaler not use in Motoraola Slave mode. force to default value */
+      hspi->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
+    }
+  }
+  else
+  {
+    assert_param(IS_SPI_BAUDRATE_PRESCALER(hspi->Init.BaudRatePrescaler));
+
+    /* Force polarity and phase to TI protocaol requirements */
+    hspi->Init.CLKPolarity = SPI_POLARITY_LOW;
+    hspi->Init.CLKPhase    = SPI_PHASE_1EDGE;
   }
 #if (USE_SPI_CRC != 0U)
   assert_param(IS_SPI_CRC_CALCULATION(hspi->Init.CRCCalculation));
@@ -397,44 +418,56 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
     hspi->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
   }
 
-  /* Align the CRC Length on the data size */
-  if (hspi->Init.CRCLength == SPI_CRC_LENGTH_DATASIZE)
-  {
-    /* CRC Length aligned on the data size : value set by default */
-    if (hspi->Init.DataSize > SPI_DATASIZE_8BIT)
-    {
-      hspi->Init.CRCLength = SPI_CRC_LENGTH_16BIT;
-    }
-    else
-    {
-      hspi->Init.CRCLength = SPI_CRC_LENGTH_8BIT;
-    }
-  }
-
   /*----------------------- SPIx CR1 & CR2 Configuration ---------------------*/
   /* Configure : SPI Mode, Communication Mode, Clock polarity and phase, NSS management,
   Communication speed, First bit and CRC calculation state */
-  WRITE_REG(hspi->Instance->CR1, (hspi->Init.Mode | hspi->Init.Direction |
-                                  hspi->Init.CLKPolarity | hspi->Init.CLKPhase | (hspi->Init.NSS & SPI_CR1_SSM) |
-                                  hspi->Init.BaudRatePrescaler | hspi->Init.FirstBit  | hspi->Init.CRCCalculation));
+  WRITE_REG(hspi->Instance->CR1, ((hspi->Init.Mode & (SPI_CR1_MSTR | SPI_CR1_SSI)) |
+                                  (hspi->Init.Direction & (SPI_CR1_RXONLY | SPI_CR1_BIDIMODE)) |
+                                  (hspi->Init.CLKPolarity & SPI_CR1_CPOL) |
+                                  (hspi->Init.CLKPhase & SPI_CR1_CPHA) |
+                                  (hspi->Init.NSS & SPI_CR1_SSM) |
+                                  (hspi->Init.BaudRatePrescaler & SPI_CR1_BR_Msk) |
+                                  (hspi->Init.FirstBit  & SPI_CR1_LSBFIRST) |
+                                  (hspi->Init.CRCCalculation & SPI_CR1_CRCEN)));
 #if (USE_SPI_CRC != 0U)
-  /* Configure : CRC Length */
-  if (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+  /*---------------------------- SPIx CRCL Configuration -------------------*/
+  if (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
   {
-    hspi->Instance->CR1 |= SPI_CR1_CRCL;
+    /* Align the CRC Length on the data size */
+    if (hspi->Init.CRCLength == SPI_CRC_LENGTH_DATASIZE)
+    {
+      /* CRC Length aligned on the data size : value set by default */
+      if (hspi->Init.DataSize > SPI_DATASIZE_8BIT)
+      {
+        hspi->Init.CRCLength = SPI_CRC_LENGTH_16BIT;
+      }
+      else
+      {
+        hspi->Init.CRCLength = SPI_CRC_LENGTH_8BIT;
+      }
+    }
+
+    /* Configure : CRC Length */
+    if (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
+    {
+      SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCL);
+    }
   }
 #endif /* USE_SPI_CRC */
 
   /* Configure : NSS management, TI Mode, NSS Pulse, Data size and Rx Fifo threshold */
-  WRITE_REG(hspi->Instance->CR2, (((hspi->Init.NSS >> 16U) & SPI_CR2_SSOE) | hspi->Init.TIMode |
-                                  hspi->Init.NSSPMode | hspi->Init.DataSize) | frxth);
+  WRITE_REG(hspi->Instance->CR2, (((hspi->Init.NSS >> 16U) & SPI_CR2_SSOE) |
+                                  (hspi->Init.TIMode & SPI_CR2_FRF) |
+                                  (hspi->Init.NSSPMode & SPI_CR2_NSSP) |
+                                  (hspi->Init.DataSize & SPI_CR2_DS_Msk) |
+                                  (frxth & SPI_CR2_FRXTH)));
 
 #if (USE_SPI_CRC != 0U)
   /*---------------------------- SPIx CRCPOLY Configuration ------------------*/
   /* Configure : CRC Polynomial */
   if (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
   {
-    WRITE_REG(hspi->Instance->CRCPR, hspi->Init.CRCPolynomial);
+    WRITE_REG(hspi->Instance->CRCPR, (hspi->Init.CRCPolynomial & SPI_CRCPR_CRCPOLY_Msk));
   }
 #endif /* USE_SPI_CRC */
 
@@ -535,7 +568,8 @@ __weak void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID, pSPI_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID,
+                                           pSPI_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -745,8 +779,8 @@ HAL_StatusTypeDef HAL_SPI_UnRegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Ca
   */
 
 /** @defgroup SPI_Exported_Functions_Group2 IO operation functions
- *  @brief   Data transfers functions
- *
+  *  @brief   Data transfers functions
+  *
 @verbatim
   ==============================================================================
                       ##### IO operation functions #####
@@ -831,6 +865,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
   /* Configure communication direction : 1Line */
   if (hspi->Init.Direction == SPI_DIRECTION_1LINE)
   {
+    /* Disable SPI Peripheral before set 1Line direction (BIDIOE bit) */
+    __HAL_SPI_DISABLE(hspi);
     SPI_1LINE_TX(hspi);
   }
 
@@ -884,38 +920,18 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
   {
     if ((hspi->Init.Mode == SPI_MODE_SLAVE) || (initial_TxXferCount == 0x01U))
     {
-      if (hspi->TxXferCount > 1U)
-      {
-        /* write on the data register in packing mode */
-        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
-        hspi->pTxBuffPtr += sizeof(uint16_t);
-        hspi->TxXferCount -= 2U;
-      }
-      else
-      {
-        *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
-        hspi->pTxBuffPtr ++;
-        hspi->TxXferCount--;
-      }
+      *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
+      hspi->pTxBuffPtr += sizeof(uint8_t);
+      hspi->TxXferCount--;
     }
     while (hspi->TxXferCount > 0U)
     {
       /* Wait until TXE flag is set to send data */
       if (__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXE))
       {
-        if (hspi->TxXferCount > 1U)
-        {
-          /* write on the data register in packing mode */
-          hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
-          hspi->pTxBuffPtr += sizeof(uint16_t);
-          hspi->TxXferCount -= 2U;
-        }
-        else
-        {
-          *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
-          hspi->pTxBuffPtr++;
-          hspi->TxXferCount--;
-        }
+        *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr += sizeof(uint8_t);
+        hspi->TxXferCount--;
       }
       else
       {
@@ -1038,6 +1054,8 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   /* Configure communication direction: 1Line */
   if (hspi->Init.Direction == SPI_DIRECTION_1LINE)
   {
+    /* Disable SPI Peripheral before set 1Line direction (BIDIOE bit) */
+    __HAL_SPI_DISABLE(hspi);
     SPI_1LINE_RX(hspi);
   }
 
@@ -1198,7 +1216,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
                                           uint32_t Timeout)
 {
   uint16_t             initial_TxXferCount;
-  uint16_t             initial_RxXferCount;
   uint32_t             tmp_mode;
   HAL_SPI_StateTypeDef tmp_state;
   uint32_t             tickstart;
@@ -1224,7 +1241,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   tmp_state           = hspi->State;
   tmp_mode            = hspi->Init.Mode;
   initial_TxXferCount = Size;
-  initial_RxXferCount = Size;
 #if (USE_SPI_CRC != 0U)
   spi_cr1             = READ_REG(hspi->Instance->CR1);
   spi_cr2             = READ_REG(hspi->Instance->CR2);
@@ -1271,7 +1287,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
 #endif /* USE_SPI_CRC */
 
   /* Set the Rx Fifo threshold */
-  if ((hspi->Init.DataSize > SPI_DATASIZE_8BIT) || (initial_RxXferCount > 1U))
+  if (hspi->Init.DataSize > SPI_DATASIZE_8BIT)
   {
     /* Set fiforxthreshold according the reception data length: 16bit */
     CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
@@ -1344,36 +1360,18 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   {
     if ((hspi->Init.Mode == SPI_MODE_SLAVE) || (initial_TxXferCount == 0x01U))
     {
-      if (hspi->TxXferCount > 1U)
-      {
-        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
-        hspi->pTxBuffPtr += sizeof(uint16_t);
-        hspi->TxXferCount -= 2U;
-      }
-      else
-      {
-        *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
-        hspi->pTxBuffPtr++;
-        hspi->TxXferCount--;
-      }
+      *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
+      hspi->pTxBuffPtr += sizeof(uint8_t);
+      hspi->TxXferCount--;
     }
     while ((hspi->TxXferCount > 0U) || (hspi->RxXferCount > 0U))
     {
       /* Check TXE flag */
       if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXE)) && (hspi->TxXferCount > 0U) && (txallowed == 1U))
       {
-        if (hspi->TxXferCount > 1U)
-        {
-          hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
-          hspi->pTxBuffPtr += sizeof(uint16_t);
-          hspi->TxXferCount -= 2U;
-        }
-        else
-        {
-          *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
-          hspi->pTxBuffPtr++;
-          hspi->TxXferCount--;
-        }
+        *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr++;
+        hspi->TxXferCount--;
         /* Next Data is a reception (Rx). Tx not allowed */
         txallowed = 0U;
 
@@ -1394,23 +1392,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       /* Wait until RXNE flag is reset */
       if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_RXNE)) && (hspi->RxXferCount > 0U))
       {
-        if (hspi->RxXferCount > 1U)
-        {
-          *((uint16_t *)hspi->pRxBuffPtr) = (uint16_t)hspi->Instance->DR;
-          hspi->pRxBuffPtr += sizeof(uint16_t);
-          hspi->RxXferCount -= 2U;
-          if (hspi->RxXferCount <= 1U)
-          {
-            /* Set RX Fifo threshold before to switch on 8 bit data size */
-            SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
-          }
-        }
-        else
-        {
-          (*(uint8_t *)hspi->pRxBuffPtr) = *(__IO uint8_t *)&hspi->Instance->DR;
-          hspi->pRxBuffPtr++;
-          hspi->RxXferCount--;
-        }
+        (*(uint8_t *)hspi->pRxBuffPtr) = *(__IO uint8_t *)&hspi->Instance->DR;
+        hspi->pRxBuffPtr++;
+        hspi->RxXferCount--;
         /* Next Data is a Transmission (Tx). Tx is allowed */
         txallowed = 1U;
       }
@@ -1540,6 +1524,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   /* Configure communication direction : 1Line */
   if (hspi->Init.Direction == SPI_DIRECTION_1LINE)
   {
+    /* Disable SPI Peripheral before set 1Line direction (BIDIOE bit) */
+    __HAL_SPI_DISABLE(hspi);
     SPI_1LINE_TX(hspi);
   }
 
@@ -1631,6 +1617,8 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
   /* Configure communication direction : 1Line */
   if (hspi->Init.Direction == SPI_DIRECTION_1LINE)
   {
+    /* Disable SPI Peripheral before set 1Line direction (BIDIOE bit) */
+    __HAL_SPI_DISABLE(hspi);
     SPI_1LINE_RX(hspi);
   }
 
@@ -1831,6 +1819,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
   /* Configure communication direction : 1Line */
   if (hspi->Init.Direction == SPI_DIRECTION_1LINE)
   {
+    /* Disable SPI Peripheral before set 1Line direction (BIDIOE bit) */
+    __HAL_SPI_DISABLE(hspi);
     SPI_1LINE_TX(hspi);
   }
 
@@ -1872,7 +1862,8 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
   }
 
   /* Enable the Tx DMA Stream/Channel */
-  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount))
+  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR,
+                                 hspi->TxXferCount))
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
@@ -1960,6 +1951,8 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   /* Configure communication direction : 1Line */
   if (hspi->Init.Direction == SPI_DIRECTION_1LINE)
   {
+    /* Disable SPI Peripheral before set 1Line direction (BIDIOE bit) */
+    __HAL_SPI_DISABLE(hspi);
     SPI_1LINE_RX(hspi);
   }
 
@@ -2014,7 +2007,8 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   hspi->hdmarx->XferAbortCallback = NULL;
 
   /* Enable the Rx DMA Stream/Channel  */
-  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr, hspi->RxXferCount))
+  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr,
+                                 hspi->RxXferCount))
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
@@ -2181,7 +2175,8 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
   hspi->hdmarx->XferAbortCallback = NULL;
 
   /* Enable the Rx DMA Stream/Channel  */
-  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr, hspi->RxXferCount))
+  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr,
+                                 hspi->RxXferCount))
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
@@ -2202,7 +2197,8 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
   hspi->hdmatx->XferAbortCallback    = NULL;
 
   /* Enable the Tx DMA Stream/Channel  */
-  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount))
+  if (HAL_OK != HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR,
+                                 hspi->TxXferCount))
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
@@ -2242,11 +2238,12 @@ error :
   *           - Set handle State to READY
   * @note   This procedure is executed in blocking mode : when exiting function, Abort is considered as completed.
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
 {
   HAL_StatusTypeDef errorcode;
-  __IO uint32_t count, resetcount;
+  __IO uint32_t count;
+  __IO uint32_t resetcount;
 
   /* Initialized local variable  */
   errorcode = HAL_OK;
@@ -2269,8 +2266,7 @@ HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
         break;
       }
       count--;
-    }
-    while (hspi->State != HAL_SPI_STATE_ABORT);
+    } while (hspi->State != HAL_SPI_STATE_ABORT);
     /* Reset Timeout Counter */
     count = resetcount;
   }
@@ -2287,8 +2283,7 @@ HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
         break;
       }
       count--;
-    }
-    while (hspi->State != HAL_SPI_STATE_ABORT);
+    } while (hspi->State != HAL_SPI_STATE_ABORT);
     /* Reset Timeout Counter */
     count = resetcount;
   }
@@ -2403,12 +2398,13 @@ HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
   * @note   This procedure is executed in Interrupt mode, meaning that abort procedure could be
   *         considered as completed only when user abort complete callback is executed (not when exiting function).
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_SPI_Abort_IT(SPI_HandleTypeDef *hspi)
 {
   HAL_StatusTypeDef errorcode;
   uint32_t abortcplt ;
-  __IO uint32_t count, resetcount;
+  __IO uint32_t count;
+  __IO uint32_t resetcount;
 
   /* Initialized local variable  */
   errorcode = HAL_OK;
@@ -2432,8 +2428,7 @@ HAL_StatusTypeDef HAL_SPI_Abort_IT(SPI_HandleTypeDef *hspi)
         break;
       }
       count--;
-    }
-    while (hspi->State != HAL_SPI_STATE_ABORT);
+    } while (hspi->State != HAL_SPI_STATE_ABORT);
     /* Reset Timeout Counter */
     count = resetcount;
   }
@@ -2450,8 +2445,7 @@ HAL_StatusTypeDef HAL_SPI_Abort_IT(SPI_HandleTypeDef *hspi)
         break;
       }
       count--;
-    }
-    while (hspi->State != HAL_SPI_STATE_ABORT);
+    } while (hspi->State != HAL_SPI_STATE_ABORT);
     /* Reset Timeout Counter */
     count = resetcount;
   }
@@ -2667,7 +2661,8 @@ void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
   }
 
   /* SPI in Error Treatment --------------------------------------------------*/
-  if (((SPI_CHECK_FLAG(itflag, SPI_FLAG_MODF) != RESET) || (SPI_CHECK_FLAG(itflag, SPI_FLAG_OVR) != RESET) || (SPI_CHECK_FLAG(itflag, SPI_FLAG_FRE) != RESET)) && (SPI_CHECK_IT_SOURCE(itsource, SPI_IT_ERR) != RESET))
+  if (((SPI_CHECK_FLAG(itflag, SPI_FLAG_MODF) != RESET) || (SPI_CHECK_FLAG(itflag, SPI_FLAG_OVR) != RESET)
+       || (SPI_CHECK_FLAG(itflag, SPI_FLAG_FRE) != RESET)) && (SPI_CHECK_IT_SOURCE(itsource, SPI_IT_ERR) != RESET))
   {
     /* SPI Overrun error interrupt occurred ----------------------------------*/
     if (SPI_CHECK_FLAG(itflag, SPI_FLAG_OVR) != RESET)
@@ -3044,8 +3039,17 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
     }
 #endif /* USE_SPI_CRC */
 
-    /* Disable Rx/Tx DMA Request (done by default to handle the case master rx direction 2 lines) */
-    CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+    /* Check if we are in Master RX 2 line mode */
+    if ((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
+    {
+      /* Disable Rx/Tx DMA Request (done by default to handle the case master rx direction 2 lines) */
+      CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+    }
+    else
+    {
+      /* Normal case */
+      CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_RXDMAEN);
+    }
 
     /* Check the end of the transaction */
     if (SPI_EndRxTransaction(hspi, SPI_DEFAULT_TIMEOUT, tickstart) != HAL_OK)
@@ -3462,7 +3466,7 @@ static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_2linesRxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
 {
-  /* Read 8bit CRC to flush Data Regsiter */
+  /* Read 8bit CRC to flush Data Register */
   READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
 
   hspi->CRCSize--;
@@ -3570,7 +3574,7 @@ static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
 {
-  /* Read 16bit CRC to flush Data Regsiter */
+  /* Read 16bit CRC to flush Data Register */
   READ_REG(hspi->Instance->DR);
 
   /* Disable RXNE interrupt */
@@ -3787,69 +3791,22 @@ static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, FlagStatus State,
                                                        uint32_t Timeout, uint32_t Tickstart)
 {
+  __IO uint32_t count;
+  uint32_t tmp_timeout;
+  uint32_t tmp_tickstart;
+
+  /* Adjust Timeout value  in case of end of transfer */
+  tmp_timeout   = Timeout - (HAL_GetTick() - Tickstart);
+  tmp_tickstart = HAL_GetTick();
+
+  /* Calculate Timeout based on a software loop to avoid blocking issue if Systick is disabled */
+  count = tmp_timeout * ((SystemCoreClock * 32U) >> 20U);
+
   while ((__HAL_SPI_GET_FLAG(hspi, Flag) ? SET : RESET) != State)
   {
     if (Timeout != HAL_MAX_DELAY)
     {
-      if (((HAL_GetTick() - Tickstart) >= Timeout) || (Timeout == 0U))
-      {
-        /* Disable the SPI and reset the CRC: the CRC value should be cleared
-        on both master and slave sides in order to resynchronize the master
-        and slave for their respective CRC calculation */
-
-        /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
-        __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
-
-        if ((hspi->Init.Mode == SPI_MODE_MASTER) && ((hspi->Init.Direction == SPI_DIRECTION_1LINE)
-                                                     || (hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
-        {
-          /* Disable SPI peripheral */
-          __HAL_SPI_DISABLE(hspi);
-        }
-
-        /* Reset CRC Calculation */
-        if (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
-        {
-          SPI_RESET_CRC(hspi);
-        }
-
-        hspi->State = HAL_SPI_STATE_READY;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(hspi);
-
-        return HAL_TIMEOUT;
-      }
-    }
-  }
-
-  return HAL_OK;
-}
-
-/**
-  * @brief  Handle SPI FIFO Communication Timeout.
-  * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
-  *              the configuration information for SPI module.
-  * @param  Fifo Fifo to check
-  * @param  State Fifo state to check
-  * @param  Timeout Timeout duration
-  * @param  Tickstart tick start value
-  * @retval HAL status
-  */
-static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Fifo, uint32_t State,
-                                                       uint32_t Timeout, uint32_t Tickstart)
-{
-  while ((hspi->Instance->SR & Fifo) != State)
-  {
-    if ((Fifo == SPI_SR_FRLVL) && (State == SPI_FRLVL_EMPTY))
-    {
-      /* Read 8bit CRC to flush Data Register */
-      READ_REG(*((__IO uint8_t *)&hspi->Instance->DR));
-    }
-
-    if (Timeout != HAL_MAX_DELAY)
-    {
-      if (((HAL_GetTick() - Tickstart) >= Timeout) || (Timeout == 0U))
+      if (((HAL_GetTick() - tmp_tickstart) >= tmp_timeout) || (tmp_timeout == 0U))
       {
         /* Disable the SPI and reset the CRC: the CRC value should be cleared
            on both master and slave sides in order to resynchronize the master
@@ -3878,6 +3835,87 @@ static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, 
 
         return HAL_TIMEOUT;
       }
+      /* If Systick is disabled or not incremented, deactivate timeout to go in disable loop procedure */
+      if(count == 0U)
+      {
+        tmp_timeout = 0U;
+      }
+      count--;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle SPI FIFO Communication Timeout.
+  * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
+  *              the configuration information for SPI module.
+  * @param  Fifo Fifo to check
+  * @param  State Fifo state to check
+  * @param  Timeout Timeout duration
+  * @param  Tickstart tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Fifo, uint32_t State,
+                                                       uint32_t Timeout, uint32_t Tickstart)
+{
+  __IO uint32_t count;
+  uint32_t tmp_timeout;
+  uint32_t tmp_tickstart;
+
+  /* Adjust Timeout value  in case of end of transfer */
+  tmp_timeout = Timeout - (HAL_GetTick() - Tickstart);
+  tmp_tickstart = HAL_GetTick();
+
+  /* Calculate Timeout based on a software loop to avoid blocking issue if Systick is disabled */
+  count = tmp_timeout * ((SystemCoreClock * 35U) >> 20U);
+
+  while ((hspi->Instance->SR & Fifo) != State)
+  {
+    if ((Fifo == SPI_SR_FRLVL) && (State == SPI_FRLVL_EMPTY))
+    {
+      /* Read 8bit CRC to flush Data Register */
+      READ_REG(*((__IO uint8_t *)&hspi->Instance->DR));
+    }
+
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if (((HAL_GetTick() - tmp_tickstart) >= tmp_timeout) || (tmp_timeout == 0U))
+      {
+        /* Disable the SPI and reset the CRC: the CRC value should be cleared
+           on both master and slave sides in order to resynchronize the master
+           and slave for their respective CRC calculation */
+
+        /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+        __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+        if ((hspi->Init.Mode == SPI_MODE_MASTER) && ((hspi->Init.Direction == SPI_DIRECTION_1LINE)
+                                                     || (hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+        {
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+        }
+
+        /* Reset CRC Calculation */
+        if (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE)
+        {
+          SPI_RESET_CRC(hspi);
+        }
+
+        hspi->State = HAL_SPI_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hspi);
+
+        return HAL_TIMEOUT;
+      }
+      /* If Systick is disabled or not incremented, deactivate timeout to go in disable loop procedure */
+      if(count == 0U)
+      {
+        tmp_timeout = 0U;
+      }
+      count--;
     }
   }
 
@@ -3964,7 +4002,7 @@ static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi)
 {
   uint32_t tickstart;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Disable ERR interrupt */
@@ -4164,8 +4202,7 @@ static void SPI_AbortRx_ISR(SPI_HandleTypeDef *hspi)
       break;
     }
     count--;
-  }
-  while (HAL_IS_BIT_SET(hspi->Instance->CR2, SPI_CR2_RXNEIE));
+  } while (HAL_IS_BIT_SET(hspi->Instance->CR2, SPI_CR2_RXNEIE));
 
   /* Control the BSY flag */
   if (SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
@@ -4206,8 +4243,7 @@ static void SPI_AbortTx_ISR(SPI_HandleTypeDef *hspi)
       break;
     }
     count--;
-  }
-  while (HAL_IS_BIT_SET(hspi->Instance->CR2, SPI_CR2_TXEIE));
+  } while (HAL_IS_BIT_SET(hspi->Instance->CR2, SPI_CR2_TXEIE));
 
   if (SPI_EndRxTxTransaction(hspi, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
   {
@@ -4238,8 +4274,7 @@ static void SPI_AbortTx_ISR(SPI_HandleTypeDef *hspi)
         break;
       }
       count--;
-    }
-    while (HAL_IS_BIT_SET(hspi->Instance->CR2, SPI_CR2_RXNEIE));
+    } while (HAL_IS_BIT_SET(hspi->Instance->CR2, SPI_CR2_RXNEIE));
 
     /* Control the BSY flag */
     if (SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_BSY, RESET, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_tim.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_tim.c
@@ -207,7 +207,7 @@ all interrupt callbacks are set to the corresponding weak functions:
   * @}
   */
 
-/* Private macro -------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /** @addtogroup TIM_Private_Functions
@@ -229,6 +229,7 @@ static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
 static void TIM_ITRx_SetConfig(TIM_TypeDef *TIMx, uint32_t InputTriggerSource);
 static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma);
 static void TIM_DMAPeriodElapsedHalfCplt(DMA_HandleTypeDef *hdma);
+static void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma);
 static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
 static void TIM_DMATriggerHalfCplt(DMA_HandleTypeDef *hdma);
 static HAL_StatusTypeDef TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
@@ -314,6 +315,13 @@ HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
   /* Set the Time Base configuration */
   TIM_Base_SetConfig(htim->Instance, &htim->Init);
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Initialize the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -346,6 +354,13 @@ HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
   HAL_TIM_Base_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Change the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -399,18 +414,28 @@ HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim)
   /* Check the parameters */
   assert_param(IS_TIM_INSTANCE(htim->Instance));
 
+  /* Check the TIM state */
+  if (htim->State != HAL_TIM_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
   /* Set the TIM state */
   htim->State = HAL_TIM_STATE_BUSY;
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
-
-  /* Change the TIM state*/
-  htim->State = HAL_TIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -426,13 +451,10 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim)
   /* Check the parameters */
   assert_param(IS_TIM_INSTANCE(htim->Instance));
 
-  /* Set the TIM state */
-  htim->State = HAL_TIM_STATE_BUSY;
-
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the TIM state*/
+  /* Set the TIM state */
   htim->State = HAL_TIM_STATE_READY;
 
   /* Return function status */
@@ -451,12 +473,28 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim)
   /* Check the parameters */
   assert_param(IS_TIM_INSTANCE(htim->Instance));
 
+  /* Check the TIM state */
+  if (htim->State != HAL_TIM_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM state */
+  htim->State = HAL_TIM_STATE_BUSY;
+
   /* Enable the TIM Update interrupt */
   __HAL_TIM_ENABLE_IT(htim, TIM_IT_UPDATE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -474,11 +512,15 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim)
 {
   /* Check the parameters */
   assert_param(IS_TIM_INSTANCE(htim->Instance));
+
   /* Disable the TIM Update interrupt */
   __HAL_TIM_DISABLE_IT(htim, TIM_IT_UPDATE);
 
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
+
+  /* Set the TIM state */
+  htim->State = HAL_TIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -498,6 +540,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pDat
   /* Check the parameters */
   assert_param(IS_TIM_DMA_INSTANCE(htim->Instance));
 
+  /* Set the TIM state */
   if (htim->State == HAL_TIM_STATE_BUSY)
   {
     return HAL_BUSY;
@@ -515,7 +558,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pDat
   }
   else
   {
-    /* nothing to do */
+    return HAL_ERROR;
   }
 
   /* Set the DMA Period elapsed callbacks */
@@ -528,6 +571,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pDat
   /* Enable the DMA channel */
   if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)pData, (uint32_t)&htim->Instance->ARR, Length) != HAL_OK)
   {
+    /* Return error status */
     return HAL_ERROR;
   }
 
@@ -535,8 +579,15 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pDat
   __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_UPDATE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -563,7 +614,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
+  /* Set the TIM state */
   htim->State = HAL_TIM_STATE_READY;
 
   /* Return function status */
@@ -646,6 +697,13 @@ HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef *htim)
   /* Init the base time for the Output Compare */
   TIM_Base_SetConfig(htim->Instance,  &htim->Init);
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Initialize the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -678,6 +736,13 @@ HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
   HAL_TIM_OC_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Change the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -738,6 +803,15 @@ HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
 
+  /* Check the TIM channel state */
+  if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+
   /* Enable the Output compare channel */
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
@@ -748,8 +822,15 @@ HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   }
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -788,6 +869,9 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -809,6 +893,15 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Check the TIM channel state */
+  if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   switch (Channel)
   {
@@ -854,8 +947,15 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   }
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -926,6 +1026,9 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -950,11 +1053,12 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Set the TIM channel state */
+  if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
     if ((pData == NULL) && (Length > 0U))
     {
@@ -962,12 +1066,12 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
     }
   }
   else
   {
-    /* nothing to do */
+    return HAL_ERROR;
   }
 
   switch (Channel)
@@ -984,6 +1088,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
 
@@ -1004,6 +1109,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
 
@@ -1024,6 +1130,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 3 DMA request */
@@ -1043,6 +1150,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 4 DMA request */
@@ -1064,8 +1172,15 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   }
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1140,8 +1255,8 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1223,6 +1338,13 @@ HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
   /* Init the base time for the PWM */
   TIM_Base_SetConfig(htim->Instance, &htim->Init);
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Initialize the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -1255,6 +1377,13 @@ HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
   HAL_TIM_PWM_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Change the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -1315,6 +1444,15 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
 
+  /* Check the TIM channel state */
+  if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+
   /* Enable the Capture compare channel */
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
@@ -1325,8 +1463,15 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   }
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1365,8 +1510,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1388,6 +1533,15 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel
   uint32_t tmpsmcr;
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Check the TIM channel state */
+  if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   switch (Channel)
   {
@@ -1433,8 +1587,15 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel
   }
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1505,6 +1666,9 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -1529,11 +1693,12 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Set the TIM channel state */
+  if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
     if ((pData == NULL) && (Length > 0U))
     {
@@ -1541,12 +1706,12 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
     }
   }
   else
   {
-    /* nothing to do */
+    return HAL_ERROR;
   }
 
   switch (Channel)
@@ -1563,6 +1728,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
 
@@ -1583,6 +1749,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 2 DMA request */
@@ -1602,6 +1769,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Output Capture/Compare 3 request */
@@ -1621,6 +1789,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 4 DMA request */
@@ -1642,8 +1811,15 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
   }
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1718,8 +1894,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1801,6 +1977,13 @@ HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
   /* Init the base time for the input capture */
   TIM_Base_SetConfig(htim->Instance, &htim->Init);
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Initialize the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -1833,6 +2016,13 @@ HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
   HAL_TIM_IC_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Change the TIM channels state */
+  TIM_CHANNEL_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET_ALL(htim, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -1887,16 +2077,36 @@ __weak void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim)
 HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Check the TIM channel state */
+  if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the Input Capture channel */
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1927,6 +2137,10 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -1945,9 +2159,22 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Check the TIM channel state */
+  if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   switch (Channel)
   {
@@ -1986,8 +2213,15 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -2052,6 +2286,10 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -2072,16 +2310,21 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
 {
   uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
   assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Set the TIM channel state */
+  if ((channel_state == HAL_TIM_CHANNEL_STATE_BUSY)
+      || (complementary_channel_state == HAL_TIM_CHANNEL_STATE_BUSY))
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if ((channel_state == HAL_TIM_CHANNEL_STATE_READY)
+           && (complementary_channel_state == HAL_TIM_CHANNEL_STATE_READY))
   {
     if ((pData == NULL) && (Length > 0U))
     {
@@ -2089,12 +2332,13 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
     }
   }
   else
   {
-    /* nothing to do */
+    return HAL_ERROR;
   }
 
   switch (Channel)
@@ -2111,6 +2355,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 1 DMA request */
@@ -2130,6 +2375,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 2  DMA request */
@@ -2149,6 +2395,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->CCR3, (uint32_t)pData, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 3  DMA request */
@@ -2168,6 +2415,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->CCR4, (uint32_t)pData, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 4  DMA request */
@@ -2183,8 +2431,15 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -2209,6 +2464,9 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Check the parameters */
   assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
   assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
 
   switch (Channel)
   {
@@ -2248,14 +2506,12 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
       break;
   }
 
-  /* Disable the Input Capture channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
-
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -2292,6 +2548,9 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   *         requires a timer reset to avoid unexpected direction
   *         due to DIR bit readonly in center aligned mode.
   *         Ex: call @ref HAL_TIM_OnePulse_DeInit() before HAL_TIM_OnePulse_Init()
+  * @note   When the timer instance is initialized in One Pulse mode, timer
+  *         channels 1 and channel 2 are reserved and cannot be used for other
+  *         purpose.
   * @param  htim TIM One Pulse handle
   * @param  OnePulseMode Select the One pulse mode.
   *         This parameter can be one of the following values:
@@ -2347,6 +2606,15 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePul
   /* Configure the OPM Mode */
   htim->Instance->CR1 |= OnePulseMode;
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Initialize the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -2379,6 +2647,15 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
   HAL_TIM_OnePulse_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -2430,8 +2707,28 @@ __weak void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim)
   */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
+
   /* Prevent unused argument(s) compilation warning */
   UNUSED(OutputChannel);
+
+  /* Check the TIM channels state */
+  if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the Capture compare and the Input Capture channels
     (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
@@ -2487,6 +2784,12 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t Output
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -2502,8 +2805,28 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t Output
   */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
+
   /* Prevent unused argument(s) compilation warning */
   UNUSED(OutputChannel);
+
+  /* Check the TIM channels state */
+  if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the Capture compare and the Input Capture channels
     (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
@@ -2570,6 +2893,12 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -2608,6 +2937,9 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   * @note   Encoder mode and External clock mode 2 are not compatible and must not be selected together
   *         Ex: A call for @ref HAL_TIM_Encoder_Init will erase the settings of @ref HAL_TIM_ConfigClockSource
   *         using TIM_CLOCKSOURCE_ETRMODE2 and vice versa
+  * @note   When the timer instance is initialized in Encoder mode, timer
+  *         channels 1 and channel 2 are reserved and cannot be used for other
+  *         purpose.
   * @param  htim TIM Encoder Interface handle
   * @param  sConfig TIM Encoder Interface configuration structure
   * @retval HAL status
@@ -2625,15 +2957,15 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_Ini
   }
 
   /* Check the parameters */
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
   assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
-  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
   assert_param(IS_TIM_ENCODER_MODE(sConfig->EncoderMode));
   assert_param(IS_TIM_IC_SELECTION(sConfig->IC1Selection));
   assert_param(IS_TIM_IC_SELECTION(sConfig->IC2Selection));
-  assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
-  assert_param(IS_TIM_IC_POLARITY(sConfig->IC2Polarity));
+  assert_param(IS_TIM_ENCODERINPUT_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_ENCODERINPUT_POLARITY(sConfig->IC2Polarity));
   assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
   assert_param(IS_TIM_IC_PRESCALER(sConfig->IC2Prescaler));
   assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
@@ -2705,6 +3037,15 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_Ini
   /* Write to TIMx CCER */
   htim->Instance->CCER = tmpccer;
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -2738,6 +3079,15 @@ HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
   HAL_TIM_Encoder_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -2790,8 +3140,58 @@ __weak void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim)
   */
 HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
+
   /* Check the parameters */
-  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
+
+  /* Set the TIM channel(s) state */
+  if (Channel == TIM_CHANNEL_1)
+  {
+    if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+    }
+  }
+  else if (Channel == TIM_CHANNEL_2)
+  {
+    if ((channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+    }
+  }
+  else
+  {
+    if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+    }
+  }
 
   /* Enable the encoder interface channels */
   switch (Channel)
@@ -2835,7 +3235,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channe
 HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   /* Check the parameters */
-  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channels 1 and 2
     (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
@@ -2864,6 +3264,20 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channel(s) state */
+  if ((Channel == TIM_CHANNEL_1) || (Channel == TIM_CHANNEL_2))
+  {
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else
+  {
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  }
+
   /* Return function status */
   return HAL_OK;
 }
@@ -2880,8 +3294,58 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel
   */
 HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
+
   /* Check the parameters */
-  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
+
+  /* Set the TIM channel(s) state */
+  if (Channel == TIM_CHANNEL_1)
+  {
+    if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+    }
+  }
+  else if (Channel == TIM_CHANNEL_2)
+  {
+    if ((channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+    }
+  }
+  else
+  {
+    if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+        || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+    }
+  }
 
   /* Enable the encoder interface channels */
   /* Enable the capture compare Interrupts 1 and/or 2 */
@@ -2931,7 +3395,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Cha
 HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   /* Check the parameters */
-  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channels 1 and 2
     (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
@@ -2962,8 +3426,19 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chan
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM channel(s) state */
+  if ((Channel == TIM_CHANNEL_1) || (Channel == TIM_CHANNEL_2))
+  {
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else
+  {
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  }
 
   /* Return function status */
   return HAL_OK;
@@ -2985,27 +3460,95 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chan
 HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1,
                                             uint32_t *pData2, uint16_t Length)
 {
-  /* Check the parameters */
-  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Check the parameters */
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
+
+  /* Set the TIM channel(s) state */
+  if (Channel == TIM_CHANNEL_1)
   {
-    return HAL_BUSY;
-  }
-  else if (htim->State == HAL_TIM_STATE_READY)
-  {
-    if ((((pData1 == NULL) || (pData2 == NULL))) && (Length > 0U))
+    if ((channel_1_state == HAL_TIM_CHANNEL_STATE_BUSY)
+        || (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_BUSY))
     {
-      return HAL_ERROR;
+      return HAL_BUSY;
+    }
+    else if ((channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
+             && (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_READY))
+    {
+      if ((pData1 == NULL) && (Length > 0U))
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+        TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      }
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      return HAL_ERROR;
+    }
+  }
+  else if (Channel == TIM_CHANNEL_2)
+  {
+    if ((channel_2_state == HAL_TIM_CHANNEL_STATE_BUSY)
+        || (complementary_channel_2_state == HAL_TIM_CHANNEL_STATE_BUSY))
+    {
+      return HAL_BUSY;
+    }
+    else if ((channel_2_state == HAL_TIM_CHANNEL_STATE_READY)
+             && (complementary_channel_2_state == HAL_TIM_CHANNEL_STATE_READY))
+    {
+      if ((pData2 == NULL) && (Length > 0U))
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+        TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+      }
+    }
+    else
+    {
+      return HAL_ERROR;
     }
   }
   else
   {
-    /* nothing to do */
+    if ((channel_1_state == HAL_TIM_CHANNEL_STATE_BUSY)
+        || (channel_2_state == HAL_TIM_CHANNEL_STATE_BUSY)
+        || (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_BUSY)
+        || (complementary_channel_2_state == HAL_TIM_CHANNEL_STATE_BUSY))
+    {
+      return HAL_BUSY;
+    }
+    else if ((channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
+             && (channel_2_state == HAL_TIM_CHANNEL_STATE_READY)
+             && (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
+             && (complementary_channel_2_state == HAL_TIM_CHANNEL_STATE_READY))
+    {
+      if ((((pData1 == NULL) || (pData2 == NULL))) && (Length > 0U))
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+        TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+        TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+        TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+      }
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
   }
 
   switch (Channel)
@@ -3022,6 +3565,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Input Capture DMA request */
@@ -3046,6 +3590,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Input Capture  DMA request */
@@ -3071,6 +3616,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
 
@@ -3084,6 +3630,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the Peripheral */
@@ -3103,6 +3650,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
     default:
       break;
   }
+
   /* Return function status */
   return HAL_OK;
 }
@@ -3120,7 +3668,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
 HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   /* Check the parameters */
-  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_INTERFACE_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channels 1 and 2
     (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */
@@ -3155,8 +3703,19 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM channel(s) state */
+  if ((Channel == TIM_CHANNEL_1) || (Channel == TIM_CHANNEL_2))
+  {
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else
+  {
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  }
 
   /* Return function status */
   return HAL_OK;
@@ -3425,8 +3984,6 @@ HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim,
   /* Process Locked */
   __HAL_LOCK(htim);
 
-  htim->State = HAL_TIM_STATE_BUSY;
-
   switch (Channel)
   {
     case TIM_CHANNEL_1:
@@ -3493,8 +4050,6 @@ HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim,
       break;
   }
 
-  htim->State = HAL_TIM_STATE_READY;
-
   __HAL_UNLOCK(htim);
 
   return HAL_OK;
@@ -3524,8 +4079,6 @@ HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitT
 
   /* Process Locked */
   __HAL_LOCK(htim);
-
-  htim->State = HAL_TIM_STATE_BUSY;
 
   if (Channel == TIM_CHANNEL_1)
   {
@@ -3590,8 +4143,6 @@ HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitT
     htim->Instance->CCMR2 |= (sConfig->ICPrescaler << 8U);
   }
 
-  htim->State = HAL_TIM_STATE_READY;
-
   __HAL_UNLOCK(htim);
 
   return HAL_OK;
@@ -3624,8 +4175,6 @@ HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
 
   /* Process Locked */
   __HAL_LOCK(htim);
-
-  htim->State = HAL_TIM_STATE_BUSY;
 
   switch (Channel)
   {
@@ -3734,8 +4283,6 @@ HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
     default:
       break;
   }
-
-  htim->State = HAL_TIM_STATE_READY;
 
   __HAL_UNLOCK(htim);
 
@@ -3907,20 +4454,75 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
   * @note   This function should be used only when BurstLength is equal to DMA data transfer length.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
-                                              uint32_t *BurstBuffer, uint32_t  BurstLength)
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
+                                              uint32_t BurstRequestSrc, uint32_t *BurstBuffer, uint32_t  BurstLength)
+{
+  return HAL_TIM_DMABurst_MultiWriteStart(htim, BurstBaseAddress, BurstRequestSrc, BurstBuffer, BurstLength,
+                                          ((BurstLength) >> 8U) + 1U);
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer multiple Data from the memory to the TIM peripheral
+  * @param  htim TIM handle
+  * @param  BurstBaseAddress TIM Base address from where the DMA will start the Data write
+  *         This parameter can be one of the following values:
+  *            @arg TIM_DMABASE_CR1
+  *            @arg TIM_DMABASE_CR2
+  *            @arg TIM_DMABASE_SMCR
+  *            @arg TIM_DMABASE_DIER
+  *            @arg TIM_DMABASE_SR
+  *            @arg TIM_DMABASE_EGR
+  *            @arg TIM_DMABASE_CCMR1
+  *            @arg TIM_DMABASE_CCMR2
+  *            @arg TIM_DMABASE_CCER
+  *            @arg TIM_DMABASE_CNT
+  *            @arg TIM_DMABASE_PSC
+  *            @arg TIM_DMABASE_ARR
+  *            @arg TIM_DMABASE_RCR
+  *            @arg TIM_DMABASE_CCR1
+  *            @arg TIM_DMABASE_CCR2
+  *            @arg TIM_DMABASE_CCR3
+  *            @arg TIM_DMABASE_CCR4
+  *            @arg TIM_DMABASE_BDTR
+  *            @arg TIM_DMABASE_OR1
+  *            @arg TIM_DMABASE_CCMR3
+  *            @arg TIM_DMABASE_CCR5
+  *            @arg TIM_DMABASE_CCR6
+  *            @arg TIM_DMABASE_AF1
+  *            @arg TIM_DMABASE_AF2
+  *            @arg TIM_DMABASE_TISEL
+  * @param  BurstRequestSrc TIM DMA Request sources
+  *         This parameter can be one of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer The Buffer address.
+  * @param  BurstLength DMA Burst length. This parameter can be one value
+  *         between: TIM_DMABURSTLENGTH_1TRANSFER and TIM_DMABURSTLENGTH_18TRANSFERS.
+  * @param  DataLength Data length. This parameter can be one value
+  *         between 1 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
+                                                   uint32_t BurstRequestSrc, uint32_t *BurstBuffer,
+                                                   uint32_t  BurstLength,  uint32_t  DataLength)
 {
   /* Check the parameters */
   assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
   assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
   assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
   assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+  assert_param(IS_TIM_DMA_DATA_LENGTH(DataLength));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  if (htim->DMABurstState == HAL_DMA_BURST_STATE_BUSY)
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if (htim->DMABurstState == HAL_DMA_BURST_STATE_READY)
   {
     if ((BurstBuffer == NULL) && (BurstLength > 0U))
     {
@@ -3928,7 +4530,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      htim->DMABurstState = HAL_DMA_BURST_STATE_BUSY;
     }
   }
   else
@@ -3947,8 +4549,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
       htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)BurstBuffer,
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -3964,8 +4568,9 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)BurstBuffer,
-                           (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -3981,8 +4586,9 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)BurstBuffer,
-                           (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -3998,8 +4604,9 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)BurstBuffer,
-                           (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4015,8 +4622,9 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)BurstBuffer,
-                           (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4032,8 +4640,9 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)BurstBuffer,
-                           (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4049,8 +4658,9 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)BurstBuffer,
-                           (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4058,13 +4668,11 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
     default:
       break;
   }
-  /* configure the DMA Burst Mode */
-  htim->Instance->DCR = (BurstBaseAddress | BurstLength);
 
+  /* Configure the DMA Burst Mode */
+  htim->Instance->DCR = (BurstBaseAddress | BurstLength);
   /* Enable the TIM DMA Request */
   __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
-
-  htim->State = HAL_TIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -4078,7 +4686,6 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
 {
-  HAL_StatusTypeDef status = HAL_OK;
   /* Check the parameters */
   assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
 
@@ -4087,51 +4694,51 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t B
   {
     case TIM_DMA_UPDATE:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_UPDATE]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_UPDATE]);
       break;
     }
     case TIM_DMA_CC1:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC1]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC1]);
       break;
     }
     case TIM_DMA_CC2:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC2]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC2]);
       break;
     }
     case TIM_DMA_CC3:
     {
-      status =  HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC3]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC3]);
       break;
     }
     case TIM_DMA_CC4:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC4]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC4]);
       break;
     }
     case TIM_DMA_COM:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_COMMUTATION]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_COMMUTATION]);
       break;
     }
     case TIM_DMA_TRIGGER:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_TRIGGER]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_TRIGGER]);
       break;
     }
     default:
       break;
   }
 
-  if (HAL_OK == status)
-  {
-    /* Disable the TIM Update DMA request */
-    __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
-  }
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
 
   /* Return function status */
-  return status;
+  return HAL_OK;
 }
 
 /**
@@ -4182,17 +4789,72 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t B
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                              uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength)
 {
+  return HAL_TIM_DMABurst_MultiReadStart(htim, BurstBaseAddress, BurstRequestSrc, BurstBuffer, BurstLength,
+                                         ((BurstLength) >> 8U) + 1U);
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the TIM peripheral to the memory
+  * @param  htim TIM handle
+  * @param  BurstBaseAddress TIM Base address from where the DMA  will start the Data read
+  *         This parameter can be one of the following values:
+  *            @arg TIM_DMABASE_CR1
+  *            @arg TIM_DMABASE_CR2
+  *            @arg TIM_DMABASE_SMCR
+  *            @arg TIM_DMABASE_DIER
+  *            @arg TIM_DMABASE_SR
+  *            @arg TIM_DMABASE_EGR
+  *            @arg TIM_DMABASE_CCMR1
+  *            @arg TIM_DMABASE_CCMR2
+  *            @arg TIM_DMABASE_CCER
+  *            @arg TIM_DMABASE_CNT
+  *            @arg TIM_DMABASE_PSC
+  *            @arg TIM_DMABASE_ARR
+  *            @arg TIM_DMABASE_RCR
+  *            @arg TIM_DMABASE_CCR1
+  *            @arg TIM_DMABASE_CCR2
+  *            @arg TIM_DMABASE_CCR3
+  *            @arg TIM_DMABASE_CCR4
+  *            @arg TIM_DMABASE_BDTR
+  *            @arg TIM_DMABASE_OR1
+  *            @arg TIM_DMABASE_CCMR3
+  *            @arg TIM_DMABASE_CCR5
+  *            @arg TIM_DMABASE_CCR6
+  *            @arg TIM_DMABASE_AF1
+  *            @arg TIM_DMABASE_AF2
+  *            @arg TIM_DMABASE_TISEL
+  * @param  BurstRequestSrc TIM DMA Request sources
+  *         This parameter can be one of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_COM: TIM Commutation DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer The Buffer address.
+  * @param  BurstLength DMA Burst length. This parameter can be one value
+  *         between: TIM_DMABURSTLENGTH_1TRANSFER and TIM_DMABURSTLENGTH_18TRANSFERS.
+  * @param  DataLength Data length. This parameter can be one value
+  *         between 1 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
+                                                  uint32_t BurstRequestSrc, uint32_t  *BurstBuffer,
+                                                  uint32_t  BurstLength, uint32_t  DataLength)
+{
   /* Check the parameters */
   assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
   assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
   assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
   assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+  assert_param(IS_TIM_DMA_DATA_LENGTH(DataLength));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  if (htim->DMABurstState == HAL_DMA_BURST_STATE_BUSY)
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if (htim->DMABurstState == HAL_DMA_BURST_STATE_READY)
   {
     if ((BurstBuffer == NULL) && (BurstLength > 0U))
     {
@@ -4200,7 +4862,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      htim->DMABurstState = HAL_DMA_BURST_STATE_BUSY;
     }
   }
   else
@@ -4219,8 +4881,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4235,15 +4899,17 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
     }
     case TIM_DMA_CC2:
     {
-      /* Set the DMA capture/compare callbacks */
+      /* Set the DMA capture callbacks */
       htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMACaptureCplt;
       htim->hdma[TIM_DMA_ID_CC2]->XferHalfCpltCallback = TIM_DMACaptureHalfCplt;
 
@@ -4251,8 +4917,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4267,8 +4935,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4283,8 +4953,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4299,8 +4971,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_COMMUTATION]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4315,8 +4989,10 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8U) + 1U) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
+                         DataLength) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       break;
@@ -4325,13 +5001,11 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
       break;
   }
 
-  /* configure the DMA Burst Mode */
+  /* Configure the DMA Burst Mode */
   htim->Instance->DCR = (BurstBaseAddress | BurstLength);
 
   /* Enable the TIM DMA Request */
   __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
-
-  htim->State = HAL_TIM_STATE_READY;
 
   /* Return function status */
   return HAL_OK;
@@ -4345,7 +5019,6 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
 {
-  HAL_StatusTypeDef status = HAL_OK;
   /* Check the parameters */
   assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
 
@@ -4354,51 +5027,51 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t Bu
   {
     case TIM_DMA_UPDATE:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_UPDATE]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_UPDATE]);
       break;
     }
     case TIM_DMA_CC1:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC1]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC1]);
       break;
     }
     case TIM_DMA_CC2:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC2]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC2]);
       break;
     }
     case TIM_DMA_CC3:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC3]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC3]);
       break;
     }
     case TIM_DMA_CC4:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC4]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC4]);
       break;
     }
     case TIM_DMA_COM:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_COMMUTATION]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_COMMUTATION]);
       break;
     }
     case TIM_DMA_TRIGGER:
     {
-      status = HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_TRIGGER]);
+      (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_TRIGGER]);
       break;
     }
     default:
       break;
   }
 
-  if (HAL_OK == status)
-  {
-    /* Disable the TIM Update DMA request */
-    __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
-  }
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
 
   /* Return function status */
-  return status;
+  return HAL_OK;
 }
 
 /**
@@ -4485,26 +5158,23 @@ HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
       CLEAR_BIT(htim->Instance->OR1, TIMx_OR1_OCREF_CLR);
       break;
     }
+#if defined(COMP1) || defined(COMP2) || defined(COMP3)
 #if defined(COMP1) && defined(COMP2)
     case TIM_CLEARINPUTSOURCE_COMP1:
-    {
-      /* Clear the OCREF clear selection bit */
-      CLEAR_BIT(htim->Instance->SMCR, TIM_SMCR_OCCS);
-
-      /* OCREF_CLR_INT is connected to COMP1 output */
-      CLEAR_BIT(htim->Instance->OR1, TIMx_OR1_OCREF_CLR);
-      break;
-    }
     case TIM_CLEARINPUTSOURCE_COMP2:
-    {
-      /* Clear the OCREF clear selection bit */
-      CLEAR_BIT(htim->Instance->SMCR, TIM_SMCR_OCCS);
-
-      /* OCREF_CLR_INT is connected to COMP2 output */
-      SET_BIT(htim->Instance->OR1, TIMx_OR1_OCREF_CLR);
-      break;
-    }
 #endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+    case TIM_CLEARINPUTSOURCE_COMP3:
+#endif /* COMP3 */
+      {
+        /* Clear the OCREF clear selection bit */
+        CLEAR_BIT(htim->Instance->SMCR, TIM_SMCR_OCCS);
+
+        /* OCREF_CLR_INT is connected to COMPx output */
+        MODIFY_REG(htim->Instance->OR1, TIMx_OR1_OCREF_CLR, sClearInputConfig->ClearInputSource);
+        break;
+      }
+#endif /* COMP1 || COMP2 || COMP3 */
 
     case TIM_CLEARINPUTSOURCE_ETR:
     {
@@ -4764,13 +5434,13 @@ HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockCo
     case TIM_CLOCKSOURCE_ITR1:
     case TIM_CLOCKSOURCE_ITR2:
     case TIM_CLOCKSOURCE_ITR3:
-    {
-      /* Check whether or not the timer instance supports internal trigger input */
-      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+      {
+        /* Check whether or not the timer instance supports internal trigger input */
+        assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
 
-      TIM_ITRx_SetConfig(htim->Instance, sClockSourceConfig->ClockSource);
-      break;
-    }
+        TIM_ITRx_SetConfig(htim->Instance, sClockSourceConfig->ClockSource);
+        break;
+      }
 
     default:
       break;
@@ -5711,6 +6381,54 @@ HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim)
 }
 
 /**
+  * @brief  Return the TIM Encoder Mode handle state.
+  * @param  htim TIM handle
+  * @retval Active channel
+  */
+HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(TIM_HandleTypeDef *htim)
+{
+  return htim->Channel;
+}
+
+/**
+  * @brief  Return actual state of the TIM channel.
+  * @param  htim TIM handle
+  * @param  Channel TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1
+  *            @arg TIM_CHANNEL_2: TIM Channel 2
+  *            @arg TIM_CHANNEL_3: TIM Channel 3
+  *            @arg TIM_CHANNEL_4: TIM Channel 4
+  *            @arg TIM_CHANNEL_5: TIM Channel 5
+  *            @arg TIM_CHANNEL_6: TIM Channel 6
+  * @retval TIM Channel state
+  */
+HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(TIM_HandleTypeDef *htim,  uint32_t Channel)
+{
+  HAL_TIM_ChannelStateTypeDef channel_state;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
+
+  return channel_state;
+}
+
+/**
+  * @brief  Return actual state of a DMA burst operation.
+  * @param  htim TIM handle
+  * @retval DMA burst state
+  */
+HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+
+  return htim->DMABurstState;
+}
+
+/**
   * @}
   */
 
@@ -5731,13 +6449,38 @@ void TIM_DMAError(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
-  htim->State = HAL_TIM_STATE_READY;
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+    TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else
+  {
+    htim->State = HAL_TIM_STATE_READY;
+  }
 
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->ErrorCallback(htim);
 #else
   HAL_TIM_ErrorCallback(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
 }
 
 /**
@@ -5745,27 +6488,45 @@ void TIM_DMAError(DMA_HandleTypeDef *hdma)
   * @param  hdma pointer to DMA handle.
   * @retval None
   */
-void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
+static void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
-
-  htim->State = HAL_TIM_STATE_READY;
 
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else
   {
@@ -5789,8 +6550,6 @@ void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
 void TIM_DMADelayPulseHalfCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
-
-  htim->State = HAL_TIM_STATE_READY;
 
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
@@ -5831,23 +6590,45 @@ void TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
-  htim->State = HAL_TIM_STATE_READY;
-
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
   {
     htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
+    }
   }
   else
   {
@@ -5871,8 +6652,6 @@ void TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma)
 void TIM_DMACaptureHalfCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
-
-  htim->State = HAL_TIM_STATE_READY;
 
   if (hdma == htim->hdma[TIM_DMA_ID_CC1])
   {
@@ -5913,7 +6692,10 @@ static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
-  htim->State = HAL_TIM_STATE_READY;
+  if (htim->hdma[TIM_DMA_ID_UPDATE]->Init.Mode == DMA_NORMAL)
+  {
+    htim->State = HAL_TIM_STATE_READY;
+  }
 
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->PeriodElapsedCallback(htim);
@@ -5931,8 +6713,6 @@ static void TIM_DMAPeriodElapsedHalfCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
-  htim->State = HAL_TIM_STATE_READY;
-
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->PeriodElapsedHalfCpltCallback(htim);
 #else
@@ -5949,7 +6729,10 @@ static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
 
-  htim->State = HAL_TIM_STATE_READY;
+  if (htim->hdma[TIM_DMA_ID_TRIGGER]->Init.Mode == DMA_NORMAL)
+  {
+    htim->State = HAL_TIM_STATE_READY;
+  }
 
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->TriggerCallback(htim);
@@ -5966,8 +6749,6 @@ static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma)
 static void TIM_DMATriggerHalfCplt(DMA_HandleTypeDef *hdma)
 {
   TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
-
-  htim->State = HAL_TIM_STATE_READY;
 
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
   htim->TriggerHalfCpltCallback(htim);
@@ -6027,7 +6808,7 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
 /**
   * @brief  Timer Output Compare 1 configuration
   * @param  TIMx to select the TIM peripheral
-  * @param  OC_Config The ouput configuration structure
+  * @param  OC_Config The output configuration structure
   * @retval None
   */
 static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
@@ -6102,7 +6883,7 @@ static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
 /**
   * @brief  Timer Output Compare 2 configuration
   * @param  TIMx to select the TIM peripheral
-  * @param  OC_Config The ouput configuration structure
+  * @param  OC_Config The output configuration structure
   * @retval None
   */
 void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
@@ -6178,7 +6959,7 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
 /**
   * @brief  Timer Output Compare 3 configuration
   * @param  TIMx to select the TIM peripheral
-  * @param  OC_Config The ouput configuration structure
+  * @param  OC_Config The output configuration structure
   * @retval None
   */
 static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
@@ -6252,7 +7033,7 @@ static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
 /**
   * @brief  Timer Output Compare 4 configuration
   * @param  TIMx to select the TIM peripheral
-  * @param  OC_Config The ouput configuration structure
+  * @param  OC_Config The output configuration structure
   * @retval None
   */
 static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
@@ -6312,7 +7093,7 @@ static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
 /**
   * @brief  Timer Output Compare 5 configuration
   * @param  TIMx to select the TIM peripheral
-  * @param  OC_Config The ouput configuration structure
+  * @param  OC_Config The output configuration structure
   * @retval None
   */
 static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
@@ -6365,7 +7146,7 @@ static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
 /**
   * @brief  Timer Output Compare 6 configuration
   * @param  TIMx to select the TIM peripheral
-  * @param  OC_Config The ouput configuration structure
+  * @param  OC_Config The output configuration structure
   * @retval None
   */
 static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
@@ -6469,7 +7250,7 @@ static HAL_StatusTypeDef TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
       assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
       assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
 
-      if(sSlaveConfig->SlaveMode == TIM_SLAVEMODE_GATED)
+      if (sSlaveConfig->SlaveMode == TIM_SLAVEMODE_GATED)
       {
         return HAL_ERROR;
       }
@@ -6521,11 +7302,11 @@ static HAL_StatusTypeDef TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
     case TIM_TS_ITR1:
     case TIM_TS_ITR2:
     case TIM_TS_ITR3:
-    {
-      /* Check the parameter */
-      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
-      break;
-    }
+      {
+        /* Check the parameter */
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+        break;
+      }
 
     default:
       break;

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_tim_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_tim_ex.c
@@ -56,7 +56,7 @@
                the commutation event).
 
      (#) Activate the TIM peripheral using one of the start functions:
-           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OC_Start_IT()
+           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OCN_Start_IT()
            (++) Complementary PWM generation : HAL_TIMEx_PWMN_Start(), HAL_TIMEx_PWMN_Start_DMA(), HAL_TIMEx_PWMN_Start_IT()
            (++) Complementary One-pulse mode output : HAL_TIMEx_OnePulseN_Start(), HAL_TIMEx_OnePulseN_Start_IT()
            (++) Hall Sensor output : HAL_TIMEx_HallSensor_Start(), HAL_TIMEx_HallSensor_Start_DMA(), HAL_TIMEx_HallSensor_Start_IT().
@@ -103,9 +103,11 @@
   */
 /* End of private constants --------------------------------------------------*/
 
-/* Private macro -------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+static void TIM_DMADelayPulseNCplt(DMA_HandleTypeDef *hdma);
+static void TIM_DMAErrorCCxN(DMA_HandleTypeDef *hdma);
 static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t ChannelNState);
 
 /* Exported functions --------------------------------------------------------*/
@@ -136,6 +138,9 @@ static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Cha
   */
 /**
   * @brief  Initializes the TIM Hall Sensor Interface and initialize the associated handle.
+  * @note   When the timer instance is initialized in Hall Sensor Interface mode,
+  *         timer channels 1 and channel 2 are reserved and cannot be used for
+  *         other purpose.
   * @param  htim TIM Hall Sensor Interface handle
   * @param  sConfig TIM Hall Sensor configuration structure
   * @retval HAL status
@@ -221,6 +226,15 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSen
   htim->Instance->CR2 &= ~TIM_CR2_MMS;
   htim->Instance->CR2 |= TIM_TRGO_OC2REF;
 
+  /* Initialize the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+
+  /* Initialize the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Initialize the TIM state*/
   htim->State = HAL_TIM_STATE_READY;
 
@@ -253,6 +267,15 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef *htim)
   /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
   HAL_TIMEx_HallSensor_MspDeInit(htim);
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  /* Change the DMA burst operation state */
+  htim->DMABurstState = HAL_DMA_BURST_STATE_RESET;
+
+  /* Change the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_RESET);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_RESET);
 
   /* Change TIM state */
   htim->State = HAL_TIM_STATE_RESET;
@@ -301,17 +324,43 @@ __weak void HAL_TIMEx_HallSensor_MspDeInit(TIM_HandleTypeDef *htim)
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start(TIM_HandleTypeDef *htim)
 {
   uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
 
   /* Check the parameters */
   assert_param(IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(htim->Instance));
 
+  /* Check the TIM channels state */
+  if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+
   /* Enable the Input Capture channel 1
-    (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -337,6 +386,12 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef *htim)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -349,9 +404,28 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef *htim)
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef *htim)
 {
   uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
 
   /* Check the parameters */
   assert_param(IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(htim->Instance));
+
+  /* Check the TIM channels state */
+  if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the capture compare Interrupts 1 event */
   __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
@@ -361,8 +435,15 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef *htim)
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -391,6 +472,12 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM channels state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -405,29 +492,36 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim)
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
 {
   uint32_t tmpsmcr;
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
 
   /* Check the parameters */
   assert_param(IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(htim->Instance));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Set the TIM channel state */
+  if ((channel_1_state == HAL_TIM_CHANNEL_STATE_BUSY)
+      || (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_BUSY))
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if ((channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
+           && (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_READY))
   {
-    if (((uint32_t)pData == 0U) && (Length > 0U))
+    if ((pData == NULL) && (Length > 0U))
     {
       return HAL_ERROR;
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
     }
   }
   else
   {
-    /* nothing to do */
+    return HAL_ERROR;
   }
+
   /* Enable the Input Capture channel 1
     (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
@@ -441,14 +535,22 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32
   /* Enable the DMA channel for Capture 1*/
   if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length) != HAL_OK)
   {
+    /* Return error status */
     return HAL_ERROR;
   }
   /* Enable the capture compare 1 Interrupt */
   __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -476,8 +578,13 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim)
   __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
 
   (void)HAL_DMA_Abort_IT(htim->hdma[TIM_DMA_ID_CC1]);
+
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
+
+  /* Set the TIM channel state */
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -525,6 +632,15 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
+  /* Check the TIM complementary channel state */
+  if (TIM_CHANNEL_N_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+
   /* Enable the Capture compare channel N */
   TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
 
@@ -532,8 +648,15 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   __HAL_TIM_MOE_ENABLE(htim);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -567,6 +690,9 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -588,6 +714,15 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
 
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Check the TIM complementary channel state */
+  if (TIM_CHANNEL_N_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   switch (Channel)
   {
@@ -627,8 +762,15 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
   __HAL_TIM_MOE_ENABLE(htim);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -697,6 +839,9 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -721,24 +866,25 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Set the TIM complementary channel state */
+  if (TIM_CHANNEL_N_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if (TIM_CHANNEL_N_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
-    if (((uint32_t)pData == 0U) && (Length > 0U))
+    if ((pData == NULL) && (Length > 0U))
     {
       return HAL_ERROR;
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
     }
   }
   else
   {
-    /* nothing to do  */
+    return HAL_ERROR;
   }
 
   switch (Channel)
@@ -746,15 +892,16 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
     case TIM_CHANNEL_1:
     {
       /* Set the DMA compare callbacks */
-      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseCplt;
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseNCplt;
       htim->hdma[TIM_DMA_ID_CC1]->XferHalfCpltCallback = TIM_DMADelayPulseHalfCplt;
 
       /* Set the DMA error callback */
-      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Output Compare DMA request */
@@ -765,15 +912,16 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
     case TIM_CHANNEL_2:
     {
       /* Set the DMA compare callbacks */
-      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseCplt;
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseNCplt;
       htim->hdma[TIM_DMA_ID_CC2]->XferHalfCpltCallback = TIM_DMADelayPulseHalfCplt;
 
       /* Set the DMA error callback */
-      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Output Compare DMA request */
@@ -784,15 +932,16 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
     case TIM_CHANNEL_3:
     {
       /* Set the DMA compare callbacks */
-      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseCplt;
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseNCplt;
       htim->hdma[TIM_DMA_ID_CC3]->XferHalfCpltCallback = TIM_DMADelayPulseHalfCplt;
 
       /* Set the DMA error callback */
-      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Output Compare DMA request */
@@ -811,8 +960,15 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   __HAL_TIM_MOE_ENABLE(htim);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -876,8 +1032,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chann
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -934,6 +1090,15 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef *htim, uint32_t Channel
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
+  /* Check the TIM complementary channel state */
+  if (TIM_CHANNEL_N_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
+
   /* Enable the complementary PWM output  */
   TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
 
@@ -941,8 +1106,15 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef *htim, uint32_t Channel
   __HAL_TIM_MOE_ENABLE(htim);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -975,6 +1147,9 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -996,6 +1171,15 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chan
 
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
+
+  /* Check the TIM complementary channel state */
+  if (TIM_CHANNEL_N_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   switch (Channel)
   {
@@ -1034,8 +1218,15 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chan
   __HAL_TIM_MOE_ENABLE(htim);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1105,6 +1296,9 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chann
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+
   /* Return function status */
   return HAL_OK;
 }
@@ -1129,39 +1323,42 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
-  if (htim->State == HAL_TIM_STATE_BUSY)
+  /* Set the TIM complementary channel state */
+  if (TIM_CHANNEL_N_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
   {
     return HAL_BUSY;
   }
-  else if (htim->State == HAL_TIM_STATE_READY)
+  else if (TIM_CHANNEL_N_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
-    if (((uint32_t)pData == 0U) && (Length > 0U))
+    if ((pData == NULL) && (Length > 0U))
     {
       return HAL_ERROR;
     }
     else
     {
-      htim->State = HAL_TIM_STATE_BUSY;
+      TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_BUSY);
     }
   }
   else
   {
-    /* nothing to do */
+    return HAL_ERROR;
   }
+
   switch (Channel)
   {
     case TIM_CHANNEL_1:
     {
       /* Set the DMA compare callbacks */
-      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseCplt;
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMADelayPulseNCplt;
       htim->hdma[TIM_DMA_ID_CC1]->XferHalfCpltCallback = TIM_DMADelayPulseHalfCplt;
 
       /* Set the DMA error callback */
-      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 1 DMA request */
@@ -1172,15 +1369,16 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
     case TIM_CHANNEL_2:
     {
       /* Set the DMA compare callbacks */
-      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseCplt;
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = TIM_DMADelayPulseNCplt;
       htim->hdma[TIM_DMA_ID_CC2]->XferHalfCpltCallback = TIM_DMADelayPulseHalfCplt;
 
       /* Set the DMA error callback */
-      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 2 DMA request */
@@ -1191,15 +1389,16 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
     case TIM_CHANNEL_3:
     {
       /* Set the DMA compare callbacks */
-      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseCplt;
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = TIM_DMADelayPulseNCplt;
       htim->hdma[TIM_DMA_ID_CC3]->XferHalfCpltCallback = TIM_DMADelayPulseHalfCplt;
 
       /* Set the DMA error callback */
-      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
       {
+        /* Return error status */
         return HAL_ERROR;
       }
       /* Enable the TIM Capture/Compare 3 DMA request */
@@ -1218,8 +1417,15 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   __HAL_TIM_MOE_ENABLE(htim);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-  if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    {
+      __HAL_TIM_ENABLE(htim);
+    }
+  }
+  else
   {
     __HAL_TIM_ENABLE(htim);
   }
@@ -1283,8 +1489,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
 
-  /* Change the htim state */
-  htim->State = HAL_TIM_STATE_READY;
+  /* Set the TIM complementary channel state */
+  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1324,11 +1530,27 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   */
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
+  uint32_t input_channel = (OutputChannel == TIM_CHANNEL_1) ? TIM_CHANNEL_2 : TIM_CHANNEL_1;
+  HAL_TIM_ChannelStateTypeDef input_channel_state = TIM_CHANNEL_STATE_GET(htim, input_channel);
+  HAL_TIM_ChannelStateTypeDef output_channel_state = TIM_CHANNEL_N_STATE_GET(htim, OutputChannel);
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
 
-  /* Enable the complementary One Pulse output */
+  /* Check the TIM channels state */
+  if ((output_channel_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (input_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_BUSY);
+
+  /* Enable the complementary One Pulse output channel and the Input Capture channel */
   TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
+  TIM_CCxChannelCmd(htim->Instance, input_channel, TIM_CCx_ENABLE);
 
   /* Enable the Main Output */
   __HAL_TIM_MOE_ENABLE(htim);
@@ -1349,18 +1571,24 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t Ou
   */
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
+  uint32_t input_channel = (OutputChannel == TIM_CHANNEL_1) ? TIM_CHANNEL_2 : TIM_CHANNEL_1;
 
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
 
-  /* Disable the complementary One Pulse output */
+  /* Disable the complementary One Pulse output channel and the Input Capture channel */
   TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+  TIM_CCxChannelCmd(htim->Instance, input_channel, TIM_CCx_DISABLE);
 
   /* Disable the Main Output */
   __HAL_TIM_MOE_DISABLE(htim);
 
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
+
+  /* Set the TIM  channels state */
+  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1378,8 +1606,23 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t Out
   */
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
+  uint32_t input_channel = (OutputChannel == TIM_CHANNEL_1) ? TIM_CHANNEL_2 : TIM_CHANNEL_1;
+  HAL_TIM_ChannelStateTypeDef input_channel_state = TIM_CHANNEL_STATE_GET(htim, input_channel);
+  HAL_TIM_ChannelStateTypeDef output_channel_state = TIM_CHANNEL_N_STATE_GET(htim, OutputChannel);
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
+
+  /* Check the TIM channels state */
+  if ((output_channel_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (input_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  {
+    return HAL_ERROR;
+  }
+
+  /* Set the TIM channels state */
+  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the TIM Capture/Compare 1 interrupt */
   __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
@@ -1387,8 +1630,9 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t
   /* Enable the TIM Capture/Compare 2 interrupt */
   __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
 
-  /* Enable the complementary One Pulse output */
+  /* Enable the complementary One Pulse output channel and the Input Capture channel */
   TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
+  TIM_CCxChannelCmd(htim->Instance, input_channel, TIM_CCx_ENABLE);
 
   /* Enable the Main Output */
   __HAL_TIM_MOE_ENABLE(htim);
@@ -1409,6 +1653,8 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t
   */
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
+  uint32_t input_channel = (OutputChannel == TIM_CHANNEL_1) ? TIM_CHANNEL_2 : TIM_CHANNEL_1;
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
 
@@ -1418,14 +1664,19 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t 
   /* Disable the TIM Capture/Compare 2 interrupt */
   __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
 
-  /* Disable the complementary One Pulse output */
+  /* Disable the complementary One Pulse output channel and the Input Capture channel */
   TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+  TIM_CCxChannelCmd(htim->Instance, input_channel, TIM_CCx_DISABLE);
 
   /* Disable the Main Output */
   __HAL_TIM_MOE_DISABLE(htim);
 
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
+
+  /* Set the TIM  channels state */
+  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1648,7 +1899,7 @@ HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_SYNCHRO_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_MASTER_INSTANCE(htim->Instance));
   assert_param(IS_TIM_TRGO_SOURCE(sMasterConfig->MasterOutputTrigger));
   assert_param(IS_TIM_MSM_STATE(sMasterConfig->MasterSlaveMode));
 
@@ -1681,16 +1932,19 @@ HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
   /* Select the TRGO source */
   tmpcr2 |=  sMasterConfig->MasterOutputTrigger;
 
-  /* Reset the MSM Bit */
-  tmpsmcr &= ~TIM_SMCR_MSM;
-  /* Set master mode */
-  tmpsmcr |= sMasterConfig->MasterSlaveMode;
-
   /* Update TIMx CR2 */
   htim->Instance->CR2 = tmpcr2;
 
-  /* Update TIMx SMCR */
-  htim->Instance->SMCR = tmpsmcr;
+  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  {
+    /* Reset the MSM Bit */
+    tmpsmcr &= ~TIM_SMCR_MSM;
+    /* Set master mode */
+    tmpsmcr |= sMasterConfig->MasterSlaveMode;
+
+    /* Update TIMx SMCR */
+    htim->Instance->SMCR = tmpsmcr;
+  }
 
   /* Change the htim state */
   htim->State = HAL_TIM_STATE_READY;
@@ -1842,6 +2096,16 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
       break;
     }
 #endif /* COMP1 && COMP2 */
+#if defined(COMP3)
+    case TIM_BREAKINPUTSOURCE_COMP3:
+    {
+      bkin_enable_mask = TIM1_AF1_BKCMP3E;
+      bkin_enable_bitpos = TIM1_AF1_BKCMP3E_Pos;
+      bkin_polarity_mask = TIM1_AF1_BKCMP3P;
+      bkin_polarity_bitpos = TIM1_AF1_BKCMP3P_Pos;
+      break;
+    }
+#endif /* COMP3 */
 
     default:
     {
@@ -1904,26 +2168,36 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
   * @param  Remap specifies the TIM remapping source.
   *         For TIM1, the parameter can take one of the following values:
   *            @arg TIM_TIM1_ETR_GPIO:                TIM1 ETR is is connected to GPIO
-  @if STM32G081xx
   *            @arg TIM_TIM1_ETR_COMP1:               TIM1 ETR is connected to COMP1 output
   *            @arg TIM_TIM1_ETR_COMP2:               TIM1 ETR is connected to COMP2 output
-  @endif
+  *            @arg TIM_TIM1_ETR_COMP3:               TIM1 ETR is connected to COMP3 output    (**)
   *            @arg TIM_TIM1_ETR_ADC1_AWD1:           TIM1 ETR is connected to ADC1 AWD1
   *            @arg TIM_TIM1_ETR_ADC1_AWD2:           TIM1 ETR is connected to ADC1 AWD2
   *            @arg TIM_TIM1_ETR_ADC1_AWD3:           TIM1 ETR is connected to ADC1 AWD3
   *
-  @if STM32G081xx
-  *         For TIM2, the parameter can take one of the following values:
+  *         For TIM2, the parameter can take one of the following values: (*)
   *            @arg TIM_TIM2_ETR_GPIO:                TIM2_ETR is connected to GPIO
   *            @arg TIM_TIM2_ETR_COMP1:               TIM2_ETR is connected to COMP1 output
   *            @arg TIM_TIM2_ETR_COMP2:               TIM2_ETR is connected to COMP2 output
+  *            @arg TIM_TIM2_ETR_COMP3:               TIM2_ETR is connected to COMP3 output    (**)
   *            @arg TIM_TIM2_ETR_LSE:                 TIM2_ETR is connected to LSE
+  *            @arg TIM_TIM2_ETR_MCO:                 TIM2_ETR is connected to MCO             (**)
+  *            @arg TIM_TIM2_ETR_MCO2:                TIM2_ETR is connected to MCO2            (**)
   *
   *         For TIM3, the parameter can take one of the following values:
   *            @arg TIM_TIM3_ETR_GPIO                TIM3_ETR is connected to GPIO
   *            @arg TIM_TIM3_ETR_COMP1               TIM3_ETR is connected to COMP1 output
   *            @arg TIM_TIM3_ETR_COMP2               TIM3_ETR is connected to COMP2 output
-  @endif
+  *            @arg TIM_TIM3_ETR_COMP3               TIM3_ETR is connected to COMP3 output    (**)
+  *
+  *         For TIM4, the parameter can take one of the following values:(*)
+  *            @arg TIM_TIM4_ETR_GPIO                TIM4_ETR is connected to GPIO
+  *            @arg TIM_TIM4_ETR_COMP1               TIM4_ETR is connected to COMP1 output
+  *            @arg TIM_TIM4_ETR_COMP2               TIM4_ETR is connected to COMP2 output
+  *            @arg TIM_TIM4_ETR_COMP3               TIM4_ETR is connected to COMP3 output    (**)
+  *
+  *  (*) Timer instance not available on all devices \n
+  *  (**) Value not defined in all devices. \n
   *
   * @retval HAL status
   */
@@ -1949,35 +2223,50 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
   *          This parameter can be one of the following values:
   *            @arg TIM_CHANNEL_1: TI1 input channel
   *            @arg TIM_CHANNEL_2: TI2 input channel
+  *            @arg TIM_CHANNEL_3: TI3 input channel
   * @param  TISelection specifies the timer input source
-  @if STM32G081xx
+  *
   *         For TIM1 this parameter can be one of the following values:
   *            @arg TIM_TIM1_TI1_GPIO:                TIM1 TI1 is connected to GPIO
   *            @arg TIM_TIM1_TI1_COMP1:               TIM1 TI1 is connected to COMP1 output
   *            @arg TIM_TIM1_TI2_GPIO:                TIM1 TI2 is connected to GPIO
   *            @arg TIM_TIM1_TI2_COMP2:               TIM1 TI2 is connected to COMP2 output
+  *            @arg TIM_TIM1_TI3_GPIO:                TIM1 TI3 is connected to GPIO
+  *            @arg TIM_TIM1_TI3_COMP3:               TIM1 TI3 is connected to COMP3 output   (**)
   *
-  *         For TIM2, the parameter is one of the following values:
+  *         For TIM2, the parameter is one of the following values: (*)
   *            @arg TIM_TIM2_TI1_GPIO:                TIM2 TI1 is connected to GPIO
   *            @arg TIM_TIM2_TI1_COMP1:               TIM2 TI1 is connected to COMP1 output
   *            @arg TIM_TIM2_TI2_GPIO:                TIM2 TI2 is connected to GPIO
   *            @arg TIM_TIM2_TI2_COMP2:               TIM2 TI2 is connected to COMP2 output
+  *            @arg TIM_TIM2_TI3_GPIO:                TIM2 TI3 is connected to GPIO
+  *            @arg TIM_TIM2_TI3_COMP3:               TIM2 TI3 is connected to COMP3 output   (**)
   *
   *         For TIM3, the parameter is one of the following values:
   *            @arg TIM_TIM3_TI1_GPIO:                TIM3 TI1 is connected to GPIO
   *            @arg TIM_TIM3_TI1_COMP1:               TIM3 TI1 is connected to COMP1 output
   *            @arg TIM_TIM3_TI2_GPIO:                TIM3 TI2 is connected to GPIO
   *            @arg TIM_TIM3_TI2_COMP2:               TIM3 TI2 is connected to COMP2 output
-  @endif
+  *            @arg TIM_TIM3_TI3_GPIO:                TIM3 TI3 is connected to GPIO
+  *            @arg TIM_TIM3_TI3_COMP3:               TIM3 TI3 is connected to COMP3 output   (**)
+  *
+  *         For TIM4, the parameter is one of the following values: (*)
+  *            @arg TIM_TIM4_TI1_GPIO:                TIM4 TI1 is connected to GPIO
+  *            @arg TIM_TIM4_TI1_COMP1:               TIM4 TI1 is connected to COMP1 output
+  *            @arg TIM_TIM4_TI2_GPIO:                TIM4 TI2 is connected to GPIO
+  *            @arg TIM_TIM4_TI2_COMP2:               TIM4 TI2 is connected to COMP2 output
+  *            @arg TIM_TIM4_TI3_GPIO:                TIM4 TI3 is connected to GPIO
+  *            @arg TIM_TIM4_TI3_COMP3:               TIM4 TI3 is connected to COMP3 output
   *
   *         For TIM14, the parameter is one of the following values:
   *            @arg TIM_TIM14_TI1_GPIO:               TIM14 TI1 is connected to GPIO
   *            @arg TIM_TIM14_TI1_RTC:                TIM14 TI1 is connected to RTC clock
   *            @arg TIM_TIM14_TI1_HSE_32:             TIM14 TI1 is connected to HSE div 32
   *            @arg TIM_TIM14_TI1_MCO:                TIM14 TI1 is connected to MCO
+  *            @arg TIM_TIM14_TI1_MCO2:               TIM14 TI1 is connected to MCO2          (**)
   *
   *         For TIM15, the parameter is one of the following values:
-  *            @arg TIM_TIM15_TI1_GPIO:              TIM15 TI1 is connected to GPIO
+  *            @arg TIM_TIM15_TI1_GPIO:               TIM15 TI1 is connected to GPIO
   *            @arg TIM_TIM15_TI1_TIM2_CH1:           TIM15 TI1 is connected to TIM2 CH1
   *            @arg TIM_TIM15_TI1_TIM3_CH1:           TIM15 TI1 is connected to TIM3 CH1
   *            @arg TIM_TIM15_TI2_GPIO:               TIM15 TI2 is connected to GPIO
@@ -1985,15 +2274,21 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
   *            @arg TIM_TIM15_TI2_TIM3_CH2:           TIM15 TI2 is connected to TIM3 CH2
   *
   *         For TIM16, the parameter can have the following values:
-  *            @arg TIM_TIM16_TI1_GPIO:              TIM16 TI1 is connected to GPIO
-  *            @arg TIM_TIM16_TI1_LSI:               TIM16 TI1 is connected to LSI
-  *            @arg TIM_TIM16_TI1_LSE:               TIM16 TI1 is connected to LSE
+  *            @arg TIM_TIM16_TI1_GPIO:               TIM16 TI1 is connected to GPIO
+  *            @arg TIM_TIM16_TI1_LSI:                TIM16 TI1 is connected to LSI
+  *            @arg TIM_TIM16_TI1_LSE:                TIM16 TI1 is connected to LSE
   *            @arg TIM_TIM16_TI1_RTC_WAKEUP:         TIM16 TI1 is connected to TRC wakeup interrupt
+  *            @arg TIM_TIM16_TI1_MCO2:               TIM16 TI1 is connected to MCO2          (**)
   *
   *         For TIM17, the parameter can have the following values:
-  *            @arg TIM_TIM17_TI1_GPIO:              TIM17 TI1 is connected to GPIO
-  *            @arg TIM_TIM17_TI1_HSE_32:            TIM17 TI1 is connected to HSE div 32
-  *            @arg TIM_TIM17_TI1_MCO:               TIM17 TI1 is connected to MCO
+  *            @arg TIM_TIM17_TI1_GPIO:               TIM17 TI1 is connected to GPIO
+  *            @arg TIM_TIM14_TI1_HSI:                TIM17 TI1 is connected to HSI           (**)
+  *            @arg TIM_TIM17_TI1_HSE_32:             TIM17 TI1 is connected to HSE div 32
+  *            @arg TIM_TIM17_TI1_MCO:                TIM17 TI1 is connected to MCO
+  *            @arg TIM_TIM17_TI1_MCO2:               TIM17 TI1 is connected to MCO2          (**)
+  *
+  *  (*) Timer instance not available on all devices \n
+  *  (**) Value not defined in all devices. \n
   *
   * @retval HAL status
   */
@@ -2014,6 +2309,9 @@ HAL_StatusTypeDef  HAL_TIMEx_TISelection(TIM_HandleTypeDef *htim, uint32_t TISel
       break;
     case TIM_CHANNEL_2:
       MODIFY_REG(htim->Instance->TISEL, TIM_TISEL_TI2SEL, TISelection);
+      break;
+    case TIM_CHANNEL_3:
+      MODIFY_REG(htim->Instance->TISEL, TIM_TISEL_TI3SEL, TISelection);
       break;
     default:
       status = HAL_ERROR;
@@ -2293,6 +2591,27 @@ HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim)
 }
 
 /**
+  * @brief  Return actual state of the TIM complementary channel.
+  * @param  htim TIM handle
+  * @param  ChannelN TIM Complementary channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1
+  *            @arg TIM_CHANNEL_2: TIM Channel 2
+  *            @arg TIM_CHANNEL_3: TIM Channel 3
+  * @retval TIM Complementary channel state
+  */
+HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(TIM_HandleTypeDef *htim,  uint32_t ChannelN)
+{
+  HAL_TIM_ChannelStateTypeDef channel_state;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, ChannelN));
+
+  channel_state = TIM_CHANNEL_N_STATE_GET(htim, ChannelN);
+
+  return channel_state;
+}
+/**
   * @}
   */
 
@@ -2343,6 +2662,103 @@ void TIMEx_DMACommutationHalfCplt(DMA_HandleTypeDef *hdma)
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
 }
 
+
+/**
+  * @brief  TIM DMA Delay Pulse complete callback (complementary channel).
+  * @param  hdma pointer to DMA handle.
+  * @retval None
+  */
+static void TIM_DMADelayPulseNCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+    }
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+    }
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
+    }
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+
+    if (hdma->Init.Mode == DMA_NORMAL)
+    {
+      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
+    }
+  }
+  else
+  {
+    /* nothing to do */
+  }
+
+#if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
+  htim->PWM_PulseFinishedCallback(htim);
+#else
+  HAL_TIM_PWM_PulseFinishedCallback(htim);
+#endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+}
+
+/**
+  * @brief  TIM DMA error callback (complementary channel)
+  * @param  hdma pointer to DMA handle.
+  * @retval None
+  */
+static void TIM_DMAErrorCCxN(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef *htim = (TIM_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  if (hdma == htim->hdma[TIM_DMA_ID_CC1])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC2])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else if (hdma == htim->hdma[TIM_DMA_ID_CC3])
+  {
+    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+    TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
+  }
+  else
+  {
+    /* nothing to do */
+  }
+
+#if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
+  htim->ErrorCallback(htim);
+#else
+  HAL_TIM_ErrorCallback(htim);
+#endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
+
+  htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+}
 
 /**
   * @brief  Enables or disables the TIM Capture Compare Channel xN.

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_timebase_rtc_alarm_template.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_timebase_rtc_alarm_template.c
@@ -6,7 +6,7 @@
   *
   *          This file override the native HAL time base functions (defined as weak)
   *          to use the RTC ALARM for time base generation:
-  *           + Intializes the RTC peripheral to increment the seconds registers each 1ms
+  *           + Initializes the RTC peripheral to increment the seconds registers each 1ms
   *           + The alarm is configured to assert an interrupt when the RTC reaches 1ms
   *           + HAL_IncTick is called at each Alarm event and the time is reset to 00:00:00
   *           + HSE (default), LSE or LSI can be selected as RTC clock source
@@ -63,86 +63,133 @@
   + RTC_CLOCK_SOURCE_LSI: can be selected for applications with low constraint on timing
                           precision.
   */
-#define RTC_CLOCK_SOURCE_HSE
+/* #define RTC_CLOCK_SOURCE_HSE */
 /* #define RTC_CLOCK_SOURCE_LSE */
-/* #define RTC_CLOCK_SOURCE_LSI */
+#define RTC_CLOCK_SOURCE_LSI
 
-#ifdef RTC_CLOCK_SOURCE_HSE
-#define RTC_ASYNCH_PREDIV       49U
-#define RTC_SYNCH_PREDIV        4U
-#else /* RTC_CLOCK_SOURCE_LSE || RTC_CLOCK_SOURCE_LSI */
-#define RTC_ASYNCH_PREDIV       0U
-#define RTC_SYNCH_PREDIV        31U
-#endif /* RTC_CLOCK_SOURCE_HSE */
+/* Minimize Asynchronous prescaler for power consumption :
+  ck_apre = RTCCLK / (ASYNC prediv + 1)
+  ck_spre = ck_apre/(SYNC prediv + 1) = 1 Hz */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+/* LSE Freq = 32.768 kHz RC */
+#define RTC_ASYNCH_PREDIV                   0u
+#define RTC_SYNCH_PREDIV                    0x3FFFu /* (16384 - 1) */
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+/* LSI Freq = 32 kHz RC  */
+#define RTC_ASYNCH_PREDIV                   0u
+#define RTC_SYNCH_PREDIV                    0x3E7Fu /* (16000 - 1) */
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+/* HSE Freq as RTCCLK = 8 MHz / 32 = 250 kHz */
+#define RTC_ASYNCH_PREDIV                   0x07u   /* (8 - 1) */
+#define RTC_SYNCH_PREDIV                    0x7A11u /* (31250 -1) */
+#endif
+
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-extern RTC_HandleTypeDef hRTC_Handle;
-RTC_HandleTypeDef hRTC_Handle;
+RTC_HandleTypeDef        hRTC_Handle = {.Init = {0}};
 
 /* Private function prototypes -----------------------------------------------*/
 void RTC_TAMP_IRQHandler(void);
 /* Private functions ---------------------------------------------------------*/
 
 /**
-  * @brief  This function configures the RTC_ALARMA as a time base source.
-  *         The time source is configured  to have 1ms time base with a dedicated
+  * @brief  This function configures the RTC ALARM A as a time base source.
+  *         The time source is configured to have 1ms time base with a dedicated
   *         Tick interrupt priority.
-  * @note   This function is called  automatically at the beginning of program after
+  *         Calendar time base is = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
+  *                               = 1s
+  *         Alarm interrupt timebase is = (RTC_SYNCH_PREDIV / (1000 / uwTickFreq))
+  *                                     = 1 ms when uwTickFreq is set to 1 kHz
+  * @note   This function is called automatically at the beginning of program after
   *         reset by HAL_Init() or at any time when clock is configured, by HAL_RCC_ClockConfig().
-  * @param  TickPriority: Tick interrupt priority.
+  * @param  TickPriority Tick interrupt priority.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
-  __IO uint32_t counter = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+  RCC_OscInitTypeDef        RCC_OscInitStruct = {0};
+  RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct = {0};
+  RTC_TimeTypeDef           time;
+  RTC_DateTypeDef           date;
+  RTC_AlarmTypeDef          alarm;
 
-  RCC_OscInitTypeDef        RCC_OscInitStruct;
-  RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct;
 
-#ifdef RTC_CLOCK_SOURCE_LSE
-  /* Configue LSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero)*/
+  if ((uint32_t)uwTickFreq != 0U)
+  {
+    /* Disable backup domeain protection */
+    HAL_PWR_EnableBkUpAccess();
+
+    /* Enable RTC APB clock gating */
+    __HAL_RCC_RTCAPB_CLK_ENABLE();
+
+    /* Disable the Alarm A */
+    __HAL_RTC_ALARMA_DISABLE(&hRTC_Handle);
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
+    __HAL_RTC_ALARM_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_ALRAF);
+
+    /* Get RTC clock configuration */
+    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkInitStruct);
+
+    /*In case of RTC clock already enable, make sure it's the good one */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSE) && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_LSI)
-  /* Configue LSI as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSIState = RCC_LSI_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSI) && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_HSE)
-  /* Configue HSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV32;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_HSE_DIV32) && (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != 0x00u))
 #else
 #error Please select the RTC Clock source
-#endif /* RTC_CLOCK_SOURCE_LSE */
-
-  if(HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK)
-  {
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
-    if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) == HAL_OK)
+#endif
     {
-      /* Enable RTC Clock */
-      __HAL_RCC_RTC_ENABLE();
-      __HAL_RCC_RTCAPB_CLK_ENABLE();
+      /* Do nothing */
+    }
+    else
+    {
+#ifdef RTC_CLOCK_SOURCE_LSE
+      /* Configure LSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+      /* Configure LSI as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSIState = RCC_LSI_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+      /* Configure HSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV32;
+#endif
 
-      /* The time base should be 1ms
-         Time base = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
-         HSE as RTC clock
-           Time base = ((49 + 1) * (4 + 1)) / 250kHz
-                     = 1ms
-         LSE as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32.768KHz
-                     = ~1ms
-         LSI as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32KHz
-                     = 1ms
-      */
+      /* Configure oscillator */
+      status = HAL_RCC_OscConfig(&RCC_OscInitStruct);
+      if (status == HAL_OK)
+      {
+        /* Configure RTC clock source */
+        PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+        status = HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+
+        /* Enable RTC Clock */
+        if(status == HAL_OK)
+        {
+          __HAL_RCC_RTC_ENABLE();
+        }
+      }
+    }
+
+    /* If RTC Clock configuration is ok */
+    if (status == HAL_OK)
+    {
+      /* The time base is defined to have highest synchronous prescaler but keeping
+         a 1Hz RTC frequency. */
       hRTC_Handle.Instance = RTC;
       hRTC_Handle.Init.HourFormat = RTC_HOURFORMAT_24;
       hRTC_Handle.Init.AsynchPrediv = RTC_ASYNCH_PREDIV;
@@ -150,80 +197,104 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
       hRTC_Handle.Init.OutPut = RTC_OUTPUT_DISABLE;
       hRTC_Handle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
       hRTC_Handle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-      if (HAL_RTC_Init(&hRTC_Handle) != HAL_OK)
+      status = HAL_RTC_Init(&hRTC_Handle);
+    }
+
+    /* HAL RTC Init is ok & calendar has never been initialized */
+    if((status == HAL_OK)  && (__HAL_RTC_GET_FLAG(&hRTC_Handle, RTC_FLAG_INITS) == 0x00u))
+    {
+      time.Hours = 0x00u;
+      time.Minutes = 0x00u;
+      time.Seconds = 0x00u;
+      time.TimeFormat = RTC_HOURFORMAT12_PM;
+      time.SubSeconds = 0x00u;
+      time.SecondFraction = 0x00u;
+      time.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+      time.StoreOperation = RTC_STOREOPERATION_RESET;
+      status = HAL_RTC_SetTime(&hRTC_Handle, &time, RTC_FORMAT_BCD);
+      if(status == HAL_OK)
       {
-        return HAL_ERROR;
+        date.WeekDay = RTC_WEEKDAY_MONDAY;
+        date.Date = 0x01u;
+        date.Month = RTC_MONTH_JANUARY;
+        date.Year = 0x01u;
+        status = HAL_RTC_SetDate(&hRTC_Handle, &date, RTC_FORMAT_BCD);
       }
+    }
 
-      /* Disable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
+    /* If RTC calendar is initialized */
+    if (status == HAL_OK)
+    {
+      alarm.AlarmTime.Hours = 0x00u;
+      alarm.AlarmTime.Minutes = 0x00u;
+      alarm.AlarmTime.Seconds = 0x00u;
+      alarm.AlarmTime.TimeFormat = RTC_HOURFORMAT12_PM;
+      alarm.AlarmTime.SubSeconds = (RTC_SYNCH_PREDIV / (1000 / (uint32_t)uwTickFreq));
+      alarm.AlarmTime.SecondFraction = 0x00u;
+      alarm.AlarmTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+      alarm.AlarmTime.StoreOperation = RTC_STOREOPERATION_RESET;
+      alarm.AlarmMask = RTC_ALARMMASK_ALL;
 
-      /* Disable the Alarm A interrupt */
-      __HAL_RTC_ALARMA_DISABLE(&hRTC_Handle);
-
-      /* Clear flag alarm A */
-      __HAL_RTC_ALARM_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_ALRAF);
-
-      counter = 0U;
-      /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
-      while(__HAL_RTC_ALARM_GET_FLAG(&hRTC_Handle, RTC_FLAG_ALRAWF) == 0U)
+      /* Depending on input frequency select Subsecond mask */
+      if (uwTickFreq == HAL_TICK_FREQ_1KHZ)
       {
-        if(counter++ == (SystemCoreClock / 56U)) /* Timeout = ~ 1s */
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_5;
+      }
+      else if (uwTickFreq == HAL_TICK_FREQ_100HZ)
+      {
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_9;
+      }
+      else
+      {
+#if defined (RTC_CLOCK_SOURCE_HSE)
+        /* When RTCCLK = 1 MHz, need to mask Subsecond register bit 12 to 14
+          to have 10 Hhz interrupt */
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_12;
+#else
+        /* When RTCCLK is around 32 kHz, need to mask Subsecond register bit 12 to 11
+          to have 10 Hhz interrupt */
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_11;
+#endif
+      }
+      alarm.AlarmDateWeekDaySel = RTC_ALARMDATEWEEKDAYSEL_DATE;
+      alarm.AlarmDateWeekDay = RTC_WEEKDAY_MONDAY;
+      alarm.Alarm = RTC_ALARM_A;
+      status = HAL_RTC_SetAlarm_IT(&hRTC_Handle, &alarm, RTC_FORMAT_BCD);
+      if(status == HAL_OK)
+      {
+        /* Enable the RTC global Interrupt */
+        HAL_NVIC_EnableIRQ(RTC_TAMP_IRQn);
+
+        /* Configure the SysTick IRQ priority */
+        if (TickPriority < (1UL << __NVIC_PRIO_BITS))
         {
-          return HAL_ERROR;
+          HAL_NVIC_SetPriority(RTC_TAMP_IRQn, TickPriority, 0U);
+          uwTickPrio = TickPriority;
+        }
+        else
+        {
+          status = HAL_ERROR;
         }
       }
-
-      hRTC_Handle.Instance->ALRMAR = (uint32_t)0x01U;
-
-      /* Configure the Alarm state: Enable Alarm */
-      __HAL_RTC_ALARMA_ENABLE(&hRTC_Handle);
-      /* Configure the Alarm interrupt */
-      __HAL_RTC_ALARM_ENABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
-
-      /* RTC Alarm Interrupt Configuration: EXTI configuration */
-      __HAL_RTC_ALARM_EXTI_ENABLE_IT();
-
-      /* Check if the Initialization mode is set */
-      if((hRTC_Handle.Instance->ICSR & RTC_ICSR_INITF) == (uint32_t)RESET)
-      {
-        /* Set the Initialization mode */
-        hRTC_Handle.Instance->ICSR = (uint32_t)RTC_INIT_MASK;
-        counter = 0U;
-        while((hRTC_Handle.Instance->ICSR & RTC_ICSR_INITF) == (uint32_t)RESET)
-        {
-          if(counter++ == (SystemCoreClock / 56U)) /* Timeout = ~ 1s */
-          {
-            return HAL_ERROR;
-          }
-        }
-      }
-      hRTC_Handle.Instance->DR = 0U;
-      hRTC_Handle.Instance->TR = 0U;
-
-      hRTC_Handle.Instance->ICSR &= (uint32_t)~RTC_ICSR_INIT;
-
-      /* Enable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
-
-      HAL_NVIC_SetPriority(RTC_TAMP_IRQn, TickPriority, 0U);
-      HAL_NVIC_EnableIRQ(RTC_TAMP_IRQn);
-      return HAL_OK;
     }
   }
-  return HAL_ERROR;
+  else
+  {
+    status = HAL_ERROR;
+  }
+  return status;
 }
 
 /**
   * @brief  Suspend Tick increment.
-  * @note   Disable the tick increment by disabling RTC ALARM interrupt.
+  * @note   Disable the tick increment by disabling RTC_ALRA interrupt.
   * @retval None
   */
 void HAL_SuspendTick(void)
 {
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-  /* Disable RTC ALARM update Interrupt */
+  /* Disable ALARM A Interrupt */
   __HAL_RTC_ALARM_DISABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
@@ -238,46 +309,23 @@ void HAL_ResumeTick(void)
 {
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-  /* Enable RTC ALARM Update interrupt */
+  /* Enable ALARM A interrupt */
   __HAL_RTC_ALARM_ENABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
 }
 
 /**
-  * @brief  ALARM A Event Callback in non blocking mode
-  * @note   This function is called  when RTC_ALARM interrupt took place, inside
-  * RTC_ALARM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
-  * a global variable "uwTick" used as application time base.
-  * @param  hrtc : RTC handle
+  * @brief  Alarm Timer Event Callback in non blocking mode
+  * @note   This function is called  when RTC Alarm takes place, inside
+  *         HAL_RTC_AlarmIRQHandler(). It makes a direct call to HAL_IncTick() to increment
+  *         a global variable "uwTick" used as application time base.
+  * @param  hrtc  RTC handle
   * @retval None
   */
 void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
 {
-  __IO uint32_t counter = 0U;
-
   HAL_IncTick();
-
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
-  /* Set the Initialization mode */
-  hrtc->Instance->ICSR = (uint32_t)RTC_INIT_MASK;
-
-  while((hrtc->Instance->ICSR & RTC_ICSR_INITF) == (uint32_t)RESET)
-  {
-    if(counter++ == (SystemCoreClock / 56U)) /* Timeout = ~ 1s */
-    {
-      break;
-    }
-  }
-
-  hrtc->Instance->DR = 0U;
-  hrtc->Instance->TR = 0U;
-
-  hrtc->Instance->ICSR &= (uint32_t)~RTC_ICSR_INIT;
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 }
 
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_timebase_rtc_wakeup_template.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_timebase_rtc_wakeup_template.c
@@ -6,7 +6,7 @@
   *
   *          This file overrides the native HAL time base functions (defined as weak)
   *          to use the RTC WAKEUP for the time base generation:
-  *           + Intializes the RTC peripheral and configures the wakeup timer to be
+  *           + Initializes the RTC peripheral and configures the wakeup timer to be
   *             incremented each 1ms
   *           + The wakeup feature is configured to assert an interrupt each 1ms
   *           + HAL_IncTick is called inside the HAL_RTCEx_WakeUpTimerEventCallback
@@ -64,22 +64,28 @@
   + RTC_CLOCK_SOURCE_LSI: can be selected for applications with low constraint on timing
                           precision.
   */
-#define RTC_CLOCK_SOURCE_HSE
+/* #define RTC_CLOCK_SOURCE_HSE */
 /* #define RTC_CLOCK_SOURCE_LSE */
-/* #define RTC_CLOCK_SOURCE_LSI */
+#define RTC_CLOCK_SOURCE_LSI
 
-#ifdef RTC_CLOCK_SOURCE_HSE
-#define RTC_ASYNCH_PREDIV       49U
-#define RTC_SYNCH_PREDIV        4U
-#else /* RTC_CLOCK_SOURCE_LSE || RTC_CLOCK_SOURCE_LSI */
-#define RTC_ASYNCH_PREDIV       0U
-#define RTC_SYNCH_PREDIV        31U
-#endif /* RTC_CLOCK_SOURCE_HSE */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+/* LSE Freq = 32.768 kHz RC */
+#define RTC_ASYNCH_PREDIV                   0x7Fu
+#define RTC_SYNCH_PREDIV                    0x00FFu
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+/* LSI Freq = 32 kHz RC  */
+#define RTC_ASYNCH_PREDIV                   0x7Fu
+#define RTC_SYNCH_PREDIV                    0x00FEu
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+/* HSE Freq as RTCCLK = 8 MHz / 32 = 250 kHz */
+#define RTC_ASYNCH_PREDIV                   0x07u   /* (8 - 1) */
+#define RTC_SYNCH_PREDIV                    0x7A11u /* (31250 -1) */
+#endif
+
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-extern RTC_HandleTypeDef hRTC_Handle;
-RTC_HandleTypeDef        hRTC_Handle;
+RTC_HandleTypeDef        hRTC_Handle = {.Init = {0}};
 
 /* Private function prototypes -----------------------------------------------*/
 void RTC_TAMP_IRQHandler(void);
@@ -101,54 +107,85 @@ void RTC_TAMP_IRQHandler(void);
   */
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
-  __IO uint32_t counter = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t wucounter;
+  RCC_OscInitTypeDef        RCC_OscInitStruct = {0};
+  RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct = {0};
 
-  RCC_OscInitTypeDef        RCC_OscInitStruct;
-  RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct;
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero)*/
+  if ((uint32_t)uwTickFreq != 0U)
+  {
+    /* Disable backup domain protection */
+    HAL_PWR_EnableBkUpAccess();
 
+    /* Enable RTC APB clock gating */
+    __HAL_RCC_RTCAPB_CLK_ENABLE();
+
+    /* Disable the Wake-up Timer */
+    __HAL_RTC_WAKEUPTIMER_DISABLE(&hRTC_Handle);
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_WAKEUPTIMER_DISABLE_IT(&hRTC_Handle,RTC_IT_WUT);
+    __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hRTC_Handle,RTC_FLAG_WUTF);
+
+    /* Get RTC clock configuration */
+    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkInitStruct);
+
+    /*In case of RTC clock already enable, make sure it's the good one */
 #ifdef RTC_CLOCK_SOURCE_LSE
-  /* Configue LSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSE) && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_LSI)
-  /* Configue LSI as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSIState = RCC_LSI_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSI) && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_HSE)
-  /* Configue HSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV32;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_HSE_DIV32) && (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != 0x00u))
 #else
 #error Please select the RTC Clock source
-#endif /* RTC_CLOCK_SOURCE_LSE */
-
-  if(HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK)
-  {
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
-    if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) == HAL_OK)
+#endif
     {
-      /* Enable RTC Clock */
-      __HAL_RCC_RTC_ENABLE();
-      __HAL_RCC_RTCAPB_CLK_ENABLE();
+      /* Do nothing */
+    }
+    else
+    {
+#ifdef RTC_CLOCK_SOURCE_LSE
+      /* Configure LSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+      /* Configure LSI as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSIState = RCC_LSI_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+      /* Configure HSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV32;
+#endif
 
-      /* The time base should be 1ms
-         Time base = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
-         HSE as RTC clock
-           Time base = ((49 + 1) * (4 + 1)) / 250khz
-                     = 1ms
-         LSE as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32.768Khz
-                     = ~1ms
-         LSI as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32Khz
-                     = 1ms
-      */
+      /* COnfigure oscillator */
+      status = HAL_RCC_OscConfig(&RCC_OscInitStruct);
+      if(status == HAL_OK)
+      {
+        /* Configure RTC clock source */
+        PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+        status = HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+
+        /* Enable RTC Clock */
+        if(status == HAL_OK)
+        {
+          __HAL_RCC_RTC_ENABLE();
+        }
+      }
+    }
+
+    /* If RTC Clock configuration is ok */
+    if(status == HAL_OK)
+    {
+      /* No care of RTC init parameter here. Only needed if RTC is being used
+        for other features in same time: calendar, alarm, timestamp, etc... */
       hRTC_Handle.Instance = RTC;
       hRTC_Handle.Init.HourFormat = RTC_HOURFORMAT_24;
       hRTC_Handle.Init.AsynchPrediv = RTC_ASYNCH_PREDIV;
@@ -156,62 +193,50 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
       hRTC_Handle.Init.OutPut = RTC_OUTPUT_DISABLE;
       hRTC_Handle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
       hRTC_Handle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-      if (HAL_RTC_Init(&hRTC_Handle) != HAL_OK)
+      status = HAL_RTC_Init(&hRTC_Handle);
+
+      if(status == HAL_OK)
       {
-        return HAL_ERROR;
-      }
+        /* The time base should be of (uint32_t)uwTickFreq) ms. Tick counter
+          is incremented eachtime wakeup time reaches zero. Wakeup timer is
+          clocked on RTCCLK divided by 2. So downcounting counter has to be
+          set to (RTCCLK / 2) / (1000 / (uint32_t)uwTickFreq)) minus 1 */
+#ifdef RTC_CLOCK_SOURCE_LSE
+        wucounter = LSE_VALUE;
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+        wucounter = LSI_VALUE;
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+        /* HSE input clock to RTC is divided by 32 */
+        wucounter = (HSE_VALUE >> 5);
+#endif
+        wucounter = ((wucounter >> 1) / (1000U / (uint32_t)uwTickFreq)) -1u;
+        status = HAL_RTCEx_SetWakeUpTimer_IT(&hRTC_Handle, wucounter, RTC_WAKEUPCLOCK_RTCCLK_DIV2);
 
-      /* Disable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-
-      /* Disable the Wake-up Timer */
-      __HAL_RTC_WAKEUPTIMER_DISABLE(&hRTC_Handle);
-
-      /* In case of interrupt mode is used, the interrupt source must disabled */
-      __HAL_RTC_WAKEUPTIMER_DISABLE_IT(&hRTC_Handle,RTC_IT_WUT);
-
-      /* Wait till RTC WUTWF flag is set  */
-      while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(&hRTC_Handle, RTC_FLAG_WUTWF) == 0U)
-      {
-        if(counter++ == (SystemCoreClock / 56U))
+        if(status == HAL_OK)
         {
-          return HAL_ERROR;
+          /* Enable the RTC global Interrupt */
+
+          HAL_NVIC_EnableIRQ(RTC_TAMP_IRQn);
+
+          /* Configure the SysTick IRQ priority */
+          if (TickPriority < (1UL << __NVIC_PRIO_BITS))
+          {
+            HAL_NVIC_SetPriority(RTC_TAMP_IRQn, TickPriority, 0U);
+            uwTickPrio = TickPriority;
+          }
+          else
+          {
+            status = HAL_ERROR;
+          }
         }
       }
-
-      /* Clear PWR wake up Flag */
-      __HAL_PWR_CLEAR_FLAG(PWR_FLAG_WUF);
-
-      /* Clear RTC Wake Up timer Flag */
-      __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_WUTF);
-
-      /* Configure the Wake-up Timer counter */
-      hRTC_Handle.Instance->WUTR = 0U;
-
-      /* Clear the Wake-up Timer clock source bits in CR register */
-      hRTC_Handle.Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
-
-      /* Configure the clock source */
-      hRTC_Handle.Instance->CR |= (uint32_t)RTC_WAKEUPCLOCK_CK_SPRE_16BITS;
-
-      /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
-      __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
-
-      /* Configure the Interrupt in the RTC_CR register */
-      __HAL_RTC_WAKEUPTIMER_ENABLE_IT(&hRTC_Handle,RTC_IT_WUT);
-
-      /* Enable the Wake-up Timer */
-      __HAL_RTC_WAKEUPTIMER_ENABLE(&hRTC_Handle);
-
-      /* Enable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
-
-      HAL_NVIC_SetPriority(RTC_TAMP_IRQn, TickPriority, 0U);
-      HAL_NVIC_EnableIRQ(RTC_TAMP_IRQn);
-      return HAL_OK;
     }
   }
-  return HAL_ERROR;
+  else
+  {
+    status = HAL_ERROR;
+  }
+  return status;
 }
 
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_timebase_tim_template.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_timebase_tim_template.c
@@ -6,7 +6,7 @@
   *
   *          This file overrides the native HAL time base functions (defined as weak)
   *          the TIM time base:
-  *           + Intializes the TIM peripheral to generate a Period elapsed Event each 1ms
+  *           + Initializes the TIM peripheral to generate a Period elapsed Event each 1ms
   *           + HAL_IncTick is called inside HAL_TIM_PeriodElapsedCallback ie each 1ms
   *
  @verbatim
@@ -17,7 +17,7 @@
     This file must be copied to the application folder and modified as follows:
     (#) Rename it to 'stm32g0xx_hal_timebase_tim.c'
     (#) Add this file and the TIM HAL driver files to your project and make sure
-       HAL_TIM_MODULE_ENABLED is defined in stm32l4xx_hal_conf.h
+       HAL_TIM_MODULE_ENABLED is defined in stm32g0xx_hal_conf.h
 
     [..]
     (@) The application needs to ensure that the time base is always set to 1 millisecond
@@ -53,105 +53,134 @@
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-extern TIM_HandleTypeDef TimHandle;
-TIM_HandleTypeDef        TimHandle;
+TIM_HandleTypeDef TimHandle = {.Init = {0}};
+
 /* Private function prototypes -----------------------------------------------*/
-void TIM6_DAC_LPTIM1_IRQHandler(void);
+void TIM14_IRQHandler(void);
 /* Private functions ---------------------------------------------------------*/
 
 /**
-  * @brief  This function configures the TIM6 as a time base source.
+  * @brief  This function configures the TIM14 as a time base source.
   *         The time source is configured to have 1ms time base with a dedicated
   *         Tick interrupt priority.
-  * @note   This function is called  automatically at the beginning of program after
-  *         reset by HAL_Init() or at any time when clock is configured, by HAL_RCC_ClockConfig().
+  * @note   This function is called  automatically at the beginning of program
+  *         after reset by HAL_Init() or at any time when clock is configured,
+  *         by HAL_RCC_ClockConfig().
   * @param  TickPriority Tick interrupt priority.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
   RCC_ClkInitTypeDef    clkconfig;
-  uint32_t              uwTimclock, uwAPB1Prescaler;
+  uint32_t              uwTimclock;
+  uint32_t              uwAPB1Prescaler;
   uint32_t              uwPrescalerValue;
   uint32_t              pFLatency;
+  HAL_StatusTypeDef     status = HAL_OK;
 
-  /*Configure the TIM6 IRQ priority */
-  HAL_NVIC_SetPriority(TIM6_DAC_LPTIM1_IRQn, TickPriority, 0U);
-
-  /* Enable the TIM6 global Interrupt */
-  HAL_NVIC_EnableIRQ(TIM6_DAC_LPTIM1_IRQn);
-
-  /* Enable TIM6 clock */
-  __HAL_RCC_TIM6_CLK_ENABLE();
-
-  /* Get clock configuration */
-  HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
-
-  /* Get APB1 prescaler */
-  uwAPB1Prescaler = clkconfig.APB1CLKDivider;
-
-  /* Compute TIM6 clock */
-  if (uwAPB1Prescaler == RCC_HCLK_DIV1)
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero)*/
+  if ((uint32_t)uwTickFreq != 0U)
   {
-    uwTimclock = HAL_RCC_GetPCLK1Freq();
+    /* Enable TIM14 clock */
+    __HAL_RCC_TIM14_CLK_ENABLE();
+
+    /* Get clock configuration */
+    HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
+
+    /* Get APB1 prescaler */
+    uwAPB1Prescaler = clkconfig.APB1CLKDivider;
+
+    /* Compute TIM14 clock */
+    if (uwAPB1Prescaler == RCC_HCLK_DIV1)
+    {
+      uwTimclock = HAL_RCC_GetPCLK1Freq();
+    }
+    else
+    {
+      uwTimclock = 2U*HAL_RCC_GetPCLK1Freq();
+    }
+
+    /* Compute the prescaler value to have TIM14 counter clock equal to 1MHz */
+    uwPrescalerValue = (uint32_t)((uwTimclock / 1000000U) - 1U);
+
+    /* Initialize TIM14 */
+    TimHandle.Instance = TIM14;
+
+    /* Initialize TIMx peripheral as follow:
+    + Period = [(TIM14CLK/uwTickFreq) - 1]. to have a (1/uwTickFreq) s time base.
+    + Prescaler = (uwTimclock/1000000 - 1) to have a 1MHz counter clock.
+    + ClockDivision = 0
+    + Counter direction = Up
+    */
+    TimHandle.Init.Period = (1000000U / (1000U / (uint32_t)uwTickFreq)) - 1U;
+    TimHandle.Init.Prescaler = uwPrescalerValue;
+    TimHandle.Init.ClockDivision = 0U;
+    TimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
+    TimHandle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&TimHandle) == HAL_OK)
+    {
+      /* Start the TIM time Base generation in interrupt mode */
+      if (HAL_TIM_Base_Start_IT(&TimHandle) == HAL_OK)
+      {
+        /* Enable the TIM14 global Interrupt */
+        HAL_NVIC_EnableIRQ(TIM14_IRQn);
+
+        /* Configure the SysTick IRQ priority */
+        if (TickPriority < (1UL << __NVIC_PRIO_BITS))
+        {
+          /*Configure the TIM14 IRQ priority */
+          HAL_NVIC_SetPriority(TIM14_IRQn, TickPriority,0U);
+          uwTickPrio = TickPriority;
+        }
+        else
+        {
+          status = HAL_ERROR;
+        }
+      }
+      else
+      {
+        status = HAL_ERROR;
+      }
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
   }
   else
   {
-    uwTimclock = 2U*HAL_RCC_GetPCLK1Freq();
-  }
-
-  /* Compute the prescaler value to have TIM6 counter clock equal to 1MHz */
-  uwPrescalerValue = (uint32_t)((uwTimclock / 1000000U) - 1U);
-
-  /* Initialize TIM6 */
-  TimHandle.Instance = TIM6;
-
-  /* Initialize TIMx peripheral as follow:
-  + Period = [(TIM6CLK/1000) - 1]. to have a (1/1000) s time base.
-  + Prescaler = (uwTimclock/1000000 - 1) to have a 1MHz counter clock.
-  + ClockDivision = 0
-  + Counter direction = Up
-  */
-  TimHandle.Init.Period = (1000000U / 1000U) - 1U;
-  TimHandle.Init.Prescaler = uwPrescalerValue;
-  TimHandle.Init.ClockDivision = 0U;
-  TimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
-  TimHandle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-  if(HAL_TIM_Base_Init(&TimHandle) == HAL_OK)
-  {
-    /* Start the TIM time Base generation in interrupt mode */
-    return HAL_TIM_Base_Start_IT(&TimHandle);
+      status = HAL_ERROR;
   }
 
   /* Return function status */
-  return HAL_ERROR;
+  return status;
 }
 
 /**
   * @brief  Suspend Tick increment.
-  * @note   Disable the tick increment by disabling TIM6 update interrupt.
+  * @note   Disable the tick increment by disabling TIM14 update interrupt.
   * @retval None
   */
 void HAL_SuspendTick(void)
 {
-  /* Disable TIM6 update interrupt */
+  /* Disable TIM14 update interrupt */
   __HAL_TIM_DISABLE_IT(&TimHandle, TIM_IT_UPDATE);
 }
 
 /**
   * @brief  Resume Tick increment.
-  * @note   Enable the tick increment by enabling TIM6 update interrupt.
+  * @note   Enable the tick increment by enabling TIM14 update interrupt.
   * @retval None
   */
 void HAL_ResumeTick(void)
 {
-  /* Enable TIM6 update interrupt */
+  /* Enable TIM14 update interrupt */
   __HAL_TIM_ENABLE_IT(&TimHandle, TIM_IT_UPDATE);
 }
 
 /**
   * @brief  Period elapsed callback in non blocking mode
-  * @note   This function is called  when TIM6 interrupt took place, inside
+  * @note   This function is called  when TIM14 interrupt took place, inside
   * HAL_TIM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
   * a global variable "uwTick" used as application time base.
   * @param  htim TIM handle
@@ -166,7 +195,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   * @brief  This function handles TIM interrupt request.
   * @retval None
   */
-void TIM6_DAC_LPTIM1_IRQHandler(void)
+void TIM14_IRQHandler(void)
 {
   HAL_TIM_IRQHandler(&TimHandle);
 }

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_uart.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_uart.c
@@ -39,7 +39,8 @@
             (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
             (+++) Configure the DMA Tx/Rx channel.
             (+++) Associate the initialized DMA handle to the UART DMA Tx/Rx handle.
-            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+            (+++) Configure the priority and enable the NVIC for the transfer complete
+                  interrupt on the DMA Tx/Rx channel.
 
     (#) Program the Baud Rate, Word Length, Stop Bit, Parity, Prescaler value , Hardware
         flow control and Mode (Receiver/Transmitter) in the huart handle Init structure.
@@ -112,6 +113,10 @@
     (+) TxFifoEmptyCallback       : Tx Fifo Empty Callback.
     (+) MspInitCallback           : UART MspInit.
     (+) MspDeInitCallback         : UART MspDeInit.
+
+    [..]
+    For specific callback RxEventCallback, use dedicated registration/reset functions:
+    respectively @ref HAL_UART_RegisterRxEventCallback() , @ref HAL_UART_UnRegisterRxEventCallback().
 
     [..]
     By default, after the @ref HAL_UART_Init() and when the state is HAL_UART_STATE_RESET
@@ -191,6 +196,8 @@
 
 /* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
+const uint16_t UARTPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
+
 /* Private function prototypes -----------------------------------------------*/
 /** @addtogroup UART_Private_Functions
   * @{
@@ -643,6 +650,7 @@ HAL_StatusTypeDef HAL_UART_DeInit(UART_HandleTypeDef *huart)
   huart->ErrorCode = HAL_UART_ERROR_NONE;
   huart->gState = HAL_UART_STATE_RESET;
   huart->RxState = HAL_UART_STATE_RESET;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   __HAL_UNLOCK(huart);
 
@@ -842,55 +850,57 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
     switch (CallbackID)
     {
       case HAL_UART_TX_HALFCOMPLETE_CB_ID :
-        huart->TxHalfCpltCallback = HAL_UART_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback       */
+        huart->TxHalfCpltCallback = HAL_UART_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback    */
         break;
 
       case HAL_UART_TX_COMPLETE_CB_ID :
-        huart->TxCpltCallback = HAL_UART_TxCpltCallback;                       /* Legacy weak TxCpltCallback            */
+        huart->TxCpltCallback = HAL_UART_TxCpltCallback;                       /* Legacy weak TxCpltCallback         */
         break;
 
       case HAL_UART_RX_HALFCOMPLETE_CB_ID :
-        huart->RxHalfCpltCallback = HAL_UART_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback        */
+        huart->RxHalfCpltCallback = HAL_UART_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback     */
         break;
 
       case HAL_UART_RX_COMPLETE_CB_ID :
-        huart->RxCpltCallback = HAL_UART_RxCpltCallback;                       /* Legacy weak RxCpltCallback            */
+        huart->RxCpltCallback = HAL_UART_RxCpltCallback;                       /* Legacy weak RxCpltCallback         */
         break;
 
       case HAL_UART_ERROR_CB_ID :
-        huart->ErrorCallback = HAL_UART_ErrorCallback;                         /* Legacy weak ErrorCallback             */
+        huart->ErrorCallback = HAL_UART_ErrorCallback;                         /* Legacy weak ErrorCallback          */
         break;
 
       case HAL_UART_ABORT_COMPLETE_CB_ID :
-        huart->AbortCpltCallback = HAL_UART_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback         */
+        huart->AbortCpltCallback = HAL_UART_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback      */
         break;
 
       case HAL_UART_ABORT_TRANSMIT_COMPLETE_CB_ID :
-        huart->AbortTransmitCpltCallback = HAL_UART_AbortTransmitCpltCallback; /* Legacy weak AbortTransmitCpltCallback */
+        huart->AbortTransmitCpltCallback = HAL_UART_AbortTransmitCpltCallback; /* Legacy weak
+                                                                                  AbortTransmitCpltCallback          */
         break;
 
       case HAL_UART_ABORT_RECEIVE_COMPLETE_CB_ID :
-        huart->AbortReceiveCpltCallback = HAL_UART_AbortReceiveCpltCallback;   /* Legacy weak AbortReceiveCpltCallback  */
+        huart->AbortReceiveCpltCallback = HAL_UART_AbortReceiveCpltCallback;   /* Legacy weak
+                                                                                  AbortReceiveCpltCallback           */
         break;
 
       case HAL_UART_WAKEUP_CB_ID :
-        huart->WakeupCallback = HAL_UARTEx_WakeupCallback;                     /* Legacy weak WakeupCallback            */
+        huart->WakeupCallback = HAL_UARTEx_WakeupCallback;                     /* Legacy weak WakeupCallback         */
         break;
 
       case HAL_UART_RX_FIFO_FULL_CB_ID :
-        huart->RxFifoFullCallback = HAL_UARTEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback        */
+        huart->RxFifoFullCallback = HAL_UARTEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback     */
         break;
 
       case HAL_UART_TX_FIFO_EMPTY_CB_ID :
-        huart->TxFifoEmptyCallback = HAL_UARTEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback       */
+        huart->TxFifoEmptyCallback = HAL_UARTEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback    */
         break;
 
       case HAL_UART_MSPINIT_CB_ID :
-        huart->MspInitCallback = HAL_UART_MspInit;                             /* Legacy weak MspInitCallback           */
+        huart->MspInitCallback = HAL_UART_MspInit;                             /* Legacy weak MspInitCallback        */
         break;
 
       case HAL_UART_MSPDEINIT_CB_ID :
-        huart->MspDeInitCallback = HAL_UART_MspDeInit;                         /* Legacy weak MspDeInitCallback         */
+        huart->MspDeInitCallback = HAL_UART_MspDeInit;                         /* Legacy weak MspDeInitCallback      */
         break;
 
       default :
@@ -930,6 +940,74 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
 
   return status;
 }
+
+/**
+  * @brief  Register a User UART Rx Event Callback
+  *         To be used instead of the weak predefined callback
+  * @param  huart     Uart handle
+  * @param  pCallback Pointer to the Rx Event Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_RegisterRxEventCallback(UART_HandleTypeDef *huart, pUART_RxEventCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    huart->ErrorCode |= HAL_UART_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(huart);
+
+  if (huart->gState == HAL_UART_STATE_READY)
+  {
+    huart->RxEventCallback = pCallback;
+  }
+  else
+  {
+    huart->ErrorCode |= HAL_UART_ERROR_INVALID_CALLBACK;
+
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(huart);
+
+  return status;
+}
+
+/**
+  * @brief  UnRegister the UART Rx Event Callback
+  *         UART Rx Event Callback is redirected to the weak HAL_UARTEx_RxEventCallback() predefined callback
+  * @param  huart     Uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_UnRegisterRxEventCallback(UART_HandleTypeDef *huart)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(huart);
+
+  if (huart->gState == HAL_UART_STATE_READY)
+  {
+    huart->RxEventCallback = HAL_UARTEx_RxEventCallback; /* Legacy weak UART Rx Event Callback  */
+  }
+  else
+  {
+    huart->ErrorCode |= HAL_UART_ERROR_INVALID_CALLBACK;
+
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(huart);
+  return status;
+}
+
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 
 /**
@@ -995,16 +1073,22 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
         (+) HAL_UART_AbortTransmitCpltCallback()
         (+) HAL_UART_AbortReceiveCpltCallback()
 
+    (#) A Rx Event Reception Callback (Rx event notification) is available for Non_Blocking modes of enhanced reception services:
+        (+) HAL_UARTEx_RxEventCallback()
+
     (#) In Non-Blocking mode transfers, possible errors are split into 2 categories.
         Errors are handled as follows :
        (+) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
-           to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
-           Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
-           and HAL_UART_ErrorCallback() user callback is executed. Transfer is kept ongoing on UART side.
+           to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error
+           in Interrupt mode reception .
+           Received character is then retrieved and stored in Rx buffer, Error code is set to allow user
+           to identify error type, and HAL_UART_ErrorCallback() user callback is executed.
+           Transfer is kept ongoing on UART side.
            If user wants to abort it, Abort services should be called by user.
        (+) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
            This concerns Overrun Error In Interrupt mode reception and all errors in DMA mode.
-           Error code is set to allow user to identify error type, and HAL_UART_ErrorCallback() user callback is executed.
+           Error code is set to allow user to identify error type, and HAL_UART_ErrorCallback()
+           user callback is executed.
 
     -@- In the Half duplex communication, it is forbidden to run the transmit
         and receive process in parallel, the UART state HAL_UART_STATE_BUSY_TX_RX can't be useful.
@@ -1025,7 +1109,8 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
   *         (as sent data will be handled using u16 pointer cast). Depending on compilation chain,
-  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
   * @param huart   UART handle.
   * @param pData   Pointer to data buffer (u8 or u16 data elements).
   * @param Size    Amount of data elements (u8 or u16) to be sent.
@@ -1062,7 +1147,7 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->gState = HAL_UART_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     huart->TxXferSize  = Size;
@@ -1079,6 +1164,8 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
       pdata8bits  = pData;
       pdata16bits = NULL;
     }
+
+    __HAL_UNLOCK(huart);
 
     while (huart->TxXferCount > 0U)
     {
@@ -1107,8 +1194,6 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
     /* At end of Tx process, restore huart->gState to Ready */
     huart->gState = HAL_UART_STATE_READY;
 
-    __HAL_UNLOCK(huart);
-
     return HAL_OK;
   }
   else
@@ -1129,7 +1214,8 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
   *         (as received data will be handled using u16 pointer cast). Depending on compilation chain,
-  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
   * @param huart   UART handle.
   * @param pData   Pointer to data buffer (u8 or u16 data elements).
   * @param Size    Amount of data elements (u8 or u16) to be received.
@@ -1166,8 +1252,9 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
 
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->RxState = HAL_UART_STATE_BUSY_RX;
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     huart->RxXferSize  = Size;
@@ -1188,6 +1275,8 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
       pdata8bits  = pData;
       pdata16bits = NULL;
     }
+
+    __HAL_UNLOCK(huart);
 
     /* as long as data have to be received */
     while (huart->RxXferCount > 0U)
@@ -1212,8 +1301,6 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
     /* At end of Rx process, restore huart->RxState to Ready */
     huart->RxState = HAL_UART_STATE_READY;
 
-    __HAL_UNLOCK(huart);
-
     return HAL_OK;
   }
   else
@@ -1230,7 +1317,8 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
   *         (as sent data will be handled using u16 pointer cast). Depending on compilation chain,
-  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be sent.
@@ -1319,7 +1407,8 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
   *         (as received data will be handled using u16 pointer cast). Depending on compilation chain,
-  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be received.
@@ -1348,58 +1437,10 @@ HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData,
 
     __HAL_LOCK(huart);
 
-    huart->pRxBuffPtr  = pData;
-    huart->RxXferSize  = Size;
-    huart->RxXferCount = Size;
-    huart->RxISR       = NULL;
+    /* Set Reception type to Standard reception */
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
-    /* Computation of UART mask to apply to RDR register */
-    UART_MASK_COMPUTATION(huart);
-
-    huart->ErrorCode = HAL_UART_ERROR_NONE;
-    huart->RxState = HAL_UART_STATE_BUSY_RX;
-
-    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
-    SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
-
-    /* Configure Rx interrupt processing*/
-    if ((huart->FifoMode == UART_FIFOMODE_ENABLE) && (Size >= huart->NbRxDataToProcess))
-    {
-      /* Set the Rx ISR function pointer according to the data word length */
-      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
-      {
-        huart->RxISR = UART_RxISR_16BIT_FIFOEN;
-      }
-      else
-      {
-        huart->RxISR = UART_RxISR_8BIT_FIFOEN;
-      }
-
-      __HAL_UNLOCK(huart);
-
-      /* Enable the UART Parity Error interrupt and RX FIFO Threshold interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-      SET_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
-    }
-    else
-    {
-      /* Set the Rx ISR function pointer according to the data word length */
-      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
-      {
-        huart->RxISR = UART_RxISR_16BIT;
-      }
-      else
-      {
-        huart->RxISR = UART_RxISR_8BIT;
-      }
-
-      __HAL_UNLOCK(huart);
-
-      /* Enable the UART Parity Error interrupt and Data Register Not Empty interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
-    }
-
-    return HAL_OK;
+    return(UART_Start_Receive_IT(huart, pData, Size));
   }
   else
   {
@@ -1415,7 +1456,8 @@ HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData,
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
   *         (as sent data will be handled by DMA from halfword frontier). Depending on compilation chain,
-  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be sent.
@@ -1504,9 +1546,10 @@ HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pDat
   *         the received data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 available through pData.
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
-  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
-  *         (as received data will be handled by DMA from halfword frontier). Depending on compilation chain,
-  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier
+  *         (16 bits) (as received data will be handled by DMA from halfword frontier). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be received.
@@ -1535,53 +1578,10 @@ HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData
 
     __HAL_LOCK(huart);
 
-    huart->pRxBuffPtr = pData;
-    huart->RxXferSize = Size;
+    /* Set Reception type to Standard reception */
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
-    huart->ErrorCode = HAL_UART_ERROR_NONE;
-    huart->RxState = HAL_UART_STATE_BUSY_RX;
-
-    if (huart->hdmarx != NULL)
-    {
-      /* Set the UART DMA transfer complete callback */
-      huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
-
-      /* Set the UART DMA Half transfer complete callback */
-      huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
-
-      /* Set the DMA error callback */
-      huart->hdmarx->XferErrorCallback = UART_DMAError;
-
-      /* Set the DMA abort callback */
-      huart->hdmarx->XferAbortCallback = NULL;
-
-      /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, (uint32_t)huart->pRxBuffPtr, Size) != HAL_OK)
-      {
-        /* Set error code to DMA */
-        huart->ErrorCode = HAL_UART_ERROR_DMA;
-
-        __HAL_UNLOCK(huart);
-
-        /* Restore huart->gState to ready */
-        huart->gState = HAL_UART_STATE_READY;
-
-        return HAL_ERROR;
-      }
-    }
-    __HAL_UNLOCK(huart);
-
-    /* Enable the UART Parity Error Interrupt */
-    SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-
-    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
-    SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
-
-    /* Enable the DMA transfer for the receiver request by setting the DMAR bit
-    in the UART CR3 register */
-    SET_BIT(huart->Instance->CR3, USART_CR3_DMAR);
-
-    return HAL_OK;
+    return(UART_Start_Receive_DMA(huart, pData, Size));
   }
   else
   {
@@ -1642,7 +1642,7 @@ HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
     /* Clear the Overrun flag before resuming the Rx transfer */
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
 
-    /* Reenable PE and ERR (Frame error, noise error, overrun error) interrupts */
+    /* Re-enable PE and ERR (Frame error, noise error, overrun error) interrupts */
     SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
     SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
@@ -1738,8 +1738,15 @@ HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
 {
   /* Disable TXE, TC, RXNE, PE, RXFT, TXFT and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE |
+                                   USART_CR1_TCIE));
   CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE);
+
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
 
   /* Disable the UART DMA Tx request if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
@@ -1810,6 +1817,7 @@ HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
   /* Restore huart->gState and huart->RxState to Ready */
   huart->gState  = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   huart->ErrorCode = HAL_UART_ERROR_NONE;
 
@@ -1892,6 +1900,12 @@ HAL_StatusTypeDef HAL_UART_AbortReceive(UART_HandleTypeDef *huart)
   CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE));
   CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE | USART_CR3_RXFTIE);
 
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
+
   /* Disable the UART DMA Rx request if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
@@ -1928,6 +1942,7 @@ HAL_StatusTypeDef HAL_UART_AbortReceive(UART_HandleTypeDef *huart)
 
   /* Restore huart->RxState to Ready */
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   return HAL_OK;
 }
@@ -1951,8 +1966,15 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
   uint32_t abortcplt = 1U;
 
   /* Disable interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_TCIE | USART_CR1_RXNEIE_RXFNEIE | USART_CR1_TXEIE_TXFNFIE));
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_TCIE | USART_CR1_RXNEIE_RXFNEIE |
+                                   USART_CR1_TXEIE_TXFNFIE));
   CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE));
+
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
 
   /* If DMA Tx and/or DMA Rx Handles are associated to UART Handle, DMA Abort complete callbacks should be initialised
      before any call to DMA Abort functions */
@@ -2062,6 +2084,7 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
     /* Restore huart->gState and huart->RxState to Ready */
     huart->gState  = HAL_UART_STATE_READY;
     huart->RxState = HAL_UART_STATE_READY;
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
     /* As no DMA to be aborted, call directly user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -2186,6 +2209,12 @@ HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
   CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE));
   CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
+
   /* Disable the UART DMA Rx request if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
@@ -2221,6 +2250,7 @@ HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
 
       /* Restore huart->RxState to Ready */
       huart->RxState = HAL_UART_STATE_READY;
+      huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
       /* As no DMA to be aborted, call directly user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -2245,6 +2275,7 @@ HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
 
     /* Restore huart->RxState to Ready */
     huart->RxState = HAL_UART_STATE_READY;
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
     /* As no DMA to be aborted, call directly user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -2274,7 +2305,7 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   uint32_t errorcode;
 
   /* If no error occurs */
-  errorflags = (isrflags & (uint32_t)(USART_ISR_PE | USART_ISR_FE | USART_ISR_ORE | USART_ISR_NE));
+  errorflags = (isrflags & (uint32_t)(USART_ISR_PE | USART_ISR_FE | USART_ISR_ORE | USART_ISR_NE | USART_ISR_RTOF));
   if (errorflags == 0U)
   {
     /* UART in mode Receiver ---------------------------------------------------*/
@@ -2293,7 +2324,7 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   /* If some errors occur */
   if ((errorflags != 0U)
       && ((((cr3its & (USART_CR3_RXFTIE | USART_CR3_EIE)) != 0U)
-           || ((cr1its & (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE)) != 0U))))
+           || ((cr1its & (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_RTOIE)) != 0U))))
   {
     /* UART parity error interrupt occurred -------------------------------------*/
     if (((isrflags & USART_ISR_PE) != 0U) && ((cr1its & USART_CR1_PEIE) != 0U))
@@ -2329,10 +2360,18 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
       huart->ErrorCode |= HAL_UART_ERROR_ORE;
     }
 
-    /* Call UART Error Call back function if need be --------------------------*/
+    /* UART Receiver Timeout interrupt occurred ---------------------------------*/
+    if (((isrflags & USART_ISR_RTOF) != 0U) && ((cr1its & USART_CR1_RTOIE) != 0U))
+    {
+      __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_RTOF);
+
+      huart->ErrorCode |= HAL_UART_ERROR_RTO;
+    }
+
+    /* Call UART Error Call back function if need be ----------------------------*/
     if (huart->ErrorCode != HAL_UART_ERROR_NONE)
     {
-      /* UART in mode Receiver ---------------------------------------------------*/
+      /* UART in mode Receiver --------------------------------------------------*/
       if (((isrflags & USART_ISR_RXNE_RXFNE) != 0U)
           && (((cr1its & USART_CR1_RXNEIE_RXFNEIE) != 0U)
               || ((cr3its & USART_CR3_RXFTIE) != 0U)))
@@ -2343,11 +2382,14 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
         }
       }
 
-      /* If Overrun error occurs, or if any error occurs in DMA mode reception,
-         consider error as blocking */
+      /* If Error is to be considered as blocking :
+          - Receiver Timeout error in Reception
+          - Overrun error in Reception
+          - any error occurs in DMA mode reception
+      */
       errorcode = huart->ErrorCode;
       if ((HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR)) ||
-          ((errorcode & HAL_UART_ERROR_ORE) != 0U))
+          ((errorcode & (HAL_UART_ERROR_RTO | HAL_UART_ERROR_ORE)) != 0U))
       {
         /* Blocking error : transfer is aborted
            Set the UART state ready to be able to start again the process,
@@ -2415,6 +2457,93 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
     return;
 
   } /* End if some error occurs */
+
+  /* Check current reception Mode :
+     If Reception till IDLE event has been selected : */
+  if (  (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      &&((isrflags & USART_ISR_IDLE) != 0U)
+      &&((cr1its & USART_ISR_IDLE) != 0U))
+  {
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+
+    /* Check if DMA mode is enabled in UART */
+    if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
+    {
+      /* DMA mode enabled */
+      /* Check received length : If all expected data are received, do nothing,
+         (DMA cplt callback will be called).
+         Otherwise, if at least one data has already been received, IDLE event is to be notified to user */
+      uint16_t nb_remaining_rx_data = (uint16_t) __HAL_DMA_GET_COUNTER(huart->hdmarx);
+      if (  (nb_remaining_rx_data > 0U)
+          &&(nb_remaining_rx_data < huart->RxXferSize))
+      {
+        /* Reception is not complete */
+        huart->RxXferCount = nb_remaining_rx_data;
+
+        /* In Normal mode, end DMA xfer and HAL UART Rx process*/
+        if (HAL_IS_BIT_CLR(huart->hdmarx->Instance->CCR, DMA_CCR_CIRC))
+        {
+          /* Disable PE and ERR (Frame error, noise error, overrun error) interrupts */
+          CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+          CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+          /* Disable the DMA transfer for the receiver request by resetting the DMAR bit
+             in the UART CR3 register */
+          CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+          /* At end of Rx process, restore huart->RxState to Ready */
+          huart->RxState = HAL_UART_STATE_READY;
+          huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+          CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+          /* Last bytes received, so no need as the abort is immediate */
+          (void)HAL_DMA_Abort(huart->hdmarx);
+        }
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx Event callback*/
+        huart->RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
+#else
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
+#endif
+      }
+      return;
+    }
+    else
+    {
+      /* DMA mode not enabled */
+      /* Check received length : If all expected data are received, do nothing.
+         Otherwise, if at least one data has already been received, IDLE event is to be notified to user */
+      uint16_t nb_rx_data = huart->RxXferSize - huart->RxXferCount;
+      if (  (huart->RxXferCount > 0U)
+          &&(nb_rx_data > 0U) )
+      {
+        /* Disable the UART Parity Error Interrupt and RXNE interrupts */
+        CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
+
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
+        CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+
+        /* Rx process is completed, restore huart->RxState to Ready */
+        huart->RxState = HAL_UART_STATE_READY;
+        huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+        /* Clear RxISR function pointer */
+        huart->RxISR = NULL;
+
+        CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx complete callback*/
+        huart->RxEventCallback(huart, nb_rx_data);
+#else
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, nb_rx_data);
+#endif
+      }
+      return;
+    }
+  }
 
   /* UART wakeup from Stop mode interrupt occurred ---------------------------*/
   if (((isrflags & USART_ISR_WUF) != 0U) && ((cr3its & USART_CR3_WUFIE) != 0U))
@@ -2601,6 +2730,24 @@ __weak void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart)
 }
 
 /**
+  * @brief  Reception Event Callback (Rx event notification called after use of advanced reception service).
+  * @param  huart UART handle
+  * @param  Size  Number of data available in application reception buffer (indicates a position in
+  *               reception buffer until which, data are available)
+  * @retval None
+  */
+__weak void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+  UNUSED(Size);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UARTEx_RxEventCallback can be implemented in the user file.
+   */
+}
+
+/**
   * @}
   */
 
@@ -2613,6 +2760,9 @@ __weak void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart)
  ===============================================================================
     [..]
     This subsection provides a set of functions allowing to control the UART.
+     (+) HAL_UART_ReceiverTimeout_Config() API allows to configure the receiver timeout value on the fly
+     (+) HAL_UART_EnableReceiverTimeout() API enables the receiver timeout feature
+     (+) HAL_UART_DisableReceiverTimeout() API disables the receiver timeout feature
      (+) HAL_MultiProcessor_EnableMuteMode() API enables mute mode
      (+) HAL_MultiProcessor_DisableMuteMode() API disables mute mode
      (+) HAL_MultiProcessor_EnterMuteMode() API enters mute mode
@@ -2625,6 +2775,99 @@ __weak void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart)
 @endverbatim
   * @{
   */
+
+/**
+  * @brief  Update on the fly the receiver timeout value in RTOR register.
+  * @param  huart Pointer to a UART_HandleTypeDef structure that contains
+  *                    the configuration information for the specified UART module.
+  * @param  TimeoutValue receiver timeout value in number of baud blocks. The timeout
+  *                     value must be less or equal to 0x0FFFFFFFF.
+  * @retval None
+  */
+void HAL_UART_ReceiverTimeout_Config(UART_HandleTypeDef *huart, uint32_t TimeoutValue)
+{
+  if (!(IS_LPUART_INSTANCE(huart->Instance)))
+  {
+    assert_param(IS_UART_RECEIVER_TIMEOUT_VALUE(TimeoutValue));
+    MODIFY_REG(huart->Instance->RTOR, USART_RTOR_RTO, TimeoutValue);
+  }
+}
+
+/**
+  * @brief  Enable the UART receiver timeout feature.
+  * @param  huart Pointer to a UART_HandleTypeDef structure that contains
+  *                    the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_EnableReceiverTimeout(UART_HandleTypeDef *huart)
+{
+  if (!(IS_LPUART_INSTANCE(huart->Instance)))
+  {
+    if (huart->gState == HAL_UART_STATE_READY)
+    {
+      /* Process Locked */
+      __HAL_LOCK(huart);
+
+      huart->gState = HAL_UART_STATE_BUSY;
+
+      /* Set the USART RTOEN bit */
+      SET_BIT(huart->Instance->CR2, USART_CR2_RTOEN);
+
+      huart->gState = HAL_UART_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(huart);
+
+      return HAL_OK;
+    }
+    else
+    {
+      return HAL_BUSY;
+    }
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Disable the UART receiver timeout feature.
+  * @param  huart Pointer to a UART_HandleTypeDef structure that contains
+  *                    the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DisableReceiverTimeout(UART_HandleTypeDef *huart)
+{
+  if (!(IS_LPUART_INSTANCE(huart->Instance)))
+  {
+    if (huart->gState == HAL_UART_STATE_READY)
+    {
+      /* Process Locked */
+      __HAL_LOCK(huart);
+
+      huart->gState = HAL_UART_STATE_BUSY;
+
+      /* Clear the USART RTOEN bit */
+      CLEAR_BIT(huart->Instance->CR2, USART_CR2_RTOEN);
+
+      huart->gState = HAL_UART_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(huart);
+
+      return HAL_OK;
+    }
+    else
+    {
+      return HAL_BUSY;
+    }
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
 
 /**
   * @brief  Enable UART in mute mode (does not mean UART enters mute mode;
@@ -2826,6 +3069,7 @@ void UART_InitCallbacksToDefault(UART_HandleTypeDef *huart)
   huart->WakeupCallback            = HAL_UARTEx_WakeupCallback;          /* Legacy weak WakeupCallback            */
   huart->RxFifoFullCallback        = HAL_UARTEx_RxFifoFullCallback;      /* Legacy weak RxFifoFullCallback        */
   huart->TxFifoEmptyCallback       = HAL_UARTEx_TxFifoEmptyCallback;     /* Legacy weak TxFifoEmptyCallback       */
+  huart->RxEventCallback           = HAL_UARTEx_RxEventCallback;         /* Legacy weak RxEventCallback           */
 
 }
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
@@ -2840,9 +3084,9 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
   uint32_t tmpreg;
   uint16_t brrtemp;
   UART_ClockSourceTypeDef clocksource;
-  uint32_t usartdiv                   = 0x00000000U;
+  uint32_t usartdiv;
   HAL_StatusTypeDef ret               = HAL_OK;
-  uint32_t lpuart_ker_ck_pres         = 0x00000000U;
+  uint32_t lpuart_ker_ck_pres;
   uint32_t pclk;
 
   /* Check the parameters */
@@ -2909,26 +3153,30 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
     switch (clocksource)
     {
       case UART_CLOCKSOURCE_PCLK1:
-        lpuart_ker_ck_pres = (HAL_RCC_GetPCLK1Freq() / UART_GET_DIV_FACTOR(huart->Init.ClockPrescaler));
+        pclk = HAL_RCC_GetPCLK1Freq();
         break;
       case UART_CLOCKSOURCE_HSI:
-        lpuart_ker_ck_pres = ((uint32_t)HSI_VALUE / UART_GET_DIV_FACTOR(huart->Init.ClockPrescaler));
+        pclk = (uint32_t) HSI_VALUE;
         break;
       case UART_CLOCKSOURCE_SYSCLK:
-        lpuart_ker_ck_pres = (HAL_RCC_GetSysClockFreq() / UART_GET_DIV_FACTOR(huart->Init.ClockPrescaler));
+        pclk = HAL_RCC_GetSysClockFreq();
         break;
       case UART_CLOCKSOURCE_LSE:
-        lpuart_ker_ck_pres = ((uint32_t)LSE_VALUE / UART_GET_DIV_FACTOR(huart->Init.ClockPrescaler));
+        pclk = (uint32_t) LSE_VALUE;
         break;
       default:
+        pclk = 0U;
         ret = HAL_ERROR;
         break;
     }
 
-    /* if proper clock source reported */
-    if (lpuart_ker_ck_pres != 0U)
+    /* If proper clock source reported */
+    if (pclk != 0U)
     {
-      /* ensure that Frequency clock is in the range [3 * baudrate, 4096 * baudrate] */
+      /* Compute clock after Prescaler */
+      lpuart_ker_ck_pres = (pclk / UARTPrescTable[huart->Init.ClockPrescaler]);
+
+      /* Ensure that Frequency clock is in the range [3 * baudrate, 4096 * baudrate] */
       if ((lpuart_ker_ck_pres < (3U * huart->Init.BaudRate)) ||
           (lpuart_ker_ck_pres > (4096U * huart->Init.BaudRate)))
       {
@@ -2936,28 +3184,9 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
       }
       else
       {
-        switch (clocksource)
-        {
-          case UART_CLOCKSOURCE_PCLK1:
-            pclk = HAL_RCC_GetPCLK1Freq();
-            usartdiv = (uint32_t)(UART_DIV_LPUART(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
-            break;
-          case UART_CLOCKSOURCE_HSI:
-            usartdiv = (uint32_t)(UART_DIV_LPUART(HSI_VALUE, huart->Init.BaudRate, huart->Init.ClockPrescaler));
-            break;
-          case UART_CLOCKSOURCE_SYSCLK:
-            pclk = HAL_RCC_GetSysClockFreq();
-            usartdiv = (uint32_t)(UART_DIV_LPUART(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
-            break;
-          case UART_CLOCKSOURCE_LSE:
-            usartdiv = (uint32_t)(UART_DIV_LPUART(LSE_VALUE, huart->Init.BaudRate, huart->Init.ClockPrescaler));
-            break;
-          default:
-            ret = HAL_ERROR;
-            break;
-        }
-
-        /* It is forbidden to write values lower than 0x300 in the LPUART_BRR register */
+        /* Check computed UsartDiv value is in allocated range
+           (it is forbidden to write values lower than 0x300 in the LPUART_BRR register) */
+        usartdiv = (uint32_t)(UART_DIV_LPUART(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
         if ((usartdiv >= LPUART_BRR_MIN) && (usartdiv <= LPUART_BRR_MAX))
         {
           huart->Instance->BRR = usartdiv;
@@ -2966,8 +3195,9 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
         {
           ret = HAL_ERROR;
         }
-      } /*   if ( (lpuart_ker_ck_pres < (3 * huart->Init.BaudRate) ) || (lpuart_ker_ck_pres > (4096 * huart->Init.BaudRate) )) */
-    } /* if (lpuart_ker_ck_pres != 0) */
+      } /* if ( (lpuart_ker_ck_pres < (3 * huart->Init.BaudRate) ) ||
+                (lpuart_ker_ck_pres > (4096 * huart->Init.BaudRate) )) */
+    } /* if (pclk != 0) */
   }
   /* Check UART Over Sampling to set Baud Rate Register */
   else if (huart->Init.OverSampling == UART_OVERSAMPLING_8)
@@ -2976,33 +3206,36 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
     {
       case UART_CLOCKSOURCE_PCLK1:
         pclk = HAL_RCC_GetPCLK1Freq();
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
         break;
       case UART_CLOCKSOURCE_HSI:
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(HSI_VALUE, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+        pclk = (uint32_t) HSI_VALUE;
         break;
       case UART_CLOCKSOURCE_SYSCLK:
         pclk = HAL_RCC_GetSysClockFreq();
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING8(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
         break;
       case UART_CLOCKSOURCE_LSE:
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING8((uint32_t)LSE_VALUE, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+        pclk = (uint32_t) LSE_VALUE;
         break;
       default:
+        pclk = 0U;
         ret = HAL_ERROR;
         break;
     }
 
     /* USARTDIV must be greater than or equal to 0d16 */
-    if ((usartdiv >= UART_BRR_MIN) && (usartdiv <= UART_BRR_MAX))
+    if (pclk != 0U)
     {
-      brrtemp = (uint16_t)(usartdiv & 0xFFF0U);
-      brrtemp |= (uint16_t)((usartdiv & (uint16_t)0x000FU) >> 1U);
-      huart->Instance->BRR = brrtemp;
-    }
-    else
-    {
-      ret = HAL_ERROR;
+      usartdiv = (uint16_t)(UART_DIV_SAMPLING8(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+      if ((usartdiv >= UART_BRR_MIN) && (usartdiv <= UART_BRR_MAX))
+      {
+        brrtemp = (uint16_t)(usartdiv & 0xFFF0U);
+        brrtemp |= (uint16_t)((usartdiv & (uint16_t)0x000FU) >> 1U);
+        huart->Instance->BRR = brrtemp;
+      }
+      else
+      {
+        ret = HAL_ERROR;
+      }
     }
   }
   else
@@ -3011,31 +3244,34 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
     {
       case UART_CLOCKSOURCE_PCLK1:
         pclk = HAL_RCC_GetPCLK1Freq();
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING16(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
         break;
       case UART_CLOCKSOURCE_HSI:
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING16(HSI_VALUE, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+        pclk = (uint32_t) HSI_VALUE;
         break;
       case UART_CLOCKSOURCE_SYSCLK:
         pclk = HAL_RCC_GetSysClockFreq();
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING16(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
         break;
       case UART_CLOCKSOURCE_LSE:
-        usartdiv = (uint16_t)(UART_DIV_SAMPLING16((uint32_t)LSE_VALUE, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+        pclk = (uint32_t) LSE_VALUE;
         break;
       default:
+        pclk = 0U;
         ret = HAL_ERROR;
         break;
     }
 
-    /* USARTDIV must be greater than or equal to 0d16 */
-    if ((usartdiv >= UART_BRR_MIN) && (usartdiv <= UART_BRR_MAX))
+    if (pclk != 0U)
     {
-      huart->Instance->BRR = usartdiv;
-    }
-    else
-    {
-      ret = HAL_ERROR;
+      /* USARTDIV must be greater than or equal to 0d16 */
+      usartdiv = (uint16_t)(UART_DIV_SAMPLING16(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+      if ((usartdiv >= UART_BRR_MIN) && (usartdiv <= UART_BRR_MAX))
+      {
+        huart->Instance->BRR = usartdiv;
+      }
+      else
+      {
+        ret = HAL_ERROR;
+      }
     }
   }
 
@@ -3136,7 +3372,7 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
   /* Initialize the UART ErrorCode */
   huart->ErrorCode = HAL_UART_ERROR_NONE;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Check if the Transmitter is enabled */
@@ -3164,6 +3400,7 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
   /* Initialize the UART State */
   huart->gState = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   __HAL_UNLOCK(huart);
 
@@ -3190,7 +3427,8 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error)
+           interrupts for the interrupt process */
         CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE));
         CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
@@ -3201,8 +3439,159 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
 
         return HAL_TIMEOUT;
       }
+
+      if (READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U)
+      {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RTOF) == SET)
+        {
+          /* Clear Receiver Timeout flag*/
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_RTOF);
+
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error)
+             interrupts for the interrupt process */
+          CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE));
+          CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+          huart->gState = HAL_UART_STATE_READY;
+          huart->RxState = HAL_UART_STATE_READY;
+          huart->ErrorCode = HAL_UART_ERROR_RTO;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+
+          return HAL_TIMEOUT;
+        }
+      }
     }
   }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start Receive operation in interrupt mode.
+  * @note   This function could be called by all HAL UART API providing reception in Interrupt mode.
+  * @note   When calling this function, parameters validity is considered as already checked,
+  *         i.e. Rx State, buffer address, ...
+  *         UART Handle is assumed as Locked.
+  * @param  huart UART handle.
+  * @param  pData Pointer to data buffer (u8 or u16 data elements).
+  * @param  Size  Amount of data elements (u8 or u16) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_Start_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  huart->pRxBuffPtr  = pData;
+  huart->RxXferSize  = Size;
+  huart->RxXferCount = Size;
+  huart->RxISR       = NULL;
+
+  /* Computation of UART mask to apply to RDR register */
+  UART_MASK_COMPUTATION(huart);
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->RxState = HAL_UART_STATE_BUSY_RX;
+
+  /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+  SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+  /* Configure Rx interrupt processing */
+  if ((huart->FifoMode == UART_FIFOMODE_ENABLE) && (Size >= huart->NbRxDataToProcess))
+  {
+    /* Set the Rx ISR function pointer according to the data word length */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      huart->RxISR = UART_RxISR_16BIT_FIFOEN;
+    }
+    else
+    {
+      huart->RxISR = UART_RxISR_8BIT_FIFOEN;
+    }
+
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Parity Error interrupt and RX FIFO Threshold interrupt */
+    SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+    SET_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
+  }
+  else
+  {
+    /* Set the Rx ISR function pointer according to the data word length */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      huart->RxISR = UART_RxISR_16BIT;
+    }
+    else
+    {
+      huart->RxISR = UART_RxISR_8BIT;
+    }
+
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Parity Error interrupt and Data Register Not Empty interrupt */
+    SET_BIT(huart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start Receive operation in DMA mode.
+  * @note   This function could be called by all HAL UART API providing reception in DMA mode.
+  * @note   When calling this function, parameters validity is considered as already checked,
+  *         i.e. Rx State, buffer address, ...
+  *         UART Handle is assumed as Locked.
+  * @param  huart UART handle.
+  * @param  pData Pointer to data buffer (u8 or u16 data elements).
+  * @param  Size  Amount of data elements (u8 or u16) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_Start_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  huart->pRxBuffPtr = pData;
+  huart->RxXferSize = Size;
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->RxState = HAL_UART_STATE_BUSY_RX;
+
+  if (huart->hdmarx != NULL)
+  {
+    /* Set the UART DMA transfer complete callback */
+    huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
+
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
+
+    /* Set the DMA error callback */
+    huart->hdmarx->XferErrorCallback = UART_DMAError;
+
+    /* Set the DMA abort callback */
+    huart->hdmarx->XferAbortCallback = NULL;
+
+    /* Enable the DMA channel */
+    if (HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, (uint32_t)huart->pRxBuffPtr, Size) != HAL_OK)
+    {
+      /* Set error code to DMA */
+      huart->ErrorCode = HAL_UART_ERROR_DMA;
+
+      __HAL_UNLOCK(huart);
+
+      /* Restore huart->gState to ready */
+      huart->gState = HAL_UART_STATE_READY;
+
+      return HAL_ERROR;
+    }
+  }
+  __HAL_UNLOCK(huart);
+
+  /* Enable the UART Parity Error Interrupt */
+  SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+
+  /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+  SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+  /* Enable the DMA transfer for the receiver request by setting the DMAR bit
+  in the UART CR3 register */
+  SET_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
   return HAL_OK;
 }
 
@@ -3234,8 +3623,15 @@ static void UART_EndRxTransfer(UART_HandleTypeDef *huart)
   CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
   CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
+  /* In case of reception waiting for IDLE event, disable also the IDLE IE interrupt source */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+  }
+
   /* At end of Rx process, restore huart->RxState to Ready */
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Reset RxIsr function pointer */
   huart->RxISR = NULL;
@@ -3318,15 +3714,37 @@ static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 
     /* At end of Rx process, restore huart->RxState to Ready */
     huart->RxState = HAL_UART_STATE_READY;
+
+    /* If Reception till IDLE event has been selected, Disable IDLE Interrupt */
+    if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+    {
+      CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+    }
   }
 
+  /* Check current reception Mode :
+     If Reception till IDLE event has been selected : use Rx Event callback */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-  /*Call registered Rx complete callback*/
-  huart->RxCpltCallback(huart);
+    /*Call registered Rx Event callback*/
+    huart->RxEventCallback(huart, huart->RxXferSize);
 #else
-  /*Call legacy weak Rx complete callback*/
-  HAL_UART_RxCpltCallback(huart);
+    /*Call legacy weak Rx Event callback*/
+    HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
+  else
+  {
+    /* In other cases : use Rx Complete callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+    /*Call registered Rx complete callback*/
+    huart->RxCpltCallback(huart);
+#else
+    /*Call legacy weak Rx complete callback*/
+    HAL_UART_RxCpltCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
 }
 
 /**
@@ -3338,13 +3756,29 @@ static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
 {
   UART_HandleTypeDef *huart = (UART_HandleTypeDef *)(hdma->Parent);
 
+  /* Check current reception Mode :
+     If Reception till IDLE event has been selected : use Rx Event callback */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-  /*Call registered Rx Half complete callback*/
-  huart->RxHalfCpltCallback(huart);
+    /*Call registered Rx Event callback*/
+    huart->RxEventCallback(huart, huart->RxXferSize/2U);
 #else
-  /*Call legacy weak Rx Half complete callback*/
-  HAL_UART_RxHalfCpltCallback(huart);
+    /*Call legacy weak Rx Event callback*/
+    HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize/2U);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
+  else
+  {
+    /* In other cases : use Rx Half Complete callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+    /*Call registered Rx Half complete callback*/
+    huart->RxHalfCpltCallback(huart);
+#else
+    /*Call legacy weak Rx Half complete callback*/
+    HAL_UART_RxHalfCpltCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
 }
 
 /**
@@ -3449,6 +3883,7 @@ static void UART_DMATxAbortCallback(DMA_HandleTypeDef *hdma)
   /* Restore huart->gState and huart->RxState to Ready */
   huart->gState  = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Call user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -3500,6 +3935,7 @@ static void UART_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
   /* Restore huart->gState and huart->RxState to Ready */
   huart->gState  = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Call user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -3567,6 +4003,7 @@ static void UART_DMARxOnlyAbortCallback(DMA_HandleTypeDef *hdma)
 
   /* Restore huart->RxState to Ready */
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Call user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -3579,7 +4016,7 @@ static void UART_DMARxOnlyAbortCallback(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief TX interrrupt handler for 7 or 8 bits data word length .
+  * @brief TX interrupt handler for 7 or 8 bits data word length .
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3608,7 +4045,7 @@ static void UART_TxISR_8BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief TX interrrupt handler for 9 bits data word length.
+  * @brief TX interrupt handler for 9 bits data word length.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3640,7 +4077,7 @@ static void UART_TxISR_16BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief TX interrrupt handler for 7 or 8 bits data word length and FIFO mode is enabled.
+  * @brief TX interrupt handler for 7 or 8 bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3680,7 +4117,7 @@ static void UART_TxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief TX interrrupt handler for 9 bits data word length and FIFO mode is enabled.
+  * @brief TX interrupt handler for 9 bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3748,7 +4185,7 @@ static void UART_EndTransmit_IT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 7 or 8 bits data word length .
+  * @brief RX interrupt handler for 7 or 8 bits data word length .
   * @param huart UART handle.
   * @retval None
   */
@@ -3779,13 +4216,33 @@ static void UART_RxISR_8BIT(UART_HandleTypeDef *huart)
       /* Clear RxISR function pointer */
       huart->RxISR = NULL;
 
+      /* Check current reception Mode :
+         If Reception till IDLE event has been selected : */
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        /* Disable IDLE interrupt */
+        CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-      /*Call registered Rx complete callback*/
-      huart->RxCpltCallback(huart);
+        /*Call registered Rx Event callback*/
+        huart->RxEventCallback(huart, huart->RxXferSize);
 #else
-      /*Call legacy weak Rx complete callback*/
-      HAL_UART_RxCpltCallback(huart);
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif
+      }
+      else
+      {
+        /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx complete callback*/
+        huart->RxCpltCallback(huart);
+#else
+        /*Call legacy weak Rx complete callback*/
+        HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+      }
+      huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
     }
   }
   else
@@ -3796,7 +4253,7 @@ static void UART_RxISR_8BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 9 bits data word length .
+  * @brief RX interrupt handler for 9 bits data word length .
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Receive_IT()
   * @param huart UART handle.
@@ -3831,13 +4288,33 @@ static void UART_RxISR_16BIT(UART_HandleTypeDef *huart)
       /* Clear RxISR function pointer */
       huart->RxISR = NULL;
 
+      /* Check current reception Mode :
+         If Reception till IDLE event has been selected : */
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        /* Disable IDLE interrupt */
+        CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-      /*Call registered Rx complete callback*/
-      huart->RxCpltCallback(huart);
+        /*Call registered Rx Event callback*/
+        huart->RxEventCallback(huart, huart->RxXferSize);
 #else
-      /*Call legacy weak Rx complete callback*/
-      HAL_UART_RxCpltCallback(huart);
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif
+      }
+      else
+      {
+        /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx complete callback*/
+        huart->RxCpltCallback(huart);
+#else
+        /*Call legacy weak Rx complete callback*/
+        HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+      }
+      huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
     }
   }
   else
@@ -3848,7 +4325,7 @@ static void UART_RxISR_16BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 7 or 8  bits data word length and FIFO mode is enabled.
+  * @brief RX interrupt handler for 7 or 8  bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Receive_IT()
   * @param huart UART handle.
@@ -3858,25 +4335,74 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
 {
   uint16_t  uhMask = huart->Mask;
   uint16_t  uhdata;
-  uint16_t   nb_rx_data;
+  uint16_t  nb_rx_data;
   uint16_t  rxdatacount;
+  uint32_t  isrflags = READ_REG(huart->Instance->ISR);
+  uint32_t  cr1its   = READ_REG(huart->Instance->CR1);
+  uint32_t  cr3its   = READ_REG(huart->Instance->CR3);
 
   /* Check that a Rx process is ongoing */
   if (huart->RxState == HAL_UART_STATE_BUSY_RX)
   {
-    for (nb_rx_data = huart->NbRxDataToProcess ; nb_rx_data > 0U ; nb_rx_data--)
+    nb_rx_data = huart->NbRxDataToProcess;
+    while ((nb_rx_data > 0U) && ((isrflags & USART_ISR_RXNE_RXFNE) != 0U))
     {
       uhdata = (uint16_t) READ_REG(huart->Instance->RDR);
       *huart->pRxBuffPtr = (uint8_t)(uhdata & (uint8_t)uhMask);
       huart->pRxBuffPtr++;
       huart->RxXferCount--;
+      isrflags = READ_REG(huart->Instance->ISR);
+
+      /* If some non blocking errors occurred */
+      if ((isrflags & (USART_ISR_PE | USART_ISR_FE | USART_ISR_NE)) != 0U)
+      {
+        /* UART parity error interrupt occurred -------------------------------------*/
+        if (((isrflags & USART_ISR_PE) != 0U) && ((cr1its & USART_CR1_PEIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_PE;
+        }
+
+        /* UART frame error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_FE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_FE;
+        }
+
+        /* UART noise error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_NE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_NE;
+        }
+
+        /* Call UART Error Call back function if need be ----------------------------*/
+        if (huart->ErrorCode != HAL_UART_ERROR_NONE)
+        {
+          /* Non Blocking error : transfer could go on.
+          Error is notified to user through user error callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered error callback*/
+          huart->ErrorCallback(huart);
+#else
+          /*Call legacy weak error callback*/
+          HAL_UART_ErrorCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+          huart->ErrorCode = HAL_UART_ERROR_NONE;
+        }
+      }
 
       if (huart->RxXferCount == 0U)
       {
         /* Disable the UART Parity Error Interrupt and RXFT interrupt*/
         CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
 
-        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error)
+           and RX FIFO Threshold interrupt */
         CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
         /* Rx process is completed, restore huart->RxState to Ready */
@@ -3885,13 +4411,33 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
         /* Clear RxISR function pointer */
         huart->RxISR = NULL;
 
+        /* Check current reception Mode :
+           If Reception till IDLE event has been selected : */
+        if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+        {
+          /* Disable IDLE interrupt */
+          CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-        /*Call registered Rx complete callback*/
-        huart->RxCpltCallback(huart);
+          /*Call registered Rx Event callback*/
+          huart->RxEventCallback(huart, huart->RxXferSize);
 #else
-        /*Call legacy weak Rx complete callback*/
-        HAL_UART_RxCpltCallback(huart);
+          /*Call legacy weak Rx Event callback*/
+          HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif
+        }
+        else
+        {
+          /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered Rx complete callback*/
+          huart->RxCpltCallback(huart);
+#else
+          /*Call legacy weak Rx complete callback*/
+          HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+        }
+        huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
       }
     }
 
@@ -3920,7 +4466,7 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 9 bits data word length and FIFO mode is enabled.
+  * @brief RX interrupt handler for 9 bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Receive_IT()
   * @param huart UART handle.
@@ -3931,26 +4477,75 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
   uint16_t *tmp;
   uint16_t  uhMask = huart->Mask;
   uint16_t  uhdata;
-  uint16_t   nb_rx_data;
+  uint16_t  nb_rx_data;
   uint16_t  rxdatacount;
+  uint32_t  isrflags = READ_REG(huart->Instance->ISR);
+  uint32_t  cr1its   = READ_REG(huart->Instance->CR1);
+  uint32_t  cr3its   = READ_REG(huart->Instance->CR3);
 
   /* Check that a Rx process is ongoing */
   if (huart->RxState == HAL_UART_STATE_BUSY_RX)
   {
-    for (nb_rx_data = huart->NbRxDataToProcess ; nb_rx_data > 0U ; nb_rx_data--)
+    nb_rx_data = huart->NbRxDataToProcess;
+    while ((nb_rx_data > 0U) && ((isrflags & USART_ISR_RXNE_RXFNE) != 0U))
     {
       uhdata = (uint16_t) READ_REG(huart->Instance->RDR);
       tmp = (uint16_t *) huart->pRxBuffPtr ;
       *tmp = (uint16_t)(uhdata & uhMask);
       huart->pRxBuffPtr += 2U;
       huart->RxXferCount--;
+      isrflags = READ_REG(huart->Instance->ISR);
+
+      /* If some non blocking errors occurred */
+      if ((isrflags & (USART_ISR_PE | USART_ISR_FE | USART_ISR_NE)) != 0U)
+      {
+        /* UART parity error interrupt occurred -------------------------------------*/
+        if (((isrflags & USART_ISR_PE) != 0U) && ((cr1its & USART_CR1_PEIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_PE;
+        }
+
+        /* UART frame error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_FE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_FE;
+        }
+
+        /* UART noise error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_NE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_NE;
+        }
+
+        /* Call UART Error Call back function if need be ----------------------------*/
+        if (huart->ErrorCode != HAL_UART_ERROR_NONE)
+        {
+          /* Non Blocking error : transfer could go on.
+          Error is notified to user through user error callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered error callback*/
+          huart->ErrorCallback(huart);
+#else
+          /*Call legacy weak error callback*/
+          HAL_UART_ErrorCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+          huart->ErrorCode = HAL_UART_ERROR_NONE;
+        }
+      }
 
       if (huart->RxXferCount == 0U)
       {
         /* Disable the UART Parity Error Interrupt and RXFT interrupt*/
         CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
 
-        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error)
+           and RX FIFO Threshold interrupt */
         CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
         /* Rx process is completed, restore huart->RxState to Ready */
@@ -3959,13 +4554,33 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
         /* Clear RxISR function pointer */
         huart->RxISR = NULL;
 
+        /* Check current reception Mode :
+           If Reception till IDLE event has been selected : */
+        if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+        {
+          /* Disable IDLE interrupt */
+          CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-        /*Call registered Rx complete callback*/
-        huart->RxCpltCallback(huart);
+          /*Call registered Rx Event callback*/
+          huart->RxEventCallback(huart, huart->RxXferSize);
 #else
-        /*Call legacy weak Rx complete callback*/
-        HAL_UART_RxCpltCallback(huart);
+          /*Call legacy weak Rx Event callback*/
+          HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif
+        }
+        else
+        {
+          /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered Rx complete callback*/
+          huart->RxCpltCallback(huart);
+#else
+          /*Call legacy weak Rx complete callback*/
+          HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+        }
+        huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
       }
     }
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_uart_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_uart_ex.c
@@ -332,12 +332,44 @@ __weak void HAL_UARTEx_TxFifoEmptyCallback(UART_HandleTypeDef *huart)
      (+) HAL_UARTEx_SetTxFifoThreshold() API sets the TX FIFO threshold
      (+) HAL_UARTEx_SetRxFifoThreshold() API sets the RX FIFO threshold
 
+    [..] This subsection also provides a set of additional functions providing enhanced reception
+    services to user. (For example, these functions allow application to handle use cases
+    where number of data to be received is unknown).
+
+    (#) Compared to standard reception services which only consider number of received
+        data elements as reception completion criteria, these functions also consider additional events
+        as triggers for updating reception status to caller :
+       (+) Detection of inactivity period (RX line has not been active for a given period).
+          (++) RX inactivity detected by IDLE event, i.e. RX line has been in idle state (normally high state)
+               for 1 frame time, after last received byte.
+          (++) RX inactivity detected by RTO, i.e. line has been in idle state
+               for a programmable time, after last received byte.
+       (+) Detection that a specific character has been received.
+
+    (#) There are two mode of transfer:
+       (+) Blocking mode: The reception is performed in polling mode, until either expected number of data is received,
+           or till IDLE event occurs. Reception is handled only during function execution.
+           When function exits, no data reception could occur. HAL status and number of actually received data elements,
+           are returned by function after finishing transfer.
+       (+) Non-Blocking mode: The reception is performed using Interrupts or DMA.
+           These API's return the HAL status.
+           The end of the data processing will be indicated through the
+           dedicated UART IRQ when using Interrupt mode or the DMA IRQ when using DMA mode.
+           The HAL_UARTEx_RxEventCallback() user callback will be executed during Receive process
+           The HAL_UART_ErrorCallback()user callback will be executed when a reception error is detected.
+
+    (#) Blocking mode API:
+        (+) HAL_UARTEx_ReceiveToIdle()
+
+    (#) Non-Blocking mode API with Interrupt:
+        (+) HAL_UARTEx_ReceiveToIdle_IT()
+
+    (#) Non-Blocking mode API with DMA:
+        (+) HAL_UARTEx_ReceiveToIdle_DMA()
+
 @endverbatim
   * @{
   */
-
-
-
 
 /**
   * @brief By default in multiprocessor mode, when the wake up method is set
@@ -419,7 +451,7 @@ HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huar
   /* Enable the Peripheral */
   __HAL_UART_ENABLE(huart);
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Wait until REACK flag is set */
@@ -656,6 +688,299 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
 }
 
 /**
+  * @brief Receive an amount of data in blocking mode till either the expected number of data is received or an IDLE event occurs.
+  * @note   HAL_OK is returned if reception is completed (expected number of data has been received)
+  *         or if reception is stopped after IDLE event (less than the expected number of data has been received)
+  *         In this case, RxLen output parameter indicates number of data available in reception buffer.
+  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         the received data is handled as a set of uint16_t. In this case, Size must indicate the number
+  *         of uint16_t available through pData.
+  * @note When FIFO mode is enabled, the RXFNE flag is set as long as the RXFIFO
+  *       is not empty. Read operations from the RDR register are performed when
+  *       RXFNE flag is set. From hardware perspective, RXFNE flag and
+  *       RXNE are mapped on the same bit-field.
+  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
+  *         (as received data will be handled using uint16_t pointer cast). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  * @param huart   UART handle.
+  * @param pData   Pointer to data buffer (uint8_t or uint16_t data elements).
+  * @param Size    Amount of data elements (uint8_t or uint16_t) to be received.
+  * @param RxLen   Number of data elements finally received (could be lower than Size, in case reception ends on IDLE event)
+  * @param Timeout Timeout duration expressed in ms (covers the whole reception sequence).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint16_t *RxLen, uint32_t Timeout)
+{
+  uint8_t  *pdata8bits;
+  uint16_t *pdata16bits;
+  uint16_t uhMask;
+  uint32_t tickstart;
+
+  /* Check that a Rx process is not already ongoing */
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    if ((pData == NULL) || (Size == 0U))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
+       should be aligned on a uint16_t frontier, as data to be received from RDR will be
+       handled through a uint16_t cast. */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      if ((((uint32_t)pData) & 1U) != 0U)
+      {
+        return  HAL_ERROR;
+      }
+    }
+
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    huart->RxState = HAL_UART_STATE_BUSY_RX;
+    huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
+
+    /* Init tickstart for timeout management */
+    tickstart = HAL_GetTick();
+
+    huart->RxXferSize  = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    UART_MASK_COMPUTATION(huart);
+    uhMask = huart->Mask;
+
+    /* In case of 9bits/No Parity transfer, pRxData needs to be handled as a uint16_t pointer */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      pdata8bits  = NULL;
+      pdata16bits = (uint16_t *) pData;
+    }
+    else
+    {
+      pdata8bits  = pData;
+      pdata16bits = NULL;
+    }
+
+    __HAL_UNLOCK(huart);
+
+    /* Initialize output number of received elements */
+    *RxLen = 0U;
+
+    /* as long as data have to be received */
+    while (huart->RxXferCount > 0U)
+    {
+      /* Check if IDLE flag is set */
+      if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE))
+      {
+        /* Clear IDLE flag in ISR */
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+
+        /* If Set, but no data ever received, clear flag without exiting loop */
+        /* If Set, and data has already been received, this means Idle Event is valid : End reception */
+        if (*RxLen > 0U)
+        {
+          huart->RxState = HAL_UART_STATE_READY;
+
+          return HAL_OK;
+        }
+      }
+
+      /* Check if RXNE flag is set */
+      if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE))
+      {
+        if (pdata8bits == NULL)
+        {
+          *pdata16bits = (uint16_t)(huart->Instance->RDR & uhMask);
+          pdata16bits++;
+        }
+        else
+        {
+          *pdata8bits = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask);
+          pdata8bits++;
+        }
+        /* Increment number of received elements */
+        *RxLen += 1U;
+        huart->RxXferCount--;
+      }
+
+      /* Check for the Timeout */
+      if (Timeout != HAL_MAX_DELAY)
+      {
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
+        {
+          huart->RxState = HAL_UART_STATE_READY;
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Set number of received elements in output parameter : RxLen */
+    *RxLen = huart->RxXferSize - huart->RxXferCount;
+    /* At end of Rx process, restore huart->RxState to Ready */
+    huart->RxState = HAL_UART_STATE_READY;
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode till either the expected number of data is received or an IDLE event occurs.
+  * @note   Reception is initiated by this function call. Further progress of reception is achieved thanks
+  *         to UART interrupts raised by RXNE and IDLE events. Callback is called at end of reception indicating
+  *         number of received data elements.
+  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         the received data is handled as a set of uint16_t. In this case, Size must indicate the number
+  *         of uint16_t available through pData.
+  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
+  *         (as received data will be handled using uint16_t pointer cast). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  * @param huart UART handle.
+  * @param pData Pointer to data buffer (uint8_t or uint16_t data elements).
+  * @param Size  Amount of data elements (uint8_t or uint16_t) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef status;
+
+  /* Check that a Rx process is not already ongoing */
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    if ((pData == NULL) || (Size == 0U))
+    {
+      return HAL_ERROR;
+    }
+
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
+       should be aligned on a uint16_t frontier, as data to be received from RDR will be
+       handled through a uint16_t cast. */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      if ((((uint32_t)pData) & 1U) != 0U)
+      {
+        return  HAL_ERROR;
+      }
+    }
+
+    __HAL_LOCK(huart);
+
+    /* Set Reception type to reception till IDLE Event*/
+    huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
+
+    status =  UART_Start_Receive_IT(huart, pData, Size);
+
+    /* Check Rx process has been successfully started */
+    if (status == HAL_OK)
+    {
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+        SET_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+      }
+      else
+      {
+        /* In case of errors already pending when reception is started,
+           Interrupts may have already been raised and lead to reception abortion.
+           (Overrun error for instance).
+           In such case Reception Type has been reset to HAL_UART_RECEPTION_STANDARD. */
+        status = HAL_ERROR;
+      }
+    }
+
+    return status;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode till either the expected number of data is received or an IDLE event occurs.
+  * @note   Reception is initiated by this function call. Further progress of reception is achieved thanks
+  *         to DMA services, transferring automatically received data elements in user reception buffer and
+  *         calling registered callbacks at half/end of reception. UART IDLE events are also used to consider
+  *         reception phase as ended. In all cases, callback execution will indicate number of received data elements.
+  * @note   When the UART parity is enabled (PCE = 1), the received data contain
+  *         the parity bit (MSB position).
+  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         the received data is handled as a set of uint16_t. In this case, Size must indicate the number
+  *         of uint16_t available through pData.
+  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
+  *         (as received data will be handled by DMA from halfword frontier). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pData.
+  * @param huart UART handle.
+  * @param pData Pointer to data buffer (uint8_t or uint16_t data elements).
+  * @param Size  Amount of data elements (uint8_t or uint16_t) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef status;
+
+  /* Check that a Rx process is not already ongoing */
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    if ((pData == NULL) || (Size == 0U))
+    {
+      return HAL_ERROR;
+    }
+
+    /* In case of 9bits/No Parity transfer, pData buffer provided as input parameter
+       should be aligned on a uint16_t frontier, as data copy from RDR will be
+       handled by DMA from a uint16_t frontier. */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      if ((((uint32_t)pData) & 1U) != 0U)
+      {
+        return  HAL_ERROR;
+      }
+    }
+
+    __HAL_LOCK(huart);
+
+    /* Set Reception type to reception till IDLE Event*/
+    huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
+
+    status =  UART_Start_Receive_DMA(huart, pData, Size);
+
+    /* Check Rx process has been successfully started */
+    if (status == HAL_OK)
+    {
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+        SET_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+      }
+      else
+      {
+        /* In case of errors already pending when reception is started,
+           Interrupts may have already been raised and lead to reception abortion.
+           (Overrun error for instance).
+           In such case Reception Type has been reset to HAL_UART_RECEPTION_STANDARD. */
+        status = HAL_ERROR;
+      }
+    }
+
+    return status;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
   * @}
   */
 
@@ -711,8 +1036,10 @@ static void UARTEx_SetNbDataToProcess(UART_HandleTypeDef *huart)
     tx_fifo_depth = TX_FIFO_DEPTH;
     rx_fifo_threshold = (uint8_t)(READ_BIT(huart->Instance->CR3, USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos);
     tx_fifo_threshold = (uint8_t)(READ_BIT(huart->Instance->CR3, USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos);
-    huart->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) / (uint16_t)denominator[tx_fifo_threshold];
-    huart->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) / (uint16_t)denominator[rx_fifo_threshold];
+    huart->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) /
+                               (uint16_t)denominator[tx_fifo_threshold];
+    huart->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) /
+                               (uint16_t)denominator[rx_fifo_threshold];
   }
 }
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_usart.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_usart.c
@@ -531,9 +531,9 @@ HAL_StatusTypeDef HAL_USART_RegisterCallback(USART_HandleTypeDef *husart, HAL_US
 }
 
 /**
-  * @brief  Unregister an UART Callback
-  *         UART callaback is redirected to the weak predefined callback
-  * @param  husart uart handle
+  * @brief  Unregister an USART Callback
+  *         USART callback is redirected to the weak predefined callback
+  * @param  husart usart handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
   *           @arg @ref HAL_USART_TX_HALFCOMPLETE_CB_ID Tx Half Complete Callback ID
@@ -734,10 +734,10 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
 
 /**
   * @brief  Simplex send an amount of data in blocking mode.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 provided through pTxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
   *         (as sent data will be handled using u16 pointer cast). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pTxData.
@@ -777,7 +777,7 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     husart->TxXferSize = Size;
@@ -846,10 +846,10 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
 /**
   * @brief Receive an amount of data in blocking mode.
   * @note   To receive synchronous data, dummy data are simultaneously transmitted.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the received data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 available through pRxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
   *         (as received data will be handled using u16 pointer cast). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pRxData.
@@ -890,7 +890,7 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     husart->RxXferSize = Size;
@@ -972,10 +972,10 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
 
 /**
   * @brief Full-Duplex Send and Receive an amount of data in blocking mode.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data and the received data are handled as sets of u16. In this case, Size must indicate the number
   *         of u16 available through pTxData and through pRxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffers containing data to be sent/received, should be aligned on a half word frontier (16 bits)
   *         (as sent/received data will be handled using u16 pointer cast). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pTxData and pRxData.
@@ -1021,7 +1021,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     husart->RxXferSize = Size;
@@ -1136,10 +1136,10 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
 
 /**
   * @brief  Send an amount of data in interrupt mode.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 provided through pTxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
   *         (as sent data will be handled using u16 pointer cast). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pTxData.
@@ -1234,10 +1234,10 @@ HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pT
 /**
   * @brief Receive an amount of data in interrupt mode.
   * @note   To receive synchronous data, dummy data are simultaneously transmitted.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the received data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 available through pRxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
   *         (as received data will be handled using u16 pointer cast). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pRxData.
@@ -1352,10 +1352,10 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
 
 /**
   * @brief Full-Duplex Send and Receive an amount of data in interrupt mode.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data and the received data are handled as sets of u16. In this case, Size must indicate the number
   *         of u16 available through pTxData and through pRxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffers containing data to be sent/received, should be aligned on a half word frontier (16 bits)
   *         (as sent/received data will be handled using u16 pointer cast). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pTxData and pRxData.
@@ -1466,10 +1466,10 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
 
 /**
   * @brief Send an amount of data in DMA mode.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 provided through pTxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
   *         (as sent data will be handled by DMA from halfword frontier). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pTxData.
@@ -1566,10 +1566,10 @@ HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *p
   * @note   When the USART parity is enabled (PCE = 1), the received data contain
   *         the parity bit (MSB position).
   * @note   The USART DMA transmit channel must be configured in order to generate the clock for the slave.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the received data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 available through pRxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffer for storing data to be received, should be aligned on a half word frontier (16 bits)
   *         (as received data will be handled by DMA from halfword frontier). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pRxData.
@@ -1697,10 +1697,10 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
 /**
   * @brief Full-Duplex Transmit Receive an amount of data in non-blocking mode.
   * @note   When the USART parity is enabled (PCE = 1) the data received contain the parity bit.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data and the received data are handled as sets of u16. In this case, Size must indicate the number
   *         of u16 available through pTxData and through pRxData.
-  * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  * @note   When USART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         address of user data buffers containing data to be sent/received, should be aligned on a half word frontier (16 bits)
   *         (as sent/received data will be handled by DMA from halfword frontier). Depending on compilation chain,
   *         use of specific alignment compilation directives or pragmas might be required to ensure proper alignment for pTxData and pRxData.
@@ -1903,7 +1903,7 @@ HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart)
     /* Clear the Overrun flag before resuming the Rx transfer*/
     __HAL_USART_CLEAR_FLAG(husart, USART_CLEAR_OREF);
 
-    /* Reenable PE and ERR (Frame error, noise error, overrun error) interrupts */
+    /* Re-enable PE and ERR (Frame error, noise error, overrun error) interrupts */
     SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
     SET_BIT(husart->Instance->CR3, USART_CR3_EIE);
 
@@ -3074,7 +3074,7 @@ static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart)
   /* Initialize the USART ErrorCode */
   husart->ErrorCode = HAL_USART_ERROR_NONE;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Check if the Transmitter is enabled */

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_usart_ex.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_usart_ex.c
@@ -243,7 +243,7 @@ HAL_StatusTypeDef HAL_USARTEx_DisableSlaveMode(USART_HandleTypeDef *husart)
   /* Restore USART configuration */
   WRITE_REG(husart->Instance->CR1, tmpcr1);
 
-  husart->SlaveMode = USART_SLAVEMODE_ENABLE;
+  husart->SlaveMode = USART_SLAVEMODE_DISABLE;
 
   husart->State = HAL_USART_STATE_READY;
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_wwdg.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_hal_wwdg.c
@@ -21,6 +21,13 @@
         before the counter has reached the refresh window value. This
         implies that the counter must be refreshed in a limited window.
     (+) Once enabled the WWDG cannot be disabled except by a system reset.
+    (+) If required by application, an Early Wakeup Interrupt can be triggered
+        in order to be warned before WWDG expiration. The Early Wakeup Interrupt
+        (EWI) can be used if specific safety operations or data logging must
+        be performed before the actual reset is generated. When the downcounter
+        reaches 0x40, interrupt occurs. This mechanism requires WWDG interrupt
+        line to be enabled in NVIC. Once enabled, EWI interrupt cannot be
+        disabled except by a system reset.
     (+) WWDGRST flag in RCC CSR register can be used to inform when a WWDG
         reset occurs.
     (+) The WWDG counter input clock is derived from the APB clock divided
@@ -32,12 +39,12 @@
         (++) min time (mS) = 1000 * (Counter - Window) / WWDG clock
         (++) max time (mS) = 1000 * (Counter - 0x40) / WWDG clock
     (+) Typical values:
-        (++) Counter min (T[5;0] = 0x00) @56 MHz(PCLK1) with zero prescaler:
-             max timeout before reset: approximately 73.14 microseconds
-        (++) Counter max (T[5;0] = 0x3F) @56 MHz(PCLK1) with prescaler dividing by 128:
-             max timeout before reset: approximately 599.18 milliseconds
+        (++) Counter min (T[5;0] = 0x00) at 64 MHz (PCLK1) with zero prescaler:
+             max timeout before reset: approximately 64µs
+        (++) Counter max (T[5;0] = 0x3F) at 64 MHz (PCLK1) with prescaler
+             dividing by 128:
+             max timeout before reset: approximately 524.28ms
 
-  ==============================================================================
                      ##### How to use this driver #####
   ==============================================================================
 
@@ -46,16 +53,16 @@
 
   [..]
     (+) Enable WWDG APB1 clock using __HAL_RCC_WWDG_CLK_ENABLE().
-    (+) Set the WWDG prescaler, refresh window and counter value
-        using HAL_WWDG_Init() function.
-    (+) Start the WWDG using HAL_WWDG_Start() function.
-        When the WWDG is enabled the counter value should be configured to
-        a value greater than 0x40 to prevent generating an immediate reset.
-    (+) Optionally you can enable the Early Wakeup Interrupt (EWI) which is
-        generated when the counter reaches 0x40, and then start the WWDG using
-        HAL_WWDG_Start_IT(). At EWI HAL_WWDG_WakeupCallback is executed and user can
-        add his own code by customization of callback HAL_WWDG_WakeupCallback.
-        Once enabled, EWI interrupt cannot be disabled except by a system reset.
+    (+) Configure the WWDG prescaler, refresh window value, counter value and early
+        interrupt status using HAL_WWDG_Init() function. This will automatically
+        enable WWDG and start its downcounter. Time reference can be taken from
+        function exit. Care must be taken to provide a counter value
+        greater than 0x40 to prevent generation of immediate reset.
+    (+) If the Early Wakeup Interrupt (EWI) feature is enabled, an interrupt is
+        generated when the counter reaches 0x40. When HAL_WWDG_IRQHandler is
+        triggered by the interrupt service routine, flag will be automatically
+        cleared and HAL_WWDG_WakeupCallback user callback will be executed. User
+        can add his own code by customization of callback HAL_WWDG_WakeupCallback.
     (+) Then the application program must refresh the WWDG counter at regular
         intervals during normal operation to prevent an MCU reset, using
         HAL_WWDG_Refresh() function. This operation must occur only when
@@ -65,28 +72,28 @@
     =============================
 
   [..]
-    The compilation define  USE_HAL_WWDG_REGISTER_CALLBACKS when set to 1 allows
+    The compilation define USE_HAL_WWDG_REGISTER_CALLBACKS when set to 1 allows
     the user to configure dynamically the driver callbacks. Use Functions
-    @ref HAL_WWDG_RegisterCallback() to register a user callback.
+    HAL_WWDG_RegisterCallback() to register a user callback.
 
-    (+) Function @ref HAL_WWDG_RegisterCallback() allows to register following
+    (+) Function HAL_WWDG_RegisterCallback() allows to register following
         callbacks:
         (++) EwiCallback : callback for Early WakeUp Interrupt.
         (++) MspInitCallback : WWDG MspInit.
     This function takes as parameters the HAL peripheral handle, the Callback ID
     and a pointer to the user callback function.
 
-    (+) Use function @ref HAL_WWDG_UnRegisterCallback() to reset a callback to
-    the default weak (surcharged) function. @ref HAL_WWDG_UnRegisterCallback()
+    (+) Use function HAL_WWDG_UnRegisterCallback() to reset a callback to
+    the default weak (surcharged) function. HAL_WWDG_UnRegisterCallback()
     takes as parameters the HAL peripheral handle and the Callback ID.
     This function allows to reset following callbacks:
         (++) EwiCallback : callback for  Early WakeUp Interrupt.
         (++) MspInitCallback : WWDG MspInit.
 
     [..]
-    When calling @ref HAL_WWDG_Init function, callbacks are reset to the
+    When calling HAL_WWDG_Init function, callbacks are reset to the
     corresponding legacy weak (surcharged) functions:
-    @ref HAL_WWDG_EarlyWakeupCallback() and HAL_WWDG_MspInit() only if they have
+    HAL_WWDG_EarlyWakeupCallback() and HAL_WWDG_MspInit() only if they have
     not been registered before.
 
     [..]
@@ -97,7 +104,7 @@
     *** WWDG HAL driver macros list ***
     ===================================
     [..]
-      Below the list of most used macros in WWDG HAL driver.
+      Below the list of available macros in WWDG HAL driver.
       (+) __HAL_WWDG_ENABLE: Enable the WWDG peripheral
       (+) __HAL_WWDG_GET_FLAG: Get the selected WWDG's flag status
       (+) __HAL_WWDG_CLEAR_FLAG: Clear the WWDG's pending flags
@@ -143,8 +150,8 @@
   */
 
 /** @defgroup WWDG_Exported_Functions_Group1 Initialization and Configuration functions
- *  @brief    Initialization and Configuration functions.
- *
+  *  @brief    Initialization and Configuration functions.
+  *
 @verbatim
   ==============================================================================
           ##### Initialization and Configuration functions #####
@@ -183,12 +190,12 @@ HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
 
 #if (USE_HAL_WWDG_REGISTER_CALLBACKS == 1)
   /* Reset Callback pointers */
-  if(hwwdg->EwiCallback == NULL)
+  if (hwwdg->EwiCallback == NULL)
   {
     hwwdg->EwiCallback = HAL_WWDG_EarlyWakeupCallback;
   }
 
-  if(hwwdg->MspInitCallback == NULL)
+  if (hwwdg->MspInitCallback == NULL)
   {
     hwwdg->MspInitCallback = HAL_WWDG_MspInit;
   }
@@ -198,7 +205,7 @@ HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
 #else
   /* Init the low level hardware */
   HAL_WWDG_MspInit(hwwdg);
-#endif
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
 
   /* Set WWDG Counter */
   WRITE_REG(hwwdg->Instance->CR, (WWDG_CR_WDGA | hwwdg->Init.Counter));
@@ -243,17 +250,18 @@ __weak void HAL_WWDG_MspInit(WWDG_HandleTypeDef *hwwdg)
   * @param  pCallback pointer to the Callback function
   * @retval status
   */
-HAL_StatusTypeDef HAL_WWDG_RegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWDG_CallbackIDTypeDef CallbackID, pWWDG_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_WWDG_RegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWDG_CallbackIDTypeDef CallbackID,
+                                            pWWDG_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if(pCallback == NULL)
+  if (pCallback == NULL)
   {
     status = HAL_ERROR;
   }
   else
   {
-    switch(CallbackID)
+    switch (CallbackID)
     {
       case HAL_WWDG_EWI_CB_ID:
         hwwdg->EwiCallback = pCallback;
@@ -287,7 +295,7 @@ HAL_StatusTypeDef HAL_WWDG_UnRegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWD
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  switch(CallbackID)
+  switch (CallbackID)
   {
     case HAL_WWDG_EWI_CB_ID:
       hwwdg->EwiCallback = HAL_WWDG_EarlyWakeupCallback;
@@ -304,15 +312,15 @@ HAL_StatusTypeDef HAL_WWDG_UnRegisterCallback(WWDG_HandleTypeDef *hwwdg, HAL_WWD
 
   return status;
 }
-#endif
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
 
 /**
   * @}
   */
 
 /** @defgroup WWDG_Exported_Functions_Group2 IO operation functions
- *  @brief    IO operation functions
- *
+  *  @brief    IO operation functions
+  *
 @verbatim
   ==============================================================================
                       ##### IO operation functions #####
@@ -372,7 +380,7 @@ void HAL_WWDG_IRQHandler(WWDG_HandleTypeDef *hwwdg)
 #else
       /* Early Wakeup callback */
       HAL_WWDG_EarlyWakeupCallback(hwwdg);
-#endif
+#endif /* USE_HAL_WWDG_REGISTER_CALLBACKS */
     }
   }
 }

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_adc.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_adc.c
@@ -23,9 +23,9 @@
 #include "stm32g0xx_ll_bus.h"
 
 #ifdef  USE_FULL_ASSERT
-  #include "stm32_assert.h"
+#include "stm32_assert.h"
 #else
-  #define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)0U)
 #endif
 
 /** @addtogroup STM32G0xx_LL_Driver
@@ -85,7 +85,7 @@
 /* Check of parameters for configuration of ADC hierarchical scope:           */
 /* common to several ADC instances.                                           */
 #define IS_LL_ADC_COMMON_CLOCK(__CLOCK__)                                      \
-  (   ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV1)                                 \
+  (((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV1)                                    \
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV2)                                 \
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV4)                                 \
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV6)                                 \
@@ -100,33 +100,33 @@
   )
 
 #define IS_LL_ADC_CLOCK_FREQ_MODE(__CLOCK_FREQ_MODE__)                         \
-  (   ((__CLOCK_FREQ_MODE__) == LL_ADC_CLOCK_FREQ_MODE_HIGH)                   \
+  (((__CLOCK_FREQ_MODE__) == LL_ADC_CLOCK_FREQ_MODE_HIGH)                      \
    || ((__CLOCK_FREQ_MODE__) == LL_ADC_CLOCK_FREQ_MODE_LOW)                    \
   )
 
 /* Check of parameters for configuration of ADC hierarchical scope:           */
 /* ADC instance.                                                              */
 #define IS_LL_ADC_CLOCK(__CLOCK__)                                             \
-  (   ((__CLOCK__) == LL_ADC_CLOCK_SYNC_PCLK_DIV4)                             \
+  (((__CLOCK__) == LL_ADC_CLOCK_SYNC_PCLK_DIV4)                                \
    || ((__CLOCK__) == LL_ADC_CLOCK_SYNC_PCLK_DIV2)                             \
    || ((__CLOCK__) == LL_ADC_CLOCK_SYNC_PCLK_DIV1)                             \
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC)                                      \
   )
 
 #define IS_LL_ADC_RESOLUTION(__RESOLUTION__)                                   \
-  (   ((__RESOLUTION__) == LL_ADC_RESOLUTION_12B)                              \
+  (((__RESOLUTION__) == LL_ADC_RESOLUTION_12B)                                 \
    || ((__RESOLUTION__) == LL_ADC_RESOLUTION_10B)                              \
    || ((__RESOLUTION__) == LL_ADC_RESOLUTION_8B)                               \
    || ((__RESOLUTION__) == LL_ADC_RESOLUTION_6B)                               \
   )
 
 #define IS_LL_ADC_DATA_ALIGN(__DATA_ALIGN__)                                   \
-  (   ((__DATA_ALIGN__) == LL_ADC_DATA_ALIGN_RIGHT)                            \
+  (((__DATA_ALIGN__) == LL_ADC_DATA_ALIGN_RIGHT)                               \
    || ((__DATA_ALIGN__) == LL_ADC_DATA_ALIGN_LEFT)                             \
   )
 
 #define IS_LL_ADC_LOW_POWER(__LOW_POWER__)                                     \
-  (   ((__LOW_POWER__) == LL_ADC_LP_MODE_NONE)                                 \
+  (((__LOW_POWER__) == LL_ADC_LP_MODE_NONE)                                    \
    || ((__LOW_POWER__) == LL_ADC_LP_AUTOWAIT)                                  \
    || ((__LOW_POWER__) == LL_ADC_LP_AUTOPOWEROFF)                              \
    || ((__LOW_POWER__) == LL_ADC_LP_AUTOWAIT_AUTOPOWEROFF)                     \
@@ -136,7 +136,7 @@
 /* ADC group regular                                                          */
 #if defined(TIM15) && defined(TIM6) && defined(TIM2)
 #define IS_LL_ADC_REG_TRIG_SOURCE(__REG_TRIG_SOURCE__)                         \
-  (   ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                      \
+  (((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                         \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_TRGO2)                \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_CH4 )                 \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM2_TRGO)                 \
@@ -147,7 +147,7 @@
   )
 #elif defined(TIM15) && defined(TIM6)
 #define IS_LL_ADC_REG_TRIG_SOURCE(__REG_TRIG_SOURCE__)                         \
-  (   ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                      \
+  (((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                         \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_TRGO2)                \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_CH4 )                 \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM3_TRGO)                 \
@@ -157,7 +157,7 @@
   )
 #elif defined(TIM2)
 #define IS_LL_ADC_REG_TRIG_SOURCE(__REG_TRIG_SOURCE__)                         \
-  (   ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                      \
+  (((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                         \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_TRGO2)                \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_CH4 )                 \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM2_TRGO)                 \
@@ -166,7 +166,7 @@
   )
 #else
 #define IS_LL_ADC_REG_TRIG_SOURCE(__REG_TRIG_SOURCE__)                         \
-  (   ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                      \
+  (((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                         \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_TRGO2)                \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_CH4 )                 \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM3_TRGO)                 \
@@ -175,28 +175,28 @@
 #endif
 
 #define IS_LL_ADC_REG_CONTINUOUS_MODE(__REG_CONTINUOUS_MODE__)                 \
-  (   ((__REG_CONTINUOUS_MODE__) == LL_ADC_REG_CONV_SINGLE)                    \
+  (((__REG_CONTINUOUS_MODE__) == LL_ADC_REG_CONV_SINGLE)                       \
    || ((__REG_CONTINUOUS_MODE__) == LL_ADC_REG_CONV_CONTINUOUS)                \
   )
 
 #define IS_LL_ADC_REG_DMA_TRANSFER(__REG_DMA_TRANSFER__)                       \
-  (   ((__REG_DMA_TRANSFER__) == LL_ADC_REG_DMA_TRANSFER_NONE)                 \
+  (((__REG_DMA_TRANSFER__) == LL_ADC_REG_DMA_TRANSFER_NONE)                    \
    || ((__REG_DMA_TRANSFER__) == LL_ADC_REG_DMA_TRANSFER_LIMITED)              \
    || ((__REG_DMA_TRANSFER__) == LL_ADC_REG_DMA_TRANSFER_UNLIMITED)            \
   )
 
 #define IS_LL_ADC_REG_OVR_DATA_BEHAVIOR(__REG_OVR_DATA_BEHAVIOR__)             \
-  (   ((__REG_OVR_DATA_BEHAVIOR__) == LL_ADC_REG_OVR_DATA_PRESERVED)           \
+  (((__REG_OVR_DATA_BEHAVIOR__) == LL_ADC_REG_OVR_DATA_PRESERVED)              \
    || ((__REG_OVR_DATA_BEHAVIOR__) == LL_ADC_REG_OVR_DATA_OVERWRITTEN)         \
   )
 
 #define IS_LL_ADC_REG_SEQ_MODE(__REG_SEQ_MODE__)                               \
-  (   ((__REG_SEQ_MODE__) == LL_ADC_REG_SEQ_FIXED)                             \
+  (((__REG_SEQ_MODE__) == LL_ADC_REG_SEQ_FIXED)                                \
    || ((__REG_SEQ_MODE__) == LL_ADC_REG_SEQ_CONFIGURABLE)                      \
   )
 
 #define IS_LL_ADC_REG_SEQ_SCAN_LENGTH(__REG_SEQ_SCAN_LENGTH__)                 \
-  (   ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_DISABLE)               \
+  (((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_DISABLE)                  \
    || ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_ENABLE_2RANKS)         \
    || ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_ENABLE_3RANKS)         \
    || ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_ENABLE_4RANKS)         \
@@ -207,7 +207,7 @@
   )
 
 #define IS_LL_ADC_REG_SEQ_SCAN_DISCONT_MODE(__REG_SEQ_DISCONT_MODE__)          \
-  (   ((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_DISABLE)           \
+  (((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_DISABLE)              \
    || ((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_1RANK)             \
   )
 
@@ -277,10 +277,10 @@ ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, LL_ADC_CommonIni
 
   /* Note: Hardware constraint (refer to description of functions             */
   /*       "LL_ADC_SetCommonXXX()":                                           */
-  /*       On this STM32 serie, setting of these features is conditioned to   */
+  /*       On this STM32 series, setting of these features is conditioned to  */
   /*       ADC state:                                                         */
   /*       All ADC instances of the ADC common group must be disabled.        */
-  if(__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(ADCxy_COMMON) == 0UL)
+  if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(ADCxy_COMMON) == 0UL)
   {
     /* Configuration of ADC hierarchical scope:                               */
     /*  - common to several ADC                                               */
@@ -338,7 +338,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
   assert_param(IS_ADC_ALL_INSTANCE(ADCx));
 
   /* Disable ADC instance if not already disabled.                            */
-  if(LL_ADC_IsEnabled(ADCx) == 1UL)
+  if (LL_ADC_IsEnabled(ADCx) == 1UL)
   {
     /* Set ADC group regular trigger source to SW start to ensure to not      */
     /* have an external trigger event occurring during the conversion stop    */
@@ -346,9 +346,9 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     LL_ADC_REG_SetTriggerSource(ADCx, LL_ADC_REG_TRIG_SOFTWARE);
 
     /* Stop potential ADC conversion on going on ADC group regular.           */
-    if(LL_ADC_REG_IsConversionOngoing(ADCx) != 0UL)
+    if (LL_ADC_REG_IsConversionOngoing(ADCx) != 0UL)
     {
-      if(LL_ADC_REG_IsStopConversionOngoing(ADCx) == 0UL)
+      if (LL_ADC_REG_IsStopConversionOngoing(ADCx) == 0UL)
       {
         LL_ADC_REG_StopConversion(ADCx);
       }
@@ -359,7 +359,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     while (LL_ADC_REG_IsStopConversionOngoing(ADCx) == 1UL)
     {
       timeout_cpu_cycles--;
-      if(timeout_cpu_cycles == 0UL)
+      if (timeout_cpu_cycles == 0UL)
       {
         /* Time-out error */
         status = ERROR;
@@ -375,7 +375,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     while (LL_ADC_IsDisableOngoing(ADCx) == 1UL)
     {
       timeout_cpu_cycles--;
-      if(timeout_cpu_cycles == 0UL)
+      if (timeout_cpu_cycles == 0UL)
       {
         /* Time-out error */
         status = ERROR;
@@ -385,16 +385,16 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
   }
 
   /* Check whether ADC state is compliant with expected state */
-  if(READ_BIT(ADCx->CR,
-              (  ADC_CR_ADSTP | ADC_CR_ADSTART
-               | ADC_CR_ADDIS | ADC_CR_ADEN   )
-             )
-     == 0UL)
+  if (READ_BIT(ADCx->CR,
+               (ADC_CR_ADSTP | ADC_CR_ADSTART
+                | ADC_CR_ADDIS | ADC_CR_ADEN)
+              )
+      == 0UL)
   {
     /* ========== Reset ADC registers ========== */
     /* Reset register IER */
     CLEAR_BIT(ADCx->IER,
-              (  LL_ADC_IT_ADRDY
+              (LL_ADC_IT_ADRDY
                | LL_ADC_IT_EOC
                | LL_ADC_IT_EOS
                | LL_ADC_IT_OVR
@@ -409,7 +409,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
 
     /* Reset register ISR */
     SET_BIT(ADCx->ISR,
-            (  LL_ADC_FLAG_ADRDY
+            (LL_ADC_FLAG_ADRDY
              | LL_ADC_FLAG_EOC
              | LL_ADC_FLAG_EOS
              | LL_ADC_FLAG_OVR
@@ -429,19 +429,19 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
 
     /* Reset register CFGR1 */
     CLEAR_BIT(ADCx->CFGR1,
-              (  ADC_CFGR1_AWD1CH  | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL | ADC_CFGR1_DISCEN
+              (ADC_CFGR1_AWD1CH  | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL | ADC_CFGR1_DISCEN
                | ADC_CFGR1_AUTOFF  | ADC_CFGR1_WAIT   | ADC_CFGR1_CONT    | ADC_CFGR1_OVRMOD
                | ADC_CFGR1_EXTEN   | ADC_CFGR1_EXTSEL | ADC_CFGR1_ALIGN   | ADC_CFGR1_RES
-               | ADC_CFGR1_SCANDIR | ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN                     )
+               | ADC_CFGR1_SCANDIR | ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN)
              );
 
     /* Reset register CFGR2 */
     /* Note: Update of ADC clock mode is conditioned to ADC state disabled:   */
     /*       already done above.                                              */
     CLEAR_BIT(ADCx->CFGR2,
-              (  ADC_CFGR2_CKMODE
+              (ADC_CFGR2_CKMODE
                | ADC_CFGR2_TOVS   | ADC_CFGR2_OVSS  | ADC_CFGR2_OVSR
-               | ADC_CFGR2_OVSE                                     )
+               | ADC_CFGR2_OVSE)
              );
 
     /* Reset register SMPR */
@@ -458,11 +458,11 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
 
     /* Reset register CHSELR */
     CLEAR_BIT(ADCx->CHSELR,
-              (  ADC_CHSELR_CHSEL18 | ADC_CHSELR_CHSEL17 | ADC_CHSELR_CHSEL16
+              (ADC_CHSELR_CHSEL18 | ADC_CHSELR_CHSEL17 | ADC_CHSELR_CHSEL16
                | ADC_CHSELR_CHSEL15 | ADC_CHSELR_CHSEL14 | ADC_CHSELR_CHSEL13 | ADC_CHSELR_CHSEL12
                | ADC_CHSELR_CHSEL11 | ADC_CHSELR_CHSEL10 | ADC_CHSELR_CHSEL9  | ADC_CHSELR_CHSEL8
                | ADC_CHSELR_CHSEL7  | ADC_CHSELR_CHSEL6  | ADC_CHSELR_CHSEL5  | ADC_CHSELR_CHSEL4
-               | ADC_CHSELR_CHSEL3  | ADC_CHSELR_CHSEL2  | ADC_CHSELR_CHSEL1  | ADC_CHSELR_CHSEL0 )
+               | ADC_CHSELR_CHSEL3  | ADC_CHSELR_CHSEL2  | ADC_CHSELR_CHSEL1  | ADC_CHSELR_CHSEL0)
              );
 
     /* Wait for ADC channel configuration ready */
@@ -470,7 +470,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     while (LL_ADC_IsActiveFlag_CCRDY(ADCx) == 0UL)
     {
       timeout_cpu_cycles--;
-      if(timeout_cpu_cycles == 0UL)
+      if (timeout_cpu_cycles == 0UL)
       {
         /* Time-out error */
         status = ERROR;
@@ -493,7 +493,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     /* ADC instance is in an unknown state */
     /* Need to performing a hard reset of ADC instance, using high level      */
     /* clock source RCC ADC reset.                                            */
-    /* Caution: On this STM32 serie, if several ADC instances are available   */
+    /* Caution: On this STM32 series, if several ADC instances are available  */
     /*          on the selected device, RCC ADC reset will reset              */
     /*          all ADC instances belonging to the common ADC instance.       */
     status = ERROR;
@@ -552,7 +552,7 @@ ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct)
 
   /* Note: Hardware constraint (refer to description of this function):       */
   /*       ADC instance must be disabled.                                     */
-  if(LL_ADC_IsEnabled(ADCx) == 0UL)
+  if (LL_ADC_IsEnabled(ADCx) == 0UL)
   {
     /* Configuration of ADC hierarchical scope:                               */
     /*  - ADC instance                                                        */
@@ -560,19 +560,19 @@ ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct)
     /*    - Set ADC conversion data alignment                                 */
     /*    - Set ADC low power mode                                            */
     MODIFY_REG(ADCx->CFGR1,
-                 ADC_CFGR1_RES
+               ADC_CFGR1_RES
                | ADC_CFGR1_ALIGN
                | ADC_CFGR1_WAIT
                | ADC_CFGR1_AUTOFF
-              ,
-                 ADC_InitStruct->Resolution
+               ,
+               ADC_InitStruct->Resolution
                | ADC_InitStruct->DataAlignment
                | ADC_InitStruct->LowPowerMode
               );
 
     MODIFY_REG(ADCx->CFGR2,
                ADC_CFGR2_CKMODE
-              ,
+               ,
                ADC_InitStruct->Clock
               );
   }
@@ -620,6 +620,9 @@ void LL_ADC_StructInit(LL_ADC_InitTypeDef *ADC_InitStruct)
   *         and potentially with ADC in a different state than disabled,
   *         refer to description of each function for setting
   *         conditioned to ADC state.
+  * @note   Before using this function, ADC group regular sequencer
+  *         must be configured: refer to function
+  *         @ref LL_ADC_REG_SetSequencerConfigurable().
   * @note   After using this function, other features must be configured
   *         using LL unitary functions.
   *         The minimum configuration remaining to be done is:
@@ -646,18 +649,30 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(ADCx));
   assert_param(IS_LL_ADC_REG_TRIG_SOURCE(ADC_REG_InitStruct->TriggerSource));
-  assert_param(IS_LL_ADC_REG_SEQ_SCAN_LENGTH(ADC_REG_InitStruct->SequencerLength));
-  if(ADC_REG_InitStruct->SequencerLength != LL_ADC_REG_SEQ_SCAN_DISABLE)
-  {
-    assert_param(IS_LL_ADC_REG_SEQ_SCAN_DISCONT_MODE(ADC_REG_InitStruct->SequencerDiscont));
-  }
   assert_param(IS_LL_ADC_REG_CONTINUOUS_MODE(ADC_REG_InitStruct->ContinuousMode));
   assert_param(IS_LL_ADC_REG_DMA_TRANSFER(ADC_REG_InitStruct->DMATransfer));
   assert_param(IS_LL_ADC_REG_OVR_DATA_BEHAVIOR(ADC_REG_InitStruct->Overrun));
 
+  if (LL_ADC_REG_GetSequencerConfigurable(ADCx) != LL_ADC_REG_SEQ_FIXED)
+  {
+    assert_param(IS_LL_ADC_REG_SEQ_SCAN_LENGTH(ADC_REG_InitStruct->SequencerLength));
+  }
+
+  if ((LL_ADC_REG_GetSequencerConfigurable(ADCx) == LL_ADC_REG_SEQ_FIXED)
+      || (ADC_REG_InitStruct->SequencerLength != LL_ADC_REG_SEQ_SCAN_DISABLE)
+     )
+  {
+    assert_param(IS_LL_ADC_REG_SEQ_SCAN_DISCONT_MODE(ADC_REG_InitStruct->SequencerDiscont));
+
+    /* ADC group regular continuous mode and discontinuous mode                 */
+    /* can not be enabled simultenaeously                                       */
+    assert_param((ADC_REG_InitStruct->ContinuousMode == LL_ADC_REG_CONV_SINGLE)
+                 || (ADC_REG_InitStruct->SequencerDiscont == LL_ADC_REG_SEQ_DISCONT_DISABLE));
+  }
+
   /* Note: Hardware constraint (refer to description of this function):       */
   /*       ADC instance must be disabled.                                     */
-  if(LL_ADC_IsEnabled(ADCx) == 0UL)
+  if (LL_ADC_IsEnabled(ADCx) == 0UL)
   {
     /* Configuration of ADC hierarchical scope:                               */
     /*  - ADC group regular                                                   */
@@ -668,22 +683,25 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
     /*    - Set ADC group regular conversion data transfer: no transfer or    */
     /*      transfer by DMA, and DMA requests mode                            */
     /*    - Set ADC group regular overrun behavior                            */
-    /* Note: On this STM32 serie, ADC trigger edge is set to value 0x0 by     */
+    /* Note: On this STM32 series, ADC trigger edge is set to value 0x0 by    */
     /*       setting of trigger source to SW start.                           */
-    if(   (LL_ADC_REG_GetSequencerConfigurable(ADCx) == LL_ADC_REG_SEQ_FIXED)
-       || (ADC_REG_InitStruct->SequencerLength != LL_ADC_REG_SEQ_SCAN_DISABLE)
-      )
+    if ((LL_ADC_REG_GetSequencerConfigurable(ADCx) == LL_ADC_REG_SEQ_FIXED)
+        || (ADC_REG_InitStruct->SequencerLength != LL_ADC_REG_SEQ_SCAN_DISABLE)
+       )
     {
+      /* Case of sequencer mode fixed
+         or sequencer length >= 2 ranks with sequencer mode fully configurable:
+         discontinuous mode configured */
       MODIFY_REG(ADCx->CFGR1,
-                   ADC_CFGR1_EXTSEL
+                 ADC_CFGR1_EXTSEL
                  | ADC_CFGR1_EXTEN
                  | ADC_CFGR1_DISCEN
                  | ADC_CFGR1_CONT
                  | ADC_CFGR1_DMAEN
                  | ADC_CFGR1_DMACFG
                  | ADC_CFGR1_OVRMOD
-                ,
-                   ADC_REG_InitStruct->TriggerSource
+                 ,
+                 ADC_REG_InitStruct->TriggerSource
                  | ADC_REG_InitStruct->SequencerDiscont
                  | ADC_REG_InitStruct->ContinuousMode
                  | ADC_REG_InitStruct->DMATransfer
@@ -692,16 +710,19 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
     }
     else
     {
+      /* Case of sequencer mode fully configurable
+         and sequencer length 1 rank (sequencer disabled):
+         discontinuous mode discarded (fixed to disable) */
       MODIFY_REG(ADCx->CFGR1,
-                   ADC_CFGR1_EXTSEL
+                 ADC_CFGR1_EXTSEL
                  | ADC_CFGR1_EXTEN
                  | ADC_CFGR1_DISCEN
                  | ADC_CFGR1_CONT
                  | ADC_CFGR1_DMAEN
                  | ADC_CFGR1_DMACFG
                  | ADC_CFGR1_OVRMOD
-                ,
-                   ADC_REG_InitStruct->TriggerSource
+                 ,
+                 ADC_REG_InitStruct->TriggerSource
                  | LL_ADC_REG_SEQ_DISCONT_DISABLE
                  | ADC_REG_InitStruct->ContinuousMode
                  | ADC_REG_InitStruct->DMATransfer
@@ -709,8 +730,11 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
                 );
     }
 
-    /* Set ADC group regular sequencer length and scan direction */
-    LL_ADC_REG_SetSequencerLength(ADCx, ADC_REG_InitStruct->SequencerLength);
+    /* Set ADC group regular sequencer length */
+    if (LL_ADC_REG_GetSequencerConfigurable(ADCx) != LL_ADC_REG_SEQ_FIXED)
+    {
+      LL_ADC_REG_SetSequencerLength(ADCx, ADC_REG_InitStruct->SequencerLength);
+    }
   }
   else
   {
@@ -730,7 +754,7 @@ void LL_ADC_REG_StructInit(LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct)
 {
   /* Set ADC_REG_InitStruct fields to default values */
   /* Set fields of ADC group regular */
-  /* Note: On this STM32 serie, ADC trigger edge is set to value 0x0 by       */
+  /* Note: On this STM32 series, ADC trigger edge is set to value 0x0 by      */
   /*       setting of trigger source to SW start.                             */
   ADC_REG_InitStruct->TriggerSource    = LL_ADC_REG_TRIG_SOFTWARE;
   ADC_REG_InitStruct->SequencerLength  = LL_ADC_REG_SEQ_SCAN_DISABLE;

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_comp.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_comp.c
@@ -54,7 +54,7 @@
    || ((__POWER_MODE__) == LL_COMP_POWERMODE_MEDIUMSPEED)                      \
   )
 
-/* Note: On this STM32 serie, comparator input plus parameters are            */
+/* Note: On this STM32 series, comparator input plus parameters are           */
 /*       the same on all COMP instances.                                      */
 /*       However, comparator instance kept as macro parameter for             */
 /*       compatibility with other STM32 families.                             */
@@ -64,7 +64,7 @@
    || ((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO3)                             \
   )
 
-/* Note: On this STM32 serie, comparator input minus parameters are           */
+/* Note: On this STM32 series, comparator input minus parameters are          */
 /*       the same on all COMP instances.                                      */
 /*       However, comparator instance kept as macro parameter for             */
 /*       compatibility with other STM32 families.                             */

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_crs.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_crs.c
@@ -1,0 +1,86 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_ll_crs.h
+  * @author  MCD Application Team
+  * @brief   CRS LL module driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+#if defined(USE_FULL_LL_DRIVER)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_ll_crs.h"
+#include "stm32g0xx_ll_bus.h"
+
+/** @addtogroup STM32G0xx_LL_Driver
+  * @{
+  */
+
+#if defined(CRS)
+
+/** @defgroup CRS_LL CRS
+  * @{
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup CRS_LL_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup CRS_LL_EF_Init
+  * @{
+  */
+
+/**
+  * @brief  De-Initializes CRS peripheral registers to their default reset values.
+  * @retval An ErrorStatus enumeration value:
+  *          - SUCCESS: CRS registers are de-initialized
+  *          - ERROR: not applicable
+  */
+ErrorStatus LL_CRS_DeInit(void)
+{
+  LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_CRS);
+  LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_CRS);
+
+  return  SUCCESS;
+}
+
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* defined(CRS) */
+
+/**
+  * @}
+  */
+
+#endif /* USE_FULL_LL_DRIVER */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_dma.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_dma.c
@@ -31,7 +31,7 @@
   * @{
   */
 
-#if defined (DMA1)
+#if defined (DMA1) || defined (DMA2)
 
 /** @defgroup DMA_LL DMA
   * @{
@@ -67,20 +67,30 @@
 
 #define IS_LL_DMA_NBDATA(__VALUE__)             ((__VALUE__)  <= 0x0000FFFFU)
 
-#if defined(STM32G081xx)||defined(STM32G071xx)
-#define IS_LL_DMA_PERIPHREQUEST(__VALUE__)      ((__VALUE__) <= LL_DMAMUX_REQ_UCPD2_TX)
-#elif defined(STM32G070xx)
-#define IS_LL_DMA_PERIPHREQUEST(__VALUE__)      ((__VALUE__) <= LL_DMAMUX_REQ_USART4_TX)
-#elif defined(STM32G041xx)||defined(STM32G031xx)||defined(STM32G030xx)
-#define IS_LL_DMA_PERIPHREQUEST(__VALUE__)      ((__VALUE__) <= LL_DMAMUX_REQ_USART2_TX)
-#endif
+#define IS_LL_DMA_PERIPHREQUEST(__VALUE__)      ((__VALUE__) <= LL_DMAMUX_MAX_REQ)
 
 #define IS_LL_DMA_PRIORITY(__VALUE__)           (((__VALUE__) == LL_DMA_PRIORITY_LOW)    || \
                                                  ((__VALUE__) == LL_DMA_PRIORITY_MEDIUM) || \
                                                  ((__VALUE__) == LL_DMA_PRIORITY_HIGH)   || \
                                                  ((__VALUE__) == LL_DMA_PRIORITY_VERYHIGH))
 
-#if defined(STM32G081xx) ||  defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(DMA2)
+#define IS_LL_DMA_ALL_CHANNEL_INSTANCE(INSTANCE, CHANNEL)  ((((INSTANCE) == DMA1) && \
+                                                            (((CHANNEL) == LL_DMA_CHANNEL_1) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_5) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_6) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_7))) || \
+                                                            (((INSTANCE) == DMA2) && \
+                                                            (((CHANNEL) == LL_DMA_CHANNEL_1) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                             ((CHANNEL) == LL_DMA_CHANNEL_5))))
+#else /* DMA1 */
+#if   defined(DMA1_Channel7)
 #define IS_LL_DMA_ALL_CHANNEL_INSTANCE(INSTANCE, CHANNEL)  ((((INSTANCE) == DMA1) && \
                                                             (((CHANNEL) == LL_DMA_CHANNEL_1) || \
                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
@@ -89,7 +99,7 @@
                                                              ((CHANNEL) == LL_DMA_CHANNEL_5) || \
                                                              ((CHANNEL) == LL_DMA_CHANNEL_6) || \
                                                              ((CHANNEL) == LL_DMA_CHANNEL_7))))
-#elif defined(STM32G041xx) ||  defined(STM32G031xx) || defined(STM32G030xx)
+#else
 #define IS_LL_DMA_ALL_CHANNEL_INSTANCE(INSTANCE, CHANNEL)  ((((INSTANCE) == DMA1) && \
                                                             (((CHANNEL) == LL_DMA_CHANNEL_1) || \
                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
@@ -97,6 +107,7 @@
                                                              ((CHANNEL) == LL_DMA_CHANNEL_4) || \
                                                              ((CHANNEL) == LL_DMA_CHANNEL_5))))
 #endif
+#endif /* DMA2 */
 /**
   * @}
   */
@@ -209,20 +220,20 @@ ErrorStatus LL_DMA_DeInit(DMA_TypeDef *DMAx, uint32_t Channel)
       /* Reset interrupt pending bits for DMAx Channel5 */
       LL_DMA_ClearFlag_GI5(DMAx);
     }
-#if defined(LL_DMA_CHANNEL_6)
+#if defined(DMA1_Channel6)
     else if (Channel == LL_DMA_CHANNEL_6)
     {
       /* Reset interrupt pending bits for DMAx Channel6 */
       LL_DMA_ClearFlag_GI6(DMAx);
     }
-#endif /* LL_DMA_CHANNEL_6 */
-#if defined(LL_DMA_CHANNEL_7)
+#endif
+#if defined(DMA1_Channel7)
     else if (Channel == LL_DMA_CHANNEL_7)
     {
       /* Reset interrupt pending bits for DMAx Channel7 */
       LL_DMA_ClearFlag_GI7(DMAx);
     }
-#endif /* LL_DMA_CHANNEL_7 */
+#endif
     else
     {
       status = ERROR;
@@ -347,7 +358,7 @@ void LL_DMA_StructInit(LL_DMA_InitTypeDef *DMA_InitStruct)
   * @}
   */
 
-#endif /* DMA1 */
+#endif /* DMA1 || DMA2 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_exti.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_exti.c
@@ -45,7 +45,7 @@
   */
 
 #define IS_LL_EXTI_LINE_0_31(__VALUE__)              (((__VALUE__) & ~LL_EXTI_LINE_ALL_0_31) == 0x00000000U)
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
 #define IS_LL_EXTI_LINE_32_63(__VALUE__)             (((__VALUE__) & ~LL_EXTI_LINE_ALL_32_63) == 0x00000000U)
 #endif
 #define IS_LL_EXTI_MODE(__VALUE__)                   (((__VALUE__) == LL_EXTI_MODE_IT)            \
@@ -91,14 +91,44 @@ uint32_t LL_EXTI_DeInit(void)
   /* Software interrupt event register set to default reset values */
   LL_EXTI_WriteReg(SWIER1, 0x00000000U);
   /* Pending register set to default reset values */
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx)
+  LL_EXTI_WriteReg(RPR1,    0x0017FFFFU);
+  LL_EXTI_WriteReg(FPR1,    0x0017FFFFU);
+#elif defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G061xx) || defined(STM32G051xx)
   LL_EXTI_WriteReg(RPR1,    0x0007FFFFU);
   LL_EXTI_WriteReg(FPR1,    0x0007FFFFU);
+#elif defined(STM32G041xx) || defined(STM32G031xx)
+  LL_EXTI_WriteReg(RPR1,    0x0001FFFFU);
+  LL_EXTI_WriteReg(FPR1,    0x0001FFFFU);
+#elif defined(STM32G0B0xx) || defined(STM32G070xx) || defined(STM32G050xx) || defined(STM32G030xx)
+  LL_EXTI_WriteReg(RPR1,    0x0000FFFFU);
+  LL_EXTI_WriteReg(FPR1,    0x0000FFFFU);
+#endif
 
 #if defined(STM32G081xx) || defined(STM32G071xx)
   /* Interrupt mask register 2 set to default reset values */
-  LL_EXTI_WriteReg(IMR2,        0x00000003U);
+  LL_EXTI_WriteReg(IMR2, 0x00000003U);
   /* Event mask register 2 set to default reset values */
-  LL_EXTI_WriteReg(EMR2,        0x00000000U);
+  LL_EXTI_WriteReg(EMR2, 0x00000000U);
+#elif defined(STM32G0C1xx) || defined(STM32G0B1xx)
+  /* Interrupt mask register 2 set to default reset values */
+  LL_EXTI_WriteReg(IMR2, 0x0000001FU);
+  /* Event mask register 2 set to default reset values */
+  LL_EXTI_WriteReg(EMR2, 0x00000000U);
+  /* Rising Trigger selection register set to default reset values */
+  LL_EXTI_WriteReg(RTSR2, 0x00000000U);
+  /* Falling Trigger selection register set to default reset values */
+  LL_EXTI_WriteReg(FTSR2, 0x00000000U);
+  /* Software interrupt event register set to default reset values */
+  LL_EXTI_WriteReg(SWIER2, 0x00000000U);
+  /* Pending register set to default reset values */
+  LL_EXTI_WriteReg(RPR2, 0x00000004U);
+  LL_EXTI_WriteReg(FPR2, 0x00000004U);
+#elif defined(STM32G0B0xx)
+  /* Interrupt mask register 2 set to default reset values */
+  LL_EXTI_WriteReg(IMR2, 0x00000010U);
+  /* Event mask register 2 set to default reset values */
+  LL_EXTI_WriteReg(EMR2, 0x00000000U);
 #endif
 
   return 0x00u;
@@ -109,7 +139,7 @@ uint32_t LL_EXTI_DeInit(void)
   * @param  EXTI_InitStruct pointer to a @ref LL_EXTI_InitTypeDef structure.
   * @retval An ErrorStatus enumeration value:
   *          - 0x00: EXTI registers are initialized
-  *          - any other calue : wrong configuration
+  *          - any other value : wrong configuration
   */
 uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
 {
@@ -117,7 +147,7 @@ uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
 
   /* Check the parameters */
   assert_param(IS_LL_EXTI_LINE_0_31(EXTI_InitStruct->Line_0_31));
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
   assert_param(IS_LL_EXTI_LINE_32_63(EXTI_InitStruct->Line_32_63));
 #endif
   assert_param(IS_FUNCTIONAL_STATE(EXTI_InitStruct->LineCommand));
@@ -180,7 +210,7 @@ uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
         }
       }
     }
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
     /* Configure EXTI Lines in range from 32 to 63 */
     if (EXTI_InitStruct->Line_32_63 != LL_EXTI_LINE_NONE)
     {
@@ -216,7 +246,7 @@ uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
     /* De-configure EXTI Lines in range from 0 to 31 */
     LL_EXTI_DisableIT_0_31(EXTI_InitStruct->Line_0_31);
     LL_EXTI_DisableEvent_0_31(EXTI_InitStruct->Line_0_31);
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
     /* De-configure EXTI Lines in range from 32 to 63 */
     LL_EXTI_DisableIT_32_63(EXTI_InitStruct->Line_32_63);
     LL_EXTI_DisableEvent_32_63(EXTI_InitStruct->Line_32_63);
@@ -234,7 +264,7 @@ uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
 void LL_EXTI_StructInit(LL_EXTI_InitTypeDef *EXTI_InitStruct)
 {
   EXTI_InitStruct->Line_0_31      = LL_EXTI_LINE_NONE;
-#if defined(STM32G081xx) || defined(STM32G071xx)
+#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
   EXTI_InitStruct->Line_32_63     = LL_EXTI_LINE_NONE;
 #endif
   EXTI_InitStruct->LineCommand    = DISABLE;

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_gpio.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_gpio.c
@@ -68,6 +68,19 @@
                                             ((__VALUE__) == LL_GPIO_PULL_UP)   ||\
                                             ((__VALUE__) == LL_GPIO_PULL_DOWN))
 
+#if defined(GPIOE)
+#define IS_LL_GPIO_ALTERNATE(__VALUE__)    (((__VALUE__) == LL_GPIO_AF_0  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_1  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_2  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_3  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_4  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_5  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_6  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_7  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_8  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_9  )   ||\
+                                            ((__VALUE__) == LL_GPIO_AF_10 ))
+#else
 #define IS_LL_GPIO_ALTERNATE(__VALUE__)    (((__VALUE__) == LL_GPIO_AF_0  )   ||\
                                             ((__VALUE__) == LL_GPIO_AF_1  )   ||\
                                             ((__VALUE__) == LL_GPIO_AF_2  )   ||\
@@ -76,6 +89,7 @@
                                             ((__VALUE__) == LL_GPIO_AF_5  )   ||\
                                             ((__VALUE__) == LL_GPIO_AF_6  )   ||\
                                             ((__VALUE__) == LL_GPIO_AF_7 ))
+#endif
 /**
   * @}
   */
@@ -182,9 +196,6 @@ ErrorStatus LL_GPIO_Init(GPIO_TypeDef *GPIOx, LL_GPIO_InitTypeDef *GPIO_InitStru
 
     if (currentpin != 0x00u)
     {
-      /* Pin Mode configuration */
-      LL_GPIO_SetPinMode(GPIOx, currentpin, GPIO_InitStruct->Mode);
-
       if ((GPIO_InitStruct->Mode == LL_GPIO_MODE_OUTPUT) || (GPIO_InitStruct->Mode == LL_GPIO_MODE_ALTERNATE))
       {
         /* Check Speed mode parameters */
@@ -192,6 +203,12 @@ ErrorStatus LL_GPIO_Init(GPIO_TypeDef *GPIOx, LL_GPIO_InitTypeDef *GPIO_InitStru
 
         /* Speed mode configuration */
         LL_GPIO_SetPinSpeed(GPIOx, currentpin, GPIO_InitStruct->Speed);
+
+        /* Check Output mode parameters */
+        assert_param(IS_LL_GPIO_OUTPUT_TYPE(GPIO_InitStruct->OutputType));
+
+        /* Output mode configuration*/
+        LL_GPIO_SetPinOutputType(GPIOx, currentpin, GPIO_InitStruct->OutputType);
       }
 
       /* Pull-up Pull down resistor configuration*/
@@ -212,19 +229,13 @@ ErrorStatus LL_GPIO_Init(GPIO_TypeDef *GPIOx, LL_GPIO_InitTypeDef *GPIO_InitStru
           LL_GPIO_SetAFPin_8_15(GPIOx, currentpin, GPIO_InitStruct->Alternate);
         }
       }
+
+      /* Pin Mode configuration */
+      LL_GPIO_SetPinMode(GPIOx, currentpin, GPIO_InitStruct->Mode);
     }
     pinpos++;
   }
 
-  if ((GPIO_InitStruct->Mode == LL_GPIO_MODE_OUTPUT) || (GPIO_InitStruct->Mode == LL_GPIO_MODE_ALTERNATE))
-  {
-    /* Check Output mode parameters */
-    assert_param(IS_LL_GPIO_OUTPUT_TYPE(GPIO_InitStruct->OutputType));
-
-    /* Output mode configuration*/
-    LL_GPIO_SetPinOutputType(GPIOx, GPIO_InitStruct->Pin, GPIO_InitStruct->OutputType);
-
-  }
   return (SUCCESS);
 }
 

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_i2c.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_i2c.c
@@ -31,7 +31,7 @@
   * @{
   */
 
-#if defined (I2C1) || defined (I2C2)
+#if defined (I2C1) || defined (I2C2) || defined (I2C3)
 
 /** @defgroup I2C_LL I2C
   * @{
@@ -108,6 +108,16 @@ ErrorStatus LL_I2C_DeInit(I2C_TypeDef *I2Cx)
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C2);
 
   }
+#if defined(I2C3)
+  else if (I2Cx == I2C3)
+  {
+    /* Force reset of I2C clock */
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I2C3);
+
+    /* Release reset of I2C clock */
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C3);
+  }
+#endif
   else
   {
     status = ERROR;
@@ -216,7 +226,7 @@ void LL_I2C_StructInit(LL_I2C_InitTypeDef *I2C_InitStruct)
   * @}
   */
 
-#endif /* I2C1 || I2C2 */
+#endif /* I2C1 || I2C2 || I2C3 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_lpuart.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_lpuart.c
@@ -32,7 +32,7 @@
   * @{
   */
 
-#if defined (LPUART1)
+#if defined (LPUART1) || defined (LPUART2)
 
 /** @addtogroup LPUART_LL
   * @{
@@ -142,6 +142,16 @@ ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx)
     /* Release reset of LPUART peripheral */
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LPUART1);
   }
+#if defined(LPUART2)
+  else if (LPUARTx == LPUART2)
+  {
+    /* Force reset of LPUART peripheral */
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_LPUART2);
+
+    /* Release reset of LPUART peripheral */
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LPUART2);
+  }
+#endif
   else
   {
     status = ERROR;
@@ -153,8 +163,10 @@ ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx)
 /**
   * @brief  Initialize LPUART registers according to the specified
   *         parameters in LPUART_InitStruct.
-  * @note   As some bits in LPUART configuration registers can only be written when the LPUART is disabled (USART_CR1_UE bit =0),
-  *         LPUART Peripheral should be in disabled state prior calling this function. Otherwise, ERROR result will be returned.
+  * @note   As some bits in LPUART configuration registers can only be written when
+  *         the LPUART is disabled (USART_CR1_UE bit =0),
+  *         LPUART Peripheral should be in disabled state prior calling this function.
+  *         Otherwise, ERROR result will be returned.
   * @note   Baud rate value stored in LPUART_InitStruct BaudRate field, should be valid (different from 0).
   * @param  LPUARTx LPUART Instance
   * @param  LPUART_InitStruct pointer to a @ref LL_LPUART_InitTypeDef structure
@@ -166,7 +178,11 @@ ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx)
 ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, LL_LPUART_InitTypeDef *LPUART_InitStruct)
 {
   ErrorStatus status = ERROR;
+#if defined(LPUART2)
+  uint32_t periphclk = LL_RCC_PERIPH_FREQUENCY_NO;
+#else
   uint32_t periphclk;
+#endif
 
   /* Check the parameters */
   assert_param(IS_LPUART_INSTANCE(LPUARTx));
@@ -200,14 +216,30 @@ ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, LL_LPUART_InitTypeDef *LPUART
 
     /*---------------------------- LPUART CR3 Configuration -----------------------
      * Configure LPUARTx CR3 (Hardware Flow Control) with parameters:
-     * - HardwareFlowControl: USART_CR3_RTSE, USART_CR3_CTSE bits according to LPUART_InitStruct->HardwareFlowControl value.
+     * - HardwareFlowControl: USART_CR3_RTSE, USART_CR3_CTSE bits according
+     *   to LPUART_InitStruct->HardwareFlowControl value.
      */
     LL_LPUART_SetHWFlowCtrl(LPUARTx, LPUART_InitStruct->HardwareFlowControl);
 
     /*---------------------------- LPUART BRR Configuration -----------------------
      * Retrieve Clock frequency used for LPUART Peripheral
      */
+#if defined(LPUART2)
+    if (LPUARTx == LPUART1)
+    {
+      periphclk = LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE);
+    }
+    else if (LPUARTx == LPUART2)
+    {
+      periphclk = LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART2_CLKSOURCE);
+    }
+    else
+    {
+      /* Nothing to do, as error code is already assigned to ERROR value */
+    }
+#else
     periphclk = LL_RCC_GetLPUARTClockFreq(LL_RCC_LPUART1_CLKSOURCE);
+#endif
 
     /* Configure the LPUART Baud Rate :
        - prescaler value is required
@@ -271,7 +303,7 @@ void LL_LPUART_StructInit(LL_LPUART_InitTypeDef *LPUART_InitStruct)
   * @}
   */
 
-#endif /* defined (LPUART1) */
+#endif /* LPUART1 || LPUART2 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_rcc.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_rcc.c
@@ -24,7 +24,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 /** @addtogroup STM32G0xx_LL_Driver
   * @{
   */
@@ -42,43 +42,67 @@
 /** @addtogroup RCC_LL_Private_Macros
   * @{
   */
-#if defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define IS_LL_RCC_USART_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_USART1_CLKSOURCE) \
+                                            || ((__VALUE__) == LL_RCC_USART2_CLKSOURCE) \
+                                            || ((__VALUE__) == LL_RCC_USART3_CLKSOURCE))
+#elif defined(STM32G081xx) || defined(STM32G071xx) || defined(STM32G070xx)
 #define IS_LL_RCC_USART_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_USART1_CLKSOURCE) \
                                             || ((__VALUE__) == LL_RCC_USART2_CLKSOURCE))
-#elif defined(STM32G041xx) || defined(STM32G031xx) || defined(STM32G030xx)
+#else
 #define IS_LL_RCC_USART_CLKSOURCE(__VALUE__)  ((__VALUE__) == LL_RCC_USART1_CLKSOURCE)
-#endif
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
-#if defined(LPUART1)
-#define IS_LL_RCC_LPUART_CLKSOURCE(__VALUE__) (((__VALUE__) == LL_RCC_LPUART1_CLKSOURCE))
-#endif
+#if defined(LPUART1) && defined(LPUART2)
+#define IS_LL_RCC_LPUART_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_LPUART1_CLKSOURCE) \
+                                             || ((__VALUE__) == LL_RCC_LPUART2_CLKSOURCE))
+#elif defined(LPUART1)
+#define IS_LL_RCC_LPUART_CLKSOURCE(__VALUE__)   ((__VALUE__) == LL_RCC_LPUART1_CLKSOURCE)
+#endif /* LPUART1 && LPUART2 */
 
-#define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)     ((__VALUE__) == LL_RCC_I2C1_CLKSOURCE)
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_I2C1_CLKSOURCE) \
+                                          || ((__VALUE__) == LL_RCC_I2C2_CLKSOURCE))
+#else
+#define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)   ((__VALUE__) == LL_RCC_I2C1_CLKSOURCE)
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 #if defined(LPTIM1) || defined(LPTIM2)
 #define IS_LL_RCC_LPTIM_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_LPTIM1_CLKSOURCE) \
                                             || ((__VALUE__) == LL_RCC_LPTIM2_CLKSOURCE))
-#endif
+#endif /* LPTIM1 || LPTIM2 */
 
 #if defined(RNG)
 #define IS_LL_RCC_RNG_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_RNG_CLKSOURCE))
-#endif
+#endif /* RNG */
 
 #define IS_LL_RCC_ADC_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_ADC_CLKSOURCE))
 
-
-#define IS_LL_RCC_I2S_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_I2S1_CLKSOURCE))
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define IS_LL_RCC_I2S_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_I2S1_CLKSOURCE) \
+                                          || ((__VALUE__) == LL_RCC_I2S2_CLKSOURCE))
+#else
+#define IS_LL_RCC_I2S_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_I2S1_CLKSOURCE))
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 
 #if defined(CEC)
 #define IS_LL_RCC_CEC_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_CEC_CLKSOURCE))
-#endif
+#endif /* CEC */
+
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+#define IS_LL_RCC_USB_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_USB_CLKSOURCE))
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
+#if defined(FDCAN1) || defined(FDCAN2)
+#define IS_LL_RCC_FDCAN_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_FDCAN_CLKSOURCE))
+#endif /* FDCAN1 || FDCAN2 */
 
 #if defined(RCC_CCIPR_TIM1SEL) && defined(RCC_CCIPR_TIM15SEL)
 #define IS_LL_RCC_TIM_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_TIM1_CLKSOURCE) \
                                             || ((__VALUE__) == LL_RCC_TIM15_CLKSOURCE))
 #elif defined(RCC_CCIPR_TIM1SEL)
 #define IS_LL_RCC_TIM_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_TIM1_CLKSOURCE))
-#endif
+#endif /* RCC_CCIPR_TIM1SEL */
 
 
 
@@ -96,6 +120,11 @@ uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency);
 uint32_t RCC_PLL_GetFreqDomain_SYS(void);
 uint32_t RCC_PLL_GetFreqDomain_ADC(void);
 uint32_t RCC_PLL_GetFreqDomain_I2S1(void);
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+uint32_t RCC_PLL_GetFreqDomain_I2S2(void);
+uint32_t RCC_PLL_GetFreqDomain_USB(void);
+uint32_t RCC_PLL_GetFreqDomain_FDCAN(void);
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
 uint32_t RCC_PLL_GetFreqDomain_RNG(void);
 uint32_t RCC_PLL_GetFreqDomain_TIM1(void);
 uint32_t RCC_PLL_GetFreqDomain_TIM15(void);
@@ -213,6 +242,7 @@ void LL_RCC_GetSystemClocksFreq(LL_RCC_ClocksTypeDef *RCC_Clocks)
   * @param  USARTxSource This parameter can be one of the following values:
   *         @arg @ref LL_RCC_USART1_CLKSOURCE
   *         @arg @ref LL_RCC_USART2_CLKSOURCE
+  *         @arg @ref LL_RCC_USART3_CLKSOURCE
   * @retval USART clock frequency (in Hz)
   *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (HSI or LSE) is not ready
   */
@@ -282,9 +312,41 @@ uint32_t LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource)
         break;
     }
   }
-#endif
+#endif /* RCC_CCIPR_USART2SEL */
+#if defined(RCC_CCIPR_USART3SEL)
+  else if (USARTxSource == LL_RCC_USART3_CLKSOURCE)
+  {
+    /* USART3CLK clock frequency */
+    switch (LL_RCC_GetUSARTClockSource(USARTxSource))
+    {
+      case LL_RCC_USART3_CLKSOURCE_SYSCLK: /* USART3 Clock is System Clock */
+        usart_frequency = RCC_GetSystemClockFreq();
+        break;
+
+      case LL_RCC_USART3_CLKSOURCE_HSI:    /* USART3 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          usart_frequency = HSI_VALUE;
+        }
+        break;
+
+      case LL_RCC_USART3_CLKSOURCE_LSE:    /* USART3 Clock is LSE Osc. */
+        if (LL_RCC_LSE_IsReady() == 1U)
+        {
+          usart_frequency = LSE_VALUE;
+        }
+        break;
+
+      case LL_RCC_USART3_CLKSOURCE_PCLK1:  /* USART3 Clock is PCLK1 */
+      default:
+        usart_frequency = RCC_GetPCLK1ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
+        break;
+    }
+  }
+#endif /* RCC_CCIPR_USART3SEL */
   else
   {
+    /* nothing to do */
   }
   return usart_frequency;
 }
@@ -325,6 +387,30 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
         break;
     }
   }
+#if defined(RCC_CCIPR_I2C2SEL)
+  else if (I2CxSource == LL_RCC_I2C2_CLKSOURCE)
+  {
+    /* I2C2 CLK clock frequency */
+    switch (LL_RCC_GetI2CClockSource(I2CxSource))
+    {
+      case LL_RCC_I2C2_CLKSOURCE_SYSCLK: /* I2C2 Clock is System Clock */
+        i2c_frequency = RCC_GetSystemClockFreq();
+        break;
+
+      case LL_RCC_I2C2_CLKSOURCE_HSI:    /* I2C2 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          i2c_frequency = HSI_VALUE;
+        }
+        break;
+
+      case LL_RCC_I2C2_CLKSOURCE_PCLK1:  /* I2C2 Clock is PCLK1 */
+      default:
+        i2c_frequency = RCC_GetPCLK1ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
+        break;
+    }
+  }
+#endif /* RCC_CCIPR_I2C2SEL */
   else
   {
   }
@@ -373,17 +459,49 @@ uint32_t LL_RCC_GetI2SClockFreq(uint32_t I2SxSource)
         break;
     }
   }
+#if defined(RCC_CCIPR2_I2S2SEL)
+  else if (I2SxSource == LL_RCC_I2S2_CLKSOURCE)
+  {
+    /* I2S2 CLK clock frequency */
+    switch (LL_RCC_GetI2SClockSource(I2SxSource))
+    {
+      case LL_RCC_I2S2_CLKSOURCE_HSI:    /* I2S2 Clock is HSI */
+        i2s_frequency = HSI_VALUE;
+        break;
 
+      case LL_RCC_I2S2_CLKSOURCE_PLL:    /* I2S2 Clock is PLL"P" */
+        if (LL_RCC_PLL_IsReady() == 1U)
+        {
+          i2s_frequency = RCC_PLL_GetFreqDomain_I2S2();
+        }
+        break;
+
+      case LL_RCC_I2S2_CLKSOURCE_PIN:          /* I2S2 Clock is External clock */
+        i2s_frequency = EXTERNAL_CLOCK_VALUE;
+        break;
+
+      case LL_RCC_I2S2_CLKSOURCE_SYSCLK: /* I2S2 Clock is System Clock */
+      default:
+        i2s_frequency = RCC_GetSystemClockFreq();
+        break;
+    }
+  }
+#endif /* RCC_CCIPR2_I2S2SEL */
+  else
+  {
+  }
   return i2s_frequency;
 }
 
-#if defined(LPUART1)
+#if defined(LPUART1) || defined(LPUART2)
 /**
   * @brief  Return LPUARTx clock frequency
   * @param  LPUARTxSource This parameter can be one of the following values:
   *         @arg @ref LL_RCC_LPUART1_CLKSOURCE
+  *         @arg @ref LL_RCC_LPUART2_CLKSOURCE (*)
   * @retval LPUART clock frequency (in Hz)
   *         @arg @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (HSI or LSE) is not ready
+  * (*) feature not available on all devices
   */
 uint32_t LL_RCC_GetLPUARTClockFreq(uint32_t LPUARTxSource)
 {
@@ -392,31 +510,68 @@ uint32_t LL_RCC_GetLPUARTClockFreq(uint32_t LPUARTxSource)
   /* Check parameter */
   assert_param(IS_LL_RCC_LPUART_CLKSOURCE(LPUARTxSource));
 
-  /* LPUART1CLK clock frequency */
-  switch (LL_RCC_GetLPUARTClockSource(LPUARTxSource))
+  if (LPUARTxSource == LL_RCC_LPUART1_CLKSOURCE)
   {
-    case LL_RCC_LPUART1_CLKSOURCE_SYSCLK: /* LPUART1 Clock is System Clock */
-      lpuart_frequency = RCC_GetSystemClockFreq();
-      break;
+    /* LPUART1CLK clock frequency */
+    switch (LL_RCC_GetLPUARTClockSource(LPUARTxSource))
+    {
+      case LL_RCC_LPUART1_CLKSOURCE_SYSCLK: /* LPUART1 Clock is System Clock */
+        lpuart_frequency = RCC_GetSystemClockFreq();
+        break;
 
-    case LL_RCC_LPUART1_CLKSOURCE_HSI:    /* LPUART1 Clock is HSI Osc. */
-      if (LL_RCC_HSI_IsReady() == 1U)
-      {
-        lpuart_frequency = HSI_VALUE;
-      }
-      break;
+      case LL_RCC_LPUART1_CLKSOURCE_HSI:    /* LPUART1 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          lpuart_frequency = HSI_VALUE;
+        }
+        break;
 
-    case LL_RCC_LPUART1_CLKSOURCE_LSE:    /* LPUART1 Clock is LSE Osc. */
-      if (LL_RCC_LSE_IsReady() == 1U)
-      {
-        lpuart_frequency = LSE_VALUE;
-      }
-      break;
+      case LL_RCC_LPUART1_CLKSOURCE_LSE:    /* LPUART1 Clock is LSE Osc. */
+        if (LL_RCC_LSE_IsReady() == 1U)
+        {
+          lpuart_frequency = LSE_VALUE;
+        }
+        break;
 
-    case LL_RCC_LPUART1_CLKSOURCE_PCLK1:  /* LPUART1 Clock is PCLK1 */
-    default:
-      lpuart_frequency = RCC_GetPCLK1ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
-      break;
+      case LL_RCC_LPUART1_CLKSOURCE_PCLK1:  /* LPUART1 Clock is PCLK1 */
+      default:
+        lpuart_frequency = RCC_GetPCLK1ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
+        break;
+    }
+  }
+#if defined(LPUART2)
+  else if (LPUARTxSource == LL_RCC_LPUART2_CLKSOURCE)
+  {
+    /* LPUART2CLK clock frequency */
+    switch (LL_RCC_GetLPUARTClockSource(LPUARTxSource))
+    {
+      case LL_RCC_LPUART2_CLKSOURCE_SYSCLK: /* LPUART2 Clock is System Clock */
+        lpuart_frequency = RCC_GetSystemClockFreq();
+        break;
+
+      case LL_RCC_LPUART2_CLKSOURCE_HSI:    /* LPUART2 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          lpuart_frequency = HSI_VALUE;
+        }
+        break;
+
+      case LL_RCC_LPUART2_CLKSOURCE_LSE:    /* LPUART2 Clock is LSE Osc. */
+        if (LL_RCC_LSE_IsReady() == 1U)
+        {
+          lpuart_frequency = LSE_VALUE;
+        }
+        break;
+
+      case LL_RCC_LPUART2_CLKSOURCE_PCLK1:  /* LPUART2 Clock is PCLK1 */
+      default:
+        lpuart_frequency = RCC_GetPCLK1ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
+        break;
+    }
+  }
+#endif /* LPUART2 */
+  else
+  {
   }
 
   return lpuart_frequency;
@@ -566,7 +721,7 @@ uint32_t LL_RCC_GetTIMClockFreq(uint32_t TIMxSource)
       }
     }
   }
-#endif
+#endif /* TIM15 */
   return tim_frequency;
 }
 #endif /* RCC_CCIPR_TIM1SEL && RCC_CCIPR_TIM15SEL */
@@ -661,6 +816,48 @@ uint32_t LL_RCC_GetCECClockFreq(uint32_t CECxSource)
 }
 #endif /* CEC */
 
+#if defined(FDCAN1) || defined(FDCAN2)
+/**
+  * @brief  Return FDCANx clock frequency
+  * @param  FDCANxSource This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_FDCAN_CLKSOURCE
+  * @retval FDCANx clock frequency (in Hz)
+  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (HSI, LSI or LSE) is not ready
+  */
+uint32_t LL_RCC_GetFDCANClockFreq(uint32_t FDCANxSource)
+{
+  uint32_t fdcan_frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+
+  /* Check parameter */
+  assert_param(IS_LL_RCC_FDCAN_CLKSOURCE(FDCANxSource));
+
+  /* FDCANCLK clock frequency */
+  switch (LL_RCC_GetFDCANClockSource(FDCANxSource))
+  {
+    case LL_RCC_FDCAN_CLKSOURCE_PLL:    /* FDCAN Clock is PLL "Q"  Osc. */
+      if (LL_RCC_PLL_IsReady() == 1U)
+      {
+        fdcan_frequency = RCC_PLL_GetFreqDomain_FDCAN();
+      }
+      break;
+
+    case LL_RCC_FDCAN_CLKSOURCE_HSE:    /* FDCAN Clock is HSE Osc. */
+      if (LL_RCC_HSE_IsReady() == 1U)
+      {
+        fdcan_frequency = HSE_VALUE;
+      }
+      break;
+
+    case LL_RCC_FDCAN_CLKSOURCE_PCLK1:  /* FDCAN Clock is PCLK1 */
+    default:
+      fdcan_frequency = RCC_GetPCLK1ClockFreq(RCC_GetHCLKClockFreq(RCC_GetSystemClockFreq()));
+      break;
+  }
+
+  return fdcan_frequency;
+}
+#endif /* FDCAN1 || FDCAN2 */
+
 /**
   * @brief  Return ADCx clock frequency
   * @param  ADCxSource This parameter can be one of the following values:
@@ -740,6 +937,57 @@ uint32_t LL_RCC_GetRTCClockFreq(void)
   return rtc_frequency;
 }
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Return USBx clock frequency
+  * @param  USBxSource This parameter can be one of the following values:
+  *         @arg @ref LL_RCC_USB_CLKSOURCE
+  * @retval USB clock frequency (in Hz)
+  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (HSI48) or PLL is not ready
+  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NA indicates that no clock source selected
+  */
+uint32_t LL_RCC_GetUSBClockFreq(uint32_t USBxSource)
+{
+  uint32_t usb_frequency = LL_RCC_PERIPH_FREQUENCY_NO;
+
+  /* Check parameter */
+  assert_param(IS_LL_RCC_USB_CLKSOURCE(USBxSource));
+
+  /* USBCLK clock frequency */
+  switch (LL_RCC_GetUSBClockSource(USBxSource))
+  {
+#if defined(RCC_HSI48_SUPPORT)
+    case LL_RCC_USB_CLKSOURCE_HSI48:         /* HSI48 used as USB clock source */
+      if (LL_RCC_HSI48_IsReady() != 0U)
+      {
+        usb_frequency = HSI48_VALUE;
+      }
+      break;
+#endif /* RCC_HSI48_SUPPORT */
+
+    case LL_RCC_USB_CLKSOURCE_HSE:         /* HSE used as USB clock source */
+      if (LL_RCC_HSE_IsReady() != 0U)
+      {
+        usb_frequency = HSE_VALUE;
+      }
+      break;
+
+    case LL_RCC_USB_CLKSOURCE_PLL:           /* PLL clock used as USB clock source */
+      if (LL_RCC_PLL_IsReady() != 0U)
+      {
+        usb_frequency = RCC_PLL_GetFreqDomain_USB();
+      }
+      break;
+
+    default:
+      usb_frequency = LL_RCC_PERIPH_FREQUENCY_NA;
+      break;
+  }
+
+  return usb_frequency;
+}
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx) */
+
 /**
   * @}
   */
@@ -809,7 +1057,8 @@ uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency)
   */
 uint32_t RCC_PLL_GetFreqDomain_SYS(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
      SYSCLK = PLL_VCO / PLLR
@@ -839,7 +1088,8 @@ uint32_t RCC_PLL_GetFreqDomain_SYS(void)
   */
 uint32_t RCC_PLL_GetFreqDomain_ADC(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
      ADC Domain clock = PLL_VCO / PLLP
@@ -861,13 +1111,46 @@ uint32_t RCC_PLL_GetFreqDomain_ADC(void)
                                        LL_RCC_PLL_GetN(), LL_RCC_PLL_GetP());
 }
 
+#if defined(FDCAN1) || defined(FDCAN2)
+/**
+  * @brief  Return PLL clock frequency used for FDCAN domain
+  * @retval PLL clock frequency (in Hz)
+  */
+uint32_t RCC_PLL_GetFreqDomain_FDCAN(void)
+{
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
+
+  /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM ) * PLLN
+
+     FDCAN Domain clock = PLL_VCO / PLLQ
+  */
+  pllsource = LL_RCC_PLL_GetMainSource();
+
+  switch (pllsource)
+  {
+    case LL_RCC_PLLSOURCE_HSE:  /* HSE used as PLL clock source */
+      pllinputfreq = HSE_VALUE;
+      break;
+
+    case LL_RCC_PLLSOURCE_HSI:  /* HSI used as PLL clock source */
+    default:
+      pllinputfreq = HSI_VALUE;
+      break;
+  }
+  return __LL_RCC_CALC_PLLCLK_FDCAN_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(),
+                                         LL_RCC_PLL_GetN(), LL_RCC_PLL_GetQ());
+}
+#endif /* FDCAN1 || FDCAN2 */
+
 /**
   * @brief  Return PLL clock frequency used for I2S1 domain
   * @retval PLL clock frequency (in Hz)
   */
 uint32_t RCC_PLL_GetFreqDomain_I2S1(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
      I2S1 Domain clock = PLL_VCO / PLLP
@@ -889,6 +1172,37 @@ uint32_t RCC_PLL_GetFreqDomain_I2S1(void)
                                         LL_RCC_PLL_GetN(), LL_RCC_PLL_GetP());
 }
 
+#if defined(RCC_CCIPR2_I2S2SEL)
+/**
+  * @brief  Return PLL clock frequency used for I2S2 domain
+  * @retval PLL clock frequency (in Hz)
+  */
+uint32_t RCC_PLL_GetFreqDomain_I2S2(void)
+{
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
+
+  /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
+     I2S2 Domain clock = PLL_VCO / PLLP
+  */
+  pllsource = LL_RCC_PLL_GetMainSource();
+
+  switch (pllsource)
+  {
+    case LL_RCC_PLLSOURCE_HSE:  /* HSE used as PLL clock source */
+      pllinputfreq = HSE_VALUE;
+      break;
+
+    case LL_RCC_PLLSOURCE_HSI:  /* HSI used as PLL clock source */
+    default:
+      pllinputfreq = HSI_VALUE;
+      break;
+  }
+  return __LL_RCC_CALC_PLLCLK_I2S2_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(),
+                                        LL_RCC_PLL_GetN(), LL_RCC_PLL_GetP());
+}
+#endif /* RCC_CCIPR2_I2S2SEL */
+
 #if defined(RNG)
 /**
   * @brief  Return PLL clock frequency used for RNG domain
@@ -896,7 +1210,8 @@ uint32_t RCC_PLL_GetFreqDomain_I2S1(void)
   */
 uint32_t RCC_PLL_GetFreqDomain_RNG(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM ) * PLLN
 
@@ -920,6 +1235,38 @@ uint32_t RCC_PLL_GetFreqDomain_RNG(void)
 }
 #endif /* RNG */
 
+#if defined(STM32G0C1xx) || defined(STM32G0B1xx) || defined(STM32G0B0xx)
+/**
+  * @brief  Return PLL clock frequency used for USB domain
+  * @retval PLL clock frequency (in Hz)
+  */
+uint32_t RCC_PLL_GetFreqDomain_USB(void)
+{
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
+
+  /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM ) * PLLN
+
+     RNG Domain clock = PLL_VCO / PLLQ
+  */
+  pllsource = LL_RCC_PLL_GetMainSource();
+
+  switch (pllsource)
+  {
+    case LL_RCC_PLLSOURCE_HSE:  /* HSE used as PLL clock source */
+      pllinputfreq = HSE_VALUE;
+      break;
+
+    case LL_RCC_PLLSOURCE_HSI:  /* HSI used as PLL clock source */
+    default:
+      pllinputfreq = HSI_VALUE;
+      break;
+  }
+  return __LL_RCC_CALC_PLLCLK_USB_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(),
+                                       LL_RCC_PLL_GetN(), LL_RCC_PLL_GetQ());
+}
+#endif /* STM32G0C1xx || STM32G0B1xx || STM32G0B0xx */
+
 #if defined(RCC_PLLQ_SUPPORT)
 /**
   * @brief  Return PLL clock frequency used for TIM1 domain
@@ -927,7 +1274,8 @@ uint32_t RCC_PLL_GetFreqDomain_RNG(void)
   */
 uint32_t RCC_PLL_GetFreqDomain_TIM1(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM ) * PLLN
 
@@ -958,7 +1306,8 @@ uint32_t RCC_PLL_GetFreqDomain_TIM1(void)
   */
 uint32_t RCC_PLL_GetFreqDomain_TIM15(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM ) * PLLN
 
@@ -989,7 +1338,7 @@ uint32_t RCC_PLL_GetFreqDomain_TIM15(void)
   * @}
   */
 
-#endif /* defined(RCC) */
+#endif /* RCC */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_rtc.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_rtc.c
@@ -322,7 +322,7 @@ ErrorStatus LL_RTC_TIME_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_Time
     }
 
     /* Exit Initialization mode */
-    LL_RTC_DisableInitMode(RTC);
+    LL_RTC_DisableInitMode(RTCx);
 
     /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
     if (LL_RTC_IsShadowRegBypassEnabled(RTCx) == 0U)
@@ -410,7 +410,7 @@ ErrorStatus LL_RTC_DATE_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_Date
     }
 
     /* Exit Initialization mode */
-    LL_RTC_DisableInitMode(RTC);
+    LL_RTC_DisableInitMode(RTCx);
 
     /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
     if (LL_RTC_IsShadowRegBypassEnabled(RTCx) == 0U)

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_spi.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_spi.c
@@ -33,7 +33,7 @@
   * @{
   */
 
-#if defined (SPI1) || defined (SPI2)
+#if defined (SPI1) || defined (SPI2) || defined (SPI3)
 
 /** @addtogroup SPI_LL
   * @{
@@ -60,52 +60,52 @@
 /** @defgroup SPI_LL_Private_Macros SPI Private Macros
   * @{
   */
-#define IS_LL_SPI_TRANSFER_DIRECTION(__VALUE__) (((__VALUE__) == LL_SPI_FULL_DUPLEX)    \
-                                              || ((__VALUE__) == LL_SPI_SIMPLEX_RX)     \
-                                              || ((__VALUE__) == LL_SPI_HALF_DUPLEX_RX) \
-                                              || ((__VALUE__) == LL_SPI_HALF_DUPLEX_TX))
+#define IS_LL_SPI_TRANSFER_DIRECTION(__VALUE__) (((__VALUE__) == LL_SPI_FULL_DUPLEX)       \
+                                                 || ((__VALUE__) == LL_SPI_SIMPLEX_RX)     \
+                                                 || ((__VALUE__) == LL_SPI_HALF_DUPLEX_RX) \
+                                                 || ((__VALUE__) == LL_SPI_HALF_DUPLEX_TX))
 
 #define IS_LL_SPI_MODE(__VALUE__) (((__VALUE__) == LL_SPI_MODE_MASTER) \
-                                || ((__VALUE__) == LL_SPI_MODE_SLAVE))
+                                   || ((__VALUE__) == LL_SPI_MODE_SLAVE))
 
-#define IS_LL_SPI_DATAWIDTH(__VALUE__) (((__VALUE__) == LL_SPI_DATAWIDTH_4BIT)  \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_5BIT)  \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_6BIT)  \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_7BIT)  \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_8BIT)  \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_9BIT)  \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_10BIT) \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_11BIT) \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_12BIT) \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_13BIT) \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_14BIT) \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_15BIT) \
-                                     || ((__VALUE__) == LL_SPI_DATAWIDTH_16BIT))
+#define IS_LL_SPI_DATAWIDTH(__VALUE__) (((__VALUE__) == LL_SPI_DATAWIDTH_4BIT)     \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_5BIT)  \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_6BIT)  \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_7BIT)  \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_8BIT)  \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_9BIT)  \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_10BIT) \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_11BIT) \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_12BIT) \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_13BIT) \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_14BIT) \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_15BIT) \
+                                        || ((__VALUE__) == LL_SPI_DATAWIDTH_16BIT))
 
 #define IS_LL_SPI_POLARITY(__VALUE__) (((__VALUE__) == LL_SPI_POLARITY_LOW) \
-                                    || ((__VALUE__) == LL_SPI_POLARITY_HIGH))
+                                       || ((__VALUE__) == LL_SPI_POLARITY_HIGH))
 
 #define IS_LL_SPI_PHASE(__VALUE__) (((__VALUE__) == LL_SPI_PHASE_1EDGE) \
-                                 || ((__VALUE__) == LL_SPI_PHASE_2EDGE))
+                                    || ((__VALUE__) == LL_SPI_PHASE_2EDGE))
 
-#define IS_LL_SPI_NSS(__VALUE__) (((__VALUE__) == LL_SPI_NSS_SOFT) \
-                               || ((__VALUE__) == LL_SPI_NSS_HARD_INPUT) \
-                               || ((__VALUE__) == LL_SPI_NSS_HARD_OUTPUT))
+#define IS_LL_SPI_NSS(__VALUE__) (((__VALUE__) == LL_SPI_NSS_SOFT)          \
+                                  || ((__VALUE__) == LL_SPI_NSS_HARD_INPUT) \
+                                  || ((__VALUE__) == LL_SPI_NSS_HARD_OUTPUT))
 
-#define IS_LL_SPI_BAUDRATE(__VALUE__) (((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV2)   \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV4)   \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV8)   \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV16)  \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV32)  \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV64)  \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV128) \
-                                    || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV256))
+#define IS_LL_SPI_BAUDRATE(__VALUE__) (((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV2)      \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV4)   \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV8)   \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV16)  \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV32)  \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV64)  \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV128) \
+                                       || ((__VALUE__) == LL_SPI_BAUDRATEPRESCALER_DIV256))
 
 #define IS_LL_SPI_BITORDER(__VALUE__) (((__VALUE__) == LL_SPI_LSB_FIRST) \
-                                    || ((__VALUE__) == LL_SPI_MSB_FIRST))
+                                       || ((__VALUE__) == LL_SPI_MSB_FIRST))
 
 #define IS_LL_SPI_CRCCALCULATION(__VALUE__) (((__VALUE__) == LL_SPI_CRCCALCULATION_ENABLE) \
-                                          || ((__VALUE__) == LL_SPI_CRCCALCULATION_DISABLE))
+                                             || ((__VALUE__) == LL_SPI_CRCCALCULATION_DISABLE))
 
 #define IS_LL_SPI_CRC_POLYNOMIAL(__VALUE__) ((__VALUE__) >= 0x1U)
 
@@ -162,6 +162,18 @@ ErrorStatus LL_SPI_DeInit(SPI_TypeDef *SPIx)
     status = SUCCESS;
   }
 #endif /* SPI2 */
+#if defined(SPI3)
+  if (SPIx == SPI3)
+  {
+    /* Force reset of SPI clock */
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_SPI3);
+
+    /* Release reset of SPI clock */
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_SPI3);
+
+    status = SUCCESS;
+  }
+#endif /* SPI3 */
 
   return status;
 }
@@ -298,36 +310,36 @@ void LL_SPI_StructInit(LL_SPI_InitTypeDef *SPI_InitStruct)
   * @{
   */
 
-#define IS_LL_I2S_DATAFORMAT(__VALUE__)  (((__VALUE__) == LL_I2S_DATAFORMAT_16B)          \
-                                       || ((__VALUE__) == LL_I2S_DATAFORMAT_16B_EXTENDED) \
-                                       || ((__VALUE__) == LL_I2S_DATAFORMAT_24B)          \
-                                       || ((__VALUE__) == LL_I2S_DATAFORMAT_32B))
+#define IS_LL_I2S_DATAFORMAT(__VALUE__)  (((__VALUE__) == LL_I2S_DATAFORMAT_16B)             \
+                                          || ((__VALUE__) == LL_I2S_DATAFORMAT_16B_EXTENDED) \
+                                          || ((__VALUE__) == LL_I2S_DATAFORMAT_24B)          \
+                                          || ((__VALUE__) == LL_I2S_DATAFORMAT_32B))
 
 #define IS_LL_I2S_CPOL(__VALUE__)        (((__VALUE__) == LL_I2S_POLARITY_LOW)  \
-                                       || ((__VALUE__) == LL_I2S_POLARITY_HIGH))
+                                          || ((__VALUE__) == LL_I2S_POLARITY_HIGH))
 
-#define IS_LL_I2S_STANDARD(__VALUE__)    (((__VALUE__) == LL_I2S_STANDARD_PHILIPS)   \
-                                       || ((__VALUE__) == LL_I2S_STANDARD_MSB)       \
-                                       || ((__VALUE__) == LL_I2S_STANDARD_LSB)       \
-                                       || ((__VALUE__) == LL_I2S_STANDARD_PCM_SHORT) \
-                                       || ((__VALUE__) == LL_I2S_STANDARD_PCM_LONG))
+#define IS_LL_I2S_STANDARD(__VALUE__)    (((__VALUE__) == LL_I2S_STANDARD_PHILIPS)      \
+                                          || ((__VALUE__) == LL_I2S_STANDARD_MSB)       \
+                                          || ((__VALUE__) == LL_I2S_STANDARD_LSB)       \
+                                          || ((__VALUE__) == LL_I2S_STANDARD_PCM_SHORT) \
+                                          || ((__VALUE__) == LL_I2S_STANDARD_PCM_LONG))
 
-#define IS_LL_I2S_MODE(__VALUE__)        (((__VALUE__) == LL_I2S_MODE_SLAVE_TX)  \
-                                       || ((__VALUE__) == LL_I2S_MODE_SLAVE_RX)  \
-                                       || ((__VALUE__) == LL_I2S_MODE_MASTER_TX) \
-                                       || ((__VALUE__) == LL_I2S_MODE_MASTER_RX))
+#define IS_LL_I2S_MODE(__VALUE__)        (((__VALUE__) == LL_I2S_MODE_SLAVE_TX)     \
+                                          || ((__VALUE__) == LL_I2S_MODE_SLAVE_RX)  \
+                                          || ((__VALUE__) == LL_I2S_MODE_MASTER_TX) \
+                                          || ((__VALUE__) == LL_I2S_MODE_MASTER_RX))
 
 #define IS_LL_I2S_MCLK_OUTPUT(__VALUE__) (((__VALUE__) == LL_I2S_MCLK_OUTPUT_ENABLE) \
-                                       || ((__VALUE__) == LL_I2S_MCLK_OUTPUT_DISABLE))
+                                          || ((__VALUE__) == LL_I2S_MCLK_OUTPUT_DISABLE))
 
-#define IS_LL_I2S_AUDIO_FREQ(__VALUE__) ((((__VALUE__) >= LL_I2S_AUDIOFREQ_8K)    \
-                                       && ((__VALUE__) <= LL_I2S_AUDIOFREQ_192K)) \
-                                       || ((__VALUE__) == LL_I2S_AUDIOFREQ_DEFAULT))
+#define IS_LL_I2S_AUDIO_FREQ(__VALUE__) ((((__VALUE__) >= LL_I2S_AUDIOFREQ_8K)       \
+                                          && ((__VALUE__) <= LL_I2S_AUDIOFREQ_192K)) \
+                                         || ((__VALUE__) == LL_I2S_AUDIOFREQ_DEFAULT))
 
 #define IS_LL_I2S_PRESCALER_LINEAR(__VALUE__)  ((__VALUE__) >= 0x2U)
 
 #define IS_LL_I2S_PRESCALER_PARITY(__VALUE__) (((__VALUE__) == LL_I2S_PRESCALER_PARITY_EVEN) \
-                                           || ((__VALUE__) == LL_I2S_PRESCALER_PARITY_ODD))
+                                               || ((__VALUE__) == LL_I2S_PRESCALER_PARITY_ODD))
 /**
   * @}
   */
@@ -367,7 +379,9 @@ ErrorStatus LL_I2S_DeInit(SPI_TypeDef *SPIx)
   */
 ErrorStatus LL_I2S_Init(SPI_TypeDef *SPIx, LL_I2S_InitTypeDef *I2S_InitStruct)
 {
-  uint32_t i2sdiv = 2U, i2sodd = 0U, packetlength = 1U;
+  uint32_t i2sdiv = 2U;
+  uint32_t i2sodd = 0U;
+  uint32_t packetlength = 1U;
   uint32_t tmp;
   LL_RCC_ClocksTypeDef rcc_clocks;
   uint32_t sourceclock;
@@ -518,7 +532,7 @@ void LL_I2S_ConfigPrescaler(SPI_TypeDef *SPIx, uint32_t PrescalerLinear, uint32_
   */
 #endif /* SPI_I2S_SUPPORT */
 
-#endif /* defined (SPI1) || defined (SPI2) */
+#endif /* defined (SPI1) || defined (SPI2) || defined (SPI3) */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_tim.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_tim.c
@@ -32,7 +32,7 @@
   * @{
   */
 
-#if defined (TIM1) || defined (TIM2) || defined (TIM3) ||  defined (TIM14) ||  defined (TIM15) || defined (TIM16) || defined (TIM17) || defined (TIM6) || defined (TIM7)
+#if defined (TIM1) || defined (TIM2) || defined (TIM3) || defined (TIM4) ||  defined (TIM14) ||  defined (TIM15) || defined (TIM16) || defined (TIM17) || defined (TIM6) || defined (TIM7)
 
 /** @addtogroup TIM_LL
   * @{
@@ -246,6 +246,13 @@ ErrorStatus LL_TIM_DeInit(TIM_TypeDef *TIMx)
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_TIM3);
   }
 #endif
+#if defined(TIM4)
+  else if (TIMx == TIM4)
+  {
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_TIM4);
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_TIM4);
+  }
+#endif
 #if defined(TIM6)
   else if (TIMx == TIM6)
   {
@@ -305,7 +312,7 @@ void LL_TIM_StructInit(LL_TIM_InitTypeDef *TIM_InitStruct)
   TIM_InitStruct->CounterMode       = LL_TIM_COUNTERMODE_UP;
   TIM_InitStruct->Autoreload        = 0xFFFFFFFFU;
   TIM_InitStruct->ClockDivision     = LL_TIM_CLOCKDIVISION_DIV1;
-  TIM_InitStruct->RepetitionCounter = (uint8_t)0x00;
+  TIM_InitStruct->RepetitionCounter = 0x00000000U;
 }
 
 /**
@@ -1342,7 +1349,7 @@ static ErrorStatus IC4Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
   * @}
   */
 
-#endif /* TIM1 || TIM2 || TIM3 ||  TIM14 || TIM15 || TIM16 || TIM17 || TIM6 || TIM7 */
+#endif /* TIM1 || TIM2 || TIM3 || TIM4 || TIM14 || TIM15 || TIM16 || TIM17 || TIM6 || TIM7 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_ucpd.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_ucpd.c
@@ -94,7 +94,7 @@ ErrorStatus LL_UCPD_DeInit(UCPD_TypeDef *UCPDx)
     /* Release reset of ucpd clock */
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_UCPD1);
 
-    /* Disbale ucpd clock */
+    /* Disable ucpd clock */
     LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_UCPD1);
 
     status = SUCCESS;
@@ -107,7 +107,7 @@ ErrorStatus LL_UCPD_DeInit(UCPD_TypeDef *UCPDx)
     /* Release reset of ucpd clock */
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_UCPD2);
 
-    /* Disbale ucpd clock */
+    /* Disable ucpd clock */
     LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_UCPD2);
 
     status = SUCCESS;
@@ -160,10 +160,10 @@ ErrorStatus LL_UCPD_Init(UCPD_TypeDef *UCPDx, LL_UCPD_InitTypeDef *UCPD_InitStru
 void LL_UCPD_StructInit(LL_UCPD_InitTypeDef *UCPD_InitStruct)
 {
   /* Set UCPD_InitStruct fields to default values */
-  UCPD_InitStruct->psc_ucpdclk  = LL_UCPD_PSC_DIV1;
+  UCPD_InitStruct->psc_ucpdclk  = LL_UCPD_PSC_DIV2;
   UCPD_InitStruct->transwin     = 0x7;   /* Divide by 8                     */
   UCPD_InitStruct->IfrGap       = 0x10;  /* Divide by 17                    */
-  UCPD_InitStruct->HbitClockDiv = 0x19;  /* Divide by 26 to produce HBITCLK */
+  UCPD_InitStruct->HbitClockDiv = 0x0D;  /* Divide by 14 to produce HBITCLK */
 }
 
 /**

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_usart.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_usart.c
@@ -32,7 +32,7 @@
   * @{
   */
 
-#if defined (USART1) || defined (USART2) || defined (USART3) || defined (USART4)
+#if defined (USART1) || defined (USART2) || defined (USART3) || defined (USART4) || defined (USART5) || defined (USART6)
 
 /** @addtogroup USART_LL
   * @{
@@ -172,6 +172,26 @@ ErrorStatus LL_USART_DeInit(USART_TypeDef *USARTx)
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_USART4);
   }
 #endif /* USART4 */
+#if defined(USART5)
+  else if (USARTx == USART5)
+  {
+    /* Force reset of USART clock */
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_USART5);
+
+    /* Release reset of USART clock */
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_USART5);
+  }
+#endif /* USART5 */
+#if defined(USART6)
+  else if (USARTx == USART6)
+  {
+    /* Force reset of USART clock */
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_USART6);
+
+    /* Release reset of USART clock */
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_USART6);
+  }
+#endif /* USART6 */
   else
   {
     status = ERROR;
@@ -197,7 +217,7 @@ ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, LL_USART_InitTypeDef *USART_Ini
 {
   ErrorStatus status = ERROR;
   uint32_t periphclk = LL_RCC_PERIPH_FREQUENCY_NO;
-#if !defined(RCC_CCIPR_USART3SEL)&&!defined(RCC_CCIPR_USART4SEL)||!defined(RCC_CCIPR_USART2SEL)
+#if !defined(RCC_CCIPR_USART3SEL)&&!defined(RCC_CCIPR_USART4SEL)||!defined(RCC_CCIPR_USART2SEL) ||!defined(RCC_CCIPR_USART5SEL) ||!defined(RCC_CCIPR_USART6SEL)
   LL_RCC_ClocksTypeDef RCC_Clocks;
 #endif /* !RCC_CCIPR_USART3SEL && !RCC_CCIPR_USART4SEL || !RCC_CCIPR_USART2SEL */
 
@@ -283,6 +303,22 @@ ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, LL_USART_InitTypeDef *USART_Ini
 #endif /* RCC_CCIPR_USART4SEL */
     }
 #endif /* USART4 */
+#if defined(USART5)
+    else if (USARTx == USART5)
+    {
+      /* USART5 clock is PCLK1 */
+      LL_RCC_GetSystemClocksFreq(&RCC_Clocks);
+      periphclk = RCC_Clocks.PCLK1_Frequency;
+    }
+#endif /* USART5 */
+#if defined(USART6)
+    else if (USARTx == USART6)
+    {
+      /* USART6 clock is PCLK1 */
+      LL_RCC_GetSystemClocksFreq(&RCC_Clocks);
+      periphclk = RCC_Clocks.PCLK1_Frequency;
+    }
+#endif /* USART6 */
     else
     {
       /* Nothing to do, as error code is already assigned to ERROR value */
@@ -433,7 +469,7 @@ void LL_USART_ClockStructInit(LL_USART_ClockInitTypeDef *USART_ClockInitStruct)
   * @}
   */
 
-#endif /* USART1 || USART2 || USART3 || USART4 */
+#endif /* USART1 || USART2 || USART3 || USART4 || USART5 || USART6 */
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_usb.c
+++ b/stm32cube/stm32g0xx/drivers/src/stm32g0xx_ll_usb.c
@@ -1,0 +1,1348 @@
+/**
+  ******************************************************************************
+  * @file    stm32g0xx_ll_usb.c
+  * @author  MCD Application Team
+  * @brief   USB Low Layer HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (#) Fill parameters of Init structure in USB_OTG_CfgTypeDef structure.
+
+      (#) Call USB_CoreInit() API to initialize the USB Core peripheral.
+
+      (#) The upper HAL HCD/PCD driver will call the right routines for its internal processes.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32g0xx_hal.h"
+
+/** @addtogroup STM32G0xx_LL_USB_DRIVER
+  * @{
+  */
+
+#if defined (HAL_PCD_MODULE_ENABLED) || defined (HAL_HCD_MODULE_ENABLED)
+#if defined (USB_DRD_FS)
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+
+static HAL_StatusTypeDef USB_CoreReset(USB_DRD_TypeDef *USBx);
+static HAL_StatusTypeDef USB_HC_BULK_DB_StartXfer(USB_DRD_TypeDef *USBx,
+                                                  USB_DRD_HCTypeDef *hc,
+                                                  uint32_t ch_reg,
+                                                  uint32_t *len);
+
+static HAL_StatusTypeDef USB_HC_ISO_DB_StartXfer(USB_DRD_TypeDef *USBx,
+                                                 USB_DRD_HCTypeDef *hc,
+                                                 uint32_t len);
+
+/**
+  * @brief  Reset the USB Core (needed after USB clock settings change)
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USB_CoreReset(USB_DRD_TypeDef *USBx)
+{
+  /* Disable Host Mode */
+  USBx->CNTR &= ~USB_CNTR_HOST;
+
+  /* Force Reset IP */
+  USBx->CNTR |= USB_CNTR_USBRST;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the USB Core
+  * @param  USBx USB Instance
+  * @param  cfg pointer to a USB_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_CoreInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg)
+{
+  UNUSED(cfg);
+  HAL_StatusTypeDef state;
+
+  /* Reset after a PHY select */
+  state = USB_CoreReset(USBx);
+
+  /* Clear pending interrupts */
+  USBx->ISTR = 0U;
+
+  return state;
+}
+
+/**
+  * @brief  USB_EnableGlobalInt
+  *         Enables the controller's Global Int in the AHB Config reg
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EnableGlobalInt(USB_DRD_TypeDef *USBx)
+{
+  uint32_t winterruptmask;
+
+  /* Clear pending interrupts */
+  USBx->ISTR = 0U;
+
+  /* Set winterruptmask variable */
+  winterruptmask = USB_CNTR_CTRM  | USB_CNTR_WKUPM |
+                   USB_CNTR_SUSPM | USB_CNTR_ERRM |
+                   USB_CNTR_SOFM | USB_CNTR_ESOFM |
+                   USB_CNTR_RESETM | USB_CNTR_L1REQM;
+
+  /* Set interrupt mask */
+  USBx->CNTR = winterruptmask;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DisableGlobalInt
+  *         Disable the controller's Global Int in the AHB Config reg
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DisableGlobalInt(USB_DRD_TypeDef *USBx)
+{
+  uint32_t winterruptmask;
+
+  /* Set winterruptmask variable */
+  winterruptmask = USB_CNTR_CTRM  | USB_CNTR_WKUPM |
+                   USB_CNTR_SUSPM | USB_CNTR_ERRM |
+                   USB_CNTR_SOFM | USB_CNTR_ESOFM |
+                   USB_CNTR_RESETM | USB_CNTR_L1REQM;
+
+  /* Clear interrupt mask */
+  USBx->CNTR &= ~winterruptmask;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetCurrentMode Set functional mode
+  * @param  USBx Selected device
+  * @param  mode current core mode
+  *          This parameter can be one of the these values:
+  *            @arg USB_DEVICE_MODE Peripheral mode
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_SetCurrentMode(USB_DRD_TypeDef *USBx, USB_DRD_ModeTypeDef mode)
+{
+  if (mode == USB_DEVICE_MODE)
+  {
+    USBx->CNTR &= ~USB_CNTR_HOST;
+  }
+  else
+  {
+    USBx->CNTR |= USB_CNTR_HOST;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevInit Initializes the USB controller registers
+  *         for device mode
+  * @param  USBx Selected device
+  * @param  cfg  pointer to a USB_DRD_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DevInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(cfg);
+  /* Force Reset */
+  USBx->CNTR = USB_CNTR_USBRST;
+
+  /* Release Reset */
+  USBx->CNTR &= ~USB_CNTR_USBRST;
+
+  /* Set the Device Mode */
+  (void)USB_SetCurrentMode(USBx, USB_DEVICE_MODE);
+
+  /* Clear pending interrupts */
+  USBx->ISTR = 0U;
+
+  return HAL_OK;
+}
+
+#if defined (HAL_PCD_MODULE_ENABLED)
+/**
+  * @brief  Activate and configure an endpoint
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_ActivateEndpoint(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep)
+{
+  HAL_StatusTypeDef ret = HAL_OK;
+  uint32_t wEpRegVal;
+
+  wEpRegVal = PCD_GET_ENDPOINT(USBx, ep->num) & USB_EP_T_MASK;
+
+  /* initialize Endpoint */
+  switch (ep->type)
+  {
+    case EP_TYPE_CTRL:
+      wEpRegVal |= USB_EP_CONTROL;
+      break;
+
+    case EP_TYPE_BULK:
+      wEpRegVal |= USB_EP_BULK;
+      break;
+
+    case EP_TYPE_INTR:
+      wEpRegVal |= USB_EP_INTERRUPT;
+      break;
+
+    case EP_TYPE_ISOC:
+      wEpRegVal |= USB_EP_ISOCHRONOUS;
+      break;
+
+    default:
+      ret = HAL_ERROR;
+      break;
+  }
+
+  PCD_SET_ENDPOINT(USBx, ep->num, (wEpRegVal | USB_EP_VTRX | USB_EP_VTTX));
+
+  PCD_SET_EP_ADDRESS(USBx, ep->num, ep->num);
+
+  if (ep->doublebuffer == 0U)
+  {
+    if (ep->is_in != 0U)
+    {
+      /*Set the endpoint Transmit buffer address */
+      PCD_SET_EP_TX_ADDRESS(USBx, ep->num, ep->pmaadress);
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Configure NAK status for the Endpoint */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
+      }
+      else
+      {
+        /* Configure TX Endpoint to disabled state */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+      }
+    }
+    else
+    {
+      /*Set the endpoint Receive buffer address */
+      PCD_SET_EP_RX_ADDRESS(USBx, ep->num, ep->pmaadress);
+
+      /*Set the endpoint Receive buffer counter*/
+      PCD_SET_EP_RX_CNT(USBx, ep->num, ep->maxpacket);
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+
+      /* Configure VALID status for the Endpoint*/
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+    }
+  }
+  /*Double Buffer*/
+  else
+  {
+    /* Set the endpoint as double buffered */
+    PCD_SET_EP_DBUF(USBx, ep->num);
+
+    /* Set buffer address for double buffered mode */
+    PCD_SET_EP_DBUF_ADDR(USBx, ep->num, ep->pmaaddr0, ep->pmaaddr1);
+
+    if (ep->is_in == 0U)
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT */
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+    }
+    else
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT */
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Configure NAK status for the Endpoint */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
+      }
+      else
+      {
+        /* Configure TX Endpoint to disabled state */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+      }
+
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+    }
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  De-activate and de-initialize an endpoint
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DeactivateEndpoint(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep)
+{
+  if (ep->doublebuffer == 0U)
+  {
+    if (ep->is_in != 0U)
+    {
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+    }
+    else
+    {
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+    }
+  }
+  /*Double Buffer*/
+  else
+  {
+    if (ep->is_in == 0U)
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+
+      /* Reset value of the data toggle bits for the endpoint out*/
+      PCD_TX_DTOG(USBx, ep->num);
+
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+    }
+    else
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+      PCD_RX_DTOG(USBx, ep->num);
+
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EPStartXfer setup and starts a transfer over an EP
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPStartXfer(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep)
+{
+  uint32_t len;
+  uint16_t pmabuffer;
+  uint16_t wEPVal;
+
+  /* IN endpoint */
+  if (ep->is_in == 1U)
+  {
+    /*Multi packet transfer*/
+    if (ep->xfer_len > ep->maxpacket)
+    {
+      len = ep->maxpacket;
+    }
+    else
+    {
+      len = ep->xfer_len;
+    }
+
+    /* configure and validate Tx endpoint */
+    if (ep->doublebuffer == 0U)
+    {
+      USB_WritePMA(USBx, ep->xfer_buff, ep->pmaadress, (uint16_t)len);
+      PCD_SET_EP_TX_CNT(USBx, ep->num, len);
+    }
+    else
+    {
+      /* double buffer bulk management */
+      if (ep->type == EP_TYPE_BULK)
+      {
+        if (ep->xfer_len_db > ep->maxpacket)
+        {
+          /* enable double buffer */
+          PCD_SET_EP_DBUF(USBx, ep->num);
+
+          /* each Time to write in PMA xfer_len_db will */
+          ep->xfer_len_db -= len;
+
+          /* Fill the two first buffer in the Buffer0 & Buffer1 */
+          if ((PCD_GET_ENDPOINT(USBx, ep->num) & USB_EP_DTOG_TX) != 0U)
+          {
+            /* Set the Double buffer counter for pmabuffer1 */
+            PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr1;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+            ep->xfer_buff += len;
+
+            if (ep->xfer_len_db > ep->maxpacket)
+            {
+              ep->xfer_len_db -= len;
+            }
+            else
+            {
+              len = ep->xfer_len_db;
+              ep->xfer_len_db = 0U;
+            }
+
+            /* Set the Double buffer counter for pmabuffer0 */
+            PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr0;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+          }
+          else
+          {
+            /* Set the Double buffer counter for pmabuffer0 */
+            PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr0;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+            ep->xfer_buff += len;
+
+            if (ep->xfer_len_db > ep->maxpacket)
+            {
+              ep->xfer_len_db -= len;
+            }
+            else
+            {
+              len = ep->xfer_len_db;
+              ep->xfer_len_db = 0U;
+            }
+
+            /* Set the Double buffer counter for pmabuffer1 */
+            PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr1;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+          }
+        }
+        /* auto Switch to single buffer mode when transfer <Mps no need to manage in double buffer */
+        else
+        {
+          len = ep->xfer_len_db;
+
+          /* disable double buffer mode */
+          PCD_CLEAR_EP_DBUF(USBx, ep->num);
+
+          /* Set Tx count with nbre of byte to be transmitted */
+          PCD_SET_EP_TX_CNT(USBx, ep->num, len);
+          pmabuffer = ep->pmaaddr0;
+
+          /* Write the user buffer to USB PMA */
+          USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+        }
+      }/* end if bulk double buffer */
+
+      /* manage isochronous double buffer IN mode */
+      else
+      {
+        /* Write the data to the USB endpoint */
+        if ((PCD_GET_ENDPOINT(USBx, ep->num) & USB_EP_DTOG_TX) != 0U)
+        {
+          /* Set the Double buffer counter for pmabuffer1 */
+          PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
+          pmabuffer = ep->pmaaddr1;
+        }
+        else
+        {
+          /* Set the Double buffer counter for pmabuffer0 */
+          PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
+          pmabuffer = ep->pmaaddr0;
+        }
+
+        USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+        PCD_FreeUserBuffer(USBx, ep->num, ep->is_in);
+      }
+    }
+
+    PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_VALID);
+  }
+  else /* OUT endpoint */
+  {
+    if (ep->doublebuffer == 0U)
+    {
+      /* Multi packet transfer */
+      if (ep->xfer_len > ep->maxpacket)
+      {
+        len = ep->maxpacket;
+        ep->xfer_len -= len;
+      }
+      else
+      {
+        len = ep->xfer_len;
+        ep->xfer_len = 0U;
+      }
+      /* configure and validate Rx endpoint */
+      PCD_SET_EP_RX_CNT(USBx, ep->num, len);
+    }
+    else
+    {
+      /* First Transfer Coming From HAL_PCD_EP_Receive & From ISR */
+      /* Set the Double buffer counter */
+      if (ep->type == EP_TYPE_BULK)
+      {
+        PCD_SET_EP_DBUF_CNT(USBx, ep->num, ep->is_in, ep->maxpacket);
+
+        /* Coming from ISR */
+        if (ep->xfer_count != 0U)
+        {
+          /* update last value to check if there is blocking state */
+          wEPVal = (uint16_t)PCD_GET_ENDPOINT(USBx, ep->num);
+
+          /*Blocking State */
+          if ((((wEPVal & USB_EP_DTOG_RX) != 0U) && ((wEPVal & USB_EP_DTOG_TX) != 0U)) ||
+              (((wEPVal & USB_EP_DTOG_RX) == 0U) && ((wEPVal & USB_EP_DTOG_TX) == 0U)))
+          {
+            PCD_FreeUserBuffer(USBx, ep->num, 0U);
+          }
+        }
+      }
+      /* iso out double */
+      else if (ep->type == EP_TYPE_ISOC)
+      {
+        /* Multi packet transfer */
+        if (ep->xfer_len > ep->maxpacket)
+        {
+          len = ep->maxpacket;
+          ep->xfer_len -= len;
+        }
+        else
+        {
+          len = ep->xfer_len;
+          ep->xfer_len = 0U;
+        }
+        PCD_SET_EP_DBUF_CNT(USBx, ep->num, ep->is_in, len);
+      }
+      else
+      {
+        return HAL_ERROR;
+      }
+    }
+
+    PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_EPSetStall set a stall condition over an EP
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPSetStall(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep)
+{
+  if (ep->is_in != 0U)
+  {
+    PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_STALL);
+  }
+  else
+  {
+    PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_STALL);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EPClearStall Clear a stall condition over an EP
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPClearStall(USB_DRD_TypeDef *USBx, USB_DRD_EPTypeDef *ep)
+{
+  if (ep->doublebuffer == 0U)
+  {
+    if (ep->is_in != 0U)
+    {
+      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Configure NAK status for the Endpoint */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
+      }
+    }
+    else
+    {
+      PCD_CLEAR_RX_DTOG(USBx, ep->num);
+
+      /* Configure VALID status for the Endpoint */
+      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+    }
+  }
+
+  return HAL_OK;
+}
+#endif
+
+/**
+  * @brief  USB_StopDevice Stop the usb device mode
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_StopDevice(USB_DRD_TypeDef *USBx)
+{
+  /* disable all interrupts and force USB reset */
+  USBx->CNTR = USB_CNTR_USBRST;
+
+  /* clear interrupt status register */
+  USBx->ISTR = 0U;
+
+  /* switch-off device */
+  USBx->CNTR = (USB_CNTR_USBRST | USB_CNTR_PDWN);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_SetDevAddress Stop the usb device mode
+  * @param  USBx Selected device
+  * @param  address new device address to be assigned
+  *          This parameter can be a value from 0 to 255
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_SetDevAddress(USB_DRD_TypeDef *USBx, uint8_t address)
+{
+  if (address == 0U)
+  {
+    /* set device address and enable function */
+    USBx->DADDR = USB_DADDR_EF;
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevConnect Connect the USB device by enabling the pull-up/pull-down
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_DevConnect(USB_DRD_TypeDef *USBx)
+{
+  /* Enabling DP Pull-UP bit to Connect internal PU resistor on USB DP line */
+  USBx->BCDR |= USB_BCDR_DPPU;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DevDisconnect Disconnect the USB device by disabling the pull-up/pull-down
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  USB_DevDisconnect(USB_DRD_TypeDef *USBx)
+{
+  /* Disable DP Pull-Up bit to disconnect the Internal PU resistor on USB DP line */
+  USBx->BCDR &= ~(USB_BCDR_DPPU);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_ReadInterrupts return the global USB interrupt status
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+uint32_t  USB_ReadInterrupts(USB_DRD_TypeDef *USBx)
+{
+  uint32_t tmpreg;
+
+  tmpreg = USBx->ISTR;
+  return tmpreg;
+}
+
+/**
+  * @brief  USB_ActivateRemoteWakeup : active remote wakeup signalling
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_ActivateRemoteWakeup(USB_DRD_TypeDef *USBx)
+{
+  USBx->CNTR |= USB_CNTR_L2RES;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_DeActivateRemoteWakeup de-active remote wakeup signalling
+  * @param  USBx Selected device
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_DRD_TypeDef *USBx)
+{
+  USBx->CNTR &= ~USB_CNTR_L2RES;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Copy a buffer from user memory area to packet memory area (PMA)
+  * @param   USBx USB peripheral instance register address.
+  * @param   pbUsrBuf pointer to user memory area.
+  * @param   wPMABufAddr address into PMA.
+  * @param   wNBytes no. of bytes to be copied.
+  * @retval None
+  */
+void USB_WritePMA(USB_DRD_TypeDef *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+{
+  UNUSED(USBx);
+  uint32_t count, tmp;
+  __IO uint32_t *pdwVal;
+  uint32_t NbWords = ((uint32_t)wNBytes + 3U) >> 2U;
+  /* Due to the PMA access 32bit only so the last non word data should be processed alone */
+  uint16_t remaining_bytes = wNBytes % 4U;
+  uint8_t *pBuf = pbUsrBuf;
+
+  /* Check if there is a remaining byte */
+  if (remaining_bytes != 0U)
+  {
+    NbWords--;
+  }
+
+  /* Get the PMA Buffer pointer */
+  pdwVal = (__IO uint32_t *)(USB_DRD_PMAADDR + (uint32_t)wPMABufAddr);
+
+  /* Write the Calculated Word into the PMA related Buffer */
+  for (count = NbWords; count != 0U; count--)
+  {
+    *pdwVal = __UNALIGNED_UINT32_READ(pBuf);
+    pdwVal++;
+    /* Increment pBuf 4 Time as Word Increment */
+    pBuf++;
+    pBuf++;
+    pBuf++;
+    pBuf++;
+  }
+
+  /* When Number of data is not word aligned, write the remaining Byte */
+  if (remaining_bytes != 0U)
+  {
+    count = 0U;
+    tmp = 0U;
+
+    do
+    {
+      tmp = tmp | ((uint32_t)(*(uint8_t *)pBuf) << (8U * count));
+      count++;
+      pBuf++;
+      remaining_bytes--;
+    } while (remaining_bytes != 0U);
+
+    *pdwVal = tmp;
+  }
+}
+
+/**
+  * @brief Copy data from packet memory area (PMA) to user memory buffer
+  * @param   USBx USB peripheral instance register address.
+  * @param   pbUsrBuf pointer to user memory area.
+  * @param   wPMABufAddr address into PMA.
+  * @param   wNBytes no. of bytes to be copied.
+  * @retval None
+  */
+void USB_ReadPMA(USB_DRD_TypeDef *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+{
+  UNUSED(USBx);
+  uint32_t count, tmp;
+  __IO uint32_t *pdwVal;
+  uint32_t NbWords = ((uint32_t)wNBytes + 3U) >> 2U;
+  /*Due to the PMA access 32bit only so the last non word data should be processed alone */
+  uint16_t remaining_bytes = wNBytes % 4U;
+  uint8_t *pBuf = pbUsrBuf;
+
+  /* Get the PMA Buffer pointer */
+  pdwVal = (__IO uint32_t *)(USB_DRD_PMAADDR + (uint32_t)wPMABufAddr);
+
+  /* if nbre of byte is not word aligned decrement the nbre of word*/
+  if (remaining_bytes != 0U)
+  {
+    NbWords--;
+  }
+
+  /*Read the Calculated Word From the PMA related Buffer*/
+  for (count = NbWords; count != 0U; count--)
+  {
+    __UNALIGNED_UINT32_WRITE(pBuf, *pdwVal);
+
+    pdwVal++;
+    pBuf++;
+    pBuf++;
+    pBuf++;
+    pBuf++;
+  }
+
+  /*When Number of data is not word aligned, read the remaining byte*/
+  if (remaining_bytes != 0U)
+  {
+    count = 0U;
+    tmp = *(__IO uint32_t *)pdwVal;
+    do
+    {
+      *(uint8_t *)pBuf = (uint8_t)(tmp >> (8U * (uint8_t)(count)));
+      count++;
+      pBuf++;
+      remaining_bytes-- ;
+    } while (remaining_bytes != 0U);
+  }
+}
+
+
+/*------------------------------------------------------------------------*/
+/*                                HOST API                                */
+/*------------------------------------------------------------------------*/
+
+/**
+  * @brief  USB_HostInit Initializes the USB DRD controller registers
+  *         for Host mode
+  * @param  USBx Selected device
+  * @param  cfg  pointer to a USB_DRD_CfgTypeDef structure that contains
+  *         the configuration information for the specified USBx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_HostInit(USB_DRD_TypeDef *USBx, USB_DRD_CfgTypeDef cfg)
+{
+  UNUSED(cfg);
+  /* Clear All Pending Interrupt */
+  USBx->ISTR = 0U;
+
+  HAL_Delay(200);
+
+  /* Disable all interrupts */
+  USBx->CNTR &= ~(USB_CNTR_CTRM | USB_CNTR_PMAOVRM | USB_CNTR_ERRM |
+                  USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_DCON |
+                  USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_L1REQM);
+
+  /* Clear All Pending Interrupt */
+  USBx->ISTR = 0U;
+
+  /*Enable Global interrupt */
+  USBx->CNTR |= (USB_CNTR_CTRM | USB_CNTR_PMAOVRM | USB_CNTR_ERRM |
+                 USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_DCON |
+                 USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_L1REQM);
+
+  /* Remove Reset */
+  USBx->CNTR &= ~USB_CNTR_USBRST;
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  USB_DRD_ResetPort : Reset Host Port
+  * @param  USBx Selected device
+  * @retval HAL status
+  * @note (1)The application must wait at least 10 ms
+  *   before clearing the reset bit.
+  */
+HAL_StatusTypeDef USB_ResetPort(USB_DRD_TypeDef *USBx)
+{
+  /* Force USB Reset */
+  USBx->CNTR |= USB_CNTR_USBRST;
+  HAL_Delay(100);
+  /* Release USB Reset */
+  USBx->CNTR &= ~USB_CNTR_USBRST;
+  HAL_Delay(30);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Return Host Core speed
+  * @param  USBx Selected device
+  * @retval speed Host speed
+  *          This parameter can be one of these values
+  *            @arg USB_DRD_SPEED_FULL Full speed mode
+  *            @arg USB_DRD_SPEED_LOW Low speed mode
+  */
+uint32_t USB_GetHostSpeed(USB_DRD_TypeDef *USBx)
+{
+  if ((USBx->ISTR & USB_ISTR_LS_DCONN) != 0U)
+  {
+    return USB_DRD_SPEED_LS;
+  }
+  else
+  {
+    return USB_DRD_SPEED_FS;
+  }
+}
+
+/**
+  * @brief  Return Host Current Frame number
+  * @param  USBx Selected device
+  * @retval current frame number
+  */
+uint32_t USB_GetCurrentFrame(USB_DRD_TypeDef *USBx)
+{
+  return USBx->FNR & 0x7FFU;
+}
+
+/**
+  * @brief  Set the channel Kind (Single/double buffer mode)
+  * @param  USBx Selected device
+  * @param  phy_ch_num Selected device
+  * @param  db_state double state can be USB_DRD_DBUFF_ENBALE/USB_DRD_DBUFF_DISABLE
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_HC_DoubleBuffer(USB_DRD_TypeDef *USBx,
+                                      uint8_t phy_ch_num, uint8_t db_state)
+{
+  uint32_t tmp;
+
+  if (db_state == USB_DRD_DBUFF_ENBALE)
+  {
+    tmp = (USB_DRD_GET_CHEP(USBx, phy_ch_num) | USB_CH_KIND) & USB_CHEP_DB_MSK;
+  }
+  else
+  {
+    tmp = USB_DRD_GET_CHEP(USBx, phy_ch_num) & (~USB_CH_KIND) & USB_CHEP_DB_MSK;
+  }
+
+  /* Set the device speed in case using HUB FS with device LS */
+  USB_DRD_SET_CHEP(USBx, phy_ch_num, tmp);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initialize a host channel
+  * @param  USBx Selected device
+  * @param  phy_ch_num Channel number
+  *         This parameter can be a value from 1 to 15
+  * @param  epnum Endpoint number
+  *          This parameter can be a value from 1 to 15
+  * @param  dev_address Current device address
+  *          This parameter can be a value from 0 to 255
+  * @param  speed Current device speed
+  *          This parameter can be one of these values:
+  *          @arg USB_DRD_SPEED_FULL Full speed mode
+  *          @arg USB_DRD_SPEED_LOW  Low speed mode
+  * @param  ep_type Endpoint Type
+  *          This parameter can be one of these values:
+  *            @arg EP_TYPE_CTRL Control type
+  *            @arg EP_TYPE_ISOC Isochronous type
+  *            @arg EP_TYPE_BULK Bulk type
+  *            @arg EP_TYPE_INTR Interrupt type
+  * @param  mps Max Packet Size
+  *          This parameter can be a value from 0 to 32K
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_Init(USB_DRD_TypeDef *USBx, uint8_t phy_ch_num,
+                              uint8_t epnum, uint8_t dev_address, uint8_t speed,
+                              uint8_t ep_type, uint16_t mps)
+{
+  HAL_StatusTypeDef ret = HAL_OK;
+  uint32_t wChRegVal;
+
+  wChRegVal = USB_DRD_GET_CHEP(USBx, phy_ch_num) & USB_CH_T_MASK;
+
+  /* initialize host Channel */
+  switch (ep_type)
+  {
+    case EP_TYPE_CTRL:
+      wChRegVal |= USB_EP_CONTROL;
+      break;
+
+    case EP_TYPE_BULK:
+      wChRegVal |= USB_EP_BULK;
+      break;
+
+    case EP_TYPE_INTR:
+      wChRegVal |= USB_EP_INTERRUPT;
+      break;
+
+    case EP_TYPE_ISOC:
+      wChRegVal |= USB_EP_ISOCHRONOUS;
+      break;
+
+    default:
+      ret = HAL_ERROR;
+      break;
+  }
+
+  wChRegVal &= ~USB_CHEP_DEVADDR;
+  wChRegVal |= (((uint32_t)dev_address << USB_CHEP_DEVADDR_Pos) |
+                ((uint32_t)epnum & 0x0FU));
+
+  /* Set the device speed in case using HUB FS with device LS */
+  if (speed == USB_DRD_SPEED_LSFS)
+  {
+    wChRegVal |= USB_CHEP_LSEP;
+  }
+
+  /* Set the dev_address & ep type */
+  USB_DRD_SET_CHEP(USBx, phy_ch_num, (wChRegVal | USB_CH_VTRX | USB_CH_VTTX));
+
+  /*Set the Rx Count */
+  USB_DRD_SET_CHEP_RX_CNT(USBx, phy_ch_num, mps);
+
+  return ret;
+}
+
+/**
+  * @brief  Start a transfer over a host channel
+  * @param  USBx Selected device
+  * @param  hc pointer to host channel structure
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_StartXfer(USB_DRD_TypeDef *USBx,
+                                   USB_DRD_HCTypeDef *hc)
+{
+  uint32_t len;
+  uint32_t phy_ch_num = (uint32_t)hc->phy_ch_num;
+  uint32_t ch_reg = USB_DRD_GET_CHEP(USBx, phy_ch_num);
+
+  if (hc->ch_dir == CH_IN_DIR)  /* In Channel */
+  {
+    /* Multi packet transfer */
+    if (hc->xfer_len > hc->max_packet)
+    {
+      len = hc->max_packet;
+    }
+    else
+    {
+      len = hc->xfer_len;
+    }
+
+    if (hc->doublebuffer == 0U)
+    {
+      /* Set RX buffer count */
+      USB_DRD_SET_CHEP_RX_CNT(USBx, phy_ch_num, len);
+    }
+    else if (hc->ep_type == EP_TYPE_BULK)
+    {
+      /* Double buffer activated */
+      if ((hc->xfer_len > hc->max_packet))
+      {
+        (void)USB_HC_DoubleBuffer(USBx, (uint8_t)phy_ch_num, USB_DRD_DBUFF_ENBALE);
+
+        /*Set the Double buffer counter*/
+        USB_DRD_SET_CHEP_DBUF_CNT(USBx, phy_ch_num, hc->ch_dir, len);
+      }
+      else  /* switch to single buffer mode */
+      {
+        (void)USB_HC_DoubleBuffer(USBx, (uint8_t)phy_ch_num, USB_DRD_DBUFF_DISABLE);
+
+        /* Set RX buffer count */
+        USB_DRD_SET_CHEP_RX_CNT(USBx, phy_ch_num, len);
+      }
+    }
+    else  /* isochronous */
+    {
+      /*Set the Double buffer counter*/
+      USB_DRD_SET_CHEP_DBUF_CNT(USBx, phy_ch_num, hc->ch_dir, len);
+    }
+
+    /*Enable host channel */
+    USB_DRD_SET_CHEP_RX_STATUS(USBx, phy_ch_num, USB_CHEP_RX_STRX);
+  }
+  else   /* Out Channel */
+  {
+    /* Multi packet transfer*/
+    if (hc->xfer_len > hc->max_packet)
+    {
+      len = hc->max_packet;
+    }
+    else
+    {
+      len = hc->xfer_len;
+    }
+
+    /* configure and validate Tx endpoint */
+    if (hc->doublebuffer == 0U)
+    {
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaadress, (uint16_t)len);
+      USB_DRD_SET_CHEP_TX_CNT(USBx, phy_ch_num, (uint16_t)len);
+      /*SET PID SETUP  */
+      if ((hc->data_pid) == HC_PID_SETUP)
+      {
+        USB_DRD_CHEP_TX_SETUP(USBx,  phy_ch_num);
+      }
+    }
+    else if (hc->ep_type == EP_TYPE_BULK)
+    {
+      (void)USB_HC_BULK_DB_StartXfer(USBx, hc, ch_reg, &len);
+    }
+    else
+    {
+      (void)USB_HC_ISO_DB_StartXfer(USBx, hc, len);
+    }
+
+    /* Enable host channel */
+    USB_DRD_SET_CHEP_TX_STATUS(USBx, hc->phy_ch_num, USB_CH_TX_VALID);
+  }
+
+  return HAL_OK;
+}
+/**
+  * @brief  Start Transfer of Channel isochronous out double buffer
+  * @param  USBx Selected device
+  * @param  hc_num Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @param  len Transfer Length
+  * @retval HAL state
+  */
+static HAL_StatusTypeDef USB_HC_ISO_DB_StartXfer(USB_DRD_TypeDef *USBx,
+                                                 USB_DRD_HCTypeDef *hc,
+                                                 uint32_t len)
+{
+  uint32_t phy_ch_num = (uint32_t)hc->phy_ch_num;
+
+  /* check the DTOG_TX to determine in which buffer we should write */
+  if ((USB_DRD_GET_CHEP(USBx, phy_ch_num) & USB_CH_DTOG_TX) != 0U)
+  {
+    if (hc->pmabuff1_state == USB_PMABUF_EMPTY)
+    {
+      /* Set the Double buffer counter for pmabuffer1 */
+      USB_DRD_SET_CHEP_DBUF1_CNT(USBx, phy_ch_num, hc->ch_dir, len);
+      hc->pmabuff1_state = USB_PMABUF_NOT_EMPTY;
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr1, (uint16_t)len);
+
+      if (hc->pmabuff0_state == USB_PMABUF_EMPTY)
+      {
+        hc->urb_state = URB_DONE;
+      }
+    }
+    else if (hc->pmabuff0_state == USB_PMABUF_EMPTY)
+    {
+      /* Set the Double buffer counter for pmabuffer0 */
+      USB_DRD_SET_CHEP_DBUF0_CNT(USBx, phy_ch_num, hc->ch_dir, len);
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr0, (uint16_t)len);
+      hc->pmabuff0_state = USB_PMABUF_NOT_EMPTY;
+    }
+    else
+    {
+      /* both buffer are not empty, should not be in this condition */
+      /*...*/
+    }
+  }
+  else
+  {
+    /* DTOGTX=0 */
+    if (hc->pmabuff0_state == USB_PMABUF_EMPTY)
+    {
+      /* Set the Double buffer counter for pmabuffer0 */
+      USB_DRD_SET_CHEP_DBUF0_CNT(USBx, phy_ch_num, hc->ch_dir, len);
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr0, (uint16_t)len);
+      hc->pmabuff0_state = USB_PMABUF_NOT_EMPTY;
+      if (hc->pmabuff1_state == USB_PMABUF_EMPTY)
+      {
+        hc->urb_state = URB_DONE;
+      }
+    }
+    else if (hc->pmabuff1_state == USB_PMABUF_EMPTY)
+    {
+      /* Set the Double buffer counter for pmabuffer1 */
+      USB_DRD_SET_CHEP_DBUF1_CNT(USBx, phy_ch_num, hc->ch_dir, len);
+      hc->pmabuff1_state = USB_PMABUF_NOT_EMPTY;
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr1, (uint16_t)len);
+    }
+    else
+    {
+      /*...*/
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start Transfer of Channel bulk out double buffer
+  * @param  USBx Selected device
+  * @param  hc_num Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @param  ch_reg snapshot of the CHEPR register
+  * @param  len Transfer Length
+  * @retval HAL state
+  */
+static HAL_StatusTypeDef USB_HC_BULK_DB_StartXfer(USB_DRD_TypeDef *USBx,
+                                                  USB_DRD_HCTypeDef *hc,
+                                                  uint32_t ch_reg,
+                                                  uint32_t *len)
+{
+  uint32_t phy_ch_num = (uint32_t)hc->phy_ch_num;
+
+  /* -Double Buffer Mangement- */
+  if (hc->xfer_len_db > hc->max_packet)
+  {
+    /* enable double buffer mode */
+    (void)USB_HC_DoubleBuffer(USBx, (uint8_t)phy_ch_num, USB_DRD_DBUFF_ENBALE);
+    *len = hc->max_packet;
+    hc->xfer_len_db -= *len;
+
+    /* Prepare two buffer before enabling host */
+    if ((ch_reg & USB_CH_DTOG_TX) == 0U)
+    {
+      /* Write Buffer0 */
+      USB_DRD_SET_CHEP_TX_CNT(USBx, phy_ch_num, (uint16_t)*len);
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr0, (uint16_t)*len);
+    }
+    else
+    {
+      /* Write Buffer1 */
+      USB_DRD_SET_CHEP_DBUF1_CNT(USBx, (uint8_t) phy_ch_num, 0U, (uint16_t)*len);
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr1, (uint16_t)*len);
+    }
+
+    hc->xfer_buff += *len;
+
+    /* Multi packet transfer */
+    if (hc->xfer_len_db > hc->max_packet)
+    {
+      *len = hc->max_packet;
+      hc->xfer_len_db -= *len;
+    }
+    else
+    {
+      *len = hc->xfer_len_db;
+      hc->xfer_len_db = 0U;
+    }
+
+    if ((ch_reg & USB_CH_DTOG_TX) == 0U)
+    {
+      /* Write Buffer1 */
+      USB_DRD_SET_CHEP_DBUF1_CNT(USBx, phy_ch_num, 0U, (uint16_t)*len);
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr1, (uint16_t)*len);
+    }
+    else
+    {
+      /* Write Buffer0 */
+      USB_DRD_SET_CHEP_TX_CNT(USBx, phy_ch_num, (uint16_t)*len);
+      USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr0, (uint16_t)*len);
+    }
+  }
+  else
+  {
+    /* Disable double buffer mode */
+    (void)USB_HC_DoubleBuffer(USBx, (uint8_t)phy_ch_num, USB_DRD_DBUFF_DISABLE);
+
+    USB_WritePMA(USBx, hc->xfer_buff, hc->pmaaddr0, (uint16_t)*len);
+    USB_DRD_SET_CHEP_TX_CNT(USBx, phy_ch_num, (uint16_t)*len);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Halt a host channel in
+  * @param  USBx Selected device
+  * @param  hc_num Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_IN_Halt(USB_DRD_TypeDef *USBx, uint8_t phy_ch)
+{
+  /* Set disable to Channel */
+  USB_DRD_SET_CHEP_RX_STATUS(USBx, phy_ch, USB_CH_RX_DIS);
+
+  return HAL_OK;
+}
+/**
+  * @brief  Halt a host channel out
+  * @param  USBx Selected device
+  * @param  hc_num Host Channel number
+  *         This parameter can be a value from 1 to 15
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_HC_OUT_Halt(USB_DRD_TypeDef *USBx, uint8_t phy_ch)
+{
+  /* Set disable to Channel */
+  USB_DRD_SET_CHEP_TX_STATUS(USBx, phy_ch, USB_CH_TX_DIS);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop Host Core
+  * @param  USBx Selected device
+  * @retval HAL state
+  */
+HAL_StatusTypeDef USB_StopHost(USB_DRD_TypeDef *USBx)
+{
+  USBx->ISTR &= ~(USB_ISTR_DIR | USB_ISTR_L1REQ |
+                  USB_ISTR_ESOF | USB_ISTR_SOF |
+                  USB_ISTR_RESET | USB_ISTR_DCON |
+                  USB_ISTR_SUSP | USB_ISTR_WKUP |
+                  USB_ISTR_ERR | USB_ISTR_PMAOVR |
+                  USB_ISTR_CTR);
+
+  /* Set PowerDown */
+  USBx->CNTR |= USB_CNTR_PDWN;
+
+  /* Force a Reset */
+  USBx->CNTR |= USB_CNTR_USBRST;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* defined (USB_DRD_FS) */
+#endif /* defined (HAL_PCD_MODULE_ENABLED) || defined (HAL_HCD_MODULE_ENABLED) */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/soc/stm32g030xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g030xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -247,10 +247,10 @@ typedef struct
   __IO uint32_t ECCR;         /*!< FLASH ECC register,                                Address offset: 0x18 */
        uint32_t RESERVED2;    /*!< Reserved2,                                         Address offset: 0x1C */
   __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
-       uint32_t RESERVED4[2]; /*!< Reserved4,                                         Address offset: 0x24--0x28 */
+       uint32_t RESERVED3[2]; /*!< Reserved3,                                         Address offset: 0x24--0x28 */
   __IO uint32_t WRP1AR;       /*!< FLASH Bank WRP area A address register,            Address offset: 0x2C */
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
-       uint32_t RESERVED5[2]; /*!< Reserved5,                                         Address offset: 0x34--0x38 */
+       uint32_t RESERVED4[2]; /*!< Reserved4,                                         Address offset: 0x34--0x38 */
 } FLASH_TypeDef;
 
 /**
@@ -520,6 +520,8 @@ typedef struct
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
 #define SRAM_SIZE_MAX         (0x00002000UL)  /*!< maximum SRAM size (up to 8 KBytes) */
 
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x007FU)) << 10U)
+
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
 #define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
@@ -783,7 +785,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -1581,7 +1583,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2136,32 +2138,20 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
-#define EXTI_IMR1_IM22_Pos           (22U)
-#define EXTI_IMR1_IM22_Msk           (0x1UL << EXTI_IMR1_IM22_Pos)             /*!< 0x00400000 */
-#define EXTI_IMR1_IM22               EXTI_IMR1_IM22_Msk                        /*!< Interrupt Mask on line 22 */
 #define EXTI_IMR1_IM23_Pos           (23U)
 #define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
 #define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
-#define EXTI_IMR1_IM24_Pos           (24U)
-#define EXTI_IMR1_IM24_Msk           (0x1UL << EXTI_IMR1_IM24_Pos)             /*!< 0x01000000 */
-#define EXTI_IMR1_IM24               EXTI_IMR1_IM24_Msk                        /*!< Interrupt Mask on line 24 */
 #define EXTI_IMR1_IM25_Pos           (25U)
 #define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
 #define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
-#define EXTI_IMR1_IM26_Pos           (26U)
-#define EXTI_IMR1_IM26_Msk           (0x1UL << EXTI_IMR1_IM26_Pos)             /*!< 0x04000000 */
-#define EXTI_IMR1_IM26               EXTI_IMR1_IM26_Msk                        /*!< Interrupt Mask on line 26 */
 #define EXTI_IMR1_IM31_Pos           (31U)
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0x86A8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x86A8FFFFU */
+#define EXTI_IMR1_IM_Msk             (0x82A8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x82A8FFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
 
@@ -2214,12 +2204,6 @@ typedef struct
 #define EXTI_EMR1_EM15_Pos           (15U)
 #define EXTI_EMR1_EM15_Msk           (0x1UL << EXTI_EMR1_EM15_Pos)             /*!< 0x00008000 */
 #define EXTI_EMR1_EM15               EXTI_EMR1_EM15_Msk                        /*!< Event Mask on line 15 */
-#define EXTI_EMR1_EM17_Pos           (17U)
-#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
-#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
-#define EXTI_EMR1_EM18_Pos           (18U)
-#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
-#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
 #define EXTI_EMR1_EM19_Pos           (19U)
 #define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
 #define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
@@ -2232,9 +2216,6 @@ typedef struct
 #define EXTI_EMR1_EM25_Pos           (25U)
 #define EXTI_EMR1_EM25_Msk           (0x1UL << EXTI_EMR1_EM25_Pos)             /*!< 0x02000000 */
 #define EXTI_EMR1_EM25               EXTI_EMR1_EM25_Msk                        /*!< Event Mask on line 25 */
-#define EXTI_EMR1_EM26_Pos           (26U)
-#define EXTI_EMR1_EM26_Msk           (0x1UL << EXTI_EMR1_EM26_Pos)             /*!< 0x04000000 */
-#define EXTI_EMR1_EM26               EXTI_EMR1_EM26_Msk                        /*!< Event Mask on line 26 */
 #define EXTI_EMR1_EM31_Pos           (31U)
 #define EXTI_EMR1_EM31_Msk           (0x1UL << EXTI_EMR1_EM31_Pos)             /*!< 0x80000000 */
 #define EXTI_EMR1_EM31               EXTI_EMR1_EM31_Msk                        /*!< Event Mask on line 31 */
@@ -2307,94 +2288,93 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x1FUL << FLASH_CR_PNB_Pos)       /*!< 0x000000F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
 /*******************  Bits definition for FLASH_ECCR register  ****************/
 #define FLASH_ECCR_ADDR_ECC_Pos                (0U)
-#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
 #define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
 #define FLASH_ECCR_SYSF_ECC_Pos                (20U)
-#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
 #define FLASH_ECCR_ECCCIE_Pos                  (24U)
-#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
 #define FLASH_ECCR_ECCC_Pos                    (30U)
-#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
 #define FLASH_ECCR_ECCD_Pos                    (31U)
-#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
-
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
 #define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
@@ -2411,7 +2391,6 @@ typedef struct
 #define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
 #define FLASH_WRP1BR_WRP1B_END_Msk             (0x1FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x001F0000 */
 #define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
-
 
 
 /******************************************************************************/
@@ -3882,7 +3861,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
 
 /********************  Bit definition for RCC_CR register  *****************/
@@ -3964,12 +3943,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -3987,9 +3960,10 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
@@ -5223,7 +5197,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -5428,6 +5402,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
 /*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
 #define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
 #define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
@@ -5522,9 +5497,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -5591,9 +5566,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -5635,7 +5610,7 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -6404,7 +6379,7 @@ typedef struct
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -6454,7 +6429,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -6462,7 +6437,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -6470,7 +6445,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -6478,7 +6453,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -7249,6 +7224,10 @@ typedef struct
 #define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
                                                        ((INSTANCE) == TIM3))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
 
@@ -7256,9 +7235,6 @@ typedef struct
 #define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))

--- a/stm32cube/stm32g0xx/soc/stm32g031xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g031xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -77,7 +77,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
 /******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
-  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt(EXTI line 16)           */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI line 16                                          */
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
   RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
@@ -258,7 +258,7 @@ typedef struct
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
   __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
   __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
-       uint32_t RESERVED3[17];/*!< Reserved3,                                         Address offset: 0x3C */
+       uint32_t RESERVED8[17];/*!< Reserved8,                                         Address offset: 0x3C--0x7C */
   __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
 } FLASH_TypeDef;
 
@@ -553,6 +553,8 @@ typedef struct
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
 #define SRAM_SIZE_MAX         (0x00002000UL)  /*!< maximum SRAM size (up to 8 KBytes) */
 
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x007FU)) << 10U)
+
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
 #define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
@@ -826,7 +828,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -1624,7 +1626,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2197,27 +2199,15 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
-#define EXTI_IMR1_IM22_Pos           (22U)
-#define EXTI_IMR1_IM22_Msk           (0x1UL << EXTI_IMR1_IM22_Pos)             /*!< 0x00400000 */
-#define EXTI_IMR1_IM22               EXTI_IMR1_IM22_Msk                        /*!< Interrupt Mask on line 22 */
 #define EXTI_IMR1_IM23_Pos           (23U)
 #define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
 #define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
-#define EXTI_IMR1_IM24_Pos           (24U)
-#define EXTI_IMR1_IM24_Msk           (0x1UL << EXTI_IMR1_IM24_Pos)             /*!< 0x01000000 */
-#define EXTI_IMR1_IM24               EXTI_IMR1_IM24_Msk                        /*!< Interrupt Mask on line 24 */
 #define EXTI_IMR1_IM25_Pos           (25U)
 #define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
 #define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
-#define EXTI_IMR1_IM26_Pos           (26U)
-#define EXTI_IMR1_IM26_Msk           (0x1UL << EXTI_IMR1_IM26_Pos)             /*!< 0x04000000 */
-#define EXTI_IMR1_IM26               EXTI_IMR1_IM26_Msk                        /*!< Interrupt Mask on line 26 */
 #define EXTI_IMR1_IM28_Pos           (28U)
 #define EXTI_IMR1_IM28_Msk           (0x1UL << EXTI_IMR1_IM28_Pos)             /*!< 0x10000000 */
 #define EXTI_IMR1_IM28               EXTI_IMR1_IM28_Msk                        /*!< Interrupt Mask on line 28 */
@@ -2231,7 +2221,7 @@ typedef struct
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0xF2A9FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xF6A8FFFFU */
+#define EXTI_IMR1_IM_Msk             (0xF2A9FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xF2A9FFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
 
@@ -2287,12 +2277,6 @@ typedef struct
 #define EXTI_EMR1_EM16_Pos           (16U)
 #define EXTI_EMR1_EM16_Msk           (0x1UL << EXTI_EMR1_EM16_Pos)             /*!< 0x00010000 */
 #define EXTI_EMR1_EM16               EXTI_EMR1_EM16_Msk                        /*!< Event Mask on line 16 */
-#define EXTI_EMR1_EM17_Pos           (17U)
-#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
-#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
-#define EXTI_EMR1_EM18_Pos           (18U)
-#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
-#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
 #define EXTI_EMR1_EM19_Pos           (19U)
 #define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
 #define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
@@ -2305,9 +2289,6 @@ typedef struct
 #define EXTI_EMR1_EM25_Pos           (25U)
 #define EXTI_EMR1_EM25_Msk           (0x1UL << EXTI_EMR1_EM25_Pos)             /*!< 0x02000000 */
 #define EXTI_EMR1_EM25               EXTI_EMR1_EM25_Msk                        /*!< Event Mask on line 25 */
-#define EXTI_EMR1_EM26_Pos           (26U)
-#define EXTI_EMR1_EM26_Msk           (0x1UL << EXTI_EMR1_EM26_Pos)             /*!< 0x04000000 */
-#define EXTI_EMR1_EM26               EXTI_EMR1_EM26_Msk                        /*!< Event Mask on line 26 */
 #define EXTI_EMR1_EM28_Pos           (28U)
 #define EXTI_EMR1_EM28_Msk           (0x1UL << EXTI_EMR1_EM28_Pos)             /*!< 0x10000000 */
 #define EXTI_EMR1_EM28               EXTI_EMR1_EM28_Msk                        /*!< Event Mask on line 28 */
@@ -2397,135 +2378,135 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x1FUL << FLASH_CR_PNB_Pos)       /*!< 0x000000F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_RDERRIE_Pos                   (26U)
-#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)  /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
 #define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_SEC_PROT_Pos                  (28U)
-#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos) /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
 #define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
 /*******************  Bits definition for FLASH_ECCR register  ****************/
 #define FLASH_ECCR_ADDR_ECC_Pos                (0U)
-#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
 #define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
 #define FLASH_ECCR_SYSF_ECC_Pos                (20U)
-#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
 #define FLASH_ECCR_ECCCIE_Pos                  (24U)
-#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
 #define FLASH_ECCR_ECCC_Pos                    (30U)
-#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
 #define FLASH_ECCR_ECCD_Pos                    (31U)
-#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_BOR_EN_Pos                  (8U)
-#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos) /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
 #define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
-#define FLASH_OPTR_BORF_LEV_Pos                (9U)
-#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000600 */
-#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
-#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000200 */
-#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000400 */
-#define FLASH_OPTR_BORR_LEV_Pos                (11U)
-#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001800 */
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
 #define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
-#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00000800 */
-#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_nRST_SHDW_Pos               (15U)
-#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
 #define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
 #define FLASH_OPTR_NRST_MODE_Pos               (27U)
-#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
 #define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
-#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x08000000 */
-#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x10000000 */
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
 #define FLASH_OPTR_IRHEN_Pos                   (29U)
-#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos) /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
 #define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
 
 /******************  Bits definition for FLASH_PCROP1ASR register  ************/
 #define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
-#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x7FUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x0000007F */
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x7FUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)   /*!< 0x0000007F */
 #define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1AER register  ************/
 #define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
-#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x7FUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x0000007F */
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x7FUL << FLASH_PCROP1AER_PCROP1A_END_Pos)    /*!< 0x0000007F */
 #define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
 #define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
-#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
 #define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
@@ -2546,13 +2527,14 @@ typedef struct
 
 /******************  Bits definition for FLASH_PCROP1BSR register  ************/
 #define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
-#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x7FUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x0000007F */
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x7FUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)   /*!< 0x0000007F */
 #define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1BER register  ************/
 #define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
-#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x7FUL << FLASH_PCROP1BER_PCROP1B_END_Pos)  /*!< 0x0000007F */
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x7FUL << FLASH_PCROP1BER_PCROP1B_END_Pos)    /*!< 0x0000007F */
 #define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
 
 /******************  Bits definition for FLASH_SECR register  *****************/
 #define FLASH_SECR_SEC_SIZE_Pos                (0U)
@@ -2561,7 +2543,6 @@ typedef struct
 #define FLASH_SECR_BOOT_LOCK_Pos               (16U)
 #define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
 #define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -4059,7 +4040,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
 #define RCC_PLLQ_SUPPORT
 
@@ -4142,12 +4123,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -4165,9 +4140,10 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
@@ -5467,7 +5443,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -5672,6 +5648,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
 /*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
 #define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
 #define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
@@ -5772,9 +5749,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -5841,9 +5818,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -5894,7 +5871,7 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -6679,7 +6656,7 @@ typedef struct
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -6729,7 +6706,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -6737,7 +6714,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -6745,7 +6722,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -6753,7 +6730,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -6878,7 +6855,7 @@ typedef struct
 
 #define LPTIM_CFGR_TIMOUT_Pos       (19U)
 #define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
-#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timout enable */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
 #define LPTIM_CFGR_WAVE_Pos         (20U)
 #define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
 #define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
@@ -7777,6 +7754,11 @@ typedef struct
                                                        ((INSTANCE) == TIM2) || \
                                                        ((INSTANCE) == TIM3))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM2)  || \
@@ -7786,9 +7768,6 @@ typedef struct
 #define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))

--- a/stm32cube/stm32g0xx/soc/stm32g041xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g041xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -77,7 +77,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
 /******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
-  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt(EXTI line 16)           */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI line 16                                          */
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
   RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
@@ -259,7 +259,7 @@ typedef struct
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
   __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
   __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
-       uint32_t RESERVED3[17];/*!< Reserved3,                                         Address offset: 0x3C */
+       uint32_t RESERVED8[17];/*!< Reserved8,                                         Address offset: 0x3C--0x7C */
   __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
 } FLASH_TypeDef;
 
@@ -595,6 +595,8 @@ typedef struct
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
 #define SRAM_SIZE_MAX         (0x00002000UL)  /*!< maximum SRAM size (up to 8 KBytes) */
 
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x007FU)) << 10U)
+
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
 #define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
@@ -873,7 +875,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -1860,7 +1862,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2433,27 +2435,15 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
-#define EXTI_IMR1_IM22_Pos           (22U)
-#define EXTI_IMR1_IM22_Msk           (0x1UL << EXTI_IMR1_IM22_Pos)             /*!< 0x00400000 */
-#define EXTI_IMR1_IM22               EXTI_IMR1_IM22_Msk                        /*!< Interrupt Mask on line 22 */
 #define EXTI_IMR1_IM23_Pos           (23U)
 #define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
 #define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
-#define EXTI_IMR1_IM24_Pos           (24U)
-#define EXTI_IMR1_IM24_Msk           (0x1UL << EXTI_IMR1_IM24_Pos)             /*!< 0x01000000 */
-#define EXTI_IMR1_IM24               EXTI_IMR1_IM24_Msk                        /*!< Interrupt Mask on line 24 */
 #define EXTI_IMR1_IM25_Pos           (25U)
 #define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
 #define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
-#define EXTI_IMR1_IM26_Pos           (26U)
-#define EXTI_IMR1_IM26_Msk           (0x1UL << EXTI_IMR1_IM26_Pos)             /*!< 0x04000000 */
-#define EXTI_IMR1_IM26               EXTI_IMR1_IM26_Msk                        /*!< Interrupt Mask on line 26 */
 #define EXTI_IMR1_IM28_Pos           (28U)
 #define EXTI_IMR1_IM28_Msk           (0x1UL << EXTI_IMR1_IM28_Pos)             /*!< 0x10000000 */
 #define EXTI_IMR1_IM28               EXTI_IMR1_IM28_Msk                        /*!< Interrupt Mask on line 28 */
@@ -2467,7 +2457,7 @@ typedef struct
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0xF2A9FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xF6A8FFFFU */
+#define EXTI_IMR1_IM_Msk             (0xF2A9FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xF2A9FFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
 
@@ -2523,12 +2513,6 @@ typedef struct
 #define EXTI_EMR1_EM16_Pos           (16U)
 #define EXTI_EMR1_EM16_Msk           (0x1UL << EXTI_EMR1_EM16_Pos)             /*!< 0x00010000 */
 #define EXTI_EMR1_EM16               EXTI_EMR1_EM16_Msk                        /*!< Event Mask on line 16 */
-#define EXTI_EMR1_EM17_Pos           (17U)
-#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
-#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
-#define EXTI_EMR1_EM18_Pos           (18U)
-#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
-#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
 #define EXTI_EMR1_EM19_Pos           (19U)
 #define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
 #define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
@@ -2541,9 +2525,6 @@ typedef struct
 #define EXTI_EMR1_EM25_Pos           (25U)
 #define EXTI_EMR1_EM25_Msk           (0x1UL << EXTI_EMR1_EM25_Pos)             /*!< 0x02000000 */
 #define EXTI_EMR1_EM25               EXTI_EMR1_EM25_Msk                        /*!< Event Mask on line 25 */
-#define EXTI_EMR1_EM26_Pos           (26U)
-#define EXTI_EMR1_EM26_Msk           (0x1UL << EXTI_EMR1_EM26_Pos)             /*!< 0x04000000 */
-#define EXTI_EMR1_EM26               EXTI_EMR1_EM26_Msk                        /*!< Event Mask on line 26 */
 #define EXTI_EMR1_EM28_Pos           (28U)
 #define EXTI_EMR1_EM28_Msk           (0x1UL << EXTI_EMR1_EM28_Pos)             /*!< 0x10000000 */
 #define EXTI_EMR1_EM28               EXTI_EMR1_EM28_Msk                        /*!< Event Mask on line 28 */
@@ -2633,135 +2614,135 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x1FUL << FLASH_CR_PNB_Pos)       /*!< 0x000000F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_RDERRIE_Pos                   (26U)
-#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)  /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
 #define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_SEC_PROT_Pos                  (28U)
-#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos) /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
 #define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
 /*******************  Bits definition for FLASH_ECCR register  ****************/
 #define FLASH_ECCR_ADDR_ECC_Pos                (0U)
-#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
 #define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
 #define FLASH_ECCR_SYSF_ECC_Pos                (20U)
-#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
 #define FLASH_ECCR_ECCCIE_Pos                  (24U)
-#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
 #define FLASH_ECCR_ECCC_Pos                    (30U)
-#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
 #define FLASH_ECCR_ECCD_Pos                    (31U)
-#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_BOR_EN_Pos                  (8U)
-#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos) /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
 #define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
-#define FLASH_OPTR_BORF_LEV_Pos                (9U)
-#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000600 */
-#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
-#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000200 */
-#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000400 */
-#define FLASH_OPTR_BORR_LEV_Pos                (11U)
-#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001800 */
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
 #define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
-#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00000800 */
-#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_nRST_SHDW_Pos               (15U)
-#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
 #define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
 #define FLASH_OPTR_NRST_MODE_Pos               (27U)
-#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
 #define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
-#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x08000000 */
-#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x10000000 */
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
 #define FLASH_OPTR_IRHEN_Pos                   (29U)
-#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos) /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
 #define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
 
 /******************  Bits definition for FLASH_PCROP1ASR register  ************/
 #define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
-#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x7FUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x0000007F */
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x7FUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)   /*!< 0x0000007F */
 #define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1AER register  ************/
 #define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
-#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x7FUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x0000007F */
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x7FUL << FLASH_PCROP1AER_PCROP1A_END_Pos)    /*!< 0x0000007F */
 #define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
 #define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
-#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
 #define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
@@ -2782,13 +2763,14 @@ typedef struct
 
 /******************  Bits definition for FLASH_PCROP1BSR register  ************/
 #define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
-#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x7FUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x0000007F */
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x7FUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)   /*!< 0x0000007F */
 #define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1BER register  ************/
 #define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
-#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x7FUL << FLASH_PCROP1BER_PCROP1B_END_Pos)  /*!< 0x0000007F */
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x7FUL << FLASH_PCROP1BER_PCROP1B_END_Pos)    /*!< 0x0000007F */
 #define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
 
 /******************  Bits definition for FLASH_SECR register  *****************/
 #define FLASH_SECR_SEC_SIZE_Pos                (0U)
@@ -2797,7 +2779,6 @@ typedef struct
 #define FLASH_SECR_BOOT_LOCK_Pos               (16U)
 #define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
 #define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -4295,7 +4276,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
 #define RCC_PLLQ_SUPPORT
 
@@ -4378,12 +4359,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -4401,9 +4376,10 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
@@ -5765,7 +5741,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -5970,6 +5946,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
 /*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
 #define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
 #define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
@@ -6070,9 +6047,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -6139,9 +6116,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -6192,7 +6169,7 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -6983,7 +6960,7 @@ typedef struct
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -7033,7 +7010,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -7041,7 +7018,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -7049,7 +7026,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -7057,7 +7034,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -7182,7 +7159,7 @@ typedef struct
 
 #define LPTIM_CFGR_TIMOUT_Pos       (19U)
 #define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
-#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timout enable */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
 #define LPTIM_CFGR_WAVE_Pos         (20U)
 #define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
 #define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
@@ -8085,6 +8062,11 @@ typedef struct
                                                        ((INSTANCE) == TIM2) || \
                                                        ((INSTANCE) == TIM3))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM2)  || \
@@ -8094,9 +8076,6 @@ typedef struct
 #define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))

--- a/stm32cube/stm32g0xx/soc/stm32g050xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g050xx.h
@@ -1,0 +1,7453 @@
+/**
+  ******************************************************************************
+  * @file    stm32g050xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for stm32g050xx devices.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral's registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under Apache License, Version 2.0,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/Apache-2.0
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32g050xx
+  * @{
+  */
+
+#ifndef STM32G050xx_H
+#define STM32G050xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+  * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+   */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+ * @brief stm32g050xx Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
+ */
+
+/*!< Interrupt Number Definition */
+typedef enum
+{
+/******  Cortex-M0+ Processor Exceptions Numbers ***************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  HardFault_IRQn              = -13,    /*!< 3 Cortex-M Hard Fault Interrupt                                   */
+  SVC_IRQn                    = -5,     /*!< 11 Cortex-M SV Call Interrupt                                     */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M Pend SV Interrupt                                     */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
+/******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
+  FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
+  EXTI0_1_IRQn                = 5,      /*!< EXTI 0 and 1 Interrupts                                           */
+  EXTI2_3_IRQn                = 6,      /*!< EXTI Line 2 and 3 Interrupts                                      */
+  EXTI4_15_IRQn               = 7,      /*!< EXTI Line 4 to 15 Interrupts                                      */
+  DMA1_Channel1_IRQn          = 9,      /*!< DMA1 Channel 1 Interrupt                                          */
+  DMA1_Channel2_3_IRQn        = 10,     /*!< DMA1 Channel 2 and Channel 3 Interrupts                           */
+  DMA1_Ch4_7_DMAMUX1_OVR_IRQn = 11,     /*!< DMA1 Channel 4 to Channel 7 and DMAMUX1 Overrun Interrupts        */
+  ADC1_IRQn                   = 12,     /*!< ADC1 Interrupts                                                   */
+  TIM1_BRK_UP_TRG_COM_IRQn    = 13,     /*!< TIM1 Break, Update, Trigger and Commutation Interrupts            */
+  TIM1_CC_IRQn                = 14,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM3_IRQn                   = 16,     /*!< TIM3 global Interrupt                                             */
+  TIM6_IRQn                   = 17,     /*!< TIM6 global Interrupts                                            */
+  TIM7_IRQn                   = 18,     /*!< TIM7 global Interrupt                                             */
+  TIM14_IRQn                  = 19,     /*!< TIM14 global Interrupt                                            */
+  TIM15_IRQn                  = 20,     /*!< TIM15 global Interrupt                                            */
+  TIM16_IRQn                  = 21,     /*!< TIM16 global Interrupt                                            */
+  TIM17_IRQn                  = 22,     /*!< TIM17 global Interrupt                                            */
+  I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt  (combined with EXTI 23)                           */
+  I2C2_IRQn                   = 24,     /*!< I2C2 Interrupt                                                    */
+  SPI1_IRQn                   = 25,     /*!< SPI1/I2S1 Interrupt                                               */
+  SPI2_IRQn                   = 26,     /*!< SPI2 Interrupt                                                    */
+  USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
+  USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                                  */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+#include "core_cm0plus.h"               /* Cortex-M0+ processor and core peripherals */
+#include "system_stm32g0xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC interrupt and status register,             Address offset: 0x00 */
+  __IO uint32_t IER;          /*!< ADC interrupt enable register,                 Address offset: 0x04 */
+  __IO uint32_t CR;           /*!< ADC control register,                          Address offset: 0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC configuration register 1,                  Address offset: 0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC configuration register 2,                  Address offset: 0x10 */
+  __IO uint32_t SMPR;         /*!< ADC sampling time register,                    Address offset: 0x14 */
+       uint32_t RESERVED1;    /*!< Reserved,                                                      0x18 */
+       uint32_t RESERVED2;    /*!< Reserved,                                                      0x1C */
+  __IO uint32_t TR1;          /*!< ADC analog watchdog 1 threshold register,      Address offset: 0x20 */
+  __IO uint32_t TR2;          /*!< ADC analog watchdog 2 threshold register,      Address offset: 0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC group regular sequencer register,          Address offset: 0x28 */
+  __IO uint32_t TR3;          /*!< ADC analog watchdog 3 threshold register,      Address offset: 0x2C */
+       uint32_t RESERVED3[4]; /*!< Reserved,                                               0x30 - 0x3C */
+  __IO uint32_t DR;           /*!< ADC group regular data register,               Address offset: 0x40 */
+       uint32_t RESERVED4[23];/*!< Reserved,                                               0x44 - 0x9C */
+  __IO uint32_t AWD2CR;       /*!< ADC analog watchdog 2 configuration register,  Address offset: 0xA0 */
+  __IO uint32_t AWD3CR;       /*!< ADC analog watchdog 3 configuration register,  Address offset: 0xA4 */
+       uint32_t RESERVED5[3]; /*!< Reserved,                                               0xA8 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC Calibration factor register,               Address offset: 0xB4 */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CCR;          /*!< ADC common configuration register,             Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+
+
+
+/**
+  * @brief CRC calculation unit
+  */
+typedef struct
+{
+  __IO uint32_t DR;             /*!< CRC Data register,                         Address offset: 0x00 */
+  __IO uint32_t IDR;            /*!< CRC Independent data register,             Address offset: 0x04 */
+  __IO uint32_t CR;             /*!< CRC Control register,                      Address offset: 0x08 */
+       uint32_t RESERVED1;      /*!< Reserved,                                                  0x0C */
+  __IO uint32_t INIT;           /*!< Initial CRC value register,                Address offset: 0x10 */
+  __IO uint32_t POL;            /*!< CRC polynomial register,                   Address offset: 0x14 */
+} CRC_TypeDef;
+
+
+/**
+  * @brief Debug MCU
+  */
+typedef struct
+{
+  __IO uint32_t IDCODE;      /*!< MCU device ID code,              Address offset: 0x00 */
+  __IO uint32_t CR;          /*!< Debug configuration register,    Address offset: 0x04 */
+  __IO uint32_t APBFZ1;      /*!< Debug APB freeze register 1,     Address offset: 0x08 */
+  __IO uint32_t APBFZ2;      /*!< Debug APB freeze register 2,     Address offset: 0x0C */
+} DBG_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+typedef struct
+{
+  __IO uint32_t CCR;         /*!< DMA channel x configuration register        */
+  __IO uint32_t CNDTR;       /*!< DMA channel x number of data register       */
+  __IO uint32_t CPAR;        /*!< DMA channel x peripheral address register   */
+  __IO uint32_t CMAR;        /*!< DMA channel x memory address register       */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< DMA interrupt status register,                 Address offset: 0x00 */
+  __IO uint32_t IFCR;        /*!< DMA interrupt flag clear register,             Address offset: 0x04 */
+} DMA_TypeDef;
+
+/**
+  * @brief DMA Multiplexer
+  */
+typedef struct
+{
+  __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
+}DMAMUX_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
+  __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
+}DMAMUX_ChannelStatus_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
+}DMAMUX_RequestGen_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
+  __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
+}DMAMUX_RequestGenStatus_TypeDef;
+
+/**
+  * @brief Asynch Interrupt/Event Controller (EXTI)
+  */
+typedef struct
+{
+  __IO uint32_t RTSR1;          /*!< EXTI Rising Trigger Selection Register 1,        Address offset:   0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI Falling Trigger Selection Register 1,       Address offset:   0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI Software Interrupt event Register 1,        Address offset:   0x08 */
+  __IO uint32_t RPR1;           /*!< EXTI Rising Pending Register 1,                  Address offset:   0x0C */
+  __IO uint32_t FPR1;           /*!< EXTI Falling Pending Register 1,                 Address offset:   0x10 */
+       uint32_t RESERVED1[3];   /*!< Reserved 1,                                                0x14 -- 0x1C */
+       uint32_t RESERVED2[5];   /*!< Reserved 2,                                                0x20 -- 0x30 */
+       uint32_t RESERVED3[11];  /*!< Reserved 3,                                                0x34 -- 0x5C */
+  __IO uint32_t EXTICR[4];      /*!< EXTI External Interrupt Configuration Register,            0x60 -- 0x6C */
+       uint32_t RESERVED4[4];   /*!< Reserved 4,                                                0x70 -- 0x7C */
+  __IO uint32_t IMR1;           /*!< EXTI Interrupt Mask Register 1,                  Address offset:   0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI Event Mask Register 1,                      Address offset:   0x84 */
+} EXTI_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;          /*!< FLASH Access Control register,                     Address offset: 0x00 */
+       uint32_t RESERVED1;    /*!< Reserved1,                                         Address offset: 0x04 */
+  __IO uint32_t KEYR;         /*!< FLASH Key register,                                Address offset: 0x08 */
+  __IO uint32_t OPTKEYR;      /*!< FLASH Option Key register,                         Address offset: 0x0C */
+  __IO uint32_t SR;           /*!< FLASH Status register,                             Address offset: 0x10 */
+  __IO uint32_t CR;           /*!< FLASH Control register,                            Address offset: 0x14 */
+  __IO uint32_t ECCR;         /*!< FLASH ECC register,                                Address offset: 0x18 */
+       uint32_t RESERVED2;    /*!< Reserved2,                                         Address offset: 0x1C */
+  __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
+  __IO uint32_t PCROP1ASR;    /*!< FLASH Bank PCROP area A Start address register,    Address offset: 0x24 */
+  __IO uint32_t PCROP1AER;    /*!< FLASH Bank PCROP area A End address register,      Address offset: 0x28 */
+  __IO uint32_t WRP1AR;       /*!< FLASH Bank WRP area A address register,            Address offset: 0x2C */
+  __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
+  __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
+  __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
+} FLASH_TypeDef;
+
+/**
+  * @brief General Purpose I/O
+  */
+typedef struct
+{
+  __IO uint32_t MODER;       /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;      /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;     /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;       /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;         /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;         /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;        /*!< GPIO port bit set/reset  register,     Address offset: 0x18      */
+  __IO uint32_t LCKR;        /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];      /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;         /*!< GPIO Bit Reset register,               Address offset: 0x28      */
+} GPIO_TypeDef;
+
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;          /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;          /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;         /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;          /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR;        /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+
+
+/**
+  * @brief Power Control
+  */
+typedef struct
+{
+  __IO uint32_t CR1;          /*!< PWR Power Control Register 1,                     Address offset: 0x00 */
+       uint32_t RESERVED0;    /*!< Reserved,                                         Address offset: 0x04 */
+  __IO uint32_t CR3;          /*!< PWR Power Control Register 3,                     Address offset: 0x08 */
+  __IO uint32_t CR4;          /*!< PWR Power Control Register 4,                     Address offset: 0x0C */
+  __IO uint32_t SR1;          /*!< PWR Power Status Register 1,                      Address offset: 0x10 */
+  __IO uint32_t SR2;          /*!< PWR Power Status Register 2,                      Address offset: 0x14 */
+  __IO uint32_t SCR;          /*!< PWR Power Status Clear Register,                  Address offset: 0x18 */
+       uint32_t RESERVED1;    /*!< Reserved,                                         Address offset: 0x1C */
+  __IO uint32_t PUCRA;        /*!< PWR Pull-Up Control Register of port A,           Address offset: 0x20 */
+  __IO uint32_t PDCRA;        /*!< PWR Pull-Down Control Register of port A,         Address offset: 0x24 */
+  __IO uint32_t PUCRB;        /*!< PWR Pull-Up Control Register of port B,           Address offset: 0x28 */
+  __IO uint32_t PDCRB;        /*!< PWR Pull-Down Control Register of port B,         Address offset: 0x2C */
+  __IO uint32_t PUCRC;        /*!< PWR Pull-Up Control Register of port C,           Address offset: 0x30 */
+  __IO uint32_t PDCRC;        /*!< PWR Pull-Down Control Register of port C,         Address offset: 0x34 */
+  __IO uint32_t PUCRD;        /*!< PWR Pull-Up Control Register of port D,           Address offset: 0x38 */
+  __IO uint32_t PDCRD;        /*!< PWR Pull-Down Control Register of port D,         Address offset: 0x3C */
+       uint32_t RESERVED2;    /*!< Reserved,                                         Address offset: 0x40 */
+       uint32_t RESERVED3;    /*!< Reserved,                                         Address offset: 0x44 */
+  __IO uint32_t PUCRF;        /*!< PWR Pull-Up Control Register of port F,           Address offset: 0x48 */
+  __IO uint32_t PDCRF;        /*!< PWR Pull-Down Control Register of port F,         Address offset: 0x4C */
+} PWR_TypeDef;
+
+/**
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< RCC Clock Sources Control Register,                                     Address offset: 0x00 */
+  __IO uint32_t ICSCR;       /*!< RCC Internal Clock Sources Calibration Register,                        Address offset: 0x04 */
+  __IO uint32_t CFGR;        /*!< RCC Regulated Domain Clocks Configuration Register,                     Address offset: 0x08 */
+  __IO uint32_t PLLCFGR;     /*!< RCC System PLL configuration Register,                                  Address offset: 0x0C */
+  __IO uint32_t RESERVED0;   /*!< Reserved,                                                               Address offset: 0x10 */
+  __IO uint32_t RESERVED1;   /*!< Reserved,                                                               Address offset: 0x14 */
+  __IO uint32_t CIER;        /*!< RCC Clock Interrupt Enable Register,                                    Address offset: 0x18 */
+  __IO uint32_t CIFR;        /*!< RCC Clock Interrupt Flag Register,                                      Address offset: 0x1C */
+  __IO uint32_t CICR;        /*!< RCC Clock Interrupt Clear Register,                                     Address offset: 0x20 */
+  __IO uint32_t IOPRSTR;     /*!< RCC IO port reset register,                                             Address offset: 0x24 */
+  __IO uint32_t AHBRSTR;     /*!< RCC AHB peripherals reset register,                                     Address offset: 0x28 */
+  __IO uint32_t APBRSTR1;    /*!< RCC APB peripherals reset register 1,                                   Address offset: 0x2C */
+  __IO uint32_t APBRSTR2;    /*!< RCC APB peripherals reset register 2,                                   Address offset: 0x30 */
+  __IO uint32_t IOPENR;      /*!< RCC IO port enable register,                                            Address offset: 0x34 */
+  __IO uint32_t AHBENR;      /*!< RCC AHB peripherals clock enable register,                              Address offset: 0x38 */
+  __IO uint32_t APBENR1;     /*!< RCC APB peripherals clock enable register1,                             Address offset: 0x3C */
+  __IO uint32_t APBENR2;     /*!< RCC APB peripherals clock enable register2,                             Address offset: 0x40 */
+  __IO uint32_t IOPSMENR;    /*!< RCC IO port clocks enable in sleep mode register,                       Address offset: 0x44 */
+  __IO uint32_t AHBSMENR;    /*!< RCC AHB peripheral clocks enable in sleep mode register,                Address offset: 0x48 */
+  __IO uint32_t APBSMENR1;   /*!< RCC APB peripheral clocks enable in sleep mode register1,               Address offset: 0x4C */
+  __IO uint32_t APBSMENR2;   /*!< RCC APB peripheral clocks enable in sleep mode register2,               Address offset: 0x50 */
+  __IO uint32_t CCIPR;       /*!< RCC Peripherals Independent Clocks Configuration Register,              Address offset: 0x54 */
+  __IO uint32_t RESERVED2;   /*!< Reserved,                                                               Address offset: 0x58 */
+  __IO uint32_t BDCR;        /*!< RCC Backup Domain Control Register,                                     Address offset: 0x5C */
+  __IO uint32_t CSR;         /*!< RCC Unregulated Domain Clock Control and Status Register,               Address offset: 0x60 */
+} RCC_TypeDef;
+
+/**
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;          /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;          /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t SSR;         /*!< RTC sub second register,                                   Address offset: 0x08 */
+  __IO uint32_t ICSR;        /*!< RTC initialization control and status register,            Address offset: 0x0C */
+  __IO uint32_t PRER;        /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;        /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+  __IO uint32_t CR;          /*!< RTC control register,                                      Address offset: 0x18 */
+       uint32_t RESERVED0;   /*!< Reserved                                                   Address offset: 0x1C */
+       uint32_t RESERVED1;   /*!< Reserved                                                   Address offset: 0x20 */
+  __IO uint32_t WPR;         /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t CALR;        /*!< RTC calibration register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;      /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;        /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;        /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;       /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+       uint32_t RESERVED2;   /*!< Reserved                                                   Address offset: 0x1C */
+  __IO uint32_t ALRMAR;      /*!< RTC alarm A register,                                      Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;    /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBR;      /*!< RTC alarm B register,                                      Address offset: 0x48 */
+  __IO uint32_t ALRMBSSR;    /*!< RTC alarm B sub second register,                           Address offset: 0x4C */
+  __IO uint32_t SR;          /*!< RTC Status register,                                       Address offset: 0x50 */
+  __IO uint32_t MISR;        /*!< RTC Masked Interrupt Status register,                      Address offset: 0x54 */
+       uint32_t RESERVED3;   /*!< Reserved                                                   Address offset: 0x58 */
+  __IO uint32_t SCR;         /*!< RTC Status Clear register,                                 Address offset: 0x5C */
+  __IO uint32_t OR;          /*!< RTC option register,                                       Address offset: 0x60 */
+} RTC_TypeDef;
+
+/**
+  * @brief Tamper and backup registers
+  */
+typedef struct
+{
+  __IO uint32_t CR1;            /*!< TAMP configuration register 1,                             Address offset: 0x00 */
+  __IO uint32_t CR2;            /*!< TAMP configuration register 2,                             Address offset: 0x04 */
+       uint32_t RESERVED0;      /*!< Reserved                                                   Address offset: 0x08 */
+  __IO uint32_t FLTCR;          /*!< Reserved                                                   Address offset: 0x0C */
+       uint32_t RESERVED1[7];   /*!< Reserved                                                   Address offset: 0x10 -- 0x28 */
+  __IO uint32_t IER;            /*!< TAMP Interrupt enable register,                            Address offset: 0x2C */
+  __IO uint32_t SR;             /*!< TAMP Status register,                                      Address offset: 0x30 */
+  __IO uint32_t MISR;           /*!< TAMP Masked Interrupt Status register,                     Address offset: 0x34 */
+       uint32_t RESERVED2;      /*!< Reserved                                                   Address offset: 0x38 */
+  __IO uint32_t SCR;            /*!< TAMP Status clear register,                                Address offset: 0x3C */
+       uint32_t RESERVED3[48];  /*!< Reserved                                                   Address offset: 0x54 -- 0xFC */
+  __IO uint32_t BKP0R;          /*!< TAMP backup register 0,                                    Address offset: 0x100 */
+  __IO uint32_t BKP1R;          /*!< TAMP backup register 1,                                    Address offset: 0x104 */
+  __IO uint32_t BKP2R;          /*!< TAMP backup register 2,                                    Address offset: 0x108 */
+  __IO uint32_t BKP3R;          /*!< TAMP backup register 3,                                    Address offset: 0x10C */
+  __IO uint32_t BKP4R;          /*!< TAMP backup register 4,                                    Address offset: 0x110 */
+} TAMP_TypeDef;
+
+  /**
+  * @brief Serial Peripheral Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1 (not used in I2S mode),       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,                              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,                                 Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,                                   Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register (not used in I2S mode),  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register (not used in I2S mode),          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register (not used in I2S mode),          Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;  /*!< SPI_I2S configuration register,                      Address offset: 0x1C */
+  __IO uint32_t I2SPR;    /*!< SPI_I2S prescaler register,                          Address offset: 0x20 */
+} SPI_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+typedef struct
+{
+  __IO uint32_t CFGR1;          /*!< SYSCFG configuration register 1,                   Address offset: 0x00 */
+       uint32_t RESERVED0[5];   /*!< Reserved,                                                   0x04 --0x14 */
+  __IO uint32_t CFGR2;          /*!< SYSCFG configuration register 2,                   Address offset: 0x18 */
+       uint32_t RESERVED1[25];  /*!< Reserved                                                           0x1C */
+  __IO uint32_t IT_LINE_SR[32]; /*!< SYSCFG configuration IT_LINE register,             Address offset: 0x80 */
+} SYSCFG_TypeDef;
+
+/**
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,                   Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,                   Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,          Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,        Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                      Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,            Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1,      Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2,      Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register,      Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                     Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */
+  __IO uint32_t OR1;         /*!< TIM option register,                      Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare register5,            Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare register6,            Address offset: 0x5C */
+  __IO uint32_t AF1;         /*!< TIM alternate function register 1,        Address offset: 0x60 */
+  __IO uint32_t AF2;         /*!< TIM alternate function register 2,        Address offset: 0x64 */
+  __IO uint32_t TISEL;       /*!< TIM Input Selection register,             Address offset: 0x68 */
+} TIM_TypeDef;
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< USART Control register 1,                 Address offset: 0x00  */
+  __IO uint32_t CR2;         /*!< USART Control register 2,                 Address offset: 0x04  */
+  __IO uint32_t CR3;         /*!< USART Control register 3,                 Address offset: 0x08  */
+  __IO uint32_t BRR;         /*!< USART Baud rate register,                 Address offset: 0x0C  */
+  __IO uint32_t GTPR;        /*!< USART Guard time and prescaler register,  Address offset: 0x10  */
+  __IO uint32_t RTOR;        /*!< USART Receiver Time Out register,         Address offset: 0x14  */
+  __IO uint32_t RQR;         /*!< USART Request register,                   Address offset: 0x18  */
+  __IO uint32_t ISR;         /*!< USART Interrupt and status register,      Address offset: 0x1C  */
+  __IO uint32_t ICR;         /*!< USART Interrupt flag Clear register,      Address offset: 0x20  */
+  __IO uint32_t RDR;         /*!< USART Receive Data register,              Address offset: 0x24  */
+  __IO uint32_t TDR;         /*!< USART Transmit Data register,             Address offset: 0x28  */
+  __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C  */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;         /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+#define FLASH_BASE            (0x08000000UL)  /*!< FLASH base address */
+#define SRAM_BASE             (0x20000000UL)  /*!< SRAM base address */
+#define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
+#define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
+#define SRAM_SIZE_MAX         (0x00004000UL)  /*!< maximum SRAM size (up to 16 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x007FU)) << 10U)
+
+/*!< Peripheral memory map */
+#define APBPERIPH_BASE        (PERIPH_BASE)
+#define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
+
+/*!< APB peripherals */
+
+#define TIM3_BASE             (APBPERIPH_BASE + 0x00000400UL)
+#define TIM6_BASE             (APBPERIPH_BASE + 0x00001000UL)
+#define TIM7_BASE             (APBPERIPH_BASE + 0x00001400UL)
+#define TIM14_BASE            (APBPERIPH_BASE + 0x00002000UL)
+#define RTC_BASE              (APBPERIPH_BASE + 0x00002800UL)
+#define WWDG_BASE             (APBPERIPH_BASE + 0x00002C00UL)
+#define IWDG_BASE             (APBPERIPH_BASE + 0x00003000UL)
+#define SPI2_BASE             (APBPERIPH_BASE + 0x00003800UL)
+#define USART2_BASE           (APBPERIPH_BASE + 0x00004400UL)
+#define I2C1_BASE             (APBPERIPH_BASE + 0x00005400UL)
+#define I2C2_BASE             (APBPERIPH_BASE + 0x00005800UL)
+#define PWR_BASE              (APBPERIPH_BASE + 0x00007000UL)
+#define TAMP_BASE             (APBPERIPH_BASE + 0x0000B000UL)
+#define SYSCFG_BASE           (APBPERIPH_BASE + 0x00010000UL)
+#define ADC1_BASE             (APBPERIPH_BASE + 0x00012400UL)
+#define ADC1_COMMON_BASE      (APBPERIPH_BASE + 0x00012708UL)
+#define ADC_BASE              (ADC1_COMMON_BASE) /* Kept for legacy purpose */
+#define TIM1_BASE             (APBPERIPH_BASE + 0x00012C00UL)
+#define SPI1_BASE             (APBPERIPH_BASE + 0x00013000UL)
+#define USART1_BASE           (APBPERIPH_BASE + 0x00013800UL)
+#define TIM15_BASE            (APBPERIPH_BASE + 0x00014000UL)
+#define TIM16_BASE            (APBPERIPH_BASE + 0x00014400UL)
+#define TIM17_BASE            (APBPERIPH_BASE + 0x00014800UL)
+#define DBG_BASE              (APBPERIPH_BASE + 0x00015800UL)
+
+
+/*!< AHB peripherals */
+#define DMA1_BASE             (AHBPERIPH_BASE)
+#define DMAMUX1_BASE          (AHBPERIPH_BASE + 0x00000800UL)
+#define RCC_BASE              (AHBPERIPH_BASE + 0x00001000UL)
+#define EXTI_BASE             (AHBPERIPH_BASE + 0x00001800UL)
+#define FLASH_R_BASE          (AHBPERIPH_BASE + 0x00002000UL)
+#define CRC_BASE              (AHBPERIPH_BASE + 0x00003000UL)
+
+
+#define DMA1_Channel1_BASE    (DMA1_BASE + 0x00000008UL)
+#define DMA1_Channel2_BASE    (DMA1_BASE + 0x0000001CUL)
+#define DMA1_Channel3_BASE    (DMA1_BASE + 0x00000030UL)
+#define DMA1_Channel4_BASE    (DMA1_BASE + 0x00000044UL)
+#define DMA1_Channel5_BASE    (DMA1_BASE + 0x00000058UL)
+#define DMA1_Channel6_BASE    (DMA1_BASE + 0x0000006CUL)
+#define DMA1_Channel7_BASE    (DMA1_BASE + 0x00000080UL)
+
+#define DMAMUX1_Channel0_BASE    (DMAMUX1_BASE)
+#define DMAMUX1_Channel1_BASE    (DMAMUX1_BASE + 0x00000004UL)
+#define DMAMUX1_Channel2_BASE    (DMAMUX1_BASE + 0x00000008UL)
+#define DMAMUX1_Channel3_BASE    (DMAMUX1_BASE + 0x0000000CUL)
+#define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
+#define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
+#define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+
+#define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
+#define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
+#define DMAMUX1_RequestGenerator2_BASE  (DMAMUX1_BASE + 0x00000108UL)
+#define DMAMUX1_RequestGenerator3_BASE  (DMAMUX1_BASE + 0x0000010CUL)
+
+#define DMAMUX1_ChannelStatus_BASE      (DMAMUX1_BASE + 0x00000080UL)
+#define DMAMUX1_RequestGenStatus_BASE   (DMAMUX1_BASE + 0x00000140UL)
+
+/*!< IOPORT */
+#define GPIOA_BASE            (IOPORT_BASE + 0x00000000UL)
+#define GPIOB_BASE            (IOPORT_BASE + 0x00000400UL)
+#define GPIOC_BASE            (IOPORT_BASE + 0x00000800UL)
+#define GPIOD_BASE            (IOPORT_BASE + 0x00000C00UL)
+#define GPIOF_BASE            (IOPORT_BASE + 0x00001400UL)
+
+/*!< Device Electronic Signature */
+#define PACKAGE_BASE          (0x1FFF7500UL)        /*!< Package data register base address     */
+#define UID_BASE              (0x1FFF7590UL)        /*!< Unique device ID register base address */
+#define FLASHSIZE_BASE        (0x1FFF75E0UL)        /*!< Flash size data register base address  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+#define TIM3                ((TIM_TypeDef *) TIM3_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                ((TIM_TypeDef *) TIM7_BASE)
+#define TIM14               ((TIM_TypeDef *) TIM14_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define TAMP                ((TAMP_TypeDef *) TAMP_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define TIM15               ((TIM_TypeDef *) TIM15_BASE)
+#define TIM16               ((TIM_TypeDef *) TIM16_BASE)
+#define TIM17               ((TIM_TypeDef *) TIM17_BASE)
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOF               ((GPIO_TypeDef *) GPIOF_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) ADC1_COMMON_BASE)
+#define ADC                 (ADC1_COMMON) /* Kept for legacy purpose */
+
+
+
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+#define DMAMUX1                ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
+#define DMAMUX1_Channel0       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
+#define DMAMUX1_Channel1       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel1_BASE)
+#define DMAMUX1_Channel2       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel2_BASE)
+#define DMAMUX1_Channel3       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel3_BASE)
+#define DMAMUX1_Channel4       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
+#define DMAMUX1_Channel5       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
+#define DMAMUX1_Channel6       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+
+#define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
+#define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
+#define DMAMUX1_RequestGenerator2  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator2_BASE)
+#define DMAMUX1_RequestGenerator3  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator3_BASE)
+
+#define DMAMUX1_ChannelStatus      ((DMAMUX_ChannelStatus_TypeDef *) DMAMUX1_ChannelStatus_BASE)
+#define DMAMUX1_RequestGenStatus   ((DMAMUX_RequestGenStatus_TypeDef *) DMAMUX1_RequestGenStatus_BASE)
+
+#define DBG              ((DBG_TypeDef *) DBG_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for ADC_ISR register  *******************/
+#define ADC_ISR_ADRDY_Pos              (0U)
+#define ADC_ISR_ADRDY_Msk              (0x1UL << ADC_ISR_ADRDY_Pos)            /*!< 0x00000001 */
+#define ADC_ISR_ADRDY                  ADC_ISR_ADRDY_Msk                       /*!< ADC ready flag */
+#define ADC_ISR_EOSMP_Pos              (1U)
+#define ADC_ISR_EOSMP_Msk              (0x1UL << ADC_ISR_EOSMP_Pos)            /*!< 0x00000002 */
+#define ADC_ISR_EOSMP                  ADC_ISR_EOSMP_Msk                       /*!< ADC group regular end of sampling flag */
+#define ADC_ISR_EOC_Pos                (2U)
+#define ADC_ISR_EOC_Msk                (0x1UL << ADC_ISR_EOC_Pos)              /*!< 0x00000004 */
+#define ADC_ISR_EOC                    ADC_ISR_EOC_Msk                         /*!< ADC group regular end of unitary conversion flag */
+#define ADC_ISR_EOS_Pos                (3U)
+#define ADC_ISR_EOS_Msk                (0x1UL << ADC_ISR_EOS_Pos)              /*!< 0x00000008 */
+#define ADC_ISR_EOS                    ADC_ISR_EOS_Msk                         /*!< ADC group regular end of sequence conversions flag */
+#define ADC_ISR_OVR_Pos                (4U)
+#define ADC_ISR_OVR_Msk                (0x1UL << ADC_ISR_OVR_Pos)              /*!< 0x00000010 */
+#define ADC_ISR_OVR                    ADC_ISR_OVR_Msk                         /*!< ADC group regular overrun flag */
+#define ADC_ISR_AWD1_Pos               (7U)
+#define ADC_ISR_AWD1_Msk               (0x1UL << ADC_ISR_AWD1_Pos)             /*!< 0x00000080 */
+#define ADC_ISR_AWD1                   ADC_ISR_AWD1_Msk                        /*!< ADC analog watchdog 1 flag */
+#define ADC_ISR_AWD2_Pos               (8U)
+#define ADC_ISR_AWD2_Msk               (0x1UL << ADC_ISR_AWD2_Pos)             /*!< 0x00000100 */
+#define ADC_ISR_AWD2                   ADC_ISR_AWD2_Msk                        /*!< ADC analog watchdog 2 flag */
+#define ADC_ISR_AWD3_Pos               (9U)
+#define ADC_ISR_AWD3_Msk               (0x1UL << ADC_ISR_AWD3_Pos)             /*!< 0x00000200 */
+#define ADC_ISR_AWD3                   ADC_ISR_AWD3_Msk                        /*!< ADC analog watchdog 3 flag */
+#define ADC_ISR_EOCAL_Pos              (11U)
+#define ADC_ISR_EOCAL_Msk              (0x1UL << ADC_ISR_EOCAL_Pos)            /*!< 0x00000800 */
+#define ADC_ISR_EOCAL                  ADC_ISR_EOCAL_Msk                       /*!< ADC end of calibration flag */
+#define ADC_ISR_CCRDY_Pos              (13U)
+#define ADC_ISR_CCRDY_Msk              (0x1UL << ADC_ISR_CCRDY_Pos)            /*!< 0x00002000 */
+#define ADC_ISR_CCRDY                  ADC_ISR_CCRDY_Msk                       /*!< ADC channel configuration ready flag */
+
+/* Legacy defines */
+#define ADC_ISR_EOSEQ           (ADC_ISR_EOS)
+
+/********************  Bit definition for ADC_IER register  *******************/
+#define ADC_IER_ADRDYIE_Pos            (0U)
+#define ADC_IER_ADRDYIE_Msk            (0x1UL << ADC_IER_ADRDYIE_Pos)          /*!< 0x00000001 */
+#define ADC_IER_ADRDYIE                ADC_IER_ADRDYIE_Msk                     /*!< ADC ready interrupt */
+#define ADC_IER_EOSMPIE_Pos            (1U)
+#define ADC_IER_EOSMPIE_Msk            (0x1UL << ADC_IER_EOSMPIE_Pos)          /*!< 0x00000002 */
+#define ADC_IER_EOSMPIE                ADC_IER_EOSMPIE_Msk                     /*!< ADC group regular end of sampling interrupt */
+#define ADC_IER_EOCIE_Pos              (2U)
+#define ADC_IER_EOCIE_Msk              (0x1UL << ADC_IER_EOCIE_Pos)            /*!< 0x00000004 */
+#define ADC_IER_EOCIE                  ADC_IER_EOCIE_Msk                       /*!< ADC group regular end of unitary conversion interrupt */
+#define ADC_IER_EOSIE_Pos              (3U)
+#define ADC_IER_EOSIE_Msk              (0x1UL << ADC_IER_EOSIE_Pos)            /*!< 0x00000008 */
+#define ADC_IER_EOSIE                  ADC_IER_EOSIE_Msk                       /*!< ADC group regular end of sequence conversions interrupt */
+#define ADC_IER_OVRIE_Pos              (4U)
+#define ADC_IER_OVRIE_Msk              (0x1UL << ADC_IER_OVRIE_Pos)            /*!< 0x00000010 */
+#define ADC_IER_OVRIE                  ADC_IER_OVRIE_Msk                       /*!< ADC group regular overrun interrupt */
+#define ADC_IER_AWD1IE_Pos             (7U)
+#define ADC_IER_AWD1IE_Msk             (0x1UL << ADC_IER_AWD1IE_Pos)           /*!< 0x00000080 */
+#define ADC_IER_AWD1IE                 ADC_IER_AWD1IE_Msk                      /*!< ADC analog watchdog 1 interrupt */
+#define ADC_IER_AWD2IE_Pos             (8U)
+#define ADC_IER_AWD2IE_Msk             (0x1UL << ADC_IER_AWD2IE_Pos)           /*!< 0x00000100 */
+#define ADC_IER_AWD2IE                 ADC_IER_AWD2IE_Msk                      /*!< ADC analog watchdog 2 interrupt */
+#define ADC_IER_AWD3IE_Pos             (9U)
+#define ADC_IER_AWD3IE_Msk             (0x1UL << ADC_IER_AWD3IE_Pos)           /*!< 0x00000200 */
+#define ADC_IER_AWD3IE                 ADC_IER_AWD3IE_Msk                      /*!< ADC analog watchdog 3 interrupt */
+#define ADC_IER_EOCALIE_Pos            (11U)
+#define ADC_IER_EOCALIE_Msk            (0x1UL << ADC_IER_EOCALIE_Pos)          /*!< 0x00000800 */
+#define ADC_IER_EOCALIE                ADC_IER_EOCALIE_Msk                     /*!< ADC end of calibration interrupt */
+#define ADC_IER_CCRDYIE_Pos            (13U)
+#define ADC_IER_CCRDYIE_Msk            (0x1UL << ADC_IER_CCRDYIE_Pos)          /*!< 0x00002000 */
+#define ADC_IER_CCRDYIE                ADC_IER_CCRDYIE_Msk                     /*!< ADC channel configuration ready interrupt */
+
+/* Legacy defines */
+#define ADC_IER_EOSEQIE           (ADC_IER_EOSIE)
+
+/********************  Bit definition for ADC_CR register  ********************/
+#define ADC_CR_ADEN_Pos                (0U)
+#define ADC_CR_ADEN_Msk                (0x1UL << ADC_CR_ADEN_Pos)              /*!< 0x00000001 */
+#define ADC_CR_ADEN                    ADC_CR_ADEN_Msk                         /*!< ADC enable */
+#define ADC_CR_ADDIS_Pos               (1U)
+#define ADC_CR_ADDIS_Msk               (0x1UL << ADC_CR_ADDIS_Pos)             /*!< 0x00000002 */
+#define ADC_CR_ADDIS                   ADC_CR_ADDIS_Msk                        /*!< ADC disable */
+#define ADC_CR_ADSTART_Pos             (2U)
+#define ADC_CR_ADSTART_Msk             (0x1UL << ADC_CR_ADSTART_Pos)           /*!< 0x00000004 */
+#define ADC_CR_ADSTART                 ADC_CR_ADSTART_Msk                      /*!< ADC group regular conversion start */
+#define ADC_CR_ADSTP_Pos               (4U)
+#define ADC_CR_ADSTP_Msk               (0x1UL << ADC_CR_ADSTP_Pos)             /*!< 0x00000010 */
+#define ADC_CR_ADSTP                   ADC_CR_ADSTP_Msk                        /*!< ADC group regular conversion stop */
+#define ADC_CR_ADVREGEN_Pos            (28U)
+#define ADC_CR_ADVREGEN_Msk            (0x1UL << ADC_CR_ADVREGEN_Pos)          /*!< 0x10000000 */
+#define ADC_CR_ADVREGEN                ADC_CR_ADVREGEN_Msk                     /*!< ADC voltage regulator enable */
+#define ADC_CR_ADCAL_Pos               (31U)
+#define ADC_CR_ADCAL_Msk               (0x1UL << ADC_CR_ADCAL_Pos)             /*!< 0x80000000 */
+#define ADC_CR_ADCAL                   ADC_CR_ADCAL_Msk                        /*!< ADC calibration */
+
+/********************  Bit definition for ADC_CFGR1 register  *****************/
+#define ADC_CFGR1_DMAEN_Pos            (0U)
+#define ADC_CFGR1_DMAEN_Msk            (0x1UL << ADC_CFGR1_DMAEN_Pos)          /*!< 0x00000001 */
+#define ADC_CFGR1_DMAEN                ADC_CFGR1_DMAEN_Msk                     /*!< ADC DMA transfer enable */
+#define ADC_CFGR1_DMACFG_Pos           (1U)
+#define ADC_CFGR1_DMACFG_Msk           (0x1UL << ADC_CFGR1_DMACFG_Pos)         /*!< 0x00000002 */
+#define ADC_CFGR1_DMACFG               ADC_CFGR1_DMACFG_Msk                    /*!< ADC DMA transfer configuration */
+
+#define ADC_CFGR1_SCANDIR_Pos          (2U)
+#define ADC_CFGR1_SCANDIR_Msk          (0x1UL << ADC_CFGR1_SCANDIR_Pos)        /*!< 0x00000004 */
+#define ADC_CFGR1_SCANDIR              ADC_CFGR1_SCANDIR_Msk                   /*!< ADC group regular sequencer scan direction */
+
+#define ADC_CFGR1_RES_Pos              (3U)
+#define ADC_CFGR1_RES_Msk              (0x3UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000018 */
+#define ADC_CFGR1_RES                  ADC_CFGR1_RES_Msk                       /*!< ADC data resolution */
+#define ADC_CFGR1_RES_0                (0x1U << ADC_CFGR1_RES_Pos)             /*!< 0x00000008 */
+#define ADC_CFGR1_RES_1                (0x2U << ADC_CFGR1_RES_Pos)             /*!< 0x00000010 */
+
+#define ADC_CFGR1_ALIGN_Pos            (5U)
+#define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
+
+#define ADC_CFGR1_EXTSEL_Pos           (6U)
+#define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
+#define ADC_CFGR1_EXTSEL               ADC_CFGR1_EXTSEL_Msk                    /*!< ADC group regular external trigger source */
+#define ADC_CFGR1_EXTSEL_0             (0x1UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000040 */
+#define ADC_CFGR1_EXTSEL_1             (0x2UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000080 */
+#define ADC_CFGR1_EXTSEL_2             (0x4UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000100 */
+
+#define ADC_CFGR1_EXTEN_Pos            (10U)
+#define ADC_CFGR1_EXTEN_Msk            (0x3UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000C00 */
+#define ADC_CFGR1_EXTEN                ADC_CFGR1_EXTEN_Msk                     /*!< ADC group regular external trigger polarity */
+#define ADC_CFGR1_EXTEN_0              (0x1UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000400 */
+#define ADC_CFGR1_EXTEN_1              (0x2UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000800 */
+
+#define ADC_CFGR1_OVRMOD_Pos           (12U)
+#define ADC_CFGR1_OVRMOD_Msk           (0x1UL << ADC_CFGR1_OVRMOD_Pos)         /*!< 0x00001000 */
+#define ADC_CFGR1_OVRMOD               ADC_CFGR1_OVRMOD_Msk                    /*!< ADC group regular overrun configuration */
+#define ADC_CFGR1_CONT_Pos             (13U)
+#define ADC_CFGR1_CONT_Msk             (0x1UL << ADC_CFGR1_CONT_Pos)           /*!< 0x00002000 */
+#define ADC_CFGR1_CONT                 ADC_CFGR1_CONT_Msk                      /*!< ADC group regular continuous conversion mode */
+#define ADC_CFGR1_WAIT_Pos             (14U)
+#define ADC_CFGR1_WAIT_Msk             (0x1UL << ADC_CFGR1_WAIT_Pos)           /*!< 0x00004000 */
+#define ADC_CFGR1_WAIT                 ADC_CFGR1_WAIT_Msk                      /*!< ADC low power auto wait */
+#define ADC_CFGR1_AUTOFF_Pos           (15U)
+#define ADC_CFGR1_AUTOFF_Msk           (0x1UL << ADC_CFGR1_AUTOFF_Pos)         /*!< 0x00008000 */
+#define ADC_CFGR1_AUTOFF               ADC_CFGR1_AUTOFF_Msk                    /*!< ADC low power auto power off */
+#define ADC_CFGR1_DISCEN_Pos           (16U)
+#define ADC_CFGR1_DISCEN_Msk           (0x1UL << ADC_CFGR1_DISCEN_Pos)         /*!< 0x00010000 */
+#define ADC_CFGR1_DISCEN               ADC_CFGR1_DISCEN_Msk                    /*!< ADC group regular sequencer discontinuous mode */
+#define ADC_CFGR1_CHSELRMOD_Pos        (21U)
+#define ADC_CFGR1_CHSELRMOD_Msk        (0x1UL << ADC_CFGR1_CHSELRMOD_Pos)      /*!< 0x00200000 */
+#define ADC_CFGR1_CHSELRMOD            ADC_CFGR1_CHSELRMOD_Msk                 /*!< ADC group regular sequencer mode */
+
+#define ADC_CFGR1_AWD1SGL_Pos          (22U)
+#define ADC_CFGR1_AWD1SGL_Msk          (0x1UL << ADC_CFGR1_AWD1SGL_Pos)        /*!< 0x00400000 */
+#define ADC_CFGR1_AWD1SGL              ADC_CFGR1_AWD1SGL_Msk                   /*!< ADC analog watchdog 1 monitoring a single channel or all channels */
+#define ADC_CFGR1_AWD1EN_Pos           (23U)
+#define ADC_CFGR1_AWD1EN_Msk           (0x1UL << ADC_CFGR1_AWD1EN_Pos)         /*!< 0x00800000 */
+#define ADC_CFGR1_AWD1EN               ADC_CFGR1_AWD1EN_Msk                    /*!< ADC analog watchdog 1 enable on scope ADC group regular */
+
+#define ADC_CFGR1_AWD1CH_Pos           (26U)
+#define ADC_CFGR1_AWD1CH_Msk           (0x1FUL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x7C000000 */
+#define ADC_CFGR1_AWD1CH               ADC_CFGR1_AWD1CH_Msk                    /*!< ADC analog watchdog 1 monitored channel selection */
+#define ADC_CFGR1_AWD1CH_0             (0x01UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x04000000 */
+#define ADC_CFGR1_AWD1CH_1             (0x02UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x08000000 */
+#define ADC_CFGR1_AWD1CH_2             (0x04UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x10000000 */
+#define ADC_CFGR1_AWD1CH_3             (0x08UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x20000000 */
+#define ADC_CFGR1_AWD1CH_4             (0x10UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x40000000 */
+
+/* Legacy defines */
+#define ADC_CFGR1_AUTDLY          (ADC_CFGR1_WAIT)
+
+/********************  Bit definition for ADC_CFGR2 register  *****************/
+#define ADC_CFGR2_OVSE_Pos             (0U)
+#define ADC_CFGR2_OVSE_Msk             (0x1UL << ADC_CFGR2_OVSE_Pos)           /*!< 0x00000001 */
+#define ADC_CFGR2_OVSE                 ADC_CFGR2_OVSE_Msk                      /*!< ADC oversampler enable on scope ADC group regular */
+
+#define ADC_CFGR2_OVSR_Pos             (2U)
+#define ADC_CFGR2_OVSR_Msk             (0x7UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x0000001C */
+#define ADC_CFGR2_OVSR                 ADC_CFGR2_OVSR_Msk                      /*!< ADC oversampling ratio */
+#define ADC_CFGR2_OVSR_0               (0x1UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000004 */
+#define ADC_CFGR2_OVSR_1               (0x2UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000008 */
+#define ADC_CFGR2_OVSR_2               (0x4UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000010 */
+
+#define ADC_CFGR2_OVSS_Pos             (5U)
+#define ADC_CFGR2_OVSS_Msk             (0xFUL << ADC_CFGR2_OVSS_Pos)           /*!< 0x000001E0 */
+#define ADC_CFGR2_OVSS                 ADC_CFGR2_OVSS_Msk                      /*!< ADC oversampling shift */
+#define ADC_CFGR2_OVSS_0               (0x1UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000020 */
+#define ADC_CFGR2_OVSS_1               (0x2UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000040 */
+#define ADC_CFGR2_OVSS_2               (0x4UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000080 */
+#define ADC_CFGR2_OVSS_3               (0x8UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000100 */
+
+#define ADC_CFGR2_TOVS_Pos             (9U)
+#define ADC_CFGR2_TOVS_Msk             (0x1UL << ADC_CFGR2_TOVS_Pos)           /*!< 0x00000200 */
+#define ADC_CFGR2_TOVS                 ADC_CFGR2_TOVS_Msk                      /*!< ADC oversampling discontinuous mode (triggered mode) for ADC group regular */
+
+#define ADC_CFGR2_LFTRIG_Pos           (29U)
+#define ADC_CFGR2_LFTRIG_Msk           (0x1UL << ADC_CFGR2_LFTRIG_Pos)         /*!< 0x20000000 */
+#define ADC_CFGR2_LFTRIG               ADC_CFGR2_LFTRIG_Msk                    /*!< ADC low frequency trigger mode */
+
+#define ADC_CFGR2_CKMODE_Pos           (30U)
+#define ADC_CFGR2_CKMODE_Msk           (0x3UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0xC0000000 */
+#define ADC_CFGR2_CKMODE               ADC_CFGR2_CKMODE_Msk                    /*!< ADC clock source and prescaler (prescaler only for clock source synchronous) */
+#define ADC_CFGR2_CKMODE_1             (0x2UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x80000000 */
+#define ADC_CFGR2_CKMODE_0             (0x1UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x40000000 */
+
+/********************  Bit definition for ADC_SMPR register  ******************/
+#define ADC_SMPR_SMP1_Pos              (0U)
+#define ADC_SMPR_SMP1_Msk              (0x7UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000007 */
+#define ADC_SMPR_SMP1                  ADC_SMPR_SMP1_Msk                       /*!< ADC group of channels sampling time 1 */
+#define ADC_SMPR_SMP1_0                (0x1UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000001 */
+#define ADC_SMPR_SMP1_1                (0x2UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000002 */
+#define ADC_SMPR_SMP1_2                (0x4UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000004 */
+
+#define ADC_SMPR_SMP2_Pos              (4U)
+#define ADC_SMPR_SMP2_Msk              (0x7UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000070 */
+#define ADC_SMPR_SMP2                  ADC_SMPR_SMP2_Msk                       /*!< ADC group of channels sampling time 2 */
+#define ADC_SMPR_SMP2_0                (0x1UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000010 */
+#define ADC_SMPR_SMP2_1                (0x2UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000020 */
+#define ADC_SMPR_SMP2_2                (0x4UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000040 */
+
+#define ADC_SMPR_SMPSEL_Pos            (8U)
+#define ADC_SMPR_SMPSEL_Msk            (0x7FFFFUL << ADC_SMPR_SMPSEL_Pos)      /*!< 0x07FFFF00 */
+#define ADC_SMPR_SMPSEL                ADC_SMPR_SMPSEL_Msk                     /*!< ADC all channels sampling time selection */
+#define ADC_SMPR_SMPSEL0_Pos           (8U)
+#define ADC_SMPR_SMPSEL0_Msk           (0x1UL << ADC_SMPR_SMPSEL0_Pos)         /*!< 0x00000100 */
+#define ADC_SMPR_SMPSEL0               ADC_SMPR_SMPSEL0_Msk                    /*!< ADC channel 0 sampling time selection */
+#define ADC_SMPR_SMPSEL1_Pos           (9U)
+#define ADC_SMPR_SMPSEL1_Msk           (0x1UL << ADC_SMPR_SMPSEL1_Pos)         /*!< 0x00000200 */
+#define ADC_SMPR_SMPSEL1               ADC_SMPR_SMPSEL1_Msk                    /*!< ADC channel 1 sampling time selection */
+#define ADC_SMPR_SMPSEL2_Pos           (10U)
+#define ADC_SMPR_SMPSEL2_Msk           (0x1UL << ADC_SMPR_SMPSEL2_Pos)         /*!< 0x00000400 */
+#define ADC_SMPR_SMPSEL2               ADC_SMPR_SMPSEL2_Msk                    /*!< ADC channel 2 sampling time selection */
+#define ADC_SMPR_SMPSEL3_Pos           (11U)
+#define ADC_SMPR_SMPSEL3_Msk           (0x1UL << ADC_SMPR_SMPSEL3_Pos)         /*!< 0x00000800 */
+#define ADC_SMPR_SMPSEL3               ADC_SMPR_SMPSEL3_Msk                    /*!< ADC channel 3 sampling time selection */
+#define ADC_SMPR_SMPSEL4_Pos           (12U)
+#define ADC_SMPR_SMPSEL4_Msk           (0x1UL << ADC_SMPR_SMPSEL4_Pos)         /*!< 0x00001000 */
+#define ADC_SMPR_SMPSEL4               ADC_SMPR_SMPSEL4_Msk                    /*!< ADC channel 4 sampling time selection */
+#define ADC_SMPR_SMPSEL5_Pos           (13U)
+#define ADC_SMPR_SMPSEL5_Msk           (0x1UL << ADC_SMPR_SMPSEL5_Pos)         /*!< 0x00002000 */
+#define ADC_SMPR_SMPSEL5               ADC_SMPR_SMPSEL5_Msk                    /*!< ADC channel 5 sampling time selection */
+#define ADC_SMPR_SMPSEL6_Pos           (14U)
+#define ADC_SMPR_SMPSEL6_Msk           (0x1UL << ADC_SMPR_SMPSEL6_Pos)         /*!< 0x00004000 */
+#define ADC_SMPR_SMPSEL6               ADC_SMPR_SMPSEL6_Msk                    /*!< ADC channel 6 sampling time selection */
+#define ADC_SMPR_SMPSEL7_Pos           (15U)
+#define ADC_SMPR_SMPSEL7_Msk           (0x1UL << ADC_SMPR_SMPSEL7_Pos)         /*!< 0x00008000 */
+#define ADC_SMPR_SMPSEL7               ADC_SMPR_SMPSEL7_Msk                    /*!< ADC channel 7 sampling time selection */
+#define ADC_SMPR_SMPSEL8_Pos           (16U)
+#define ADC_SMPR_SMPSEL8_Msk           (0x1UL << ADC_SMPR_SMPSEL8_Pos)         /*!< 0x00010000 */
+#define ADC_SMPR_SMPSEL8               ADC_SMPR_SMPSEL8_Msk                    /*!< ADC channel 8 sampling time selection */
+#define ADC_SMPR_SMPSEL9_Pos           (17U)
+#define ADC_SMPR_SMPSEL9_Msk           (0x1UL << ADC_SMPR_SMPSEL9_Pos)         /*!< 0x00020000 */
+#define ADC_SMPR_SMPSEL9               ADC_SMPR_SMPSEL9_Msk                    /*!< ADC channel 9 sampling time selection */
+#define ADC_SMPR_SMPSEL10_Pos          (18U)
+#define ADC_SMPR_SMPSEL10_Msk          (0x1UL << ADC_SMPR_SMPSEL10_Pos)        /*!< 0x00040000 */
+#define ADC_SMPR_SMPSEL10              ADC_SMPR_SMPSEL10_Msk                   /*!< ADC channel 10 sampling time selection */
+#define ADC_SMPR_SMPSEL11_Pos          (19U)
+#define ADC_SMPR_SMPSEL11_Msk          (0x1UL << ADC_SMPR_SMPSEL11_Pos)        /*!< 0x00080000 */
+#define ADC_SMPR_SMPSEL11              ADC_SMPR_SMPSEL11_Msk                   /*!< ADC channel 11 sampling time selection */
+#define ADC_SMPR_SMPSEL12_Pos          (20U)
+#define ADC_SMPR_SMPSEL12_Msk          (0x1UL << ADC_SMPR_SMPSEL12_Pos)        /*!< 0x00100000 */
+#define ADC_SMPR_SMPSEL12              ADC_SMPR_SMPSEL12_Msk                   /*!< ADC channel 12 sampling time selection */
+#define ADC_SMPR_SMPSEL13_Pos          (21U)
+#define ADC_SMPR_SMPSEL13_Msk          (0x1UL << ADC_SMPR_SMPSEL13_Pos)        /*!< 0x00200000 */
+#define ADC_SMPR_SMPSEL13              ADC_SMPR_SMPSEL13_Msk                   /*!< ADC channel 13 sampling time selection */
+#define ADC_SMPR_SMPSEL14_Pos          (22U)
+#define ADC_SMPR_SMPSEL14_Msk          (0x1UL << ADC_SMPR_SMPSEL14_Pos)        /*!< 0x00400000 */
+#define ADC_SMPR_SMPSEL14              ADC_SMPR_SMPSEL14_Msk                   /*!< ADC channel 14 sampling time selection */
+#define ADC_SMPR_SMPSEL15_Pos          (23U)
+#define ADC_SMPR_SMPSEL15_Msk          (0x1UL << ADC_SMPR_SMPSEL15_Pos)        /*!< 0x00800000 */
+#define ADC_SMPR_SMPSEL15              ADC_SMPR_SMPSEL15_Msk                   /*!< ADC channel 15 sampling time selection */
+#define ADC_SMPR_SMPSEL16_Pos          (24U)
+#define ADC_SMPR_SMPSEL16_Msk          (0x1UL << ADC_SMPR_SMPSEL16_Pos)        /*!< 0x01000000 */
+#define ADC_SMPR_SMPSEL16              ADC_SMPR_SMPSEL16_Msk                   /*!< ADC channel 16 sampling time selection */
+#define ADC_SMPR_SMPSEL17_Pos          (25U)
+#define ADC_SMPR_SMPSEL17_Msk          (0x1UL << ADC_SMPR_SMPSEL17_Pos)        /*!< 0x02000000 */
+#define ADC_SMPR_SMPSEL17              ADC_SMPR_SMPSEL17_Msk                   /*!< ADC channel 17 sampling time selection */
+#define ADC_SMPR_SMPSEL18_Pos          (26U)
+#define ADC_SMPR_SMPSEL18_Msk          (0x1UL << ADC_SMPR_SMPSEL18_Pos)        /*!< 0x04000000 */
+#define ADC_SMPR_SMPSEL18              ADC_SMPR_SMPSEL18_Msk                   /*!< ADC channel 18 sampling time selection */
+
+/********************  Bit definition for ADC_TR1 register  *******************/
+#define ADC_TR1_LT1_Pos                (0U)
+#define ADC_TR1_LT1_Msk                (0xFFFUL << ADC_TR1_LT1_Pos)            /*!< 0x00000FFF */
+#define ADC_TR1_LT1                    ADC_TR1_LT1_Msk                         /*!< ADC analog watchdog 1 threshold low */
+#define ADC_TR1_LT1_0                  (0x001UL << ADC_TR1_LT1_Pos)            /*!< 0x00000001 */
+#define ADC_TR1_LT1_1                  (0x002UL << ADC_TR1_LT1_Pos)            /*!< 0x00000002 */
+#define ADC_TR1_LT1_2                  (0x004UL << ADC_TR1_LT1_Pos)            /*!< 0x00000004 */
+#define ADC_TR1_LT1_3                  (0x008UL << ADC_TR1_LT1_Pos)            /*!< 0x00000008 */
+#define ADC_TR1_LT1_4                  (0x010UL << ADC_TR1_LT1_Pos)            /*!< 0x00000010 */
+#define ADC_TR1_LT1_5                  (0x020UL << ADC_TR1_LT1_Pos)            /*!< 0x00000020 */
+#define ADC_TR1_LT1_6                  (0x040UL << ADC_TR1_LT1_Pos)            /*!< 0x00000040 */
+#define ADC_TR1_LT1_7                  (0x080UL << ADC_TR1_LT1_Pos)            /*!< 0x00000080 */
+#define ADC_TR1_LT1_8                  (0x100UL << ADC_TR1_LT1_Pos)            /*!< 0x00000100 */
+#define ADC_TR1_LT1_9                  (0x200UL << ADC_TR1_LT1_Pos)            /*!< 0x00000200 */
+#define ADC_TR1_LT1_10                 (0x400UL << ADC_TR1_LT1_Pos)            /*!< 0x00000400 */
+#define ADC_TR1_LT1_11                 (0x800UL << ADC_TR1_LT1_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR1_HT1_Pos                (16U)
+#define ADC_TR1_HT1_Msk                (0xFFFUL << ADC_TR1_HT1_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR1_HT1                    ADC_TR1_HT1_Msk                         /*!< ADC Analog watchdog 1 threshold high */
+#define ADC_TR1_HT1_0                  (0x001UL << ADC_TR1_HT1_Pos)            /*!< 0x00010000 */
+#define ADC_TR1_HT1_1                  (0x002UL << ADC_TR1_HT1_Pos)            /*!< 0x00020000 */
+#define ADC_TR1_HT1_2                  (0x004UL << ADC_TR1_HT1_Pos)            /*!< 0x00040000 */
+#define ADC_TR1_HT1_3                  (0x008UL << ADC_TR1_HT1_Pos)            /*!< 0x00080000 */
+#define ADC_TR1_HT1_4                  (0x010UL << ADC_TR1_HT1_Pos)            /*!< 0x00100000 */
+#define ADC_TR1_HT1_5                  (0x020UL << ADC_TR1_HT1_Pos)            /*!< 0x00200000 */
+#define ADC_TR1_HT1_6                  (0x040UL << ADC_TR1_HT1_Pos)            /*!< 0x00400000 */
+#define ADC_TR1_HT1_7                  (0x080UL << ADC_TR1_HT1_Pos)            /*!< 0x00800000 */
+#define ADC_TR1_HT1_8                  (0x100UL << ADC_TR1_HT1_Pos)            /*!< 0x01000000 */
+#define ADC_TR1_HT1_9                  (0x200UL << ADC_TR1_HT1_Pos)            /*!< 0x02000000 */
+#define ADC_TR1_HT1_10                 (0x400UL << ADC_TR1_HT1_Pos)            /*!< 0x04000000 */
+#define ADC_TR1_HT1_11                 (0x800UL << ADC_TR1_HT1_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_TR2 register  *******************/
+#define ADC_TR2_LT2_Pos                (0U)
+#define ADC_TR2_LT2_Msk                (0xFFFUL << ADC_TR2_LT2_Pos)            /*!< 0x00000FFF */
+#define ADC_TR2_LT2                    ADC_TR2_LT2_Msk                         /*!< ADC analog watchdog 2 threshold low */
+#define ADC_TR2_LT2_0                  (0x001UL << ADC_TR2_LT2_Pos)            /*!< 0x00000001 */
+#define ADC_TR2_LT2_1                  (0x002UL << ADC_TR2_LT2_Pos)            /*!< 0x00000002 */
+#define ADC_TR2_LT2_2                  (0x004UL << ADC_TR2_LT2_Pos)            /*!< 0x00000004 */
+#define ADC_TR2_LT2_3                  (0x008UL << ADC_TR2_LT2_Pos)            /*!< 0x00000008 */
+#define ADC_TR2_LT2_4                  (0x010UL << ADC_TR2_LT2_Pos)            /*!< 0x00000010 */
+#define ADC_TR2_LT2_5                  (0x020UL << ADC_TR2_LT2_Pos)            /*!< 0x00000020 */
+#define ADC_TR2_LT2_6                  (0x040UL << ADC_TR2_LT2_Pos)            /*!< 0x00000040 */
+#define ADC_TR2_LT2_7                  (0x080UL << ADC_TR2_LT2_Pos)            /*!< 0x00000080 */
+#define ADC_TR2_LT2_8                  (0x100UL << ADC_TR2_LT2_Pos)            /*!< 0x00000100 */
+#define ADC_TR2_LT2_9                  (0x200UL << ADC_TR2_LT2_Pos)            /*!< 0x00000200 */
+#define ADC_TR2_LT2_10                 (0x400UL << ADC_TR2_LT2_Pos)            /*!< 0x00000400 */
+#define ADC_TR2_LT2_11                 (0x800UL << ADC_TR2_LT2_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR2_HT2_Pos                (16U)
+#define ADC_TR2_HT2_Msk                (0xFFFUL << ADC_TR2_HT2_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR2_HT2                    ADC_TR2_HT2_Msk                         /*!< ADC analog watchdog 2 threshold high */
+#define ADC_TR2_HT2_0                  (0x001UL << ADC_TR2_HT2_Pos)            /*!< 0x00010000 */
+#define ADC_TR2_HT2_1                  (0x002UL << ADC_TR2_HT2_Pos)            /*!< 0x00020000 */
+#define ADC_TR2_HT2_2                  (0x004UL << ADC_TR2_HT2_Pos)            /*!< 0x00040000 */
+#define ADC_TR2_HT2_3                  (0x008UL << ADC_TR2_HT2_Pos)            /*!< 0x00080000 */
+#define ADC_TR2_HT2_4                  (0x010UL << ADC_TR2_HT2_Pos)            /*!< 0x00100000 */
+#define ADC_TR2_HT2_5                  (0x020UL << ADC_TR2_HT2_Pos)            /*!< 0x00200000 */
+#define ADC_TR2_HT2_6                  (0x040UL << ADC_TR2_HT2_Pos)            /*!< 0x00400000 */
+#define ADC_TR2_HT2_7                  (0x080UL << ADC_TR2_HT2_Pos)            /*!< 0x00800000 */
+#define ADC_TR2_HT2_8                  (0x100UL << ADC_TR2_HT2_Pos)            /*!< 0x01000000 */
+#define ADC_TR2_HT2_9                  (0x200UL << ADC_TR2_HT2_Pos)            /*!< 0x02000000 */
+#define ADC_TR2_HT2_10                 (0x400UL << ADC_TR2_HT2_Pos)            /*!< 0x04000000 */
+#define ADC_TR2_HT2_11                 (0x800UL << ADC_TR2_HT2_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_CHSELR register  ****************/
+#define ADC_CHSELR_CHSEL_Pos           (0U)
+#define ADC_CHSELR_CHSEL_Msk           (0x7FFFFUL << ADC_CHSELR_CHSEL_Pos)     /*!< 0x0007FFFF */
+#define ADC_CHSELR_CHSEL               ADC_CHSELR_CHSEL_Msk                    /*!< ADC group regular sequencer channels, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL18_Pos         (18U)
+#define ADC_CHSELR_CHSEL18_Msk         (0x1UL << ADC_CHSELR_CHSEL18_Pos)       /*!< 0x00040000 */
+#define ADC_CHSELR_CHSEL18             ADC_CHSELR_CHSEL18_Msk                  /*!< ADC group regular sequencer channel 18, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL17_Pos         (17U)
+#define ADC_CHSELR_CHSEL17_Msk         (0x1UL << ADC_CHSELR_CHSEL17_Pos)       /*!< 0x00020000 */
+#define ADC_CHSELR_CHSEL17             ADC_CHSELR_CHSEL17_Msk                  /*!< ADC group regular sequencer channel 17, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL16_Pos         (16U)
+#define ADC_CHSELR_CHSEL16_Msk         (0x1UL << ADC_CHSELR_CHSEL16_Pos)       /*!< 0x00010000 */
+#define ADC_CHSELR_CHSEL16             ADC_CHSELR_CHSEL16_Msk                  /*!< ADC group regular sequencer channel 16, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL15_Pos         (15U)
+#define ADC_CHSELR_CHSEL15_Msk         (0x1UL << ADC_CHSELR_CHSEL15_Pos)       /*!< 0x00008000 */
+#define ADC_CHSELR_CHSEL15             ADC_CHSELR_CHSEL15_Msk                  /*!< ADC group regular sequencer channel 15, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL14_Pos         (14U)
+#define ADC_CHSELR_CHSEL14_Msk         (0x1UL << ADC_CHSELR_CHSEL14_Pos)       /*!< 0x00004000 */
+#define ADC_CHSELR_CHSEL14             ADC_CHSELR_CHSEL14_Msk                  /*!< ADC group regular sequencer channel 14, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL13_Pos         (13U)
+#define ADC_CHSELR_CHSEL13_Msk         (0x1UL << ADC_CHSELR_CHSEL13_Pos)       /*!< 0x00002000 */
+#define ADC_CHSELR_CHSEL13             ADC_CHSELR_CHSEL13_Msk                  /*!< ADC group regular sequencer channel 13, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL12_Pos         (12U)
+#define ADC_CHSELR_CHSEL12_Msk         (0x1UL << ADC_CHSELR_CHSEL12_Pos)       /*!< 0x00001000 */
+#define ADC_CHSELR_CHSEL12             ADC_CHSELR_CHSEL12_Msk                  /*!< ADC group regular sequencer channel 12, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL11_Pos         (11U)
+#define ADC_CHSELR_CHSEL11_Msk         (0x1UL << ADC_CHSELR_CHSEL11_Pos)       /*!< 0x00000800 */
+#define ADC_CHSELR_CHSEL11             ADC_CHSELR_CHSEL11_Msk                  /*!< ADC group regular sequencer channel 11, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL10_Pos         (10U)
+#define ADC_CHSELR_CHSEL10_Msk         (0x1UL << ADC_CHSELR_CHSEL10_Pos)       /*!< 0x00000400 */
+#define ADC_CHSELR_CHSEL10             ADC_CHSELR_CHSEL10_Msk                  /*!< ADC group regular sequencer channel 10, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL9_Pos          (9U)
+#define ADC_CHSELR_CHSEL9_Msk          (0x1UL << ADC_CHSELR_CHSEL9_Pos)        /*!< 0x00000200 */
+#define ADC_CHSELR_CHSEL9              ADC_CHSELR_CHSEL9_Msk                   /*!< ADC group regular sequencer channel 9, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL8_Pos          (8U)
+#define ADC_CHSELR_CHSEL8_Msk          (0x1UL << ADC_CHSELR_CHSEL8_Pos)        /*!< 0x00000100 */
+#define ADC_CHSELR_CHSEL8              ADC_CHSELR_CHSEL8_Msk                   /*!< ADC group regular sequencer channel 8, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL7_Pos          (7U)
+#define ADC_CHSELR_CHSEL7_Msk          (0x1UL << ADC_CHSELR_CHSEL7_Pos)        /*!< 0x00000080 */
+#define ADC_CHSELR_CHSEL7              ADC_CHSELR_CHSEL7_Msk                   /*!< ADC group regular sequencer channel 7, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL6_Pos          (6U)
+#define ADC_CHSELR_CHSEL6_Msk          (0x1UL << ADC_CHSELR_CHSEL6_Pos)        /*!< 0x00000040 */
+#define ADC_CHSELR_CHSEL6              ADC_CHSELR_CHSEL6_Msk                   /*!< ADC group regular sequencer channel 6, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL5_Pos          (5U)
+#define ADC_CHSELR_CHSEL5_Msk          (0x1UL << ADC_CHSELR_CHSEL5_Pos)        /*!< 0x00000020 */
+#define ADC_CHSELR_CHSEL5              ADC_CHSELR_CHSEL5_Msk                   /*!< ADC group regular sequencer channel 5, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL4_Pos          (4U)
+#define ADC_CHSELR_CHSEL4_Msk          (0x1UL << ADC_CHSELR_CHSEL4_Pos)        /*!< 0x00000010 */
+#define ADC_CHSELR_CHSEL4              ADC_CHSELR_CHSEL4_Msk                   /*!< ADC group regular sequencer channel 4, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL3_Pos          (3U)
+#define ADC_CHSELR_CHSEL3_Msk          (0x1UL << ADC_CHSELR_CHSEL3_Pos)        /*!< 0x00000008 */
+#define ADC_CHSELR_CHSEL3              ADC_CHSELR_CHSEL3_Msk                   /*!< ADC group regular sequencer channel 3, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL2_Pos          (2U)
+#define ADC_CHSELR_CHSEL2_Msk          (0x1UL << ADC_CHSELR_CHSEL2_Pos)        /*!< 0x00000004 */
+#define ADC_CHSELR_CHSEL2              ADC_CHSELR_CHSEL2_Msk                   /*!< ADC group regular sequencer channel 2, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL1_Pos          (1U)
+#define ADC_CHSELR_CHSEL1_Msk          (0x1UL << ADC_CHSELR_CHSEL1_Pos)        /*!< 0x00000002 */
+#define ADC_CHSELR_CHSEL1              ADC_CHSELR_CHSEL1_Msk                   /*!< ADC group regular sequencer channel 1, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL0_Pos          (0U)
+#define ADC_CHSELR_CHSEL0_Msk          (0x1UL << ADC_CHSELR_CHSEL0_Pos)        /*!< 0x00000001 */
+#define ADC_CHSELR_CHSEL0              ADC_CHSELR_CHSEL0_Msk                   /*!< ADC group regular sequencer channel 0, available when ADC_CFGR1_CHSELRMOD is reset */
+
+#define ADC_CHSELR_SQ_ALL_Pos          (0U)
+#define ADC_CHSELR_SQ_ALL_Msk          (0xFFFFFFFFUL << ADC_CHSELR_SQ_ALL_Pos) /*!< 0xFFFFFFFF */
+#define ADC_CHSELR_SQ_ALL              ADC_CHSELR_SQ_ALL_Msk                   /*!< ADC group regular sequencer all ranks, available when ADC_CFGR1_CHSELRMOD is set */
+
+#define ADC_CHSELR_SQ8_Pos             (28U)
+#define ADC_CHSELR_SQ8_Msk             (0xFUL << ADC_CHSELR_SQ8_Pos)           /*!< 0xF0000000 */
+#define ADC_CHSELR_SQ8                 ADC_CHSELR_SQ8_Msk                      /*!< ADC group regular sequencer rank 8, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ8_0               (0x1UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x10000000 */
+#define ADC_CHSELR_SQ8_1               (0x2UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x20000000 */
+#define ADC_CHSELR_SQ8_2               (0x4UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x40000000 */
+#define ADC_CHSELR_SQ8_3               (0x8UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x80000000 */
+
+#define ADC_CHSELR_SQ7_Pos             (24U)
+#define ADC_CHSELR_SQ7_Msk             (0xFUL << ADC_CHSELR_SQ7_Pos)           /*!< 0x0F000000 */
+#define ADC_CHSELR_SQ7                 ADC_CHSELR_SQ7_Msk                      /*!< ADC group regular sequencer rank 7, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ7_0               (0x1UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x01000000 */
+#define ADC_CHSELR_SQ7_1               (0x2UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x02000000 */
+#define ADC_CHSELR_SQ7_2               (0x4UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x04000000 */
+#define ADC_CHSELR_SQ7_3               (0x8UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x08000000 */
+
+#define ADC_CHSELR_SQ6_Pos             (20U)
+#define ADC_CHSELR_SQ6_Msk             (0xFUL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00F00000 */
+#define ADC_CHSELR_SQ6                 ADC_CHSELR_SQ6_Msk                      /*!< ADC group regular sequencer rank 6, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ6_0               (0x1UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00100000 */
+#define ADC_CHSELR_SQ6_1               (0x2UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00200000 */
+#define ADC_CHSELR_SQ6_2               (0x4UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00400000 */
+#define ADC_CHSELR_SQ6_3               (0x8UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00800000 */
+
+#define ADC_CHSELR_SQ5_Pos             (16U)
+#define ADC_CHSELR_SQ5_Msk             (0xFUL << ADC_CHSELR_SQ5_Pos)           /*!< 0x000F0000 */
+#define ADC_CHSELR_SQ5                 ADC_CHSELR_SQ5_Msk                      /*!< ADC group regular sequencer rank 5, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ5_0               (0x1UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00010000 */
+#define ADC_CHSELR_SQ5_1               (0x2UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00020000 */
+#define ADC_CHSELR_SQ5_2               (0x4UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00040000 */
+#define ADC_CHSELR_SQ5_3               (0x8UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00080000 */
+
+#define ADC_CHSELR_SQ4_Pos             (12U)
+#define ADC_CHSELR_SQ4_Msk             (0xFUL << ADC_CHSELR_SQ4_Pos)           /*!< 0x0000F000 */
+#define ADC_CHSELR_SQ4                 ADC_CHSELR_SQ4_Msk                      /*!< ADC group regular sequencer rank 4, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ4_0               (0x1UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00001000 */
+#define ADC_CHSELR_SQ4_1               (0x2UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00002000 */
+#define ADC_CHSELR_SQ4_2               (0x4UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00004000 */
+#define ADC_CHSELR_SQ4_3               (0x8UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00008000 */
+
+#define ADC_CHSELR_SQ3_Pos             (8U)
+#define ADC_CHSELR_SQ3_Msk             (0xFUL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000F00 */
+#define ADC_CHSELR_SQ3                 ADC_CHSELR_SQ3_Msk                      /*!< ADC group regular sequencer rank 3, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ3_0               (0x1UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000100 */
+#define ADC_CHSELR_SQ3_1               (0x2UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000200 */
+#define ADC_CHSELR_SQ3_2               (0x4UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000400 */
+#define ADC_CHSELR_SQ3_3               (0x8UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000800 */
+
+#define ADC_CHSELR_SQ2_Pos             (4U)
+#define ADC_CHSELR_SQ2_Msk             (0xFUL << ADC_CHSELR_SQ2_Pos)           /*!< 0x000000F0 */
+#define ADC_CHSELR_SQ2                 ADC_CHSELR_SQ2_Msk                      /*!< ADC group regular sequencer rank 2, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ2_0               (0x1UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000010 */
+#define ADC_CHSELR_SQ2_1               (0x2UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000020 */
+#define ADC_CHSELR_SQ2_2               (0x4UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000040 */
+#define ADC_CHSELR_SQ2_3               (0x8UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000080 */
+
+#define ADC_CHSELR_SQ1_Pos             (0U)
+#define ADC_CHSELR_SQ1_Msk             (0xFUL << ADC_CHSELR_SQ1_Pos)           /*!< 0x0000000F */
+#define ADC_CHSELR_SQ1                 ADC_CHSELR_SQ1_Msk                      /*!< ADC group regular sequencer rank 1, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ1_0               (0x1UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000001 */
+#define ADC_CHSELR_SQ1_1               (0x2UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000002 */
+#define ADC_CHSELR_SQ1_2               (0x4UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000004 */
+#define ADC_CHSELR_SQ1_3               (0x8UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000008 */
+
+/********************  Bit definition for ADC_TR3 register  *******************/
+#define ADC_TR3_LT3_Pos                (0U)
+#define ADC_TR3_LT3_Msk                (0xFFFUL << ADC_TR3_LT3_Pos)            /*!< 0x00000FFF */
+#define ADC_TR3_LT3                    ADC_TR3_LT3_Msk                         /*!< ADC analog watchdog 3 threshold low */
+#define ADC_TR3_LT3_0                  (0x001UL << ADC_TR3_LT3_Pos)            /*!< 0x00000001 */
+#define ADC_TR3_LT3_1                  (0x002UL << ADC_TR3_LT3_Pos)            /*!< 0x00000002 */
+#define ADC_TR3_LT3_2                  (0x004UL << ADC_TR3_LT3_Pos)            /*!< 0x00000004 */
+#define ADC_TR3_LT3_3                  (0x008UL << ADC_TR3_LT3_Pos)            /*!< 0x00000008 */
+#define ADC_TR3_LT3_4                  (0x010UL << ADC_TR3_LT3_Pos)            /*!< 0x00000010 */
+#define ADC_TR3_LT3_5                  (0x020UL << ADC_TR3_LT3_Pos)            /*!< 0x00000020 */
+#define ADC_TR3_LT3_6                  (0x040UL << ADC_TR3_LT3_Pos)            /*!< 0x00000040 */
+#define ADC_TR3_LT3_7                  (0x080UL << ADC_TR3_LT3_Pos)            /*!< 0x00000080 */
+#define ADC_TR3_LT3_8                  (0x100UL << ADC_TR3_LT3_Pos)            /*!< 0x00000100 */
+#define ADC_TR3_LT3_9                  (0x200UL << ADC_TR3_LT3_Pos)            /*!< 0x00000200 */
+#define ADC_TR3_LT3_10                 (0x400UL << ADC_TR3_LT3_Pos)            /*!< 0x00000400 */
+#define ADC_TR3_LT3_11                 (0x800UL << ADC_TR3_LT3_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR3_HT3_Pos                (16U)
+#define ADC_TR3_HT3_Msk                (0xFFFUL << ADC_TR3_HT3_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR3_HT3                    ADC_TR3_HT3_Msk                         /*!< ADC analog watchdog 3 threshold high */
+#define ADC_TR3_HT3_0                  (0x001UL << ADC_TR3_HT3_Pos)            /*!< 0x00010000 */
+#define ADC_TR3_HT3_1                  (0x002UL << ADC_TR3_HT3_Pos)            /*!< 0x00020000 */
+#define ADC_TR3_HT3_2                  (0x004UL << ADC_TR3_HT3_Pos)            /*!< 0x00040000 */
+#define ADC_TR3_HT3_3                  (0x008UL << ADC_TR3_HT3_Pos)            /*!< 0x00080000 */
+#define ADC_TR3_HT3_4                  (0x010UL << ADC_TR3_HT3_Pos)            /*!< 0x00100000 */
+#define ADC_TR3_HT3_5                  (0x020UL << ADC_TR3_HT3_Pos)            /*!< 0x00200000 */
+#define ADC_TR3_HT3_6                  (0x040UL << ADC_TR3_HT3_Pos)            /*!< 0x00400000 */
+#define ADC_TR3_HT3_7                  (0x080UL << ADC_TR3_HT3_Pos)            /*!< 0x00800000 */
+#define ADC_TR3_HT3_8                  (0x100UL << ADC_TR3_HT3_Pos)            /*!< 0x01000000 */
+#define ADC_TR3_HT3_9                  (0x200UL << ADC_TR3_HT3_Pos)            /*!< 0x02000000 */
+#define ADC_TR3_HT3_10                 (0x400UL << ADC_TR3_HT3_Pos)            /*!< 0x04000000 */
+#define ADC_TR3_HT3_11                 (0x800UL << ADC_TR3_HT3_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos                (0U)
+#define ADC_DR_DATA_Msk                (0xFFFFUL << ADC_DR_DATA_Pos)           /*!< 0x0000FFFF */
+#define ADC_DR_DATA                    ADC_DR_DATA_Msk                         /*!< ADC group regular conversion data */
+#define ADC_DR_DATA_0                  (0x0001UL << ADC_DR_DATA_Pos)           /*!< 0x00000001 */
+#define ADC_DR_DATA_1                  (0x0002UL << ADC_DR_DATA_Pos)           /*!< 0x00000002 */
+#define ADC_DR_DATA_2                  (0x0004UL << ADC_DR_DATA_Pos)           /*!< 0x00000004 */
+#define ADC_DR_DATA_3                  (0x0008UL << ADC_DR_DATA_Pos)           /*!< 0x00000008 */
+#define ADC_DR_DATA_4                  (0x0010UL << ADC_DR_DATA_Pos)           /*!< 0x00000010 */
+#define ADC_DR_DATA_5                  (0x0020UL << ADC_DR_DATA_Pos)           /*!< 0x00000020 */
+#define ADC_DR_DATA_6                  (0x0040UL << ADC_DR_DATA_Pos)           /*!< 0x00000040 */
+#define ADC_DR_DATA_7                  (0x0080UL << ADC_DR_DATA_Pos)           /*!< 0x00000080 */
+#define ADC_DR_DATA_8                  (0x0100UL << ADC_DR_DATA_Pos)           /*!< 0x00000100 */
+#define ADC_DR_DATA_9                  (0x0200UL << ADC_DR_DATA_Pos)           /*!< 0x00000200 */
+#define ADC_DR_DATA_10                 (0x0400UL << ADC_DR_DATA_Pos)           /*!< 0x00000400 */
+#define ADC_DR_DATA_11                 (0x0800UL << ADC_DR_DATA_Pos)           /*!< 0x00000800 */
+#define ADC_DR_DATA_12                 (0x1000UL << ADC_DR_DATA_Pos)           /*!< 0x00001000 */
+#define ADC_DR_DATA_13                 (0x2000UL << ADC_DR_DATA_Pos)           /*!< 0x00002000 */
+#define ADC_DR_DATA_14                 (0x4000UL << ADC_DR_DATA_Pos)           /*!< 0x00004000 */
+#define ADC_DR_DATA_15                 (0x8000UL << ADC_DR_DATA_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for ADC_AWD2CR register  ****************/
+#define ADC_AWD2CR_AWD2CH_Pos          (0U)
+#define ADC_AWD2CR_AWD2CH_Msk          (0x7FFFFUL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x0007FFFF */
+#define ADC_AWD2CR_AWD2CH              ADC_AWD2CR_AWD2CH_Msk                   /*!< ADC analog watchdog 2 monitored channel selection */
+#define ADC_AWD2CR_AWD2CH_0            (0x00001UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000001 */
+#define ADC_AWD2CR_AWD2CH_1            (0x00002UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000002 */
+#define ADC_AWD2CR_AWD2CH_2            (0x00004UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000004 */
+#define ADC_AWD2CR_AWD2CH_3            (0x00008UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000008 */
+#define ADC_AWD2CR_AWD2CH_4            (0x00010UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000010 */
+#define ADC_AWD2CR_AWD2CH_5            (0x00020UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000020 */
+#define ADC_AWD2CR_AWD2CH_6            (0x00040UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000040 */
+#define ADC_AWD2CR_AWD2CH_7            (0x00080UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000080 */
+#define ADC_AWD2CR_AWD2CH_8            (0x00100UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000100 */
+#define ADC_AWD2CR_AWD2CH_9            (0x00200UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000200 */
+#define ADC_AWD2CR_AWD2CH_10           (0x00400UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000400 */
+#define ADC_AWD2CR_AWD2CH_11           (0x00800UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000800 */
+#define ADC_AWD2CR_AWD2CH_12           (0x01000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00001000 */
+#define ADC_AWD2CR_AWD2CH_13           (0x02000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00002000 */
+#define ADC_AWD2CR_AWD2CH_14           (0x04000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00004000 */
+#define ADC_AWD2CR_AWD2CH_15           (0x08000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00008000 */
+#define ADC_AWD2CR_AWD2CH_16           (0x10000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00010000 */
+#define ADC_AWD2CR_AWD2CH_17           (0x20000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00020000 */
+#define ADC_AWD2CR_AWD2CH_18           (0x40000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00040000 */
+
+/********************  Bit definition for ADC_AWD3CR register  ****************/
+#define ADC_AWD3CR_AWD3CH_Pos          (0U)
+#define ADC_AWD3CR_AWD3CH_Msk          (0x7FFFFUL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x0007FFFF */
+#define ADC_AWD3CR_AWD3CH              ADC_AWD3CR_AWD3CH_Msk                   /*!< ADC analog watchdog 3 monitored channel selection */
+#define ADC_AWD3CR_AWD3CH_0            (0x00001UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000001 */
+#define ADC_AWD3CR_AWD3CH_1            (0x00002UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000002 */
+#define ADC_AWD3CR_AWD3CH_2            (0x00004UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000004 */
+#define ADC_AWD3CR_AWD3CH_3            (0x00008UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000008 */
+#define ADC_AWD3CR_AWD3CH_4            (0x00010UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000010 */
+#define ADC_AWD3CR_AWD3CH_5            (0x00020UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000020 */
+#define ADC_AWD3CR_AWD3CH_6            (0x00040UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000040 */
+#define ADC_AWD3CR_AWD3CH_7            (0x00080UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000080 */
+#define ADC_AWD3CR_AWD3CH_8            (0x00100UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000100 */
+#define ADC_AWD3CR_AWD3CH_9            (0x00200UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000200 */
+#define ADC_AWD3CR_AWD3CH_10           (0x00400UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000400 */
+#define ADC_AWD3CR_AWD3CH_11           (0x00800UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000800 */
+#define ADC_AWD3CR_AWD3CH_12           (0x01000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00001000 */
+#define ADC_AWD3CR_AWD3CH_13           (0x02000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00002000 */
+#define ADC_AWD3CR_AWD3CH_14           (0x04000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00004000 */
+#define ADC_AWD3CR_AWD3CH_15           (0x08000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00008000 */
+#define ADC_AWD3CR_AWD3CH_16           (0x10000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00010000 */
+#define ADC_AWD3CR_AWD3CH_17           (0x20000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00020000 */
+#define ADC_AWD3CR_AWD3CH_18           (0x40000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00040000 */
+
+/********************  Bit definition for ADC_CALFACT register  ***************/
+#define ADC_CALFACT_CALFACT_Pos        (0U)
+#define ADC_CALFACT_CALFACT_Msk        (0x7FUL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x0000007F */
+#define ADC_CALFACT_CALFACT            ADC_CALFACT_CALFACT_Msk                 /*!< ADC calibration factor in single-ended mode */
+#define ADC_CALFACT_CALFACT_0          (0x01UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000001 */
+#define ADC_CALFACT_CALFACT_1          (0x02UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000002 */
+#define ADC_CALFACT_CALFACT_2          (0x04UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000004 */
+#define ADC_CALFACT_CALFACT_3          (0x08UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000008 */
+#define ADC_CALFACT_CALFACT_4          (0x10UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000010 */
+#define ADC_CALFACT_CALFACT_5          (0x20UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000020 */
+#define ADC_CALFACT_CALFACT_6          (0x40UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000040 */
+
+/*************************  ADC Common registers  *****************************/
+/********************  Bit definition for ADC_CCR register  *******************/
+#define ADC_CCR_PRESC_Pos              (18U)
+#define ADC_CCR_PRESC_Msk              (0xFUL << ADC_CCR_PRESC_Pos)            /*!< 0x003C0000 */
+#define ADC_CCR_PRESC                  ADC_CCR_PRESC_Msk                       /*!< ADC common clock prescaler, only for clock source asynchronous */
+#define ADC_CCR_PRESC_0                (0x1UL << ADC_CCR_PRESC_Pos)            /*!< 0x00040000 */
+#define ADC_CCR_PRESC_1                (0x2UL << ADC_CCR_PRESC_Pos)            /*!< 0x00080000 */
+#define ADC_CCR_PRESC_2                (0x4UL << ADC_CCR_PRESC_Pos)            /*!< 0x00100000 */
+#define ADC_CCR_PRESC_3                (0x8UL << ADC_CCR_PRESC_Pos)            /*!< 0x00200000 */
+
+#define ADC_CCR_VREFEN_Pos             (22U)
+#define ADC_CCR_VREFEN_Msk             (0x1UL << ADC_CCR_VREFEN_Pos)           /*!< 0x00400000 */
+#define ADC_CCR_VREFEN                 ADC_CCR_VREFEN_Msk                      /*!< ADC internal path to VrefInt enable */
+#define ADC_CCR_TSEN_Pos               (23U)
+#define ADC_CCR_TSEN_Msk               (0x1UL << ADC_CCR_TSEN_Pos)             /*!< 0x00800000 */
+#define ADC_CCR_TSEN                   ADC_CCR_TSEN_Msk                        /*!< ADC internal path to temperature sensor enable */
+#define ADC_CCR_VBATEN_Pos             (24U)
+#define ADC_CCR_VBATEN_Msk             (0x1UL << ADC_CCR_VBATEN_Pos)           /*!< 0x01000000 */
+#define ADC_CCR_VBATEN                 ADC_CCR_VBATEN_Msk                      /*!< ADC internal path to battery voltage enable */
+
+/* Legacy */
+#define ADC_CCR_LFMEN_Pos              (25U)
+#define ADC_CCR_LFMEN_Msk              (0x1UL << ADC_CCR_LFMEN_Pos)            /*!< 0x02000000 */
+#define ADC_CCR_LFMEN                  ADC_CCR_LFMEN_Msk                       /*!< Legacy feature, useless on STM32G0 (ADC common clock low frequency mode is automatically managed by ADC peripheral on STM32G0) */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos            (0U)
+#define CRC_DR_DR_Msk            (0xFFFFFFFFUL << CRC_DR_DR_Pos)                /*!< 0xFFFFFFFF */
+#define CRC_DR_DR                CRC_DR_DR_Msk                                  /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos          (0U)
+#define CRC_IDR_IDR_Msk          (0xFFFFFFFFUL << CRC_IDR_IDR_Pos)              /*!< 0xFFFFFFFF */
+#define CRC_IDR_IDR              CRC_IDR_IDR_Msk                                /*!< General-purpose 32-bits data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos         (0U)
+#define CRC_CR_RESET_Msk         (0x1UL << CRC_CR_RESET_Pos)                    /*!< 0x00000001 */
+#define CRC_CR_RESET             CRC_CR_RESET_Msk                               /*!< RESET the CRC computation unit bit */
+#define CRC_CR_POLYSIZE_Pos      (3U)
+#define CRC_CR_POLYSIZE_Msk      (0x3UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000018 */
+#define CRC_CR_POLYSIZE          CRC_CR_POLYSIZE_Msk                            /*!< Polynomial size bits */
+#define CRC_CR_POLYSIZE_0        (0x1UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000008 */
+#define CRC_CR_POLYSIZE_1        (0x2UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000010 */
+#define CRC_CR_REV_IN_Pos        (5U)
+#define CRC_CR_REV_IN_Msk        (0x3UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000060 */
+#define CRC_CR_REV_IN            CRC_CR_REV_IN_Msk                              /*!< REV_IN Reverse Input Data bits */
+#define CRC_CR_REV_IN_0          (0x1UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000020 */
+#define CRC_CR_REV_IN_1          (0x2UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000040 */
+#define CRC_CR_REV_OUT_Pos       (7U)
+#define CRC_CR_REV_OUT_Msk       (0x1UL << CRC_CR_REV_OUT_Pos)                  /*!< 0x00000080 */
+#define CRC_CR_REV_OUT           CRC_CR_REV_OUT_Msk                             /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define CRC_INIT_INIT_Pos        (0U)
+#define CRC_INIT_INIT_Msk        (0xFFFFFFFFUL << CRC_INIT_INIT_Pos)            /*!< 0xFFFFFFFF */
+#define CRC_INIT_INIT            CRC_INIT_INIT_Msk                              /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define CRC_POL_POL_Pos          (0U)
+#define CRC_POL_POL_Msk          (0xFFFFFFFFUL << CRC_POL_POL_Pos)              /*!< 0xFFFFFFFF */
+#define CRC_POL_POL              CRC_POL_POL_Msk                                /*!< Coefficients of the polynomial */
+
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 Debug MCU                                  */
+/*                                                                            */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define DMA_ISR_GIF1_Pos       (0U)
+#define DMA_ISR_GIF1_Msk       (0x1UL << DMA_ISR_GIF1_Pos)                     /*!< 0x00000001 */
+#define DMA_ISR_GIF1           DMA_ISR_GIF1_Msk                                /*!< Channel 1 Global interrupt flag */
+#define DMA_ISR_TCIF1_Pos      (1U)
+#define DMA_ISR_TCIF1_Msk      (0x1UL << DMA_ISR_TCIF1_Pos)                    /*!< 0x00000002 */
+#define DMA_ISR_TCIF1          DMA_ISR_TCIF1_Msk                               /*!< Channel 1 Transfer Complete flag */
+#define DMA_ISR_HTIF1_Pos      (2U)
+#define DMA_ISR_HTIF1_Msk      (0x1UL << DMA_ISR_HTIF1_Pos)                    /*!< 0x00000004 */
+#define DMA_ISR_HTIF1          DMA_ISR_HTIF1_Msk                               /*!< Channel 1 Half Transfer flag */
+#define DMA_ISR_TEIF1_Pos      (3U)
+#define DMA_ISR_TEIF1_Msk      (0x1UL << DMA_ISR_TEIF1_Pos)                    /*!< 0x00000008 */
+#define DMA_ISR_TEIF1          DMA_ISR_TEIF1_Msk                               /*!< Channel 1 Transfer Error flag */
+#define DMA_ISR_GIF2_Pos       (4U)
+#define DMA_ISR_GIF2_Msk       (0x1UL << DMA_ISR_GIF2_Pos)                     /*!< 0x00000010 */
+#define DMA_ISR_GIF2           DMA_ISR_GIF2_Msk                                /*!< Channel 2 Global interrupt flag */
+#define DMA_ISR_TCIF2_Pos      (5U)
+#define DMA_ISR_TCIF2_Msk      (0x1UL << DMA_ISR_TCIF2_Pos)                    /*!< 0x00000020 */
+#define DMA_ISR_TCIF2          DMA_ISR_TCIF2_Msk                               /*!< Channel 2 Transfer Complete flag */
+#define DMA_ISR_HTIF2_Pos      (6U)
+#define DMA_ISR_HTIF2_Msk      (0x1UL << DMA_ISR_HTIF2_Pos)                    /*!< 0x00000040 */
+#define DMA_ISR_HTIF2          DMA_ISR_HTIF2_Msk                               /*!< Channel 2 Half Transfer flag */
+#define DMA_ISR_TEIF2_Pos      (7U)
+#define DMA_ISR_TEIF2_Msk      (0x1UL << DMA_ISR_TEIF2_Pos)                    /*!< 0x00000080 */
+#define DMA_ISR_TEIF2          DMA_ISR_TEIF2_Msk                               /*!< Channel 2 Transfer Error flag */
+#define DMA_ISR_GIF3_Pos       (8U)
+#define DMA_ISR_GIF3_Msk       (0x1UL << DMA_ISR_GIF3_Pos)                     /*!< 0x00000100 */
+#define DMA_ISR_GIF3           DMA_ISR_GIF3_Msk                                /*!< Channel 3 Global interrupt flag */
+#define DMA_ISR_TCIF3_Pos      (9U)
+#define DMA_ISR_TCIF3_Msk      (0x1UL << DMA_ISR_TCIF3_Pos)                    /*!< 0x00000200 */
+#define DMA_ISR_TCIF3          DMA_ISR_TCIF3_Msk                               /*!< Channel 3 Transfer Complete flag */
+#define DMA_ISR_HTIF3_Pos      (10U)
+#define DMA_ISR_HTIF3_Msk      (0x1UL << DMA_ISR_HTIF3_Pos)                    /*!< 0x00000400 */
+#define DMA_ISR_HTIF3          DMA_ISR_HTIF3_Msk                               /*!< Channel 3 Half Transfer flag */
+#define DMA_ISR_TEIF3_Pos      (11U)
+#define DMA_ISR_TEIF3_Msk      (0x1UL << DMA_ISR_TEIF3_Pos)                    /*!< 0x00000800 */
+#define DMA_ISR_TEIF3          DMA_ISR_TEIF3_Msk                               /*!< Channel 3 Transfer Error flag */
+#define DMA_ISR_GIF4_Pos       (12U)
+#define DMA_ISR_GIF4_Msk       (0x1UL << DMA_ISR_GIF4_Pos)                     /*!< 0x00001000 */
+#define DMA_ISR_GIF4           DMA_ISR_GIF4_Msk                                /*!< Channel 4 Global interrupt flag */
+#define DMA_ISR_TCIF4_Pos      (13U)
+#define DMA_ISR_TCIF4_Msk      (0x1UL << DMA_ISR_TCIF4_Pos)                    /*!< 0x00002000 */
+#define DMA_ISR_TCIF4          DMA_ISR_TCIF4_Msk                               /*!< Channel 4 Transfer Complete flag */
+#define DMA_ISR_HTIF4_Pos      (14U)
+#define DMA_ISR_HTIF4_Msk      (0x1UL << DMA_ISR_HTIF4_Pos)                    /*!< 0x00004000 */
+#define DMA_ISR_HTIF4          DMA_ISR_HTIF4_Msk                               /*!< Channel 4 Half Transfer flag */
+#define DMA_ISR_TEIF4_Pos      (15U)
+#define DMA_ISR_TEIF4_Msk      (0x1UL << DMA_ISR_TEIF4_Pos)                    /*!< 0x00008000 */
+#define DMA_ISR_TEIF4          DMA_ISR_TEIF4_Msk                               /*!< Channel 4 Transfer Error flag */
+#define DMA_ISR_GIF5_Pos       (16U)
+#define DMA_ISR_GIF5_Msk       (0x1UL << DMA_ISR_GIF5_Pos)                     /*!< 0x00010000 */
+#define DMA_ISR_GIF5           DMA_ISR_GIF5_Msk                                /*!< Channel 5 Global interrupt flag */
+#define DMA_ISR_TCIF5_Pos      (17U)
+#define DMA_ISR_TCIF5_Msk      (0x1UL << DMA_ISR_TCIF5_Pos)                    /*!< 0x00020000 */
+#define DMA_ISR_TCIF5          DMA_ISR_TCIF5_Msk                               /*!< Channel 5 Transfer Complete flag */
+#define DMA_ISR_HTIF5_Pos      (18U)
+#define DMA_ISR_HTIF5_Msk      (0x1UL << DMA_ISR_HTIF5_Pos)                    /*!< 0x00040000 */
+#define DMA_ISR_HTIF5          DMA_ISR_HTIF5_Msk                               /*!< Channel 5 Half Transfer flag */
+#define DMA_ISR_TEIF5_Pos      (19U)
+#define DMA_ISR_TEIF5_Msk      (0x1UL << DMA_ISR_TEIF5_Pos)                    /*!< 0x00080000 */
+#define DMA_ISR_TEIF5          DMA_ISR_TEIF5_Msk                               /*!< Channel 5 Transfer Error flag */
+#define DMA_ISR_GIF6_Pos       (20U)
+#define DMA_ISR_GIF6_Msk       (0x1UL << DMA_ISR_GIF6_Pos)                     /*!< 0x00100000 */
+#define DMA_ISR_GIF6           DMA_ISR_GIF6_Msk                                /*!< Channel 6 Global interrupt flag */
+#define DMA_ISR_TCIF6_Pos      (21U)
+#define DMA_ISR_TCIF6_Msk      (0x1UL << DMA_ISR_TCIF6_Pos)                    /*!< 0x00200000 */
+#define DMA_ISR_TCIF6          DMA_ISR_TCIF6_Msk                               /*!< Channel 6 Transfer Complete flag */
+#define DMA_ISR_HTIF6_Pos      (22U)
+#define DMA_ISR_HTIF6_Msk      (0x1UL << DMA_ISR_HTIF6_Pos)                    /*!< 0x00400000 */
+#define DMA_ISR_HTIF6          DMA_ISR_HTIF6_Msk                               /*!< Channel 6 Half Transfer flag */
+#define DMA_ISR_TEIF6_Pos      (23U)
+#define DMA_ISR_TEIF6_Msk      (0x1UL << DMA_ISR_TEIF6_Pos)                    /*!< 0x00800000 */
+#define DMA_ISR_TEIF6          DMA_ISR_TEIF6_Msk                               /*!< Channel 6 Transfer Error flag */
+#define DMA_ISR_GIF7_Pos       (24U)
+#define DMA_ISR_GIF7_Msk       (0x1UL << DMA_ISR_GIF7_Pos)                     /*!< 0x01000000 */
+#define DMA_ISR_GIF7           DMA_ISR_GIF7_Msk                                /*!< Channel 7 Global interrupt flag */
+#define DMA_ISR_TCIF7_Pos      (25U)
+#define DMA_ISR_TCIF7_Msk      (0x1UL << DMA_ISR_TCIF7_Pos)                    /*!< 0x02000000 */
+#define DMA_ISR_TCIF7          DMA_ISR_TCIF7_Msk                               /*!< Channel 7 Transfer Complete flag */
+#define DMA_ISR_HTIF7_Pos      (26U)
+#define DMA_ISR_HTIF7_Msk      (0x1UL << DMA_ISR_HTIF7_Pos)                    /*!< 0x04000000 */
+#define DMA_ISR_HTIF7          DMA_ISR_HTIF7_Msk                               /*!< Channel 7 Half Transfer flag */
+#define DMA_ISR_TEIF7_Pos      (27U)
+#define DMA_ISR_TEIF7_Msk      (0x1UL << DMA_ISR_TEIF7_Pos)                    /*!< 0x08000000 */
+#define DMA_ISR_TEIF7          DMA_ISR_TEIF7_Msk                               /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define DMA_IFCR_CGIF1_Pos     (0U)
+#define DMA_IFCR_CGIF1_Msk     (0x1UL << DMA_IFCR_CGIF1_Pos)                   /*!< 0x00000001 */
+#define DMA_IFCR_CGIF1         DMA_IFCR_CGIF1_Msk                              /*!< Channel 1 Global interrupt clearr */
+#define DMA_IFCR_CTCIF1_Pos    (1U)
+#define DMA_IFCR_CTCIF1_Msk    (0x1UL << DMA_IFCR_CTCIF1_Pos)                  /*!< 0x00000002 */
+#define DMA_IFCR_CTCIF1        DMA_IFCR_CTCIF1_Msk                             /*!< Channel 1 Transfer Complete clear */
+#define DMA_IFCR_CHTIF1_Pos    (2U)
+#define DMA_IFCR_CHTIF1_Msk    (0x1UL << DMA_IFCR_CHTIF1_Pos)                  /*!< 0x00000004 */
+#define DMA_IFCR_CHTIF1        DMA_IFCR_CHTIF1_Msk                             /*!< Channel 1 Half Transfer clear */
+#define DMA_IFCR_CTEIF1_Pos    (3U)
+#define DMA_IFCR_CTEIF1_Msk    (0x1UL << DMA_IFCR_CTEIF1_Pos)                  /*!< 0x00000008 */
+#define DMA_IFCR_CTEIF1        DMA_IFCR_CTEIF1_Msk                             /*!< Channel 1 Transfer Error clear */
+#define DMA_IFCR_CGIF2_Pos     (4U)
+#define DMA_IFCR_CGIF2_Msk     (0x1UL << DMA_IFCR_CGIF2_Pos)                   /*!< 0x00000010 */
+#define DMA_IFCR_CGIF2         DMA_IFCR_CGIF2_Msk                              /*!< Channel 2 Global interrupt clear */
+#define DMA_IFCR_CTCIF2_Pos    (5U)
+#define DMA_IFCR_CTCIF2_Msk    (0x1UL << DMA_IFCR_CTCIF2_Pos)                  /*!< 0x00000020 */
+#define DMA_IFCR_CTCIF2        DMA_IFCR_CTCIF2_Msk                             /*!< Channel 2 Transfer Complete clear */
+#define DMA_IFCR_CHTIF2_Pos    (6U)
+#define DMA_IFCR_CHTIF2_Msk    (0x1UL << DMA_IFCR_CHTIF2_Pos)                  /*!< 0x00000040 */
+#define DMA_IFCR_CHTIF2        DMA_IFCR_CHTIF2_Msk                             /*!< Channel 2 Half Transfer clear */
+#define DMA_IFCR_CTEIF2_Pos    (7U)
+#define DMA_IFCR_CTEIF2_Msk    (0x1UL << DMA_IFCR_CTEIF2_Pos)                  /*!< 0x00000080 */
+#define DMA_IFCR_CTEIF2        DMA_IFCR_CTEIF2_Msk                             /*!< Channel 2 Transfer Error clear */
+#define DMA_IFCR_CGIF3_Pos     (8U)
+#define DMA_IFCR_CGIF3_Msk     (0x1UL << DMA_IFCR_CGIF3_Pos)                   /*!< 0x00000100 */
+#define DMA_IFCR_CGIF3         DMA_IFCR_CGIF3_Msk                              /*!< Channel 3 Global interrupt clear */
+#define DMA_IFCR_CTCIF3_Pos    (9U)
+#define DMA_IFCR_CTCIF3_Msk    (0x1UL << DMA_IFCR_CTCIF3_Pos)                  /*!< 0x00000200 */
+#define DMA_IFCR_CTCIF3        DMA_IFCR_CTCIF3_Msk                             /*!< Channel 3 Transfer Complete clear */
+#define DMA_IFCR_CHTIF3_Pos    (10U)
+#define DMA_IFCR_CHTIF3_Msk    (0x1UL << DMA_IFCR_CHTIF3_Pos)                  /*!< 0x00000400 */
+#define DMA_IFCR_CHTIF3        DMA_IFCR_CHTIF3_Msk                             /*!< Channel 3 Half Transfer clear */
+#define DMA_IFCR_CTEIF3_Pos    (11U)
+#define DMA_IFCR_CTEIF3_Msk    (0x1UL << DMA_IFCR_CTEIF3_Pos)                  /*!< 0x00000800 */
+#define DMA_IFCR_CTEIF3        DMA_IFCR_CTEIF3_Msk                             /*!< Channel 3 Transfer Error clear */
+#define DMA_IFCR_CGIF4_Pos     (12U)
+#define DMA_IFCR_CGIF4_Msk     (0x1UL << DMA_IFCR_CGIF4_Pos)                   /*!< 0x00001000 */
+#define DMA_IFCR_CGIF4         DMA_IFCR_CGIF4_Msk                              /*!< Channel 4 Global interrupt clear */
+#define DMA_IFCR_CTCIF4_Pos    (13U)
+#define DMA_IFCR_CTCIF4_Msk    (0x1UL << DMA_IFCR_CTCIF4_Pos)                  /*!< 0x00002000 */
+#define DMA_IFCR_CTCIF4        DMA_IFCR_CTCIF4_Msk                             /*!< Channel 4 Transfer Complete clear */
+#define DMA_IFCR_CHTIF4_Pos    (14U)
+#define DMA_IFCR_CHTIF4_Msk    (0x1UL << DMA_IFCR_CHTIF4_Pos)                  /*!< 0x00004000 */
+#define DMA_IFCR_CHTIF4        DMA_IFCR_CHTIF4_Msk                             /*!< Channel 4 Half Transfer clear */
+#define DMA_IFCR_CTEIF4_Pos    (15U)
+#define DMA_IFCR_CTEIF4_Msk    (0x1UL << DMA_IFCR_CTEIF4_Pos)                  /*!< 0x00008000 */
+#define DMA_IFCR_CTEIF4        DMA_IFCR_CTEIF4_Msk                             /*!< Channel 4 Transfer Error clear */
+#define DMA_IFCR_CGIF5_Pos     (16U)
+#define DMA_IFCR_CGIF5_Msk     (0x1UL << DMA_IFCR_CGIF5_Pos)                   /*!< 0x00010000 */
+#define DMA_IFCR_CGIF5         DMA_IFCR_CGIF5_Msk                              /*!< Channel 5 Global interrupt clear */
+#define DMA_IFCR_CTCIF5_Pos    (17U)
+#define DMA_IFCR_CTCIF5_Msk    (0x1UL << DMA_IFCR_CTCIF5_Pos)                  /*!< 0x00020000 */
+#define DMA_IFCR_CTCIF5        DMA_IFCR_CTCIF5_Msk                             /*!< Channel 5 Transfer Complete clear */
+#define DMA_IFCR_CHTIF5_Pos    (18U)
+#define DMA_IFCR_CHTIF5_Msk    (0x1UL << DMA_IFCR_CHTIF5_Pos)                  /*!< 0x00040000 */
+#define DMA_IFCR_CHTIF5        DMA_IFCR_CHTIF5_Msk                             /*!< Channel 5 Half Transfer clear */
+#define DMA_IFCR_CTEIF5_Pos    (19U)
+#define DMA_IFCR_CTEIF5_Msk    (0x1UL << DMA_IFCR_CTEIF5_Pos)                  /*!< 0x00080000 */
+#define DMA_IFCR_CTEIF5        DMA_IFCR_CTEIF5_Msk                             /*!< Channel 5 Transfer Error clear */
+#define DMA_IFCR_CGIF6_Pos     (20U)
+#define DMA_IFCR_CGIF6_Msk     (0x1UL << DMA_IFCR_CGIF6_Pos)                   /*!< 0x00100000 */
+#define DMA_IFCR_CGIF6         DMA_IFCR_CGIF6_Msk                              /*!< Channel 6 Global interrupt clear */
+#define DMA_IFCR_CTCIF6_Pos    (21U)
+#define DMA_IFCR_CTCIF6_Msk    (0x1UL << DMA_IFCR_CTCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_IFCR_CTCIF6        DMA_IFCR_CTCIF6_Msk                             /*!< Channel 6 Transfer Complete clear */
+#define DMA_IFCR_CHTIF6_Pos    (22U)
+#define DMA_IFCR_CHTIF6_Msk    (0x1UL << DMA_IFCR_CHTIF6_Pos)                  /*!< 0x00400000 */
+#define DMA_IFCR_CHTIF6        DMA_IFCR_CHTIF6_Msk                             /*!< Channel 6 Half Transfer clear */
+#define DMA_IFCR_CTEIF6_Pos    (23U)
+#define DMA_IFCR_CTEIF6_Msk    (0x1UL << DMA_IFCR_CTEIF6_Pos)                  /*!< 0x00800000 */
+#define DMA_IFCR_CTEIF6        DMA_IFCR_CTEIF6_Msk                             /*!< Channel 6 Transfer Error clear */
+#define DMA_IFCR_CGIF7_Pos     (24U)
+#define DMA_IFCR_CGIF7_Msk     (0x1UL << DMA_IFCR_CGIF7_Pos)                   /*!< 0x01000000 */
+#define DMA_IFCR_CGIF7         DMA_IFCR_CGIF7_Msk                              /*!< Channel 7 Global interrupt clear */
+#define DMA_IFCR_CTCIF7_Pos    (25U)
+#define DMA_IFCR_CTCIF7_Msk    (0x1UL << DMA_IFCR_CTCIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_IFCR_CTCIF7        DMA_IFCR_CTCIF7_Msk                             /*!< Channel 7 Transfer Complete clear */
+#define DMA_IFCR_CHTIF7_Pos    (26U)
+#define DMA_IFCR_CHTIF7_Msk    (0x1UL << DMA_IFCR_CHTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_IFCR_CHTIF7        DMA_IFCR_CHTIF7_Msk                             /*!< Channel 7 Half Transfer clear */
+#define DMA_IFCR_CTEIF7_Pos    (27U)
+#define DMA_IFCR_CTEIF7_Msk    (0x1UL << DMA_IFCR_CTEIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_IFCR_CTEIF7        DMA_IFCR_CTEIF7_Msk                             /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define DMA_CCR_EN_Pos         (0U)
+#define DMA_CCR_EN_Msk         (0x1UL << DMA_CCR_EN_Pos)                       /*!< 0x00000001 */
+#define DMA_CCR_EN             DMA_CCR_EN_Msk                                  /*!< Channel enable                      */
+#define DMA_CCR_TCIE_Pos       (1U)
+#define DMA_CCR_TCIE_Msk       (0x1UL << DMA_CCR_TCIE_Pos)                     /*!< 0x00000002 */
+#define DMA_CCR_TCIE           DMA_CCR_TCIE_Msk                                /*!< Transfer complete interrupt enable  */
+#define DMA_CCR_HTIE_Pos       (2U)
+#define DMA_CCR_HTIE_Msk       (0x1UL << DMA_CCR_HTIE_Pos)                     /*!< 0x00000004 */
+#define DMA_CCR_HTIE           DMA_CCR_HTIE_Msk                                /*!< Half Transfer interrupt enable      */
+#define DMA_CCR_TEIE_Pos       (3U)
+#define DMA_CCR_TEIE_Msk       (0x1UL << DMA_CCR_TEIE_Pos)                     /*!< 0x00000008 */
+#define DMA_CCR_TEIE           DMA_CCR_TEIE_Msk                                /*!< Transfer error interrupt enable     */
+#define DMA_CCR_DIR_Pos        (4U)
+#define DMA_CCR_DIR_Msk        (0x1UL << DMA_CCR_DIR_Pos)                      /*!< 0x00000010 */
+#define DMA_CCR_DIR            DMA_CCR_DIR_Msk                                 /*!< Data transfer direction             */
+#define DMA_CCR_CIRC_Pos       (5U)
+#define DMA_CCR_CIRC_Msk       (0x1UL << DMA_CCR_CIRC_Pos)                     /*!< 0x00000020 */
+#define DMA_CCR_CIRC           DMA_CCR_CIRC_Msk                                /*!< Circular mode                       */
+#define DMA_CCR_PINC_Pos       (6U)
+#define DMA_CCR_PINC_Msk       (0x1UL << DMA_CCR_PINC_Pos)                     /*!< 0x00000040 */
+#define DMA_CCR_PINC           DMA_CCR_PINC_Msk                                /*!< Peripheral increment mode           */
+#define DMA_CCR_MINC_Pos       (7U)
+#define DMA_CCR_MINC_Msk       (0x1UL << DMA_CCR_MINC_Pos)                     /*!< 0x00000080 */
+#define DMA_CCR_MINC           DMA_CCR_MINC_Msk                                /*!< Memory increment mode               */
+
+#define DMA_CCR_PSIZE_Pos      (8U)
+#define DMA_CCR_PSIZE_Msk      (0x3UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000300 */
+#define DMA_CCR_PSIZE          DMA_CCR_PSIZE_Msk                               /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define DMA_CCR_PSIZE_0        (0x1UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000100 */
+#define DMA_CCR_PSIZE_1        (0x2UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000200 */
+
+#define DMA_CCR_MSIZE_Pos      (10U)
+#define DMA_CCR_MSIZE_Msk      (0x3UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000C00 */
+#define DMA_CCR_MSIZE          DMA_CCR_MSIZE_Msk                               /*!< MSIZE[1:0] bits (Memory size)       */
+#define DMA_CCR_MSIZE_0        (0x1UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000400 */
+#define DMA_CCR_MSIZE_1        (0x2UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000800 */
+
+#define DMA_CCR_PL_Pos         (12U)
+#define DMA_CCR_PL_Msk         (0x3UL << DMA_CCR_PL_Pos)                       /*!< 0x00003000 */
+#define DMA_CCR_PL             DMA_CCR_PL_Msk                                  /*!< PL[1:0] bits(Channel Priority level)*/
+#define DMA_CCR_PL_0           (0x1UL << DMA_CCR_PL_Pos)                       /*!< 0x00001000 */
+#define DMA_CCR_PL_1           (0x2UL << DMA_CCR_PL_Pos)                        /*!< 0x00002000 */
+
+#define DMA_CCR_MEM2MEM_Pos    (14U)
+#define DMA_CCR_MEM2MEM_Msk    (0x1UL << DMA_CCR_MEM2MEM_Pos)                  /*!< 0x00004000 */
+#define DMA_CCR_MEM2MEM        DMA_CCR_MEM2MEM_Msk                             /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define DMA_CNDTR_NDT_Pos      (0U)
+#define DMA_CNDTR_NDT_Msk      (0xFFFFUL << DMA_CNDTR_NDT_Pos)                 /*!< 0x0000FFFF */
+#define DMA_CNDTR_NDT          DMA_CNDTR_NDT_Msk                               /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define DMA_CPAR_PA_Pos        (0U)
+#define DMA_CPAR_PA_Msk        (0xFFFFFFFFUL << DMA_CPAR_PA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CPAR_PA            DMA_CPAR_PA_Msk                                 /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define DMA_CMAR_MA_Pos        (0U)
+#define DMA_CMAR_MA_Msk        (0xFFFFFFFFUL << DMA_CMAR_MA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CMAR_MA            DMA_CMAR_MA_Msk                                 /*!< Memory Address                      */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMAMUX Controller                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMAMUX_CxCR register  **************/
+#define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
+#define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
+#define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_CxCR_DMAREQ_ID_2                (0x04UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_CxCR_DMAREQ_ID_3                (0x08UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_CxCR_DMAREQ_ID_4                (0x10UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_CxCR_DMAREQ_ID_5                (0x20UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
+#define DMAMUX_CxCR_DMAREQ_ID_6                (0x40UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000040 */
+#define DMAMUX_CxCR_DMAREQ_ID_7                (0x80UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000080 */
+#define DMAMUX_CxCR_SOIE_Pos                   (8U)
+#define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk             /*!< Synchro overrun interrupt enable     */
+#define DMAMUX_CxCR_EGE_Pos                    (9U)
+#define DMAMUX_CxCR_EGE_Msk                    (0x1UL << DMAMUX_CxCR_EGE_Pos)   /*!< 0x00000200 */
+#define DMAMUX_CxCR_EGE                        DMAMUX_CxCR_EGE_Msk              /*!< Event generation interrupt enable    */
+#define DMAMUX_CxCR_SE_Pos                     (16U)
+#define DMAMUX_CxCR_SE_Msk                     (0x1UL << DMAMUX_CxCR_SE_Pos)    /*!< 0x00010000 */
+#define DMAMUX_CxCR_SE                         DMAMUX_CxCR_SE_Msk               /*!< Synchronization enable               */
+#define DMAMUX_CxCR_SPOL_Pos                   (17U)
+#define DMAMUX_CxCR_SPOL_Msk                   (0x3UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00060000 */
+#define DMAMUX_CxCR_SPOL                       DMAMUX_CxCR_SPOL_Msk             /*!< Synchronization polarity             */
+#define DMAMUX_CxCR_SPOL_0                     (0x1UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00020000 */
+#define DMAMUX_CxCR_SPOL_1                     (0x2UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00040000 */
+#define DMAMUX_CxCR_NBREQ_Pos                  (19U)
+#define DMAMUX_CxCR_NBREQ_Msk                  (0x1FUL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_CxCR_NBREQ                      DMAMUX_CxCR_NBREQ_Msk             /*!< Number of request                    */
+#define DMAMUX_CxCR_NBREQ_0                    (0x01UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_CxCR_NBREQ_1                    (0x02UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_CxCR_NBREQ_2                    (0x04UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_CxCR_NBREQ_3                    (0x08UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_CxCR_NBREQ_4                    (0x10UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00800000 */
+#define DMAMUX_CxCR_SYNC_ID_Pos                (24U)
+#define DMAMUX_CxCR_SYNC_ID_Msk                (0x1FUL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x1F000000 */
+#define DMAMUX_CxCR_SYNC_ID                    DMAMUX_CxCR_SYNC_ID_Msk             /*!< Synchronization ID                   */
+#define DMAMUX_CxCR_SYNC_ID_0                  (0x01UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x01000000 */
+#define DMAMUX_CxCR_SYNC_ID_1                  (0x02UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x02000000 */
+#define DMAMUX_CxCR_SYNC_ID_2                  (0x04UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x04000000 */
+#define DMAMUX_CxCR_SYNC_ID_3                  (0x08UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x08000000 */
+#define DMAMUX_CxCR_SYNC_ID_4                  (0x10UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x10000000 */
+
+/*******************  Bits definition for DMAMUX_CSR register  **************/
+#define DMAMUX_CSR_SOF0_Pos                    (0U)
+#define DMAMUX_CSR_SOF0_Msk                    (0x1UL << DMAMUX_CSR_SOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CSR_SOF0                        DMAMUX_CSR_SOF0_Msk             /*!< Synchronization Overrun Flag 0       */
+#define DMAMUX_CSR_SOF1_Pos                    (1U)
+#define DMAMUX_CSR_SOF1_Msk                    (0x1UL << DMAMUX_CSR_SOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CSR_SOF1                        DMAMUX_CSR_SOF1_Msk             /*!< Synchronization Overrun Flag 1       */
+#define DMAMUX_CSR_SOF2_Pos                    (2U)
+#define DMAMUX_CSR_SOF2_Msk                    (0x1UL << DMAMUX_CSR_SOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CSR_SOF2                        DMAMUX_CSR_SOF2_Msk             /*!< Synchronization Overrun Flag 2       */
+#define DMAMUX_CSR_SOF3_Pos                    (3U)
+#define DMAMUX_CSR_SOF3_Msk                    (0x1UL << DMAMUX_CSR_SOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CSR_SOF3                        DMAMUX_CSR_SOF3_Msk             /*!< Synchronization Overrun Flag 3       */
+#define DMAMUX_CSR_SOF4_Pos                    (4U)
+#define DMAMUX_CSR_SOF4_Msk                    (0x1UL << DMAMUX_CSR_SOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CSR_SOF4                        DMAMUX_CSR_SOF4_Msk             /*!< Synchronization Overrun Flag 4       */
+#define DMAMUX_CSR_SOF5_Pos                    (5U)
+#define DMAMUX_CSR_SOF5_Msk                    (0x1UL << DMAMUX_CSR_SOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CSR_SOF5                        DMAMUX_CSR_SOF5_Msk             /*!< Synchronization Overrun Flag 5       */
+#define DMAMUX_CSR_SOF6_Pos                    (6U)
+#define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+
+/********************  Bits definition for DMAMUX_CFR register  **************/
+#define DMAMUX_CFR_CSOF0_Pos                   (0U)
+#define DMAMUX_CFR_CSOF0_Msk                   (0x1UL << DMAMUX_CFR_CSOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CFR_CSOF0                       DMAMUX_CFR_CSOF0_Msk             /*!< Clear Overrun Flag 0                 */
+#define DMAMUX_CFR_CSOF1_Pos                   (1U)
+#define DMAMUX_CFR_CSOF1_Msk                   (0x1UL << DMAMUX_CFR_CSOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CFR_CSOF1                       DMAMUX_CFR_CSOF1_Msk             /*!< Clear Overrun Flag 1                 */
+#define DMAMUX_CFR_CSOF2_Pos                   (2U)
+#define DMAMUX_CFR_CSOF2_Msk                   (0x1UL << DMAMUX_CFR_CSOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CFR_CSOF2                       DMAMUX_CFR_CSOF2_Msk             /*!< Clear Overrun Flag 2                 */
+#define DMAMUX_CFR_CSOF3_Pos                   (3U)
+#define DMAMUX_CFR_CSOF3_Msk                   (0x1UL << DMAMUX_CFR_CSOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CFR_CSOF3                       DMAMUX_CFR_CSOF3_Msk             /*!< Clear Overrun Flag 3                 */
+#define DMAMUX_CFR_CSOF4_Pos                   (4U)
+#define DMAMUX_CFR_CSOF4_Msk                   (0x1UL << DMAMUX_CFR_CSOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CFR_CSOF4                       DMAMUX_CFR_CSOF4_Msk             /*!< Clear Overrun Flag 4                 */
+#define DMAMUX_CFR_CSOF5_Pos                   (5U)
+#define DMAMUX_CFR_CSOF5_Msk                   (0x1UL << DMAMUX_CFR_CSOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CFR_CSOF5                       DMAMUX_CFR_CSOF5_Msk             /*!< Clear Overrun Flag 5                 */
+#define DMAMUX_CFR_CSOF6_Pos                   (6U)
+#define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk             /*!< Clear Overrun Flag 6                 */
+
+/********************  Bits definition for DMAMUX_RGxCR register  ************/
+#define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
+#define DMAMUX_RGxCR_SIG_ID_Msk                (0x1FUL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x0000001F */
+#define DMAMUX_RGxCR_SIG_ID                    DMAMUX_RGxCR_SIG_ID_Msk             /*!< Signal ID                         */
+#define DMAMUX_RGxCR_SIG_ID_0                  (0x01UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGxCR_SIG_ID_1                  (0x02UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGxCR_SIG_ID_2                  (0x04UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGxCR_SIG_ID_3                  (0x08UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGxCR_SIG_ID_4                  (0x10UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_RGxCR_OIE_Pos                   (8U)
+#define DMAMUX_RGxCR_OIE_Msk                   (0x1UL << DMAMUX_RGxCR_OIE_Pos)  /*!< 0x00000100 */
+#define DMAMUX_RGxCR_OIE                       DMAMUX_RGxCR_OIE_Msk             /*!< Overrun interrupt enable             */
+#define DMAMUX_RGxCR_GE_Pos                    (16U)
+#define DMAMUX_RGxCR_GE_Msk                    (0x1UL << DMAMUX_RGxCR_GE_Pos)   /*!< 0x00010000 */
+#define DMAMUX_RGxCR_GE                        DMAMUX_RGxCR_GE_Msk              /*!< Generation enable                    */
+#define DMAMUX_RGxCR_GPOL_Pos                  (17U)
+#define DMAMUX_RGxCR_GPOL_Msk                  (0x3UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_RGxCR_GPOL                      DMAMUX_RGxCR_GPOL_Msk            /*!< Generation polarity                  */
+#define DMAMUX_RGxCR_GPOL_0                    (0x1UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00020000 */
+#define DMAMUX_RGxCR_GPOL_1                    (0x2UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00040000 */
+#define DMAMUX_RGxCR_GNBREQ_Pos                (19U)
+#define DMAMUX_RGxCR_GNBREQ_Msk                (0x1FUL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_RGxCR_GNBREQ                    DMAMUX_RGxCR_GNBREQ_Msk             /*!< Number of request                 */
+#define DMAMUX_RGxCR_GNBREQ_0                  (0x01UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_RGxCR_GNBREQ_1                  (0x02UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_RGxCR_GNBREQ_2                  (0x04UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_RGxCR_GNBREQ_3                  (0x08UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_RGxCR_GNBREQ_4                  (0x10UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00800000 */
+
+/********************  Bits definition for DMAMUX_RGSR register  **************/
+#define DMAMUX_RGSR_OF0_Pos                    (0U)
+#define DMAMUX_RGSR_OF0_Msk                    (0x1UL << DMAMUX_RGSR_OF0_Pos)   /*!< 0x00000001 */
+#define DMAMUX_RGSR_OF0                        DMAMUX_RGSR_OF0_Msk              /*!< Overrun flag 0                       */
+#define DMAMUX_RGSR_OF1_Pos                    (1U)
+#define DMAMUX_RGSR_OF1_Msk                    (0x1UL << DMAMUX_RGSR_OF1_Pos)   /*!< 0x00000002 */
+#define DMAMUX_RGSR_OF1                        DMAMUX_RGSR_OF1_Msk              /*!< Overrun flag 1                       */
+#define DMAMUX_RGSR_OF2_Pos                    (2U)
+#define DMAMUX_RGSR_OF2_Msk                    (0x1UL << DMAMUX_RGSR_OF2_Pos)   /*!< 0x00000004 */
+#define DMAMUX_RGSR_OF2                        DMAMUX_RGSR_OF2_Msk              /*!< Overrun flag 2                       */
+#define DMAMUX_RGSR_OF3_Pos                    (3U)
+#define DMAMUX_RGSR_OF3_Msk                    (0x1UL << DMAMUX_RGSR_OF3_Pos)   /*!< 0x00000008 */
+#define DMAMUX_RGSR_OF3                        DMAMUX_RGSR_OF3_Msk              /*!< Overrun flag 3                       */
+
+/********************  Bits definition for DMAMUX_RGCFR register  **************/
+#define DMAMUX_RGCFR_COF0_Pos                  (0U)
+#define DMAMUX_RGCFR_COF0_Msk                  (0x1UL << DMAMUX_RGCFR_COF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGCFR_COF0                      DMAMUX_RGCFR_COF0_Msk            /*!< Clear Overrun flag 0                 */
+#define DMAMUX_RGCFR_COF1_Pos                  (1U)
+#define DMAMUX_RGCFR_COF1_Msk                  (0x1UL << DMAMUX_RGCFR_COF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGCFR_COF1                      DMAMUX_RGCFR_COF1_Msk            /*!< Clear Overrun flag 1                 */
+#define DMAMUX_RGCFR_COF2_Pos                  (2U)
+#define DMAMUX_RGCFR_COF2_Msk                  (0x1UL << DMAMUX_RGCFR_COF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGCFR_COF2                      DMAMUX_RGCFR_COF2_Msk            /*!< Clear Overrun flag 2                 */
+#define DMAMUX_RGCFR_COF3_Pos                  (3U)
+#define DMAMUX_RGCFR_COF3_Msk                  (0x1UL << DMAMUX_RGCFR_COF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGCFR_COF3                      DMAMUX_RGCFR_COF3_Msk            /*!< Clear Overrun flag 3                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for EXTI_RTSR1 register  ******************/
+#define EXTI_RTSR1_RT0_Pos           (0U)
+#define EXTI_RTSR1_RT0_Msk           (0x1UL << EXTI_RTSR1_RT0_Pos)             /*!< 0x00000001 */
+#define EXTI_RTSR1_RT0               EXTI_RTSR1_RT0_Msk                        /*!< Rising trigger configuration for input line 0 */
+#define EXTI_RTSR1_RT1_Pos           (1U)
+#define EXTI_RTSR1_RT1_Msk           (0x1UL << EXTI_RTSR1_RT1_Pos)             /*!< 0x00000002 */
+#define EXTI_RTSR1_RT1               EXTI_RTSR1_RT1_Msk                        /*!< Rising trigger configuration for input line 1 */
+#define EXTI_RTSR1_RT2_Pos           (2U)
+#define EXTI_RTSR1_RT2_Msk           (0x1UL << EXTI_RTSR1_RT2_Pos)             /*!< 0x00000004 */
+#define EXTI_RTSR1_RT2               EXTI_RTSR1_RT2_Msk                        /*!< Rising trigger configuration for input line 2 */
+#define EXTI_RTSR1_RT3_Pos           (3U)
+#define EXTI_RTSR1_RT3_Msk           (0x1UL << EXTI_RTSR1_RT3_Pos)             /*!< 0x00000008 */
+#define EXTI_RTSR1_RT3               EXTI_RTSR1_RT3_Msk                        /*!< Rising trigger configuration for input line 3 */
+#define EXTI_RTSR1_RT4_Pos           (4U)
+#define EXTI_RTSR1_RT4_Msk           (0x1UL << EXTI_RTSR1_RT4_Pos)             /*!< 0x00000010 */
+#define EXTI_RTSR1_RT4               EXTI_RTSR1_RT4_Msk                        /*!< Rising trigger configuration for input line 4 */
+#define EXTI_RTSR1_RT5_Pos           (5U)
+#define EXTI_RTSR1_RT5_Msk           (0x1UL << EXTI_RTSR1_RT5_Pos)             /*!< 0x00000020 */
+#define EXTI_RTSR1_RT5               EXTI_RTSR1_RT5_Msk                        /*!< Rising trigger configuration for input line 5 */
+#define EXTI_RTSR1_RT6_Pos           (6U)
+#define EXTI_RTSR1_RT6_Msk           (0x1UL << EXTI_RTSR1_RT6_Pos)             /*!< 0x00000040 */
+#define EXTI_RTSR1_RT6               EXTI_RTSR1_RT6_Msk                        /*!< Rising trigger configuration for input line 6 */
+#define EXTI_RTSR1_RT7_Pos           (7U)
+#define EXTI_RTSR1_RT7_Msk           (0x1UL << EXTI_RTSR1_RT7_Pos)             /*!< 0x00000080 */
+#define EXTI_RTSR1_RT7               EXTI_RTSR1_RT7_Msk                        /*!< Rising trigger configuration for input line 7 */
+#define EXTI_RTSR1_RT8_Pos           (8U)
+#define EXTI_RTSR1_RT8_Msk           (0x1UL << EXTI_RTSR1_RT8_Pos)             /*!< 0x00000100 */
+#define EXTI_RTSR1_RT8               EXTI_RTSR1_RT8_Msk                        /*!< Rising trigger configuration for input line 8 */
+#define EXTI_RTSR1_RT9_Pos           (9U)
+#define EXTI_RTSR1_RT9_Msk           (0x1UL << EXTI_RTSR1_RT9_Pos)             /*!< 0x00000200 */
+#define EXTI_RTSR1_RT9               EXTI_RTSR1_RT9_Msk                        /*!< Rising trigger configuration for input line 9 */
+#define EXTI_RTSR1_RT10_Pos          (10U)
+#define EXTI_RTSR1_RT10_Msk          (0x1UL << EXTI_RTSR1_RT10_Pos)            /*!< 0x00000400 */
+#define EXTI_RTSR1_RT10              EXTI_RTSR1_RT10_Msk                       /*!< Rising trigger configuration for input line 10 */
+#define EXTI_RTSR1_RT11_Pos          (11U)
+#define EXTI_RTSR1_RT11_Msk          (0x1UL << EXTI_RTSR1_RT11_Pos)            /*!< 0x00000800 */
+#define EXTI_RTSR1_RT11              EXTI_RTSR1_RT11_Msk                       /*!< Rising trigger configuration for input line 11 */
+#define EXTI_RTSR1_RT12_Pos          (12U)
+#define EXTI_RTSR1_RT12_Msk          (0x1UL << EXTI_RTSR1_RT12_Pos)            /*!< 0x00001000 */
+#define EXTI_RTSR1_RT12              EXTI_RTSR1_RT12_Msk                       /*!< Rising trigger configuration for input line 12 */
+#define EXTI_RTSR1_RT13_Pos          (13U)
+#define EXTI_RTSR1_RT13_Msk          (0x1UL << EXTI_RTSR1_RT13_Pos)            /*!< 0x00002000 */
+#define EXTI_RTSR1_RT13              EXTI_RTSR1_RT13_Msk                       /*!< Rising trigger configuration for input line 13 */
+#define EXTI_RTSR1_RT14_Pos          (14U)
+#define EXTI_RTSR1_RT14_Msk          (0x1UL << EXTI_RTSR1_RT14_Pos)            /*!< 0x00004000 */
+#define EXTI_RTSR1_RT14              EXTI_RTSR1_RT14_Msk                       /*!< Rising trigger configuration for input line 14 */
+#define EXTI_RTSR1_RT15_Pos          (15U)
+#define EXTI_RTSR1_RT15_Msk          (0x1UL << EXTI_RTSR1_RT15_Pos)            /*!< 0x00008000 */
+#define EXTI_RTSR1_RT15              EXTI_RTSR1_RT15_Msk                       /*!< Rising trigger configuration for input line 15 */
+
+/******************  Bit definition for EXTI_FTSR1 register  ******************/
+#define EXTI_FTSR1_FT0_Pos           (0U)
+#define EXTI_FTSR1_FT0_Msk           (0x1UL << EXTI_FTSR1_FT0_Pos)             /*!< 0x00000001 */
+#define EXTI_FTSR1_FT0               EXTI_FTSR1_FT0_Msk                        /*!< Falling trigger configuration for input line 0 */
+#define EXTI_FTSR1_FT1_Pos           (1U)
+#define EXTI_FTSR1_FT1_Msk           (0x1UL << EXTI_FTSR1_FT1_Pos)             /*!< 0x00000002 */
+#define EXTI_FTSR1_FT1               EXTI_FTSR1_FT1_Msk                        /*!< Falling trigger configuration for input line 1 */
+#define EXTI_FTSR1_FT2_Pos           (2U)
+#define EXTI_FTSR1_FT2_Msk           (0x1UL << EXTI_FTSR1_FT2_Pos)             /*!< 0x00000004 */
+#define EXTI_FTSR1_FT2               EXTI_FTSR1_FT2_Msk                        /*!< Falling trigger configuration for input line 2 */
+#define EXTI_FTSR1_FT3_Pos           (3U)
+#define EXTI_FTSR1_FT3_Msk           (0x1UL << EXTI_FTSR1_FT3_Pos)             /*!< 0x00000008 */
+#define EXTI_FTSR1_FT3               EXTI_FTSR1_FT3_Msk                        /*!< Falling trigger configuration for input line 3 */
+#define EXTI_FTSR1_FT4_Pos           (4U)
+#define EXTI_FTSR1_FT4_Msk           (0x1UL << EXTI_FTSR1_FT4_Pos)             /*!< 0x00000010 */
+#define EXTI_FTSR1_FT4               EXTI_FTSR1_FT4_Msk                        /*!< Falling trigger configuration for input line 4 */
+#define EXTI_FTSR1_FT5_Pos           (5U)
+#define EXTI_FTSR1_FT5_Msk           (0x1UL << EXTI_FTSR1_FT5_Pos)             /*!< 0x00000020 */
+#define EXTI_FTSR1_FT5               EXTI_FTSR1_FT5_Msk                        /*!< Falling trigger configuration for input line 5 */
+#define EXTI_FTSR1_FT6_Pos           (6U)
+#define EXTI_FTSR1_FT6_Msk           (0x1UL << EXTI_FTSR1_FT6_Pos)             /*!< 0x00000040 */
+#define EXTI_FTSR1_FT6               EXTI_FTSR1_FT6_Msk                        /*!< Falling trigger configuration for input line 6 */
+#define EXTI_FTSR1_FT7_Pos           (7U)
+#define EXTI_FTSR1_FT7_Msk           (0x1UL << EXTI_FTSR1_FT7_Pos)             /*!< 0x00000080 */
+#define EXTI_FTSR1_FT7               EXTI_FTSR1_FT7_Msk                        /*!< Falling trigger configuration for input line 7 */
+#define EXTI_FTSR1_FT8_Pos           (8U)
+#define EXTI_FTSR1_FT8_Msk           (0x1UL << EXTI_FTSR1_FT8_Pos)             /*!< 0x00000100 */
+#define EXTI_FTSR1_FT8               EXTI_FTSR1_FT8_Msk                        /*!< Falling trigger configuration for input line 8 */
+#define EXTI_FTSR1_FT9_Pos           (9U)
+#define EXTI_FTSR1_FT9_Msk           (0x1UL << EXTI_FTSR1_FT9_Pos)             /*!< 0x00000200 */
+#define EXTI_FTSR1_FT9               EXTI_FTSR1_FT9_Msk                        /*!< Falling trigger configuration for input line 9 */
+#define EXTI_FTSR1_FT10_Pos          (10U)
+#define EXTI_FTSR1_FT10_Msk          (0x1UL << EXTI_FTSR1_FT10_Pos)            /*!< 0x00000400 */
+#define EXTI_FTSR1_FT10              EXTI_FTSR1_FT10_Msk                       /*!< Falling trigger configuration for input line 10 */
+#define EXTI_FTSR1_FT11_Pos          (11U)
+#define EXTI_FTSR1_FT11_Msk          (0x1UL << EXTI_FTSR1_FT11_Pos)            /*!< 0x00000800 */
+#define EXTI_FTSR1_FT11              EXTI_FTSR1_FT11_Msk                       /*!< Falling trigger configuration for input line 11 */
+#define EXTI_FTSR1_FT12_Pos          (12U)
+#define EXTI_FTSR1_FT12_Msk          (0x1UL << EXTI_FTSR1_FT12_Pos)            /*!< 0x00001000 */
+#define EXTI_FTSR1_FT12              EXTI_FTSR1_FT12_Msk                       /*!< Falling trigger configuration for input line 12 */
+#define EXTI_FTSR1_FT13_Pos          (13U)
+#define EXTI_FTSR1_FT13_Msk          (0x1UL << EXTI_FTSR1_FT13_Pos)            /*!< 0x00002000 */
+#define EXTI_FTSR1_FT13              EXTI_FTSR1_FT13_Msk                       /*!< Falling trigger configuration for input line 13 */
+#define EXTI_FTSR1_FT14_Pos          (14U)
+#define EXTI_FTSR1_FT14_Msk          (0x1UL << EXTI_FTSR1_FT14_Pos)            /*!< 0x00004000 */
+#define EXTI_FTSR1_FT14              EXTI_FTSR1_FT14_Msk                       /*!< Falling trigger configuration for input line 14 */
+#define EXTI_FTSR1_FT15_Pos          (15U)
+#define EXTI_FTSR1_FT15_Msk          (0x1UL << EXTI_FTSR1_FT15_Pos)            /*!< 0x00008000 */
+#define EXTI_FTSR1_FT15              EXTI_FTSR1_FT15_Msk                       /*!< Falling trigger configuration for input line 15 */
+
+/******************  Bit definition for EXTI_SWIER1 register  *****************/
+#define EXTI_SWIER1_SWI0_Pos         (0U)
+#define EXTI_SWIER1_SWI0_Msk         (0x1UL << EXTI_SWIER1_SWI0_Pos)           /*!< 0x00000001 */
+#define EXTI_SWIER1_SWI0             EXTI_SWIER1_SWI0_Msk                      /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER1_SWI1_Pos         (1U)
+#define EXTI_SWIER1_SWI1_Msk         (0x1UL << EXTI_SWIER1_SWI1_Pos)           /*!< 0x00000002 */
+#define EXTI_SWIER1_SWI1             EXTI_SWIER1_SWI1_Msk                      /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER1_SWI2_Pos         (2U)
+#define EXTI_SWIER1_SWI2_Msk         (0x1UL << EXTI_SWIER1_SWI2_Pos)           /*!< 0x00000004 */
+#define EXTI_SWIER1_SWI2             EXTI_SWIER1_SWI2_Msk                      /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER1_SWI3_Pos         (3U)
+#define EXTI_SWIER1_SWI3_Msk         (0x1UL << EXTI_SWIER1_SWI3_Pos)           /*!< 0x00000008 */
+#define EXTI_SWIER1_SWI3             EXTI_SWIER1_SWI3_Msk                      /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER1_SWI4_Pos         (4U)
+#define EXTI_SWIER1_SWI4_Msk         (0x1UL << EXTI_SWIER1_SWI4_Pos)           /*!< 0x00000010 */
+#define EXTI_SWIER1_SWI4             EXTI_SWIER1_SWI4_Msk                      /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER1_SWI5_Pos         (5U)
+#define EXTI_SWIER1_SWI5_Msk         (0x1UL << EXTI_SWIER1_SWI5_Pos)           /*!< 0x00000020 */
+#define EXTI_SWIER1_SWI5             EXTI_SWIER1_SWI5_Msk                      /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER1_SWI6_Pos         (6U)
+#define EXTI_SWIER1_SWI6_Msk         (0x1UL << EXTI_SWIER1_SWI6_Pos)           /*!< 0x00000040 */
+#define EXTI_SWIER1_SWI6             EXTI_SWIER1_SWI6_Msk                      /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER1_SWI7_Pos         (7U)
+#define EXTI_SWIER1_SWI7_Msk         (0x1UL << EXTI_SWIER1_SWI7_Pos)           /*!< 0x00000080 */
+#define EXTI_SWIER1_SWI7             EXTI_SWIER1_SWI7_Msk                      /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER1_SWI8_Pos         (8U)
+#define EXTI_SWIER1_SWI8_Msk         (0x1UL << EXTI_SWIER1_SWI8_Pos)           /*!< 0x00000100 */
+#define EXTI_SWIER1_SWI8             EXTI_SWIER1_SWI8_Msk                      /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER1_SWI9_Pos         (9U)
+#define EXTI_SWIER1_SWI9_Msk         (0x1UL << EXTI_SWIER1_SWI9_Pos)           /*!< 0x00000200 */
+#define EXTI_SWIER1_SWI9             EXTI_SWIER1_SWI9_Msk                      /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER1_SWI10_Pos        (10U)
+#define EXTI_SWIER1_SWI10_Msk        (0x1UL << EXTI_SWIER1_SWI10_Pos)          /*!< 0x00000400 */
+#define EXTI_SWIER1_SWI10            EXTI_SWIER1_SWI10_Msk                     /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER1_SWI11_Pos        (11U)
+#define EXTI_SWIER1_SWI11_Msk        (0x1UL << EXTI_SWIER1_SWI11_Pos)          /*!< 0x00000800 */
+#define EXTI_SWIER1_SWI11            EXTI_SWIER1_SWI11_Msk                     /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER1_SWI12_Pos        (12U)
+#define EXTI_SWIER1_SWI12_Msk        (0x1UL << EXTI_SWIER1_SWI12_Pos)          /*!< 0x00001000 */
+#define EXTI_SWIER1_SWI12            EXTI_SWIER1_SWI12_Msk                     /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER1_SWI13_Pos        (13U)
+#define EXTI_SWIER1_SWI13_Msk        (0x1UL << EXTI_SWIER1_SWI13_Pos)          /*!< 0x00002000 */
+#define EXTI_SWIER1_SWI13            EXTI_SWIER1_SWI13_Msk                     /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER1_SWI14_Pos        (14U)
+#define EXTI_SWIER1_SWI14_Msk        (0x1UL << EXTI_SWIER1_SWI14_Pos)          /*!< 0x00004000 */
+#define EXTI_SWIER1_SWI14            EXTI_SWIER1_SWI14_Msk                     /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER1_SWI15_Pos        (15U)
+#define EXTI_SWIER1_SWI15_Msk        (0x1UL << EXTI_SWIER1_SWI15_Pos)          /*!< 0x00008000 */
+#define EXTI_SWIER1_SWI15            EXTI_SWIER1_SWI15_Msk                     /*!< Software Interrupt on line 15 */
+
+/*******************  Bit definition for EXTI_RPR1 register  ******************/
+#define EXTI_RPR1_RPIF0_Pos          (0U)
+#define EXTI_RPR1_RPIF0_Msk          (0x1UL << EXTI_RPR1_RPIF0_Pos)            /*!< 0x00000001 */
+#define EXTI_RPR1_RPIF0              EXTI_RPR1_RPIF0_Msk                       /*!< Rising Pending Interrupt Flag on line 0 */
+#define EXTI_RPR1_RPIF1_Pos          (1U)
+#define EXTI_RPR1_RPIF1_Msk          (0x1UL << EXTI_RPR1_RPIF1_Pos)            /*!< 0x00000002 */
+#define EXTI_RPR1_RPIF1              EXTI_RPR1_RPIF1_Msk                       /*!< Rising Pending Interrupt Flag on line 1 */
+#define EXTI_RPR1_RPIF2_Pos          (2U)
+#define EXTI_RPR1_RPIF2_Msk          (0x1UL << EXTI_RPR1_RPIF2_Pos)            /*!< 0x00000004 */
+#define EXTI_RPR1_RPIF2              EXTI_RPR1_RPIF2_Msk                       /*!< Rising Pending Interrupt Flag on line 2 */
+#define EXTI_RPR1_RPIF3_Pos          (3U)
+#define EXTI_RPR1_RPIF3_Msk          (0x1UL << EXTI_RPR1_RPIF3_Pos)            /*!< 0x00000008 */
+#define EXTI_RPR1_RPIF3              EXTI_RPR1_RPIF3_Msk                       /*!< Rising Pending Interrupt Flag on line 3 */
+#define EXTI_RPR1_RPIF4_Pos          (4U)
+#define EXTI_RPR1_RPIF4_Msk          (0x1UL << EXTI_RPR1_RPIF4_Pos)            /*!< 0x00000010 */
+#define EXTI_RPR1_RPIF4              EXTI_RPR1_RPIF4_Msk                       /*!< Rising Pending Interrupt Flag on line 4 */
+#define EXTI_RPR1_RPIF5_Pos          (5U)
+#define EXTI_RPR1_RPIF5_Msk          (0x1UL << EXTI_RPR1_RPIF5_Pos)            /*!< 0x00000020 */
+#define EXTI_RPR1_RPIF5              EXTI_RPR1_RPIF5_Msk                       /*!< Rising Pending Interrupt Flag on line 5 */
+#define EXTI_RPR1_RPIF6_Pos          (6U)
+#define EXTI_RPR1_RPIF6_Msk          (0x1UL << EXTI_RPR1_RPIF6_Pos)            /*!< 0x00000040 */
+#define EXTI_RPR1_RPIF6              EXTI_RPR1_RPIF6_Msk                       /*!< Rising Pending Interrupt Flag on line 6 */
+#define EXTI_RPR1_RPIF7_Pos          (7U)
+#define EXTI_RPR1_RPIF7_Msk          (0x1UL << EXTI_RPR1_RPIF7_Pos)            /*!< 0x00000080 */
+#define EXTI_RPR1_RPIF7              EXTI_RPR1_RPIF7_Msk                       /*!< Rising Pending Interrupt Flag on line 7 */
+#define EXTI_RPR1_RPIF8_Pos          (8U)
+#define EXTI_RPR1_RPIF8_Msk          (0x1UL << EXTI_RPR1_RPIF8_Pos)            /*!< 0x00000100 */
+#define EXTI_RPR1_RPIF8              EXTI_RPR1_RPIF8_Msk                       /*!< Rising Pending Interrupt Flag on line 8 */
+#define EXTI_RPR1_RPIF9_Pos          (9U)
+#define EXTI_RPR1_RPIF9_Msk          (0x1UL << EXTI_RPR1_RPIF9_Pos)            /*!< 0x00000200 */
+#define EXTI_RPR1_RPIF9              EXTI_RPR1_RPIF9_Msk                       /*!< Rising Pending Interrupt Flag on line 9 */
+#define EXTI_RPR1_RPIF10_Pos         (10U)
+#define EXTI_RPR1_RPIF10_Msk         (0x1UL << EXTI_RPR1_RPIF10_Pos)           /*!< 0x00000400 */
+#define EXTI_RPR1_RPIF10             EXTI_RPR1_RPIF10_Msk                      /*!< Rising Pending Interrupt Flag on line 10 */
+#define EXTI_RPR1_RPIF11_Pos         (11U)
+#define EXTI_RPR1_RPIF11_Msk         (0x1UL << EXTI_RPR1_RPIF11_Pos)           /*!< 0x00000800 */
+#define EXTI_RPR1_RPIF11             EXTI_RPR1_RPIF11_Msk                      /*!< Rising Pending Interrupt Flag on line 11 */
+#define EXTI_RPR1_RPIF12_Pos         (12U)
+#define EXTI_RPR1_RPIF12_Msk         (0x1UL << EXTI_RPR1_RPIF12_Pos)           /*!< 0x00001000 */
+#define EXTI_RPR1_RPIF12             EXTI_RPR1_RPIF12_Msk                      /*!< Rising Pending Interrupt Flag on line 12 */
+#define EXTI_RPR1_RPIF13_Pos         (13U)
+#define EXTI_RPR1_RPIF13_Msk         (0x1UL << EXTI_RPR1_RPIF13_Pos)           /*!< 0x00002000 */
+#define EXTI_RPR1_RPIF13             EXTI_RPR1_RPIF13_Msk                      /*!< Rising Pending Interrupt Flag on line 13 */
+#define EXTI_RPR1_RPIF14_Pos         (14U)
+#define EXTI_RPR1_RPIF14_Msk         (0x1UL << EXTI_RPR1_RPIF14_Pos)           /*!< 0x00004000 */
+#define EXTI_RPR1_RPIF14             EXTI_RPR1_RPIF14_Msk                      /*!< Rising Pending Interrupt Flag on line 14 */
+#define EXTI_RPR1_RPIF15_Pos         (15U)
+#define EXTI_RPR1_RPIF15_Msk         (0x1UL << EXTI_RPR1_RPIF15_Pos)           /*!< 0x00008000 */
+#define EXTI_RPR1_RPIF15             EXTI_RPR1_RPIF15_Msk                      /*!< Rising Pending Interrupt Flag on line 15 */
+
+/*******************  Bit definition for EXTI_FPR1 register  ******************/
+#define EXTI_FPR1_FPIF0_Pos          (0U)
+#define EXTI_FPR1_FPIF0_Msk          (0x1UL << EXTI_FPR1_FPIF0_Pos)            /*!< 0x00000001 */
+#define EXTI_FPR1_FPIF0              EXTI_FPR1_FPIF0_Msk                       /*!< Falling Pending Interrupt Flag on line 0 */
+#define EXTI_FPR1_FPIF1_Pos          (1U)
+#define EXTI_FPR1_FPIF1_Msk          (0x1UL << EXTI_FPR1_FPIF1_Pos)            /*!< 0x00000002 */
+#define EXTI_FPR1_FPIF1              EXTI_FPR1_FPIF1_Msk                       /*!< Falling Pending Interrupt Flag on line 1 */
+#define EXTI_FPR1_FPIF2_Pos          (2U)
+#define EXTI_FPR1_FPIF2_Msk          (0x1UL << EXTI_FPR1_FPIF2_Pos)            /*!< 0x00000004 */
+#define EXTI_FPR1_FPIF2              EXTI_FPR1_FPIF2_Msk                       /*!< Falling Pending Interrupt Flag on line 2 */
+#define EXTI_FPR1_FPIF3_Pos          (3U)
+#define EXTI_FPR1_FPIF3_Msk          (0x1UL << EXTI_FPR1_FPIF3_Pos)            /*!< 0x00000008 */
+#define EXTI_FPR1_FPIF3              EXTI_FPR1_FPIF3_Msk                       /*!< Falling Pending Interrupt Flag on line 3 */
+#define EXTI_FPR1_FPIF4_Pos          (4U)
+#define EXTI_FPR1_FPIF4_Msk          (0x1UL << EXTI_FPR1_FPIF4_Pos)            /*!< 0x00000010 */
+#define EXTI_FPR1_FPIF4              EXTI_FPR1_FPIF4_Msk                       /*!< Falling Pending Interrupt Flag on line 4 */
+#define EXTI_FPR1_FPIF5_Pos          (5U)
+#define EXTI_FPR1_FPIF5_Msk          (0x1UL << EXTI_FPR1_FPIF5_Pos)            /*!< 0x00000020 */
+#define EXTI_FPR1_FPIF5              EXTI_FPR1_FPIF5_Msk                       /*!< Falling Pending Interrupt Flag on line 5 */
+#define EXTI_FPR1_FPIF6_Pos          (6U)
+#define EXTI_FPR1_FPIF6_Msk          (0x1UL << EXTI_FPR1_FPIF6_Pos)            /*!< 0x00000040 */
+#define EXTI_FPR1_FPIF6              EXTI_FPR1_FPIF6_Msk                       /*!< Falling Pending Interrupt Flag on line 6 */
+#define EXTI_FPR1_FPIF7_Pos          (7U)
+#define EXTI_FPR1_FPIF7_Msk          (0x1UL << EXTI_FPR1_FPIF7_Pos)            /*!< 0x00000080 */
+#define EXTI_FPR1_FPIF7              EXTI_FPR1_FPIF7_Msk                       /*!< Falling Pending Interrupt Flag on line 7 */
+#define EXTI_FPR1_FPIF8_Pos          (8U)
+#define EXTI_FPR1_FPIF8_Msk          (0x1UL << EXTI_FPR1_FPIF8_Pos)            /*!< 0x00000100 */
+#define EXTI_FPR1_FPIF8              EXTI_FPR1_FPIF8_Msk                       /*!< Falling Pending Interrupt Flag on line 8 */
+#define EXTI_FPR1_FPIF9_Pos          (9U)
+#define EXTI_FPR1_FPIF9_Msk          (0x1UL << EXTI_FPR1_FPIF9_Pos)            /*!< 0x00000200 */
+#define EXTI_FPR1_FPIF9              EXTI_FPR1_FPIF9_Msk                       /*!< Falling Pending Interrupt Flag on line 9 */
+#define EXTI_FPR1_FPIF10_Pos         (10U)
+#define EXTI_FPR1_FPIF10_Msk         (0x1UL << EXTI_FPR1_FPIF10_Pos)           /*!< 0x00000400 */
+#define EXTI_FPR1_FPIF10             EXTI_FPR1_FPIF10_Msk                      /*!< Falling Pending Interrupt Flag on line 10 */
+#define EXTI_FPR1_FPIF11_Pos         (11U)
+#define EXTI_FPR1_FPIF11_Msk         (0x1UL << EXTI_FPR1_FPIF11_Pos)           /*!< 0x00000800 */
+#define EXTI_FPR1_FPIF11             EXTI_FPR1_FPIF11_Msk                      /*!< Falling Pending Interrupt Flag on line 11 */
+#define EXTI_FPR1_FPIF12_Pos         (12U)
+#define EXTI_FPR1_FPIF12_Msk         (0x1UL << EXTI_FPR1_FPIF12_Pos)           /*!< 0x00001000 */
+#define EXTI_FPR1_FPIF12             EXTI_FPR1_FPIF12_Msk                      /*!< Falling Pending Interrupt Flag on line 12 */
+#define EXTI_FPR1_FPIF13_Pos         (13U)
+#define EXTI_FPR1_FPIF13_Msk         (0x1UL << EXTI_FPR1_FPIF13_Pos)           /*!< 0x00002000 */
+#define EXTI_FPR1_FPIF13             EXTI_FPR1_FPIF13_Msk                      /*!< Falling Pending Interrupt Flag on line 13 */
+#define EXTI_FPR1_FPIF14_Pos         (14U)
+#define EXTI_FPR1_FPIF14_Msk         (0x1UL << EXTI_FPR1_FPIF14_Pos)           /*!< 0x00004000 */
+#define EXTI_FPR1_FPIF14             EXTI_FPR1_FPIF14_Msk                      /*!< Falling Pending Interrupt Flag on line 14 */
+#define EXTI_FPR1_FPIF15_Pos         (15U)
+#define EXTI_FPR1_FPIF15_Msk         (0x1UL << EXTI_FPR1_FPIF15_Pos)           /*!< 0x00008000 */
+#define EXTI_FPR1_FPIF15             EXTI_FPR1_FPIF15_Msk                      /*!< Falling Pending Interrupt Flag on line 15 */
+
+/*****************  Bit definition for EXTI_EXTICR1 register  **************/
+#define EXTI_EXTICR1_EXTI0_Pos       (0U)
+#define EXTI_EXTICR1_EXTI0_Msk       (0x7UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR1_EXTI0           EXTI_EXTICR1_EXTI0_Msk                    /*!< EXTI 0 configuration */
+#define EXTI_EXTICR1_EXTI0_0         (0x1UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR1_EXTI0_1         (0x2UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR1_EXTI0_2         (0x4UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR1_EXTI1_Pos       (8U)
+#define EXTI_EXTICR1_EXTI1_Msk       (0x7UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR1_EXTI1           EXTI_EXTICR1_EXTI1_Msk                    /*!< EXTI 1 configuration */
+#define EXTI_EXTICR1_EXTI1_0         (0x1UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR1_EXTI1_1         (0x2UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR1_EXTI1_2         (0x4UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR1_EXTI2_Pos       (16U)
+#define EXTI_EXTICR1_EXTI2_Msk       (0x7UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00070000 */
+#define EXTI_EXTICR1_EXTI2           EXTI_EXTICR1_EXTI2_Msk                    /*!< EXTI 2 configuration */
+#define EXTI_EXTICR1_EXTI2_0         (0x1UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00010000 */
+#define EXTI_EXTICR1_EXTI2_1         (0x2UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00020000 */
+#define EXTI_EXTICR1_EXTI2_2         (0x4UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00040000 */
+#define EXTI_EXTICR1_EXTI3_Pos       (24U)
+#define EXTI_EXTICR1_EXTI3_Msk       (0x7UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x07000000 */
+#define EXTI_EXTICR1_EXTI3           EXTI_EXTICR1_EXTI3_Msk                    /*!< EXTI 3 configuration */
+#define EXTI_EXTICR1_EXTI3_0         (0x1UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x01000000 */
+#define EXTI_EXTICR1_EXTI3_1         (0x2UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x02000000 */
+#define EXTI_EXTICR1_EXTI3_2         (0x4UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR2 register  **************/
+#define EXTI_EXTICR2_EXTI4_Pos       (0U)
+#define EXTI_EXTICR2_EXTI4_Msk       (0x7UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR2_EXTI4           EXTI_EXTICR2_EXTI4_Msk                    /*!< EXTI 4 configuration */
+#define EXTI_EXTICR2_EXTI4_0         (0x1UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR2_EXTI4_1         (0x2UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR2_EXTI4_2         (0x4UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR2_EXTI5_Pos       (8U)
+#define EXTI_EXTICR2_EXTI5_Msk       (0x7UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR2_EXTI5           EXTI_EXTICR2_EXTI5_Msk                    /*!< EXTI 5 configuration */
+#define EXTI_EXTICR2_EXTI5_0         (0x1UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR2_EXTI5_1         (0x2UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR2_EXTI5_2         (0x4UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR2_EXTI6_Pos       (16U)
+#define EXTI_EXTICR2_EXTI6_Msk       (0x7UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00070000 */
+#define EXTI_EXTICR2_EXTI6           EXTI_EXTICR2_EXTI6_Msk                    /*!< EXTI 6 configuration */
+#define EXTI_EXTICR2_EXTI6_0         (0x1UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00010000 */
+#define EXTI_EXTICR2_EXTI6_1         (0x2UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00020000 */
+#define EXTI_EXTICR2_EXTI6_2         (0x4UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00040000 */
+#define EXTI_EXTICR2_EXTI7_Pos       (24U)
+#define EXTI_EXTICR2_EXTI7_Msk       (0x7UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x07000000 */
+#define EXTI_EXTICR2_EXTI7           EXTI_EXTICR2_EXTI7_Msk                    /*!< EXTI 7 configuration */
+#define EXTI_EXTICR2_EXTI7_0         (0x1UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x01000000 */
+#define EXTI_EXTICR2_EXTI7_1         (0x2UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x02000000 */
+#define EXTI_EXTICR2_EXTI7_2         (0x4UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR3 register  **************/
+#define EXTI_EXTICR3_EXTI8_Pos       (0U)
+#define EXTI_EXTICR3_EXTI8_Msk       (0x7UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR3_EXTI8           EXTI_EXTICR3_EXTI8_Msk                    /*!< EXTI 8 configuration */
+#define EXTI_EXTICR3_EXTI8_0         (0x1UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR3_EXTI8_1         (0x2UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR3_EXTI8_2         (0x4UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR3_EXTI9_Pos       (8U)
+#define EXTI_EXTICR3_EXTI9_Msk       (0x7UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR3_EXTI9           EXTI_EXTICR3_EXTI9_Msk                    /*!< EXTI 9 configuration */
+#define EXTI_EXTICR3_EXTI9_0         (0x1UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR3_EXTI9_1         (0x2UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR3_EXTI9_2         (0x4UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR3_EXTI10_Pos      (16U)
+#define EXTI_EXTICR3_EXTI10_Msk      (0x7UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00070000 */
+#define EXTI_EXTICR3_EXTI10          EXTI_EXTICR3_EXTI10_Msk                   /*!< EXTI 10 configuration */
+#define EXTI_EXTICR3_EXTI10_0        (0x1UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00010000 */
+#define EXTI_EXTICR3_EXTI10_1        (0x2UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00020000 */
+#define EXTI_EXTICR3_EXTI10_2        (0x4UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00040000 */
+#define EXTI_EXTICR3_EXTI11_Pos      (24U)
+#define EXTI_EXTICR3_EXTI11_Msk      (0x7UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x07000000 */
+#define EXTI_EXTICR3_EXTI11          EXTI_EXTICR3_EXTI11_Msk                   /*!< EXTI 11 configuration */
+#define EXTI_EXTICR3_EXTI11_0        (0x1UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x01000000 */
+#define EXTI_EXTICR3_EXTI11_1        (0x2UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x02000000 */
+#define EXTI_EXTICR3_EXTI11_2        (0x4UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR4 register  **************/
+#define EXTI_EXTICR4_EXTI12_Pos      (0U)
+#define EXTI_EXTICR4_EXTI12_Msk      (0x7UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000007 */
+#define EXTI_EXTICR4_EXTI12          EXTI_EXTICR4_EXTI12_Msk                   /*!< EXTI 12 configuration */
+#define EXTI_EXTICR4_EXTI12_0        (0x1UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000001 */
+#define EXTI_EXTICR4_EXTI12_1        (0x2UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000002 */
+#define EXTI_EXTICR4_EXTI12_2        (0x4UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000004 */
+#define EXTI_EXTICR4_EXTI13_Pos      (8U)
+#define EXTI_EXTICR4_EXTI13_Msk      (0x7UL << EXTI_EXTICR4_EXTI13_Pos)        /*!< 0x00000700 */
+#define EXTI_EXTICR4_EXTI13          EXTI_EXTICR4_EXTI13_Msk                   /*!< EXTI 13 configuration */
+#define EXTI_EXTICR4_EXTI13_0        (0x1UL << EXTI_EXTICR4_EXTI13_Pos)        /*!< 0x00000100 */
+#define EXTI_EXTICR4_EXTI13_1        (0x2UL << EXTI_EXTICR4_EXTI13_Pos)       /*!< 0x00000200 */
+#define EXTI_EXTICR4_EXTI13_2        (0x4UL << EXTI_EXTICR4_EXTI13_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR4_EXTI14_Pos      (16U)
+#define EXTI_EXTICR4_EXTI14_Msk      (0x7UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00070000 */
+#define EXTI_EXTICR4_EXTI14          EXTI_EXTICR4_EXTI14_Msk                   /*!< EXTI 14 configuration */
+#define EXTI_EXTICR4_EXTI14_0        (0x1UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00010000 */
+#define EXTI_EXTICR4_EXTI14_1        (0x2UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00020000 */
+#define EXTI_EXTICR4_EXTI14_2        (0x4UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00040000 */
+#define EXTI_EXTICR4_EXTI15_Pos      (24U)
+#define EXTI_EXTICR4_EXTI15_Msk      (0x7UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x07000000 */
+#define EXTI_EXTICR4_EXTI15          EXTI_EXTICR4_EXTI15_Msk                   /*!< EXTI 15 configuration */
+#define EXTI_EXTICR4_EXTI15_0        (0x1UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x01000000 */
+#define EXTI_EXTICR4_EXTI15_1        (0x2UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x02000000 */
+#define EXTI_EXTICR4_EXTI15_2        (0x4UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x04000000 */
+
+/*******************  Bit definition for EXTI_IMR1 register  ******************/
+#define EXTI_IMR1_IM0_Pos            (0U)
+#define EXTI_IMR1_IM0_Msk            (0x1UL << EXTI_IMR1_IM0_Pos)              /*!< 0x00000001 */
+#define EXTI_IMR1_IM0                EXTI_IMR1_IM0_Msk                         /*!< Interrupt Mask on line 0 */
+#define EXTI_IMR1_IM1_Pos            (1U)
+#define EXTI_IMR1_IM1_Msk            (0x1UL << EXTI_IMR1_IM1_Pos)              /*!< 0x00000002 */
+#define EXTI_IMR1_IM1                EXTI_IMR1_IM1_Msk                         /*!< Interrupt Mask on line 1 */
+#define EXTI_IMR1_IM2_Pos            (2U)
+#define EXTI_IMR1_IM2_Msk            (0x1UL << EXTI_IMR1_IM2_Pos)              /*!< 0x00000004 */
+#define EXTI_IMR1_IM2                EXTI_IMR1_IM2_Msk                         /*!< Interrupt Mask on line 2 */
+#define EXTI_IMR1_IM3_Pos            (3U)
+#define EXTI_IMR1_IM3_Msk            (0x1UL << EXTI_IMR1_IM3_Pos)              /*!< 0x00000008 */
+#define EXTI_IMR1_IM3                EXTI_IMR1_IM3_Msk                         /*!< Interrupt Mask on line 3 */
+#define EXTI_IMR1_IM4_Pos            (4U)
+#define EXTI_IMR1_IM4_Msk            (0x1UL << EXTI_IMR1_IM4_Pos)              /*!< 0x00000010 */
+#define EXTI_IMR1_IM4                EXTI_IMR1_IM4_Msk                         /*!< Interrupt Mask on line 4 */
+#define EXTI_IMR1_IM5_Pos            (5U)
+#define EXTI_IMR1_IM5_Msk            (0x1UL << EXTI_IMR1_IM5_Pos)              /*!< 0x00000020 */
+#define EXTI_IMR1_IM5                EXTI_IMR1_IM5_Msk                         /*!< Interrupt Mask on line 5 */
+#define EXTI_IMR1_IM6_Pos            (6U)
+#define EXTI_IMR1_IM6_Msk            (0x1UL << EXTI_IMR1_IM6_Pos)              /*!< 0x00000040 */
+#define EXTI_IMR1_IM6                EXTI_IMR1_IM6_Msk                         /*!< Interrupt Mask on line 6 */
+#define EXTI_IMR1_IM7_Pos            (7U)
+#define EXTI_IMR1_IM7_Msk            (0x1UL << EXTI_IMR1_IM7_Pos)              /*!< 0x00000080 */
+#define EXTI_IMR1_IM7                EXTI_IMR1_IM7_Msk                         /*!< Interrupt Mask on line 7 */
+#define EXTI_IMR1_IM8_Pos            (8U)
+#define EXTI_IMR1_IM8_Msk            (0x1UL << EXTI_IMR1_IM8_Pos)              /*!< 0x00000100 */
+#define EXTI_IMR1_IM8                EXTI_IMR1_IM8_Msk                         /*!< Interrupt Mask on line 8 */
+#define EXTI_IMR1_IM9_Pos            (9U)
+#define EXTI_IMR1_IM9_Msk            (0x1UL << EXTI_IMR1_IM9_Pos)              /*!< 0x00000200 */
+#define EXTI_IMR1_IM9                EXTI_IMR1_IM9_Msk                         /*!< Interrupt Mask on line 9 */
+#define EXTI_IMR1_IM10_Pos           (10U)
+#define EXTI_IMR1_IM10_Msk           (0x1UL << EXTI_IMR1_IM10_Pos)             /*!< 0x00000400 */
+#define EXTI_IMR1_IM10               EXTI_IMR1_IM10_Msk                        /*!< Interrupt Mask on line 10 */
+#define EXTI_IMR1_IM11_Pos           (11U)
+#define EXTI_IMR1_IM11_Msk           (0x1UL << EXTI_IMR1_IM11_Pos)             /*!< 0x00000800 */
+#define EXTI_IMR1_IM11               EXTI_IMR1_IM11_Msk                        /*!< Interrupt Mask on line 11 */
+#define EXTI_IMR1_IM12_Pos           (12U)
+#define EXTI_IMR1_IM12_Msk           (0x1UL << EXTI_IMR1_IM12_Pos)             /*!< 0x00001000 */
+#define EXTI_IMR1_IM12               EXTI_IMR1_IM12_Msk                        /*!< Interrupt Mask on line 12 */
+#define EXTI_IMR1_IM13_Pos           (13U)
+#define EXTI_IMR1_IM13_Msk           (0x1UL << EXTI_IMR1_IM13_Pos)             /*!< 0x00002000 */
+#define EXTI_IMR1_IM13               EXTI_IMR1_IM13_Msk                        /*!< Interrupt Mask on line 13 */
+#define EXTI_IMR1_IM14_Pos           (14U)
+#define EXTI_IMR1_IM14_Msk           (0x1UL << EXTI_IMR1_IM14_Pos)             /*!< 0x00004000 */
+#define EXTI_IMR1_IM14               EXTI_IMR1_IM14_Msk                        /*!< Interrupt Mask on line 14 */
+#define EXTI_IMR1_IM15_Pos           (15U)
+#define EXTI_IMR1_IM15_Msk           (0x1UL << EXTI_IMR1_IM15_Pos)             /*!< 0x00008000 */
+#define EXTI_IMR1_IM15               EXTI_IMR1_IM15_Msk                        /*!< Interrupt Mask on line 15 */
+#define EXTI_IMR1_IM19_Pos           (19U)
+#define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
+#define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
+#define EXTI_IMR1_IM21_Pos           (21U)
+#define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
+#define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
+#define EXTI_IMR1_IM23_Pos           (23U)
+#define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
+#define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
+#define EXTI_IMR1_IM25_Pos           (25U)
+#define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
+#define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
+#define EXTI_IMR1_IM31_Pos           (31U)
+#define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
+#define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
+#define EXTI_IMR1_IM_Pos             (0U)
+#define EXTI_IMR1_IM_Msk             (0x82A8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x82A8FFFF */
+#define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
+
+
+/*******************  Bit definition for EXTI_EMR1 register  ******************/
+#define EXTI_EMR1_EM0_Pos            (0U)
+#define EXTI_EMR1_EM0_Msk            (0x1UL << EXTI_EMR1_EM0_Pos)              /*!< 0x00000001 */
+#define EXTI_EMR1_EM0                EXTI_EMR1_EM0_Msk                         /*!< Event Mask on line 0 */
+#define EXTI_EMR1_EM1_Pos            (1U)
+#define EXTI_EMR1_EM1_Msk            (0x1UL << EXTI_EMR1_EM1_Pos)              /*!< 0x00000002 */
+#define EXTI_EMR1_EM1                EXTI_EMR1_EM1_Msk                         /*!< Event Mask on line 1 */
+#define EXTI_EMR1_EM2_Pos            (2U)
+#define EXTI_EMR1_EM2_Msk            (0x1UL << EXTI_EMR1_EM2_Pos)              /*!< 0x00000004 */
+#define EXTI_EMR1_EM2                EXTI_EMR1_EM2_Msk                         /*!< Event Mask on line 2 */
+#define EXTI_EMR1_EM3_Pos            (3U)
+#define EXTI_EMR1_EM3_Msk            (0x1UL << EXTI_EMR1_EM3_Pos)              /*!< 0x00000008 */
+#define EXTI_EMR1_EM3                EXTI_EMR1_EM3_Msk                         /*!< Event Mask on line 3 */
+#define EXTI_EMR1_EM4_Pos            (4U)
+#define EXTI_EMR1_EM4_Msk            (0x1UL << EXTI_EMR1_EM4_Pos)              /*!< 0x00000010 */
+#define EXTI_EMR1_EM4                EXTI_EMR1_EM4_Msk                         /*!< Event Mask on line 4 */
+#define EXTI_EMR1_EM5_Pos            (5U)
+#define EXTI_EMR1_EM5_Msk            (0x1UL << EXTI_EMR1_EM5_Pos)              /*!< 0x00000020 */
+#define EXTI_EMR1_EM5                EXTI_EMR1_EM5_Msk                         /*!< Event Mask on line 5 */
+#define EXTI_EMR1_EM6_Pos            (6U)
+#define EXTI_EMR1_EM6_Msk            (0x1UL << EXTI_EMR1_EM6_Pos)              /*!< 0x00000040 */
+#define EXTI_EMR1_EM6                EXTI_EMR1_EM6_Msk                         /*!< Event Mask on line 6 */
+#define EXTI_EMR1_EM7_Pos            (7U)
+#define EXTI_EMR1_EM7_Msk            (0x1UL << EXTI_EMR1_EM7_Pos)              /*!< 0x00000080 */
+#define EXTI_EMR1_EM7                EXTI_EMR1_EM7_Msk                         /*!< Event Mask on line 7 */
+#define EXTI_EMR1_EM8_Pos            (8U)
+#define EXTI_EMR1_EM8_Msk            (0x1UL << EXTI_EMR1_EM8_Pos)              /*!< 0x00000100 */
+#define EXTI_EMR1_EM8                EXTI_EMR1_EM8_Msk                         /*!< Event Mask on line 8 */
+#define EXTI_EMR1_EM9_Pos            (9U)
+#define EXTI_EMR1_EM9_Msk            (0x1UL << EXTI_EMR1_EM9_Pos)              /*!< 0x00000200 */
+#define EXTI_EMR1_EM9                EXTI_EMR1_EM9_Msk                         /*!< Event Mask on line 9 */
+#define EXTI_EMR1_EM10_Pos           (10U)
+#define EXTI_EMR1_EM10_Msk           (0x1UL << EXTI_EMR1_EM10_Pos)             /*!< 0x00000400 */
+#define EXTI_EMR1_EM10               EXTI_EMR1_EM10_Msk                        /*!< Event Mask on line 10 */
+#define EXTI_EMR1_EM11_Pos           (11U)
+#define EXTI_EMR1_EM11_Msk           (0x1UL << EXTI_EMR1_EM11_Pos)             /*!< 0x00000800 */
+#define EXTI_EMR1_EM11               EXTI_EMR1_EM11_Msk                        /*!< Event Mask on line 11 */
+#define EXTI_EMR1_EM12_Pos           (12U)
+#define EXTI_EMR1_EM12_Msk           (0x1UL << EXTI_EMR1_EM12_Pos)             /*!< 0x00001000 */
+#define EXTI_EMR1_EM12               EXTI_EMR1_EM12_Msk                        /*!< Event Mask on line 12 */
+#define EXTI_EMR1_EM13_Pos           (13U)
+#define EXTI_EMR1_EM13_Msk           (0x1UL << EXTI_EMR1_EM13_Pos)             /*!< 0x00002000 */
+#define EXTI_EMR1_EM13               EXTI_EMR1_EM13_Msk                        /*!< Event Mask on line 13 */
+#define EXTI_EMR1_EM14_Pos           (14U)
+#define EXTI_EMR1_EM14_Msk           (0x1UL << EXTI_EMR1_EM14_Pos)             /*!< 0x00004000 */
+#define EXTI_EMR1_EM14               EXTI_EMR1_EM14_Msk                        /*!< Event Mask on line 14 */
+#define EXTI_EMR1_EM15_Pos           (15U)
+#define EXTI_EMR1_EM15_Msk           (0x1UL << EXTI_EMR1_EM15_Pos)             /*!< 0x00008000 */
+#define EXTI_EMR1_EM15               EXTI_EMR1_EM15_Msk                        /*!< Event Mask on line 15 */
+#define EXTI_EMR1_EM19_Pos           (19U)
+#define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
+#define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
+#define EXTI_EMR1_EM21_Pos           (21U)
+#define EXTI_EMR1_EM21_Msk           (0x1UL << EXTI_EMR1_EM21_Pos)             /*!< 0x00200000 */
+#define EXTI_EMR1_EM21               EXTI_EMR1_EM21_Msk                        /*!< Event Mask on line 21 */
+#define EXTI_EMR1_EM23_Pos           (23U)
+#define EXTI_EMR1_EM23_Msk           (0x1UL << EXTI_EMR1_EM23_Pos)             /*!< 0x00800000 */
+#define EXTI_EMR1_EM23               EXTI_EMR1_EM23_Msk                        /*!< Event Mask on line 23 */
+#define EXTI_EMR1_EM25_Pos           (25U)
+#define EXTI_EMR1_EM25_Msk           (0x1UL << EXTI_EMR1_EM25_Pos)             /*!< 0x02000000 */
+#define EXTI_EMR1_EM25               EXTI_EMR1_EM25_Msk                        /*!< Event Mask on line 25 */
+#define EXTI_EMR1_EM31_Pos           (31U)
+#define EXTI_EMR1_EM31_Msk           (0x1UL << EXTI_EMR1_EM31_Pos)             /*!< 0x80000000 */
+#define EXTI_EMR1_EM31               EXTI_EMR1_EM31_Msk                        /*!< Event Mask on line 31 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/* Note: No specific macro feature on this device */
+
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos                  (0U)
+#define FLASH_ACR_LATENCY_Msk                  (0x7UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY                      FLASH_ACR_LATENCY_Msk
+#define FLASH_ACR_LATENCY_0                    (0x1UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000001 */
+#define FLASH_ACR_LATENCY_1                    (0x2UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000002 */
+#define FLASH_ACR_LATENCY_2                    (0x4UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000004 */
+#define FLASH_ACR_PRFTEN_Pos                   (8U)
+#define FLASH_ACR_PRFTEN_Msk                   (0x1UL << FLASH_ACR_PRFTEN_Pos)  /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN                       FLASH_ACR_PRFTEN_Msk
+#define FLASH_ACR_ICEN_Pos                     (9U)
+#define FLASH_ACR_ICEN_Msk                     (0x1UL << FLASH_ACR_ICEN_Pos)    /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                         FLASH_ACR_ICEN_Msk
+#define FLASH_ACR_ICRST_Pos                    (11U)
+#define FLASH_ACR_ICRST_Msk                    (0x1UL << FLASH_ACR_ICRST_Pos)   /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                        FLASH_ACR_ICRST_Msk
+#define FLASH_ACR_PROGEMPTY_Pos                (16U)
+#define FLASH_ACR_PROGEMPTY_Msk                (0x1UL << FLASH_ACR_PROGEMPTY_Pos) /*!< 0x00010000 */
+#define FLASH_ACR_PROGEMPTY                    FLASH_ACR_PROGEMPTY_Msk
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos                       (0U)
+#define FLASH_SR_EOP_Msk                       (0x1UL << FLASH_SR_EOP_Pos)      /*!< 0x00000001 */
+#define FLASH_SR_EOP                           FLASH_SR_EOP_Msk
+#define FLASH_SR_OPERR_Pos                     (1U)
+#define FLASH_SR_OPERR_Msk                     (0x1UL << FLASH_SR_OPERR_Pos)    /*!< 0x00000002 */
+#define FLASH_SR_OPERR                         FLASH_SR_OPERR_Msk
+#define FLASH_SR_PROGERR_Pos                   (3U)
+#define FLASH_SR_PROGERR_Msk                   (0x1UL << FLASH_SR_PROGERR_Pos)  /*!< 0x00000008 */
+#define FLASH_SR_PROGERR                       FLASH_SR_PROGERR_Msk
+#define FLASH_SR_WRPERR_Pos                    (4U)
+#define FLASH_SR_WRPERR_Msk                    (0x1UL << FLASH_SR_WRPERR_Pos)   /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                        FLASH_SR_WRPERR_Msk
+#define FLASH_SR_PGAERR_Pos                    (5U)
+#define FLASH_SR_PGAERR_Msk                    (0x1UL << FLASH_SR_PGAERR_Pos)   /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                        FLASH_SR_PGAERR_Msk
+#define FLASH_SR_SIZERR_Pos                    (6U)
+#define FLASH_SR_SIZERR_Msk                    (0x1UL << FLASH_SR_SIZERR_Pos)   /*!< 0x00000040 */
+#define FLASH_SR_SIZERR                        FLASH_SR_SIZERR_Msk
+#define FLASH_SR_PGSERR_Pos                    (7U)
+#define FLASH_SR_PGSERR_Msk                    (0x1UL << FLASH_SR_PGSERR_Pos)   /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                        FLASH_SR_PGSERR_Msk
+#define FLASH_SR_MISERR_Pos                    (8U)
+#define FLASH_SR_MISERR_Msk                    (0x1UL << FLASH_SR_MISERR_Pos)   /*!< 0x00000100 */
+#define FLASH_SR_MISERR                        FLASH_SR_MISERR_Msk
+#define FLASH_SR_FASTERR_Pos                   (9U)
+#define FLASH_SR_FASTERR_Msk                   (0x1UL << FLASH_SR_FASTERR_Pos)  /*!< 0x00000200 */
+#define FLASH_SR_FASTERR                       FLASH_SR_FASTERR_Msk
+#define FLASH_SR_OPTVERR_Pos                   (15U)
+#define FLASH_SR_OPTVERR_Msk                   (0x1UL << FLASH_SR_OPTVERR_Pos)  /*!< 0x00008000 */
+#define FLASH_SR_OPTVERR                       FLASH_SR_OPTVERR_Msk
+#define FLASH_SR_BSY1_Pos                      (16U)
+#define FLASH_SR_BSY1_Msk                      (0x1UL << FLASH_SR_BSY1_Pos)     /*!< 0x00010000 */
+#define FLASH_SR_BSY1                          FLASH_SR_BSY1_Msk
+#define FLASH_SR_CFGBSY_Pos                    (18U)
+#define FLASH_SR_CFGBSY_Msk                    (0x1UL << FLASH_SR_CFGBSY_Pos)   /*!< 0x00040000 */
+#define FLASH_SR_CFGBSY                        FLASH_SR_CFGBSY_Msk
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                        (0U)
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
+#define FLASH_CR_PG                            FLASH_CR_PG_Msk
+#define FLASH_CR_PER_Pos                       (1U)
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
+#define FLASH_CR_PER                           FLASH_CR_PER_Msk
+#define FLASH_CR_MER1_Pos                      (2U)
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
+#define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
+#define FLASH_CR_PNB_Pos                       (3U)
+#define FLASH_CR_PNB_Msk                       (0x1FUL << FLASH_CR_PNB_Pos)       /*!< 0x000000F8 */
+#define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
+#define FLASH_CR_STRT_Pos                      (16U)
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
+#define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
+#define FLASH_CR_OPTSTRT_Pos                   (17U)
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
+#define FLASH_CR_FSTPG_Pos                     (18U)
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
+#define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
+#define FLASH_CR_EOPIE_Pos                     (24U)
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
+#define FLASH_CR_ERRIE_Pos                     (25U)
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
+#define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
+#define FLASH_CR_OBL_LAUNCH_Pos                (27U)
+#define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
+#define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
+#define FLASH_CR_OPTLOCK_Pos                   (30U)
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
+#define FLASH_CR_LOCK_Pos                      (31U)
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
+#define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
+
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos                (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
+#define FLASH_ECCR_SYSF_ECC_Pos                (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
+#define FLASH_ECCR_ECCCIE_Pos                  (24U)
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
+#define FLASH_ECCR_ECCC_Pos                    (30U)
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
+#define FLASH_ECCR_ECCD_Pos                    (31U)
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
+
+/*******************  Bits definition for FLASH_OPTR register  ****************/
+#define FLASH_OPTR_RDP_Pos                     (0U)
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
+#define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
+#define FLASH_OPTR_nRST_STOP_Pos               (13U)
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
+#define FLASH_OPTR_nRST_STDBY_Pos              (14U)
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
+#define FLASH_OPTR_IWDG_SW_Pos                 (16U)
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
+#define FLASH_OPTR_IWDG_STOP_Pos               (17U)
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
+#define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
+#define FLASH_OPTR_WWDG_SW_Pos                 (19U)
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
+#define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
+#define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
+#define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
+#define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
+#define FLASH_OPTR_nBOOT1_Pos                  (25U)
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
+#define FLASH_OPTR_nBOOT0_Pos                  (26U)
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
+
+/******************  Bits definition for FLASH_WRP1AR register  ***************/
+#define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
+#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x1FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000001F */
+#define FLASH_WRP1AR_WRP1A_STRT                FLASH_WRP1AR_WRP1A_STRT_Msk
+#define FLASH_WRP1AR_WRP1A_END_Pos             (16U)
+#define FLASH_WRP1AR_WRP1A_END_Msk             (0x1FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x001F0000 */
+#define FLASH_WRP1AR_WRP1A_END                 FLASH_WRP1AR_WRP1A_END_Msk
+
+/******************  Bits definition for FLASH_WRP1BR register  ***************/
+#define FLASH_WRP1BR_WRP1B_STRT_Pos            (0U)
+#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x1FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000001F */
+#define FLASH_WRP1BR_WRP1B_STRT                FLASH_WRP1BR_WRP1B_STRT_Msk
+#define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
+#define FLASH_WRP1BR_WRP1B_END_Msk             (0x1FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x001F0000 */
+#define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0_Pos           (0U)
+#define GPIO_MODER_MODE0_Msk           (0x3UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000003 */
+#define GPIO_MODER_MODE0               GPIO_MODER_MODE0_Msk
+#define GPIO_MODER_MODE0_0             (0x1UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000001 */
+#define GPIO_MODER_MODE0_1             (0x2UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000002 */
+#define GPIO_MODER_MODE1_Pos           (2U)
+#define GPIO_MODER_MODE1_Msk           (0x3UL << GPIO_MODER_MODE1_Pos)          /*!< 0x0000000C */
+#define GPIO_MODER_MODE1               GPIO_MODER_MODE1_Msk
+#define GPIO_MODER_MODE1_0             (0x1UL << GPIO_MODER_MODE1_Pos)          /*!< 0x00000004 */
+#define GPIO_MODER_MODE1_1             (0x2UL << GPIO_MODER_MODE1_Pos)          /*!< 0x00000008 */
+#define GPIO_MODER_MODE2_Pos           (4U)
+#define GPIO_MODER_MODE2_Msk           (0x3UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000030 */
+#define GPIO_MODER_MODE2               GPIO_MODER_MODE2_Msk
+#define GPIO_MODER_MODE2_0             (0x1UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000010 */
+#define GPIO_MODER_MODE2_1             (0x2UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000020 */
+#define GPIO_MODER_MODE3_Pos           (6U)
+#define GPIO_MODER_MODE3_Msk           (0x3UL << GPIO_MODER_MODE3_Pos)          /*!< 0x000000C0 */
+#define GPIO_MODER_MODE3               GPIO_MODER_MODE3_Msk
+#define GPIO_MODER_MODE3_0             (0x1UL << GPIO_MODER_MODE3_Pos)          /*!< 0x00000040 */
+#define GPIO_MODER_MODE3_1             (0x2UL << GPIO_MODER_MODE3_Pos)          /*!< 0x00000080 */
+#define GPIO_MODER_MODE4_Pos           (8U)
+#define GPIO_MODER_MODE4_Msk           (0x3UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000300 */
+#define GPIO_MODER_MODE4               GPIO_MODER_MODE4_Msk
+#define GPIO_MODER_MODE4_0             (0x1UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000100 */
+#define GPIO_MODER_MODE4_1             (0x2UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000200 */
+#define GPIO_MODER_MODE5_Pos           (10U)
+#define GPIO_MODER_MODE5_Msk           (0x3UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000C00 */
+#define GPIO_MODER_MODE5               GPIO_MODER_MODE5_Msk
+#define GPIO_MODER_MODE5_0             (0x1UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000400 */
+#define GPIO_MODER_MODE5_1             (0x2UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000800 */
+#define GPIO_MODER_MODE6_Pos           (12U)
+#define GPIO_MODER_MODE6_Msk           (0x3UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00003000 */
+#define GPIO_MODER_MODE6               GPIO_MODER_MODE6_Msk
+#define GPIO_MODER_MODE6_0             (0x1UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00001000 */
+#define GPIO_MODER_MODE6_1             (0x2UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00002000 */
+#define GPIO_MODER_MODE7_Pos           (14U)
+#define GPIO_MODER_MODE7_Msk           (0x3UL << GPIO_MODER_MODE7_Pos)          /*!< 0x0000C000 */
+#define GPIO_MODER_MODE7               GPIO_MODER_MODE7_Msk
+#define GPIO_MODER_MODE7_0             (0x1UL << GPIO_MODER_MODE7_Pos)          /*!< 0x00004000 */
+#define GPIO_MODER_MODE7_1             (0x2UL << GPIO_MODER_MODE7_Pos)          /*!< 0x00008000 */
+#define GPIO_MODER_MODE8_Pos           (16U)
+#define GPIO_MODER_MODE8_Msk           (0x3UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00030000 */
+#define GPIO_MODER_MODE8               GPIO_MODER_MODE8_Msk
+#define GPIO_MODER_MODE8_0             (0x1UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00010000 */
+#define GPIO_MODER_MODE8_1             (0x2UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00020000 */
+#define GPIO_MODER_MODE9_Pos           (18U)
+#define GPIO_MODER_MODE9_Msk           (0x3UL << GPIO_MODER_MODE9_Pos)          /*!< 0x000C0000 */
+#define GPIO_MODER_MODE9               GPIO_MODER_MODE9_Msk
+#define GPIO_MODER_MODE9_0             (0x1UL << GPIO_MODER_MODE9_Pos)          /*!< 0x00040000 */
+#define GPIO_MODER_MODE9_1             (0x2UL << GPIO_MODER_MODE9_Pos)          /*!< 0x00080000 */
+#define GPIO_MODER_MODE10_Pos          (20U)
+#define GPIO_MODER_MODE10_Msk          (0x3UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00300000 */
+#define GPIO_MODER_MODE10              GPIO_MODER_MODE10_Msk
+#define GPIO_MODER_MODE10_0            (0x1UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00100000 */
+#define GPIO_MODER_MODE10_1            (0x2UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00200000 */
+#define GPIO_MODER_MODE11_Pos          (22U)
+#define GPIO_MODER_MODE11_Msk          (0x3UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00C00000 */
+#define GPIO_MODER_MODE11              GPIO_MODER_MODE11_Msk
+#define GPIO_MODER_MODE11_0            (0x1UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00400000 */
+#define GPIO_MODER_MODE11_1            (0x2UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00800000 */
+#define GPIO_MODER_MODE12_Pos          (24U)
+#define GPIO_MODER_MODE12_Msk          (0x3UL << GPIO_MODER_MODE12_Pos)         /*!< 0x03000000 */
+#define GPIO_MODER_MODE12              GPIO_MODER_MODE12_Msk
+#define GPIO_MODER_MODE12_0            (0x1UL << GPIO_MODER_MODE12_Pos)         /*!< 0x01000000 */
+#define GPIO_MODER_MODE12_1            (0x2UL << GPIO_MODER_MODE12_Pos)         /*!< 0x02000000 */
+#define GPIO_MODER_MODE13_Pos          (26U)
+#define GPIO_MODER_MODE13_Msk          (0x3UL << GPIO_MODER_MODE13_Pos)         /*!< 0x0C000000 */
+#define GPIO_MODER_MODE13              GPIO_MODER_MODE13_Msk
+#define GPIO_MODER_MODE13_0            (0x1UL << GPIO_MODER_MODE13_Pos)         /*!< 0x04000000 */
+#define GPIO_MODER_MODE13_1            (0x2UL << GPIO_MODER_MODE13_Pos)         /*!< 0x08000000 */
+#define GPIO_MODER_MODE14_Pos          (28U)
+#define GPIO_MODER_MODE14_Msk          (0x3UL << GPIO_MODER_MODE14_Pos)         /*!< 0x30000000 */
+#define GPIO_MODER_MODE14              GPIO_MODER_MODE14_Msk
+#define GPIO_MODER_MODE14_0            (0x1UL << GPIO_MODER_MODE14_Pos)         /*!< 0x10000000 */
+#define GPIO_MODER_MODE14_1            (0x2UL << GPIO_MODER_MODE14_Pos)         /*!< 0x20000000 */
+#define GPIO_MODER_MODE15_Pos          (30U)
+#define GPIO_MODER_MODE15_Msk          (0x3UL << GPIO_MODER_MODE15_Pos)         /*!< 0xC0000000 */
+#define GPIO_MODER_MODE15              GPIO_MODER_MODE15_Msk
+#define GPIO_MODER_MODE15_0            (0x1UL << GPIO_MODER_MODE15_Pos)         /*!< 0x40000000 */
+#define GPIO_MODER_MODE15_1            (0x2UL << GPIO_MODER_MODE15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos            (0U)
+#define GPIO_OTYPER_OT0_Msk            (0x1UL << GPIO_OTYPER_OT0_Pos)           /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                GPIO_OTYPER_OT0_Msk
+#define GPIO_OTYPER_OT1_Pos            (1U)
+#define GPIO_OTYPER_OT1_Msk            (0x1UL << GPIO_OTYPER_OT1_Pos)           /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                GPIO_OTYPER_OT1_Msk
+#define GPIO_OTYPER_OT2_Pos            (2U)
+#define GPIO_OTYPER_OT2_Msk            (0x1UL << GPIO_OTYPER_OT2_Pos)           /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                GPIO_OTYPER_OT2_Msk
+#define GPIO_OTYPER_OT3_Pos            (3U)
+#define GPIO_OTYPER_OT3_Msk            (0x1UL << GPIO_OTYPER_OT3_Pos)           /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                GPIO_OTYPER_OT3_Msk
+#define GPIO_OTYPER_OT4_Pos            (4U)
+#define GPIO_OTYPER_OT4_Msk            (0x1UL << GPIO_OTYPER_OT4_Pos)           /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                GPIO_OTYPER_OT4_Msk
+#define GPIO_OTYPER_OT5_Pos            (5U)
+#define GPIO_OTYPER_OT5_Msk            (0x1UL << GPIO_OTYPER_OT5_Pos)           /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                GPIO_OTYPER_OT5_Msk
+#define GPIO_OTYPER_OT6_Pos            (6U)
+#define GPIO_OTYPER_OT6_Msk            (0x1UL << GPIO_OTYPER_OT6_Pos)           /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                GPIO_OTYPER_OT6_Msk
+#define GPIO_OTYPER_OT7_Pos            (7U)
+#define GPIO_OTYPER_OT7_Msk            (0x1UL << GPIO_OTYPER_OT7_Pos)           /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                GPIO_OTYPER_OT7_Msk
+#define GPIO_OTYPER_OT8_Pos            (8U)
+#define GPIO_OTYPER_OT8_Msk            (0x1UL << GPIO_OTYPER_OT8_Pos)           /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                GPIO_OTYPER_OT8_Msk
+#define GPIO_OTYPER_OT9_Pos            (9U)
+#define GPIO_OTYPER_OT9_Msk            (0x1UL << GPIO_OTYPER_OT9_Pos)           /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                GPIO_OTYPER_OT9_Msk
+#define GPIO_OTYPER_OT10_Pos           (10U)
+#define GPIO_OTYPER_OT10_Msk           (0x1UL << GPIO_OTYPER_OT10_Pos)          /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10               GPIO_OTYPER_OT10_Msk
+#define GPIO_OTYPER_OT11_Pos           (11U)
+#define GPIO_OTYPER_OT11_Msk           (0x1UL << GPIO_OTYPER_OT11_Pos)          /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11               GPIO_OTYPER_OT11_Msk
+#define GPIO_OTYPER_OT12_Pos           (12U)
+#define GPIO_OTYPER_OT12_Msk           (0x1UL << GPIO_OTYPER_OT12_Pos)          /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12               GPIO_OTYPER_OT12_Msk
+#define GPIO_OTYPER_OT13_Pos           (13U)
+#define GPIO_OTYPER_OT13_Msk           (0x1UL << GPIO_OTYPER_OT13_Pos)          /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13               GPIO_OTYPER_OT13_Msk
+#define GPIO_OTYPER_OT14_Pos           (14U)
+#define GPIO_OTYPER_OT14_Msk           (0x1UL << GPIO_OTYPER_OT14_Pos)          /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14               GPIO_OTYPER_OT14_Msk
+#define GPIO_OTYPER_OT15_Pos           (15U)
+#define GPIO_OTYPER_OT15_Msk           (0x1UL << GPIO_OTYPER_OT15_Pos)          /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15               GPIO_OTYPER_OT15_Msk
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos       (0U)
+#define GPIO_OSPEEDR_OSPEED0_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0           GPIO_OSPEEDR_OSPEED0_Msk
+#define GPIO_OSPEEDR_OSPEED0_0         (0x1UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1         (0x2UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos       (2U)
+#define GPIO_OSPEEDR_OSPEED1_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1           GPIO_OSPEEDR_OSPEED1_Msk
+#define GPIO_OSPEEDR_OSPEED1_0         (0x1UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1         (0x2UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos       (4U)
+#define GPIO_OSPEEDR_OSPEED2_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2           GPIO_OSPEEDR_OSPEED2_Msk
+#define GPIO_OSPEEDR_OSPEED2_0         (0x1UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1         (0x2UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos       (6U)
+#define GPIO_OSPEEDR_OSPEED3_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3           GPIO_OSPEEDR_OSPEED3_Msk
+#define GPIO_OSPEEDR_OSPEED3_0         (0x1UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1         (0x2UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos       (8U)
+#define GPIO_OSPEEDR_OSPEED4_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4           GPIO_OSPEEDR_OSPEED4_Msk
+#define GPIO_OSPEEDR_OSPEED4_0         (0x1UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1         (0x2UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos       (10U)
+#define GPIO_OSPEEDR_OSPEED5_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5           GPIO_OSPEEDR_OSPEED5_Msk
+#define GPIO_OSPEEDR_OSPEED5_0         (0x1UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1         (0x2UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos       (12U)
+#define GPIO_OSPEEDR_OSPEED6_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6           GPIO_OSPEEDR_OSPEED6_Msk
+#define GPIO_OSPEEDR_OSPEED6_0         (0x1UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1         (0x2UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos       (14U)
+#define GPIO_OSPEEDR_OSPEED7_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7           GPIO_OSPEEDR_OSPEED7_Msk
+#define GPIO_OSPEEDR_OSPEED7_0         (0x1UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1         (0x2UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos       (16U)
+#define GPIO_OSPEEDR_OSPEED8_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8           GPIO_OSPEEDR_OSPEED8_Msk
+#define GPIO_OSPEEDR_OSPEED8_0         (0x1UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1         (0x2UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos       (18U)
+#define GPIO_OSPEEDR_OSPEED9_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9           GPIO_OSPEEDR_OSPEED9_Msk
+#define GPIO_OSPEEDR_OSPEED9_0         (0x1UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1         (0x2UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos      (20U)
+#define GPIO_OSPEEDR_OSPEED10_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10          GPIO_OSPEEDR_OSPEED10_Msk
+#define GPIO_OSPEEDR_OSPEED10_0        (0x1UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1        (0x2UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos      (22U)
+#define GPIO_OSPEEDR_OSPEED11_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11          GPIO_OSPEEDR_OSPEED11_Msk
+#define GPIO_OSPEEDR_OSPEED11_0        (0x1UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1        (0x2UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos      (24U)
+#define GPIO_OSPEEDR_OSPEED12_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12          GPIO_OSPEEDR_OSPEED12_Msk
+#define GPIO_OSPEEDR_OSPEED12_0        (0x1UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1        (0x2UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos      (26U)
+#define GPIO_OSPEEDR_OSPEED13_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13          GPIO_OSPEEDR_OSPEED13_Msk
+#define GPIO_OSPEEDR_OSPEED13_0        (0x1UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1        (0x2UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos      (28U)
+#define GPIO_OSPEEDR_OSPEED14_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14          GPIO_OSPEEDR_OSPEED14_Msk
+#define GPIO_OSPEEDR_OSPEED14_0        (0x1UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1        (0x2UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos      (30U)
+#define GPIO_OSPEEDR_OSPEED15_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15          GPIO_OSPEEDR_OSPEED15_Msk
+#define GPIO_OSPEEDR_OSPEED15_0        (0x1UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1        (0x2UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos           (0U)
+#define GPIO_PUPDR_PUPD0_Msk           (0x3UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0               GPIO_PUPDR_PUPD0_Msk
+#define GPIO_PUPDR_PUPD0_0             (0x1UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1             (0x2UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos           (2U)
+#define GPIO_PUPDR_PUPD1_Msk           (0x3UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1               GPIO_PUPDR_PUPD1_Msk
+#define GPIO_PUPDR_PUPD1_0             (0x1UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1             (0x2UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos           (4U)
+#define GPIO_PUPDR_PUPD2_Msk           (0x3UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2               GPIO_PUPDR_PUPD2_Msk
+#define GPIO_PUPDR_PUPD2_0             (0x1UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1             (0x2UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos           (6U)
+#define GPIO_PUPDR_PUPD3_Msk           (0x3UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3               GPIO_PUPDR_PUPD3_Msk
+#define GPIO_PUPDR_PUPD3_0             (0x1UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1             (0x2UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos           (8U)
+#define GPIO_PUPDR_PUPD4_Msk           (0x3UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4               GPIO_PUPDR_PUPD4_Msk
+#define GPIO_PUPDR_PUPD4_0             (0x1UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1             (0x2UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos           (10U)
+#define GPIO_PUPDR_PUPD5_Msk           (0x3UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5               GPIO_PUPDR_PUPD5_Msk
+#define GPIO_PUPDR_PUPD5_0             (0x1UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1             (0x2UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos           (12U)
+#define GPIO_PUPDR_PUPD6_Msk           (0x3UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6               GPIO_PUPDR_PUPD6_Msk
+#define GPIO_PUPDR_PUPD6_0             (0x1UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1             (0x2UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos           (14U)
+#define GPIO_PUPDR_PUPD7_Msk           (0x3UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7               GPIO_PUPDR_PUPD7_Msk
+#define GPIO_PUPDR_PUPD7_0             (0x1UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1             (0x2UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos           (16U)
+#define GPIO_PUPDR_PUPD8_Msk           (0x3UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8               GPIO_PUPDR_PUPD8_Msk
+#define GPIO_PUPDR_PUPD8_0             (0x1UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1             (0x2UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos           (18U)
+#define GPIO_PUPDR_PUPD9_Msk           (0x3UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9               GPIO_PUPDR_PUPD9_Msk
+#define GPIO_PUPDR_PUPD9_0             (0x1UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1             (0x2UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos          (20U)
+#define GPIO_PUPDR_PUPD10_Msk          (0x3UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10              GPIO_PUPDR_PUPD10_Msk
+#define GPIO_PUPDR_PUPD10_0            (0x1UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1            (0x2UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos          (22U)
+#define GPIO_PUPDR_PUPD11_Msk          (0x3UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11              GPIO_PUPDR_PUPD11_Msk
+#define GPIO_PUPDR_PUPD11_0            (0x1UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1            (0x2UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos          (24U)
+#define GPIO_PUPDR_PUPD12_Msk          (0x3UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12              GPIO_PUPDR_PUPD12_Msk
+#define GPIO_PUPDR_PUPD12_0            (0x1UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1            (0x2UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos          (26U)
+#define GPIO_PUPDR_PUPD13_Msk          (0x3UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13              GPIO_PUPDR_PUPD13_Msk
+#define GPIO_PUPDR_PUPD13_0            (0x1UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1            (0x2UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos          (28U)
+#define GPIO_PUPDR_PUPD14_Msk          (0x3UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14              GPIO_PUPDR_PUPD14_Msk
+#define GPIO_PUPDR_PUPD14_0            (0x1UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1            (0x2UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos          (30U)
+#define GPIO_PUPDR_PUPD15_Msk          (0x3UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15              GPIO_PUPDR_PUPD15_Msk
+#define GPIO_PUPDR_PUPD15_0            (0x1UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1            (0x2UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos               (0U)
+#define GPIO_IDR_ID0_Msk               (0x1UL << GPIO_IDR_ID0_Pos)              /*!< 0x00000001 */
+#define GPIO_IDR_ID0                   GPIO_IDR_ID0_Msk
+#define GPIO_IDR_ID1_Pos               (1U)
+#define GPIO_IDR_ID1_Msk               (0x1UL << GPIO_IDR_ID1_Pos)              /*!< 0x00000002 */
+#define GPIO_IDR_ID1                   GPIO_IDR_ID1_Msk
+#define GPIO_IDR_ID2_Pos               (2U)
+#define GPIO_IDR_ID2_Msk               (0x1UL << GPIO_IDR_ID2_Pos)              /*!< 0x00000004 */
+#define GPIO_IDR_ID2                   GPIO_IDR_ID2_Msk
+#define GPIO_IDR_ID3_Pos               (3U)
+#define GPIO_IDR_ID3_Msk               (0x1UL << GPIO_IDR_ID3_Pos)              /*!< 0x00000008 */
+#define GPIO_IDR_ID3                   GPIO_IDR_ID3_Msk
+#define GPIO_IDR_ID4_Pos               (4U)
+#define GPIO_IDR_ID4_Msk               (0x1UL << GPIO_IDR_ID4_Pos)              /*!< 0x00000010 */
+#define GPIO_IDR_ID4                   GPIO_IDR_ID4_Msk
+#define GPIO_IDR_ID5_Pos               (5U)
+#define GPIO_IDR_ID5_Msk               (0x1UL << GPIO_IDR_ID5_Pos)              /*!< 0x00000020 */
+#define GPIO_IDR_ID5                   GPIO_IDR_ID5_Msk
+#define GPIO_IDR_ID6_Pos               (6U)
+#define GPIO_IDR_ID6_Msk               (0x1UL << GPIO_IDR_ID6_Pos)              /*!< 0x00000040 */
+#define GPIO_IDR_ID6                   GPIO_IDR_ID6_Msk
+#define GPIO_IDR_ID7_Pos               (7U)
+#define GPIO_IDR_ID7_Msk               (0x1UL << GPIO_IDR_ID7_Pos)              /*!< 0x00000080 */
+#define GPIO_IDR_ID7                   GPIO_IDR_ID7_Msk
+#define GPIO_IDR_ID8_Pos               (8U)
+#define GPIO_IDR_ID8_Msk               (0x1UL << GPIO_IDR_ID8_Pos)              /*!< 0x00000100 */
+#define GPIO_IDR_ID8                   GPIO_IDR_ID8_Msk
+#define GPIO_IDR_ID9_Pos               (9U)
+#define GPIO_IDR_ID9_Msk               (0x1UL << GPIO_IDR_ID9_Pos)              /*!< 0x00000200 */
+#define GPIO_IDR_ID9                   GPIO_IDR_ID9_Msk
+#define GPIO_IDR_ID10_Pos              (10U)
+#define GPIO_IDR_ID10_Msk              (0x1UL << GPIO_IDR_ID10_Pos)             /*!< 0x00000400 */
+#define GPIO_IDR_ID10                  GPIO_IDR_ID10_Msk
+#define GPIO_IDR_ID11_Pos              (11U)
+#define GPIO_IDR_ID11_Msk              (0x1UL << GPIO_IDR_ID11_Pos)             /*!< 0x00000800 */
+#define GPIO_IDR_ID11                  GPIO_IDR_ID11_Msk
+#define GPIO_IDR_ID12_Pos              (12U)
+#define GPIO_IDR_ID12_Msk              (0x1UL << GPIO_IDR_ID12_Pos)             /*!< 0x00001000 */
+#define GPIO_IDR_ID12                  GPIO_IDR_ID12_Msk
+#define GPIO_IDR_ID13_Pos              (13U)
+#define GPIO_IDR_ID13_Msk              (0x1UL << GPIO_IDR_ID13_Pos)             /*!< 0x00002000 */
+#define GPIO_IDR_ID13                  GPIO_IDR_ID13_Msk
+#define GPIO_IDR_ID14_Pos              (14U)
+#define GPIO_IDR_ID14_Msk              (0x1UL << GPIO_IDR_ID14_Pos)             /*!< 0x00004000 */
+#define GPIO_IDR_ID14                  GPIO_IDR_ID14_Msk
+#define GPIO_IDR_ID15_Pos              (15U)
+#define GPIO_IDR_ID15_Msk              (0x1UL << GPIO_IDR_ID15_Pos)             /*!< 0x00008000 */
+#define GPIO_IDR_ID15                  GPIO_IDR_ID15_Msk
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos               (0U)
+#define GPIO_ODR_OD0_Msk               (0x1UL << GPIO_ODR_OD0_Pos)              /*!< 0x00000001 */
+#define GPIO_ODR_OD0                   GPIO_ODR_OD0_Msk
+#define GPIO_ODR_OD1_Pos               (1U)
+#define GPIO_ODR_OD1_Msk               (0x1UL << GPIO_ODR_OD1_Pos)              /*!< 0x00000002 */
+#define GPIO_ODR_OD1                   GPIO_ODR_OD1_Msk
+#define GPIO_ODR_OD2_Pos               (2U)
+#define GPIO_ODR_OD2_Msk               (0x1UL << GPIO_ODR_OD2_Pos)              /*!< 0x00000004 */
+#define GPIO_ODR_OD2                   GPIO_ODR_OD2_Msk
+#define GPIO_ODR_OD3_Pos               (3U)
+#define GPIO_ODR_OD3_Msk               (0x1UL << GPIO_ODR_OD3_Pos)              /*!< 0x00000008 */
+#define GPIO_ODR_OD3                   GPIO_ODR_OD3_Msk
+#define GPIO_ODR_OD4_Pos               (4U)
+#define GPIO_ODR_OD4_Msk               (0x1UL << GPIO_ODR_OD4_Pos)              /*!< 0x00000010 */
+#define GPIO_ODR_OD4                   GPIO_ODR_OD4_Msk
+#define GPIO_ODR_OD5_Pos               (5U)
+#define GPIO_ODR_OD5_Msk               (0x1UL << GPIO_ODR_OD5_Pos)              /*!< 0x00000020 */
+#define GPIO_ODR_OD5                   GPIO_ODR_OD5_Msk
+#define GPIO_ODR_OD6_Pos               (6U)
+#define GPIO_ODR_OD6_Msk               (0x1UL << GPIO_ODR_OD6_Pos)              /*!< 0x00000040 */
+#define GPIO_ODR_OD6                   GPIO_ODR_OD6_Msk
+#define GPIO_ODR_OD7_Pos               (7U)
+#define GPIO_ODR_OD7_Msk               (0x1UL << GPIO_ODR_OD7_Pos)              /*!< 0x00000080 */
+#define GPIO_ODR_OD7                   GPIO_ODR_OD7_Msk
+#define GPIO_ODR_OD8_Pos               (8U)
+#define GPIO_ODR_OD8_Msk               (0x1UL << GPIO_ODR_OD8_Pos)              /*!< 0x00000100 */
+#define GPIO_ODR_OD8                   GPIO_ODR_OD8_Msk
+#define GPIO_ODR_OD9_Pos               (9U)
+#define GPIO_ODR_OD9_Msk               (0x1UL << GPIO_ODR_OD9_Pos)              /*!< 0x00000200 */
+#define GPIO_ODR_OD9                   GPIO_ODR_OD9_Msk
+#define GPIO_ODR_OD10_Pos              (10U)
+#define GPIO_ODR_OD10_Msk              (0x1UL << GPIO_ODR_OD10_Pos)             /*!< 0x00000400 */
+#define GPIO_ODR_OD10                  GPIO_ODR_OD10_Msk
+#define GPIO_ODR_OD11_Pos              (11U)
+#define GPIO_ODR_OD11_Msk              (0x1UL << GPIO_ODR_OD11_Pos)             /*!< 0x00000800 */
+#define GPIO_ODR_OD11                  GPIO_ODR_OD11_Msk
+#define GPIO_ODR_OD12_Pos              (12U)
+#define GPIO_ODR_OD12_Msk              (0x1UL << GPIO_ODR_OD12_Pos)             /*!< 0x00001000 */
+#define GPIO_ODR_OD12                  GPIO_ODR_OD12_Msk
+#define GPIO_ODR_OD13_Pos              (13U)
+#define GPIO_ODR_OD13_Msk              (0x1UL << GPIO_ODR_OD13_Pos)             /*!< 0x00002000 */
+#define GPIO_ODR_OD13                  GPIO_ODR_OD13_Msk
+#define GPIO_ODR_OD14_Pos              (14U)
+#define GPIO_ODR_OD14_Msk              (0x1UL << GPIO_ODR_OD14_Pos)             /*!< 0x00004000 */
+#define GPIO_ODR_OD14                  GPIO_ODR_OD14_Msk
+#define GPIO_ODR_OD15_Pos              (15U)
+#define GPIO_ODR_OD15_Msk              (0x1UL << GPIO_ODR_OD15_Pos)             /*!< 0x00008000 */
+#define GPIO_ODR_OD15                  GPIO_ODR_OD15_Msk
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos              (0U)
+#define GPIO_BSRR_BS0_Msk              (0x1UL << GPIO_BSRR_BS0_Pos)             /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                  GPIO_BSRR_BS0_Msk
+#define GPIO_BSRR_BS1_Pos              (1U)
+#define GPIO_BSRR_BS1_Msk              (0x1UL << GPIO_BSRR_BS1_Pos)             /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                  GPIO_BSRR_BS1_Msk
+#define GPIO_BSRR_BS2_Pos              (2U)
+#define GPIO_BSRR_BS2_Msk              (0x1UL << GPIO_BSRR_BS2_Pos)             /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                  GPIO_BSRR_BS2_Msk
+#define GPIO_BSRR_BS3_Pos              (3U)
+#define GPIO_BSRR_BS3_Msk              (0x1UL << GPIO_BSRR_BS3_Pos)             /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                  GPIO_BSRR_BS3_Msk
+#define GPIO_BSRR_BS4_Pos              (4U)
+#define GPIO_BSRR_BS4_Msk              (0x1UL << GPIO_BSRR_BS4_Pos)             /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                  GPIO_BSRR_BS4_Msk
+#define GPIO_BSRR_BS5_Pos              (5U)
+#define GPIO_BSRR_BS5_Msk              (0x1UL << GPIO_BSRR_BS5_Pos)             /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                  GPIO_BSRR_BS5_Msk
+#define GPIO_BSRR_BS6_Pos              (6U)
+#define GPIO_BSRR_BS6_Msk              (0x1UL << GPIO_BSRR_BS6_Pos)             /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                  GPIO_BSRR_BS6_Msk
+#define GPIO_BSRR_BS7_Pos              (7U)
+#define GPIO_BSRR_BS7_Msk              (0x1UL << GPIO_BSRR_BS7_Pos)             /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                  GPIO_BSRR_BS7_Msk
+#define GPIO_BSRR_BS8_Pos              (8U)
+#define GPIO_BSRR_BS8_Msk              (0x1UL << GPIO_BSRR_BS8_Pos)             /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                  GPIO_BSRR_BS8_Msk
+#define GPIO_BSRR_BS9_Pos              (9U)
+#define GPIO_BSRR_BS9_Msk              (0x1UL << GPIO_BSRR_BS9_Pos)             /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                  GPIO_BSRR_BS9_Msk
+#define GPIO_BSRR_BS10_Pos             (10U)
+#define GPIO_BSRR_BS10_Msk             (0x1UL << GPIO_BSRR_BS10_Pos)            /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                 GPIO_BSRR_BS10_Msk
+#define GPIO_BSRR_BS11_Pos             (11U)
+#define GPIO_BSRR_BS11_Msk             (0x1UL << GPIO_BSRR_BS11_Pos)            /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                 GPIO_BSRR_BS11_Msk
+#define GPIO_BSRR_BS12_Pos             (12U)
+#define GPIO_BSRR_BS12_Msk             (0x1UL << GPIO_BSRR_BS12_Pos)            /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                 GPIO_BSRR_BS12_Msk
+#define GPIO_BSRR_BS13_Pos             (13U)
+#define GPIO_BSRR_BS13_Msk             (0x1UL << GPIO_BSRR_BS13_Pos)            /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                 GPIO_BSRR_BS13_Msk
+#define GPIO_BSRR_BS14_Pos             (14U)
+#define GPIO_BSRR_BS14_Msk             (0x1UL << GPIO_BSRR_BS14_Pos)            /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                 GPIO_BSRR_BS14_Msk
+#define GPIO_BSRR_BS15_Pos             (15U)
+#define GPIO_BSRR_BS15_Msk             (0x1UL << GPIO_BSRR_BS15_Pos)            /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                 GPIO_BSRR_BS15_Msk
+#define GPIO_BSRR_BR0_Pos              (16U)
+#define GPIO_BSRR_BR0_Msk              (0x1UL << GPIO_BSRR_BR0_Pos)             /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                  GPIO_BSRR_BR0_Msk
+#define GPIO_BSRR_BR1_Pos              (17U)
+#define GPIO_BSRR_BR1_Msk              (0x1UL << GPIO_BSRR_BR1_Pos)             /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                  GPIO_BSRR_BR1_Msk
+#define GPIO_BSRR_BR2_Pos              (18U)
+#define GPIO_BSRR_BR2_Msk              (0x1UL << GPIO_BSRR_BR2_Pos)             /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                  GPIO_BSRR_BR2_Msk
+#define GPIO_BSRR_BR3_Pos              (19U)
+#define GPIO_BSRR_BR3_Msk              (0x1UL << GPIO_BSRR_BR3_Pos)             /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                  GPIO_BSRR_BR3_Msk
+#define GPIO_BSRR_BR4_Pos              (20U)
+#define GPIO_BSRR_BR4_Msk              (0x1UL << GPIO_BSRR_BR4_Pos)             /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                  GPIO_BSRR_BR4_Msk
+#define GPIO_BSRR_BR5_Pos              (21U)
+#define GPIO_BSRR_BR5_Msk              (0x1UL << GPIO_BSRR_BR5_Pos)             /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                  GPIO_BSRR_BR5_Msk
+#define GPIO_BSRR_BR6_Pos              (22U)
+#define GPIO_BSRR_BR6_Msk              (0x1UL << GPIO_BSRR_BR6_Pos)             /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                  GPIO_BSRR_BR6_Msk
+#define GPIO_BSRR_BR7_Pos              (23U)
+#define GPIO_BSRR_BR7_Msk              (0x1UL << GPIO_BSRR_BR7_Pos)             /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                  GPIO_BSRR_BR7_Msk
+#define GPIO_BSRR_BR8_Pos              (24U)
+#define GPIO_BSRR_BR8_Msk              (0x1UL << GPIO_BSRR_BR8_Pos)             /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                  GPIO_BSRR_BR8_Msk
+#define GPIO_BSRR_BR9_Pos              (25U)
+#define GPIO_BSRR_BR9_Msk              (0x1UL << GPIO_BSRR_BR9_Pos)             /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                  GPIO_BSRR_BR9_Msk
+#define GPIO_BSRR_BR10_Pos             (26U)
+#define GPIO_BSRR_BR10_Msk             (0x1UL << GPIO_BSRR_BR10_Pos)            /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                 GPIO_BSRR_BR10_Msk
+#define GPIO_BSRR_BR11_Pos             (27U)
+#define GPIO_BSRR_BR11_Msk             (0x1UL << GPIO_BSRR_BR11_Pos)            /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                 GPIO_BSRR_BR11_Msk
+#define GPIO_BSRR_BR12_Pos             (28U)
+#define GPIO_BSRR_BR12_Msk             (0x1UL << GPIO_BSRR_BR12_Pos)            /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                 GPIO_BSRR_BR12_Msk
+#define GPIO_BSRR_BR13_Pos             (29U)
+#define GPIO_BSRR_BR13_Msk             (0x1UL << GPIO_BSRR_BR13_Pos)            /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                 GPIO_BSRR_BR13_Msk
+#define GPIO_BSRR_BR14_Pos             (30U)
+#define GPIO_BSRR_BR14_Msk             (0x1UL << GPIO_BSRR_BR14_Pos)            /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                 GPIO_BSRR_BR14_Msk
+#define GPIO_BSRR_BR15_Pos             (31U)
+#define GPIO_BSRR_BR15_Msk             (0x1UL << GPIO_BSRR_BR15_Pos)            /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                 GPIO_BSRR_BR15_Msk
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos             (0U)
+#define GPIO_LCKR_LCK0_Msk             (0x1UL << GPIO_LCKR_LCK0_Pos)            /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                 GPIO_LCKR_LCK0_Msk
+#define GPIO_LCKR_LCK1_Pos             (1U)
+#define GPIO_LCKR_LCK1_Msk             (0x1UL << GPIO_LCKR_LCK1_Pos)            /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                 GPIO_LCKR_LCK1_Msk
+#define GPIO_LCKR_LCK2_Pos             (2U)
+#define GPIO_LCKR_LCK2_Msk             (0x1UL << GPIO_LCKR_LCK2_Pos)            /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                 GPIO_LCKR_LCK2_Msk
+#define GPIO_LCKR_LCK3_Pos             (3U)
+#define GPIO_LCKR_LCK3_Msk             (0x1UL << GPIO_LCKR_LCK3_Pos)            /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                 GPIO_LCKR_LCK3_Msk
+#define GPIO_LCKR_LCK4_Pos             (4U)
+#define GPIO_LCKR_LCK4_Msk             (0x1UL << GPIO_LCKR_LCK4_Pos)            /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                 GPIO_LCKR_LCK4_Msk
+#define GPIO_LCKR_LCK5_Pos             (5U)
+#define GPIO_LCKR_LCK5_Msk             (0x1UL << GPIO_LCKR_LCK5_Pos)            /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                 GPIO_LCKR_LCK5_Msk
+#define GPIO_LCKR_LCK6_Pos             (6U)
+#define GPIO_LCKR_LCK6_Msk             (0x1UL << GPIO_LCKR_LCK6_Pos)            /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                 GPIO_LCKR_LCK6_Msk
+#define GPIO_LCKR_LCK7_Pos             (7U)
+#define GPIO_LCKR_LCK7_Msk             (0x1UL << GPIO_LCKR_LCK7_Pos)            /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                 GPIO_LCKR_LCK7_Msk
+#define GPIO_LCKR_LCK8_Pos             (8U)
+#define GPIO_LCKR_LCK8_Msk             (0x1UL << GPIO_LCKR_LCK8_Pos)            /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                 GPIO_LCKR_LCK8_Msk
+#define GPIO_LCKR_LCK9_Pos             (9U)
+#define GPIO_LCKR_LCK9_Msk             (0x1UL << GPIO_LCKR_LCK9_Pos)            /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                 GPIO_LCKR_LCK9_Msk
+#define GPIO_LCKR_LCK10_Pos            (10U)
+#define GPIO_LCKR_LCK10_Msk            (0x1UL << GPIO_LCKR_LCK10_Pos)           /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                GPIO_LCKR_LCK10_Msk
+#define GPIO_LCKR_LCK11_Pos            (11U)
+#define GPIO_LCKR_LCK11_Msk            (0x1UL << GPIO_LCKR_LCK11_Pos)           /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                GPIO_LCKR_LCK11_Msk
+#define GPIO_LCKR_LCK12_Pos            (12U)
+#define GPIO_LCKR_LCK12_Msk            (0x1UL << GPIO_LCKR_LCK12_Pos)           /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                GPIO_LCKR_LCK12_Msk
+#define GPIO_LCKR_LCK13_Pos            (13U)
+#define GPIO_LCKR_LCK13_Msk            (0x1UL << GPIO_LCKR_LCK13_Pos)           /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                GPIO_LCKR_LCK13_Msk
+#define GPIO_LCKR_LCK14_Pos            (14U)
+#define GPIO_LCKR_LCK14_Msk            (0x1UL << GPIO_LCKR_LCK14_Pos)           /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                GPIO_LCKR_LCK14_Msk
+#define GPIO_LCKR_LCK15_Pos            (15U)
+#define GPIO_LCKR_LCK15_Msk            (0x1UL << GPIO_LCKR_LCK15_Pos)           /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                GPIO_LCKR_LCK15_Msk
+#define GPIO_LCKR_LCKK_Pos             (16U)
+#define GPIO_LCKR_LCKK_Msk             (0x1UL << GPIO_LCKR_LCKK_Pos)            /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                 GPIO_LCKR_LCKK_Msk
+
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos           (0U)
+#define GPIO_AFRL_AFSEL0_Msk           (0xFUL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0               GPIO_AFRL_AFSEL0_Msk
+#define GPIO_AFRL_AFSEL0_0             (0x1UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1             (0x2UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2             (0x4UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3             (0x8UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos           (4U)
+#define GPIO_AFRL_AFSEL1_Msk           (0xFUL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1               GPIO_AFRL_AFSEL1_Msk
+#define GPIO_AFRL_AFSEL1_0             (0x1UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1             (0x2UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2             (0x4UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3             (0x8UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos           (8U)
+#define GPIO_AFRL_AFSEL2_Msk           (0xFUL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2               GPIO_AFRL_AFSEL2_Msk
+#define GPIO_AFRL_AFSEL2_0             (0x1UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1             (0x2UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2             (0x4UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3             (0x8UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos           (12U)
+#define GPIO_AFRL_AFSEL3_Msk           (0xFUL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3               GPIO_AFRL_AFSEL3_Msk
+#define GPIO_AFRL_AFSEL3_0             (0x1UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1             (0x2UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2             (0x4UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3             (0x8UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos           (16U)
+#define GPIO_AFRL_AFSEL4_Msk           (0xFUL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4               GPIO_AFRL_AFSEL4_Msk
+#define GPIO_AFRL_AFSEL4_0             (0x1UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1             (0x2UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2             (0x4UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3             (0x8UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos           (20U)
+#define GPIO_AFRL_AFSEL5_Msk           (0xFUL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5               GPIO_AFRL_AFSEL5_Msk
+#define GPIO_AFRL_AFSEL5_0             (0x1UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1             (0x2UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2             (0x4UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3             (0x8UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos           (24U)
+#define GPIO_AFRL_AFSEL6_Msk           (0xFUL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6               GPIO_AFRL_AFSEL6_Msk
+#define GPIO_AFRL_AFSEL6_0             (0x1UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1             (0x2UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2             (0x4UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3             (0x8UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos           (28U)
+#define GPIO_AFRL_AFSEL7_Msk           (0xFUL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7               GPIO_AFRL_AFSEL7_Msk
+#define GPIO_AFRL_AFSEL7_0             (0x1UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1             (0x2UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2             (0x4UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3             (0x8UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x80000000 */
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos           (0U)
+#define GPIO_AFRH_AFSEL8_Msk           (0xFUL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8               GPIO_AFRH_AFSEL8_Msk
+#define GPIO_AFRH_AFSEL8_0             (0x1UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1             (0x2UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2             (0x4UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3             (0x8UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos           (4U)
+#define GPIO_AFRH_AFSEL9_Msk           (0xFUL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9               GPIO_AFRH_AFSEL9_Msk
+#define GPIO_AFRH_AFSEL9_0             (0x1UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1             (0x2UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2             (0x4UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3             (0x8UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos          (8U)
+#define GPIO_AFRH_AFSEL10_Msk          (0xFUL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10              GPIO_AFRH_AFSEL10_Msk
+#define GPIO_AFRH_AFSEL10_0            (0x1UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1            (0x2UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2            (0x4UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3            (0x8UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos          (12U)
+#define GPIO_AFRH_AFSEL11_Msk          (0xFUL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11              GPIO_AFRH_AFSEL11_Msk
+#define GPIO_AFRH_AFSEL11_0            (0x1UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1            (0x2UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2            (0x4UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3            (0x8UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos          (16U)
+#define GPIO_AFRH_AFSEL12_Msk          (0xFUL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12              GPIO_AFRH_AFSEL12_Msk
+#define GPIO_AFRH_AFSEL12_0            (0x1UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1            (0x2UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2            (0x4UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3            (0x8UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos          (20U)
+#define GPIO_AFRH_AFSEL13_Msk          (0xFUL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13              GPIO_AFRH_AFSEL13_Msk
+#define GPIO_AFRH_AFSEL13_0            (0x1UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1            (0x2UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2            (0x4UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3            (0x8UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos          (24U)
+#define GPIO_AFRH_AFSEL14_Msk          (0xFUL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14              GPIO_AFRH_AFSEL14_Msk
+#define GPIO_AFRH_AFSEL14_0            (0x1UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1            (0x2UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2            (0x4UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3            (0x8UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos          (28U)
+#define GPIO_AFRH_AFSEL15_Msk          (0xFUL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15              GPIO_AFRH_AFSEL15_Msk
+#define GPIO_AFRH_AFSEL15_0            (0x1UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1            (0x2UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2            (0x4UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3            (0x8UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_BRR register  ******************/
+#define GPIO_BRR_BR0_Pos               (0U)
+#define GPIO_BRR_BR0_Msk               (0x1UL << GPIO_BRR_BR0_Pos)              /*!< 0x00000001 */
+#define GPIO_BRR_BR0                   GPIO_BRR_BR0_Msk
+#define GPIO_BRR_BR1_Pos               (1U)
+#define GPIO_BRR_BR1_Msk               (0x1UL << GPIO_BRR_BR1_Pos)              /*!< 0x00000002 */
+#define GPIO_BRR_BR1                   GPIO_BRR_BR1_Msk
+#define GPIO_BRR_BR2_Pos               (2U)
+#define GPIO_BRR_BR2_Msk               (0x1UL << GPIO_BRR_BR2_Pos)              /*!< 0x00000004 */
+#define GPIO_BRR_BR2                   GPIO_BRR_BR2_Msk
+#define GPIO_BRR_BR3_Pos               (3U)
+#define GPIO_BRR_BR3_Msk               (0x1UL << GPIO_BRR_BR3_Pos)              /*!< 0x00000008 */
+#define GPIO_BRR_BR3                   GPIO_BRR_BR3_Msk
+#define GPIO_BRR_BR4_Pos               (4U)
+#define GPIO_BRR_BR4_Msk               (0x1UL << GPIO_BRR_BR4_Pos)              /*!< 0x00000010 */
+#define GPIO_BRR_BR4                   GPIO_BRR_BR4_Msk
+#define GPIO_BRR_BR5_Pos               (5U)
+#define GPIO_BRR_BR5_Msk               (0x1UL << GPIO_BRR_BR5_Pos)              /*!< 0x00000020 */
+#define GPIO_BRR_BR5                   GPIO_BRR_BR5_Msk
+#define GPIO_BRR_BR6_Pos               (6U)
+#define GPIO_BRR_BR6_Msk               (0x1UL << GPIO_BRR_BR6_Pos)              /*!< 0x00000040 */
+#define GPIO_BRR_BR6                   GPIO_BRR_BR6_Msk
+#define GPIO_BRR_BR7_Pos               (7U)
+#define GPIO_BRR_BR7_Msk               (0x1UL << GPIO_BRR_BR7_Pos)              /*!< 0x00000080 */
+#define GPIO_BRR_BR7                   GPIO_BRR_BR7_Msk
+#define GPIO_BRR_BR8_Pos               (8U)
+#define GPIO_BRR_BR8_Msk               (0x1UL << GPIO_BRR_BR8_Pos)              /*!< 0x00000100 */
+#define GPIO_BRR_BR8                   GPIO_BRR_BR8_Msk
+#define GPIO_BRR_BR9_Pos               (9U)
+#define GPIO_BRR_BR9_Msk               (0x1UL << GPIO_BRR_BR9_Pos)              /*!< 0x00000200 */
+#define GPIO_BRR_BR9                   GPIO_BRR_BR9_Msk
+#define GPIO_BRR_BR10_Pos              (10U)
+#define GPIO_BRR_BR10_Msk              (0x1UL << GPIO_BRR_BR10_Pos)             /*!< 0x00000400 */
+#define GPIO_BRR_BR10                  GPIO_BRR_BR10_Msk
+#define GPIO_BRR_BR11_Pos              (11U)
+#define GPIO_BRR_BR11_Msk              (0x1UL << GPIO_BRR_BR11_Pos)             /*!< 0x00000800 */
+#define GPIO_BRR_BR11                  GPIO_BRR_BR11_Msk
+#define GPIO_BRR_BR12_Pos              (12U)
+#define GPIO_BRR_BR12_Msk              (0x1UL << GPIO_BRR_BR12_Pos)             /*!< 0x00001000 */
+#define GPIO_BRR_BR12                  GPIO_BRR_BR12_Msk
+#define GPIO_BRR_BR13_Pos              (13U)
+#define GPIO_BRR_BR13_Msk              (0x1UL << GPIO_BRR_BR13_Pos)             /*!< 0x00002000 */
+#define GPIO_BRR_BR13                  GPIO_BRR_BR13_Msk
+#define GPIO_BRR_BR14_Pos              (14U)
+#define GPIO_BRR_BR14_Msk              (0x1UL << GPIO_BRR_BR14_Pos)             /*!< 0x00004000 */
+#define GPIO_BRR_BR14                  GPIO_BRR_BR14_Msk
+#define GPIO_BRR_BR15_Pos              (15U)
+#define GPIO_BRR_BR15_Msk              (0x1UL << GPIO_BRR_BR15_Pos)             /*!< 0x00008000 */
+#define GPIO_BRR_BR15                  GPIO_BRR_BR15_Msk
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define I2C_CR1_PE_Pos               (0U)
+#define I2C_CR1_PE_Msk               (0x1UL << I2C_CR1_PE_Pos)                 /*!< 0x00000001 */
+#define I2C_CR1_PE                   I2C_CR1_PE_Msk                            /*!< Peripheral enable */
+#define I2C_CR1_TXIE_Pos             (1U)
+#define I2C_CR1_TXIE_Msk             (0x1UL << I2C_CR1_TXIE_Pos)               /*!< 0x00000002 */
+#define I2C_CR1_TXIE                 I2C_CR1_TXIE_Msk                          /*!< TX interrupt enable */
+#define I2C_CR1_RXIE_Pos             (2U)
+#define I2C_CR1_RXIE_Msk             (0x1UL << I2C_CR1_RXIE_Pos)               /*!< 0x00000004 */
+#define I2C_CR1_RXIE                 I2C_CR1_RXIE_Msk                          /*!< RX interrupt enable */
+#define I2C_CR1_ADDRIE_Pos           (3U)
+#define I2C_CR1_ADDRIE_Msk           (0x1UL << I2C_CR1_ADDRIE_Pos)             /*!< 0x00000008 */
+#define I2C_CR1_ADDRIE               I2C_CR1_ADDRIE_Msk                        /*!< Address match interrupt enable */
+#define I2C_CR1_NACKIE_Pos           (4U)
+#define I2C_CR1_NACKIE_Msk           (0x1UL << I2C_CR1_NACKIE_Pos)             /*!< 0x00000010 */
+#define I2C_CR1_NACKIE               I2C_CR1_NACKIE_Msk                        /*!< NACK received interrupt enable */
+#define I2C_CR1_STOPIE_Pos           (5U)
+#define I2C_CR1_STOPIE_Msk           (0x1UL << I2C_CR1_STOPIE_Pos)             /*!< 0x00000020 */
+#define I2C_CR1_STOPIE               I2C_CR1_STOPIE_Msk                        /*!< STOP detection interrupt enable */
+#define I2C_CR1_TCIE_Pos             (6U)
+#define I2C_CR1_TCIE_Msk             (0x1UL << I2C_CR1_TCIE_Pos)               /*!< 0x00000040 */
+#define I2C_CR1_TCIE                 I2C_CR1_TCIE_Msk                          /*!< Transfer complete interrupt enable */
+#define I2C_CR1_ERRIE_Pos            (7U)
+#define I2C_CR1_ERRIE_Msk            (0x1UL << I2C_CR1_ERRIE_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_ERRIE                I2C_CR1_ERRIE_Msk                         /*!< Errors interrupt enable */
+#define I2C_CR1_DNF_Pos              (8U)
+#define I2C_CR1_DNF_Msk              (0xFUL << I2C_CR1_DNF_Pos)                /*!< 0x00000F00 */
+#define I2C_CR1_DNF                  I2C_CR1_DNF_Msk                           /*!< Digital noise filter */
+#define I2C_CR1_ANFOFF_Pos           (12U)
+#define I2C_CR1_ANFOFF_Msk           (0x1UL << I2C_CR1_ANFOFF_Pos)             /*!< 0x00001000 */
+#define I2C_CR1_ANFOFF               I2C_CR1_ANFOFF_Msk                        /*!< Analog noise filter OFF */
+#define I2C_CR1_SWRST_Pos            (13U)
+#define I2C_CR1_SWRST_Msk            (0x1UL << I2C_CR1_SWRST_Pos)              /*!< 0x00002000 */
+#define I2C_CR1_SWRST                I2C_CR1_SWRST_Msk                         /*!< Software reset */
+#define I2C_CR1_TXDMAEN_Pos          (14U)
+#define I2C_CR1_TXDMAEN_Msk          (0x1UL << I2C_CR1_TXDMAEN_Pos)            /*!< 0x00004000 */
+#define I2C_CR1_TXDMAEN              I2C_CR1_TXDMAEN_Msk                       /*!< DMA transmission requests enable */
+#define I2C_CR1_RXDMAEN_Pos          (15U)
+#define I2C_CR1_RXDMAEN_Msk          (0x1UL << I2C_CR1_RXDMAEN_Pos)            /*!< 0x00008000 */
+#define I2C_CR1_RXDMAEN              I2C_CR1_RXDMAEN_Msk                       /*!< DMA reception requests enable */
+#define I2C_CR1_SBC_Pos              (16U)
+#define I2C_CR1_SBC_Msk              (0x1UL << I2C_CR1_SBC_Pos)                /*!< 0x00010000 */
+#define I2C_CR1_SBC                  I2C_CR1_SBC_Msk                           /*!< Slave byte control */
+#define I2C_CR1_NOSTRETCH_Pos        (17U)
+#define I2C_CR1_NOSTRETCH_Msk        (0x1UL << I2C_CR1_NOSTRETCH_Pos)          /*!< 0x00020000 */
+#define I2C_CR1_NOSTRETCH            I2C_CR1_NOSTRETCH_Msk                     /*!< Clock stretching disable */
+#define I2C_CR1_WUPEN_Pos            (18U)
+#define I2C_CR1_WUPEN_Msk            (0x1UL << I2C_CR1_WUPEN_Pos)              /*!< 0x00040000 */
+#define I2C_CR1_WUPEN                I2C_CR1_WUPEN_Msk                         /*!< Wakeup from STOP enable */
+#define I2C_CR1_GCEN_Pos             (19U)
+#define I2C_CR1_GCEN_Msk             (0x1UL << I2C_CR1_GCEN_Pos)               /*!< 0x00080000 */
+#define I2C_CR1_GCEN                 I2C_CR1_GCEN_Msk                          /*!< General call enable */
+#define I2C_CR1_SMBHEN_Pos           (20U)
+#define I2C_CR1_SMBHEN_Msk           (0x1UL << I2C_CR1_SMBHEN_Pos)             /*!< 0x00100000 */
+#define I2C_CR1_SMBHEN               I2C_CR1_SMBHEN_Msk                        /*!< SMBus host address enable */
+#define I2C_CR1_SMBDEN_Pos           (21U)
+#define I2C_CR1_SMBDEN_Msk           (0x1UL << I2C_CR1_SMBDEN_Pos)             /*!< 0x00200000 */
+#define I2C_CR1_SMBDEN               I2C_CR1_SMBDEN_Msk                        /*!< SMBus device default address enable */
+#define I2C_CR1_ALERTEN_Pos          (22U)
+#define I2C_CR1_ALERTEN_Msk          (0x1UL << I2C_CR1_ALERTEN_Pos)            /*!< 0x00400000 */
+#define I2C_CR1_ALERTEN              I2C_CR1_ALERTEN_Msk                       /*!< SMBus alert enable */
+#define I2C_CR1_PECEN_Pos            (23U)
+#define I2C_CR1_PECEN_Msk            (0x1UL << I2C_CR1_PECEN_Pos)              /*!< 0x00800000 */
+#define I2C_CR1_PECEN                I2C_CR1_PECEN_Msk                         /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_SADD_Pos             (0U)
+#define I2C_CR2_SADD_Msk             (0x3FFUL << I2C_CR2_SADD_Pos)             /*!< 0x000003FF */
+#define I2C_CR2_SADD                 I2C_CR2_SADD_Msk                          /*!< Slave address (master mode) */
+#define I2C_CR2_RD_WRN_Pos           (10U)
+#define I2C_CR2_RD_WRN_Msk           (0x1UL << I2C_CR2_RD_WRN_Pos)             /*!< 0x00000400 */
+#define I2C_CR2_RD_WRN               I2C_CR2_RD_WRN_Msk                        /*!< Transfer direction (master mode) */
+#define I2C_CR2_ADD10_Pos            (11U)
+#define I2C_CR2_ADD10_Msk            (0x1UL << I2C_CR2_ADD10_Pos)              /*!< 0x00000800 */
+#define I2C_CR2_ADD10                I2C_CR2_ADD10_Msk                         /*!< 10-bit addressing mode (master mode) */
+#define I2C_CR2_HEAD10R_Pos          (12U)
+#define I2C_CR2_HEAD10R_Msk          (0x1UL << I2C_CR2_HEAD10R_Pos)            /*!< 0x00001000 */
+#define I2C_CR2_HEAD10R              I2C_CR2_HEAD10R_Msk                       /*!< 10-bit address header only read direction (master mode) */
+#define I2C_CR2_START_Pos            (13U)
+#define I2C_CR2_START_Msk            (0x1UL << I2C_CR2_START_Pos)              /*!< 0x00002000 */
+#define I2C_CR2_START                I2C_CR2_START_Msk                         /*!< START generation */
+#define I2C_CR2_STOP_Pos             (14U)
+#define I2C_CR2_STOP_Msk             (0x1UL << I2C_CR2_STOP_Pos)               /*!< 0x00004000 */
+#define I2C_CR2_STOP                 I2C_CR2_STOP_Msk                          /*!< STOP generation (master mode) */
+#define I2C_CR2_NACK_Pos             (15U)
+#define I2C_CR2_NACK_Msk             (0x1UL << I2C_CR2_NACK_Pos)               /*!< 0x00008000 */
+#define I2C_CR2_NACK                 I2C_CR2_NACK_Msk                          /*!< NACK generation (slave mode) */
+#define I2C_CR2_NBYTES_Pos           (16U)
+#define I2C_CR2_NBYTES_Msk           (0xFFUL << I2C_CR2_NBYTES_Pos)            /*!< 0x00FF0000 */
+#define I2C_CR2_NBYTES               I2C_CR2_NBYTES_Msk                        /*!< Number of bytes */
+#define I2C_CR2_RELOAD_Pos           (24U)
+#define I2C_CR2_RELOAD_Msk           (0x1UL << I2C_CR2_RELOAD_Pos)             /*!< 0x01000000 */
+#define I2C_CR2_RELOAD               I2C_CR2_RELOAD_Msk                        /*!< NBYTES reload mode */
+#define I2C_CR2_AUTOEND_Pos          (25U)
+#define I2C_CR2_AUTOEND_Msk          (0x1UL << I2C_CR2_AUTOEND_Pos)            /*!< 0x02000000 */
+#define I2C_CR2_AUTOEND              I2C_CR2_AUTOEND_Msk                       /*!< Automatic end mode (master mode) */
+#define I2C_CR2_PECBYTE_Pos          (26U)
+#define I2C_CR2_PECBYTE_Msk          (0x1UL << I2C_CR2_PECBYTE_Pos)            /*!< 0x04000000 */
+#define I2C_CR2_PECBYTE              I2C_CR2_PECBYTE_Msk                       /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define I2C_OAR1_OA1_Pos             (0U)
+#define I2C_OAR1_OA1_Msk             (0x3FFUL << I2C_OAR1_OA1_Pos)             /*!< 0x000003FF */
+#define I2C_OAR1_OA1                 I2C_OAR1_OA1_Msk                          /*!< Interface own address 1 */
+#define I2C_OAR1_OA1MODE_Pos         (10U)
+#define I2C_OAR1_OA1MODE_Msk         (0x1UL << I2C_OAR1_OA1MODE_Pos)           /*!< 0x00000400 */
+#define I2C_OAR1_OA1MODE             I2C_OAR1_OA1MODE_Msk                      /*!< Own address 1 10-bit mode */
+#define I2C_OAR1_OA1EN_Pos           (15U)
+#define I2C_OAR1_OA1EN_Msk           (0x1UL << I2C_OAR1_OA1EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR1_OA1EN               I2C_OAR1_OA1EN_Msk                        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define I2C_OAR2_OA2_Pos             (1U)
+#define I2C_OAR2_OA2_Msk             (0x7FUL << I2C_OAR2_OA2_Pos)              /*!< 0x000000FE */
+#define I2C_OAR2_OA2                 I2C_OAR2_OA2_Msk                          /*!< Interface own address 2 */
+#define I2C_OAR2_OA2MSK_Pos          (8U)
+#define I2C_OAR2_OA2MSK_Msk          (0x7UL << I2C_OAR2_OA2MSK_Pos)            /*!< 0x00000700 */
+#define I2C_OAR2_OA2MSK              I2C_OAR2_OA2MSK_Msk                       /*!< Own address 2 masks */
+#define I2C_OAR2_OA2NOMASK           (0U)                                      /*!< No mask                                        */
+#define I2C_OAR2_OA2MASK01_Pos       (8U)
+#define I2C_OAR2_OA2MASK01_Msk       (0x1UL << I2C_OAR2_OA2MASK01_Pos)         /*!< 0x00000100 */
+#define I2C_OAR2_OA2MASK01           I2C_OAR2_OA2MASK01_Msk                    /*!< OA2[1] is masked, Only OA2[7:2] are compared   */
+#define I2C_OAR2_OA2MASK02_Pos       (9U)
+#define I2C_OAR2_OA2MASK02_Msk       (0x1UL << I2C_OAR2_OA2MASK02_Pos)         /*!< 0x00000200 */
+#define I2C_OAR2_OA2MASK02           I2C_OAR2_OA2MASK02_Msk                    /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define I2C_OAR2_OA2MASK03_Pos       (8U)
+#define I2C_OAR2_OA2MASK03_Msk       (0x3UL << I2C_OAR2_OA2MASK03_Pos)         /*!< 0x00000300 */
+#define I2C_OAR2_OA2MASK03           I2C_OAR2_OA2MASK03_Msk                    /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define I2C_OAR2_OA2MASK04_Pos       (10U)
+#define I2C_OAR2_OA2MASK04_Msk       (0x1UL << I2C_OAR2_OA2MASK04_Pos)         /*!< 0x00000400 */
+#define I2C_OAR2_OA2MASK04           I2C_OAR2_OA2MASK04_Msk                    /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define I2C_OAR2_OA2MASK05_Pos       (8U)
+#define I2C_OAR2_OA2MASK05_Msk       (0x5UL << I2C_OAR2_OA2MASK05_Pos)         /*!< 0x00000500 */
+#define I2C_OAR2_OA2MASK05           I2C_OAR2_OA2MASK05_Msk                    /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define I2C_OAR2_OA2MASK06_Pos       (9U)
+#define I2C_OAR2_OA2MASK06_Msk       (0x3UL << I2C_OAR2_OA2MASK06_Pos)         /*!< 0x00000600 */
+#define I2C_OAR2_OA2MASK06           I2C_OAR2_OA2MASK06_Msk                    /*!< OA2[6:1] is masked, Only OA2[7] are compared   */
+#define I2C_OAR2_OA2MASK07_Pos       (8U)
+#define I2C_OAR2_OA2MASK07_Msk       (0x7UL << I2C_OAR2_OA2MASK07_Pos)         /*!< 0x00000700 */
+#define I2C_OAR2_OA2MASK07           I2C_OAR2_OA2MASK07_Msk                    /*!< OA2[7:1] is masked, No comparison is done      */
+#define I2C_OAR2_OA2EN_Pos           (15U)
+#define I2C_OAR2_OA2EN_Msk           (0x1UL << I2C_OAR2_OA2EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR2_OA2EN               I2C_OAR2_OA2EN_Msk                        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define I2C_TIMINGR_SCLL_Pos         (0U)
+#define I2C_TIMINGR_SCLL_Msk         (0xFFUL << I2C_TIMINGR_SCLL_Pos)          /*!< 0x000000FF */
+#define I2C_TIMINGR_SCLL             I2C_TIMINGR_SCLL_Msk                      /*!< SCL low period (master mode) */
+#define I2C_TIMINGR_SCLH_Pos         (8U)
+#define I2C_TIMINGR_SCLH_Msk         (0xFFUL << I2C_TIMINGR_SCLH_Pos)          /*!< 0x0000FF00 */
+#define I2C_TIMINGR_SCLH             I2C_TIMINGR_SCLH_Msk                      /*!< SCL high period (master mode) */
+#define I2C_TIMINGR_SDADEL_Pos       (16U)
+#define I2C_TIMINGR_SDADEL_Msk       (0xFUL << I2C_TIMINGR_SDADEL_Pos)         /*!< 0x000F0000 */
+#define I2C_TIMINGR_SDADEL           I2C_TIMINGR_SDADEL_Msk                    /*!< Data hold time */
+#define I2C_TIMINGR_SCLDEL_Pos       (20U)
+#define I2C_TIMINGR_SCLDEL_Msk       (0xFUL << I2C_TIMINGR_SCLDEL_Pos)         /*!< 0x00F00000 */
+#define I2C_TIMINGR_SCLDEL           I2C_TIMINGR_SCLDEL_Msk                    /*!< Data setup time */
+#define I2C_TIMINGR_PRESC_Pos        (28U)
+#define I2C_TIMINGR_PRESC_Msk        (0xFUL << I2C_TIMINGR_PRESC_Pos)          /*!< 0xF0000000 */
+#define I2C_TIMINGR_PRESC            I2C_TIMINGR_PRESC_Msk                     /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define I2C_TIMEOUTR_TIMEOUTA_Pos    (0U)
+#define I2C_TIMEOUTR_TIMEOUTA_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTA_Pos)    /*!< 0x00000FFF */
+#define I2C_TIMEOUTR_TIMEOUTA        I2C_TIMEOUTR_TIMEOUTA_Msk                 /*!< Bus timeout A */
+#define I2C_TIMEOUTR_TIDLE_Pos       (12U)
+#define I2C_TIMEOUTR_TIDLE_Msk       (0x1UL << I2C_TIMEOUTR_TIDLE_Pos)         /*!< 0x00001000 */
+#define I2C_TIMEOUTR_TIDLE           I2C_TIMEOUTR_TIDLE_Msk                    /*!< Idle clock timeout detection */
+#define I2C_TIMEOUTR_TIMOUTEN_Pos    (15U)
+#define I2C_TIMEOUTR_TIMOUTEN_Msk    (0x1UL << I2C_TIMEOUTR_TIMOUTEN_Pos)      /*!< 0x00008000 */
+#define I2C_TIMEOUTR_TIMOUTEN        I2C_TIMEOUTR_TIMOUTEN_Msk                 /*!< Clock timeout enable */
+#define I2C_TIMEOUTR_TIMEOUTB_Pos    (16U)
+#define I2C_TIMEOUTR_TIMEOUTB_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTB_Pos)    /*!< 0x0FFF0000 */
+#define I2C_TIMEOUTR_TIMEOUTB        I2C_TIMEOUTR_TIMEOUTB_Msk                 /*!< Bus timeout B*/
+#define I2C_TIMEOUTR_TEXTEN_Pos      (31U)
+#define I2C_TIMEOUTR_TEXTEN_Msk      (0x1UL << I2C_TIMEOUTR_TEXTEN_Pos)        /*!< 0x80000000 */
+#define I2C_TIMEOUTR_TEXTEN          I2C_TIMEOUTR_TEXTEN_Msk                   /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define I2C_ISR_TXE_Pos              (0U)
+#define I2C_ISR_TXE_Msk              (0x1UL << I2C_ISR_TXE_Pos)                /*!< 0x00000001 */
+#define I2C_ISR_TXE                  I2C_ISR_TXE_Msk                           /*!< Transmit data register empty */
+#define I2C_ISR_TXIS_Pos             (1U)
+#define I2C_ISR_TXIS_Msk             (0x1UL << I2C_ISR_TXIS_Pos)               /*!< 0x00000002 */
+#define I2C_ISR_TXIS                 I2C_ISR_TXIS_Msk                          /*!< Transmit interrupt status */
+#define I2C_ISR_RXNE_Pos             (2U)
+#define I2C_ISR_RXNE_Msk             (0x1UL << I2C_ISR_RXNE_Pos)               /*!< 0x00000004 */
+#define I2C_ISR_RXNE                 I2C_ISR_RXNE_Msk                          /*!< Receive data register not empty */
+#define I2C_ISR_ADDR_Pos             (3U)
+#define I2C_ISR_ADDR_Msk             (0x1UL << I2C_ISR_ADDR_Pos)               /*!< 0x00000008 */
+#define I2C_ISR_ADDR                 I2C_ISR_ADDR_Msk                          /*!< Address matched (slave mode)*/
+#define I2C_ISR_NACKF_Pos            (4U)
+#define I2C_ISR_NACKF_Msk            (0x1UL << I2C_ISR_NACKF_Pos)              /*!< 0x00000010 */
+#define I2C_ISR_NACKF                I2C_ISR_NACKF_Msk                         /*!< NACK received flag */
+#define I2C_ISR_STOPF_Pos            (5U)
+#define I2C_ISR_STOPF_Msk            (0x1UL << I2C_ISR_STOPF_Pos)              /*!< 0x00000020 */
+#define I2C_ISR_STOPF                I2C_ISR_STOPF_Msk                         /*!< STOP detection flag */
+#define I2C_ISR_TC_Pos               (6U)
+#define I2C_ISR_TC_Msk               (0x1UL << I2C_ISR_TC_Pos)                 /*!< 0x00000040 */
+#define I2C_ISR_TC                   I2C_ISR_TC_Msk                            /*!< Transfer complete (master mode) */
+#define I2C_ISR_TCR_Pos              (7U)
+#define I2C_ISR_TCR_Msk              (0x1UL << I2C_ISR_TCR_Pos)                /*!< 0x00000080 */
+#define I2C_ISR_TCR                  I2C_ISR_TCR_Msk                           /*!< Transfer complete reload */
+#define I2C_ISR_BERR_Pos             (8U)
+#define I2C_ISR_BERR_Msk             (0x1UL << I2C_ISR_BERR_Pos)               /*!< 0x00000100 */
+#define I2C_ISR_BERR                 I2C_ISR_BERR_Msk                          /*!< Bus error */
+#define I2C_ISR_ARLO_Pos             (9U)
+#define I2C_ISR_ARLO_Msk             (0x1UL << I2C_ISR_ARLO_Pos)               /*!< 0x00000200 */
+#define I2C_ISR_ARLO                 I2C_ISR_ARLO_Msk                          /*!< Arbitration lost */
+#define I2C_ISR_OVR_Pos              (10U)
+#define I2C_ISR_OVR_Msk              (0x1UL << I2C_ISR_OVR_Pos)                /*!< 0x00000400 */
+#define I2C_ISR_OVR                  I2C_ISR_OVR_Msk                           /*!< Overrun/Underrun */
+#define I2C_ISR_PECERR_Pos           (11U)
+#define I2C_ISR_PECERR_Msk           (0x1UL << I2C_ISR_PECERR_Pos)             /*!< 0x00000800 */
+#define I2C_ISR_PECERR               I2C_ISR_PECERR_Msk                        /*!< PEC error in reception */
+#define I2C_ISR_TIMEOUT_Pos          (12U)
+#define I2C_ISR_TIMEOUT_Msk          (0x1UL << I2C_ISR_TIMEOUT_Pos)            /*!< 0x00001000 */
+#define I2C_ISR_TIMEOUT              I2C_ISR_TIMEOUT_Msk                       /*!< Timeout or Tlow detection flag */
+#define I2C_ISR_ALERT_Pos            (13U)
+#define I2C_ISR_ALERT_Msk            (0x1UL << I2C_ISR_ALERT_Pos)              /*!< 0x00002000 */
+#define I2C_ISR_ALERT                I2C_ISR_ALERT_Msk                         /*!< SMBus alert */
+#define I2C_ISR_BUSY_Pos             (15U)
+#define I2C_ISR_BUSY_Msk             (0x1UL << I2C_ISR_BUSY_Pos)               /*!< 0x00008000 */
+#define I2C_ISR_BUSY                 I2C_ISR_BUSY_Msk                          /*!< Bus busy */
+#define I2C_ISR_DIR_Pos              (16U)
+#define I2C_ISR_DIR_Msk              (0x1UL << I2C_ISR_DIR_Pos)                /*!< 0x00010000 */
+#define I2C_ISR_DIR                  I2C_ISR_DIR_Msk                           /*!< Transfer direction (slave mode) */
+#define I2C_ISR_ADDCODE_Pos          (17U)
+#define I2C_ISR_ADDCODE_Msk          (0x7FUL << I2C_ISR_ADDCODE_Pos)           /*!< 0x00FE0000 */
+#define I2C_ISR_ADDCODE              I2C_ISR_ADDCODE_Msk                       /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define I2C_ICR_ADDRCF_Pos           (3U)
+#define I2C_ICR_ADDRCF_Msk           (0x1UL << I2C_ICR_ADDRCF_Pos)             /*!< 0x00000008 */
+#define I2C_ICR_ADDRCF               I2C_ICR_ADDRCF_Msk                        /*!< Address matched clear flag */
+#define I2C_ICR_NACKCF_Pos           (4U)
+#define I2C_ICR_NACKCF_Msk           (0x1UL << I2C_ICR_NACKCF_Pos)             /*!< 0x00000010 */
+#define I2C_ICR_NACKCF               I2C_ICR_NACKCF_Msk                        /*!< NACK clear flag */
+#define I2C_ICR_STOPCF_Pos           (5U)
+#define I2C_ICR_STOPCF_Msk           (0x1UL << I2C_ICR_STOPCF_Pos)             /*!< 0x00000020 */
+#define I2C_ICR_STOPCF               I2C_ICR_STOPCF_Msk                        /*!< STOP detection clear flag */
+#define I2C_ICR_BERRCF_Pos           (8U)
+#define I2C_ICR_BERRCF_Msk           (0x1UL << I2C_ICR_BERRCF_Pos)             /*!< 0x00000100 */
+#define I2C_ICR_BERRCF               I2C_ICR_BERRCF_Msk                        /*!< Bus error clear flag */
+#define I2C_ICR_ARLOCF_Pos           (9U)
+#define I2C_ICR_ARLOCF_Msk           (0x1UL << I2C_ICR_ARLOCF_Pos)             /*!< 0x00000200 */
+#define I2C_ICR_ARLOCF               I2C_ICR_ARLOCF_Msk                        /*!< Arbitration lost clear flag */
+#define I2C_ICR_OVRCF_Pos            (10U)
+#define I2C_ICR_OVRCF_Msk            (0x1UL << I2C_ICR_OVRCF_Pos)              /*!< 0x00000400 */
+#define I2C_ICR_OVRCF                I2C_ICR_OVRCF_Msk                         /*!< Overrun/Underrun clear flag */
+#define I2C_ICR_PECCF_Pos            (11U)
+#define I2C_ICR_PECCF_Msk            (0x1UL << I2C_ICR_PECCF_Pos)              /*!< 0x00000800 */
+#define I2C_ICR_PECCF                I2C_ICR_PECCF_Msk                         /*!< PAC error clear flag */
+#define I2C_ICR_TIMOUTCF_Pos         (12U)
+#define I2C_ICR_TIMOUTCF_Msk         (0x1UL << I2C_ICR_TIMOUTCF_Pos)           /*!< 0x00001000 */
+#define I2C_ICR_TIMOUTCF             I2C_ICR_TIMOUTCF_Msk                      /*!< Timeout clear flag */
+#define I2C_ICR_ALERTCF_Pos          (13U)
+#define I2C_ICR_ALERTCF_Msk          (0x1UL << I2C_ICR_ALERTCF_Pos)            /*!< 0x00002000 */
+#define I2C_ICR_ALERTCF              I2C_ICR_ALERTCF_Msk                       /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define I2C_PECR_PEC_Pos             (0U)
+#define I2C_PECR_PEC_Msk             (0xFFUL << I2C_PECR_PEC_Pos)              /*!< 0x000000FF */
+#define I2C_PECR_PEC                 I2C_PECR_PEC_Msk                          /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define I2C_RXDR_RXDATA_Pos          (0U)
+#define I2C_RXDR_RXDATA_Msk          (0xFFUL << I2C_RXDR_RXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_RXDR_RXDATA              I2C_RXDR_RXDATA_Msk                       /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define I2C_TXDR_TXDATA_Pos          (0U)
+#define I2C_TXDR_TXDATA_Msk          (0xFFUL << I2C_TXDR_TXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_TXDR_TXDATA              I2C_TXDR_TXDATA_Msk                       /*!< 8-bit transmit data */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos      (0U)
+#define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
+#define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos       (0U)
+#define IWDG_PR_PR_Msk       (0x7UL << IWDG_PR_PR_Pos)                         /*!< 0x00000007 */
+#define IWDG_PR_PR           IWDG_PR_PR_Msk                                    /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0         (0x1UL << IWDG_PR_PR_Pos)                         /*!< 0x00000001 */
+#define IWDG_PR_PR_1         (0x2UL << IWDG_PR_PR_Pos)                         /*!< 0x00000002 */
+#define IWDG_PR_PR_2         (0x4UL << IWDG_PR_PR_Pos)                         /*!< 0x00000004 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos      (0U)
+#define IWDG_RLR_RL_Msk      (0xFFFUL << IWDG_RLR_RL_Pos)                      /*!< 0x00000FFF */
+#define IWDG_RLR_RL          IWDG_RLR_RL_Msk                                   /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos      (0U)
+#define IWDG_SR_PVU_Msk      (0x1UL << IWDG_SR_PVU_Pos)                        /*!< 0x00000001 */
+#define IWDG_SR_PVU          IWDG_SR_PVU_Msk                                   /*!< Watchdog prescaler value update */
+#define IWDG_SR_RVU_Pos      (1U)
+#define IWDG_SR_RVU_Msk      (0x1UL << IWDG_SR_RVU_Pos)                        /*!< 0x00000002 */
+#define IWDG_SR_RVU          IWDG_SR_RVU_Msk                                   /*!< Watchdog counter reload value update */
+#define IWDG_SR_WVU_Pos      (2U)
+#define IWDG_SR_WVU_Msk      (0x1UL << IWDG_SR_WVU_Pos)                        /*!< 0x00000004 */
+#define IWDG_SR_WVU          IWDG_SR_WVU_Msk                                   /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_WINR_WIN_Pos    (0U)
+#define IWDG_WINR_WIN_Msk    (0xFFFUL << IWDG_WINR_WIN_Pos)                    /*!< 0x00000FFF */
+#define IWDG_WINR_WIN        IWDG_WINR_WIN_Msk                                 /*!< Watchdog counter window value */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Power Control                                       */
+/*                                                                            */
+/******************************************************************************/
+/* Note: No specific macro feature on this device */
+
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define PWR_CR1_LPMS_Pos          (0U)
+#define PWR_CR1_LPMS_Msk          (0x7UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000007 */
+#define PWR_CR1_LPMS              PWR_CR1_LPMS_Msk                             /*!< Low Power Mode Selection */
+#define PWR_CR1_LPMS_0            (0x1UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000001 */
+#define PWR_CR1_LPMS_1            (0x2UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000002 */
+#define PWR_CR1_FPD_STOP_Pos      (3U)
+#define PWR_CR1_FPD_STOP_Msk      (0x1UL << PWR_CR1_FPD_STOP_Pos)              /*!< 0x00000008 */
+#define PWR_CR1_FPD_STOP          PWR_CR1_FPD_STOP_Msk                         /*!< Flash power down mode during stop */
+#define PWR_CR1_FPD_LPRUN_Pos     (4U)
+#define PWR_CR1_FPD_LPRUN_Msk     (0x1UL << PWR_CR1_FPD_LPRUN_Pos)             /*!< 0x00000010 */
+#define PWR_CR1_FPD_LPRUN         PWR_CR1_FPD_LPRUN_Msk                        /*!< Flash power down mode during run */
+#define PWR_CR1_FPD_LPSLP_Pos     (5U)
+#define PWR_CR1_FPD_LPSLP_Msk     (0x1UL << PWR_CR1_FPD_LPSLP_Pos)             /*!< 0x00000020 */
+#define PWR_CR1_FPD_LPSLP         PWR_CR1_FPD_LPSLP_Msk                        /*!< Flash power down mode during sleep */
+#define PWR_CR1_DBP_Pos           (8U)
+#define PWR_CR1_DBP_Msk           (0x1UL << PWR_CR1_DBP_Pos)                   /*!< 0x00000100 */
+#define PWR_CR1_DBP               PWR_CR1_DBP_Msk                              /*!< Disable Backup Domain write protection */
+#define PWR_CR1_VOS_Pos           (9U)
+#define PWR_CR1_VOS_Msk           (0x3UL << PWR_CR1_VOS_Pos)                   /*!< 0x00000600 */
+#define PWR_CR1_VOS               PWR_CR1_VOS_Msk                              /*!< Voltage scaling */
+#define PWR_CR1_VOS_0             (0x1UL << PWR_CR1_VOS_Pos)                   /*!< Voltage scaling bit 0 */
+#define PWR_CR1_VOS_1             (0x2UL << PWR_CR1_VOS_Pos)                   /*!< Voltage scaling bit 1 */
+#define PWR_CR1_LPR_Pos           (14U)
+#define PWR_CR1_LPR_Msk           (0x1UL << PWR_CR1_LPR_Pos)                   /*!< 0x00004000 */
+#define PWR_CR1_LPR               PWR_CR1_LPR_Msk                              /*!< Regulator Low-Power Run mode */
+
+
+/********************  Bit definition for PWR_CR3 register  ********************/
+#define PWR_CR3_EWUP_Pos          (0U)
+#define PWR_CR3_EWUP_Msk          (0x2BUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000002B */
+#define PWR_CR3_EWUP              PWR_CR3_EWUP_Msk                             /*!< Enable all Wake-Up Pins  */
+#define PWR_CR3_EWUP1_Pos         (0U)
+#define PWR_CR3_EWUP1_Msk         (0x1UL << PWR_CR3_EWUP1_Pos)                 /*!< 0x00000001 */
+#define PWR_CR3_EWUP1             PWR_CR3_EWUP1_Msk                            /*!< Enable WKUP pin 1 */
+#define PWR_CR3_EWUP2_Pos         (1U)
+#define PWR_CR3_EWUP2_Msk         (0x1UL << PWR_CR3_EWUP2_Pos)                 /*!< 0x00000002 */
+#define PWR_CR3_EWUP2             PWR_CR3_EWUP2_Msk                            /*!< Enable WKUP pin 2 */
+#define PWR_CR3_EWUP4_Pos         (3U)
+#define PWR_CR3_EWUP4_Msk         (0x1UL << PWR_CR3_EWUP4_Pos)                 /*!< 0x00000008 */
+#define PWR_CR3_EWUP4             PWR_CR3_EWUP4_Msk                            /*!< Enable WKUP pin 4 */
+#define PWR_CR3_EWUP6_Pos         (5U)
+#define PWR_CR3_EWUP6_Msk         (0x1UL << PWR_CR3_EWUP6_Pos)                 /*!< 0x00000020 */
+#define PWR_CR3_EWUP6             PWR_CR3_EWUP6_Msk                            /*!< Enable WKUP pin 6 */
+#define PWR_CR3_APC_Pos           (10U)
+#define PWR_CR3_APC_Msk           (0x1UL << PWR_CR3_APC_Pos)                   /*!< 0x00000400 */
+#define PWR_CR3_APC               PWR_CR3_APC_Msk                              /*!< Apply pull-up and pull-down configuration */
+#define PWR_CR3_EIWUL_Pos         (15U)
+#define PWR_CR3_EIWUL_Msk         (0x1UL << PWR_CR3_EIWUL_Pos)                 /*!< 0x00008000 */
+#define PWR_CR3_EIWUL             PWR_CR3_EIWUL_Msk                            /*!< Enable Internal Wake-up line */
+
+/********************  Bit definition for PWR_CR4 register  ********************/
+#define PWR_CR4_WP_Pos            (0U)
+#define PWR_CR4_WP_Msk            (0x2BUL << PWR_CR4_WP_Pos)                   /*!< 0x0000002B */
+#define PWR_CR4_WP                PWR_CR4_WP_Msk                               /*!< all Wake-Up Pin polarity */
+#define PWR_CR4_WP1_Pos           (0U)
+#define PWR_CR4_WP1_Msk           (0x1UL << PWR_CR4_WP1_Pos)                   /*!< 0x00000001 */
+#define PWR_CR4_WP1               PWR_CR4_WP1_Msk                              /*!< Wake-Up Pin 1 polarity */
+#define PWR_CR4_WP2_Pos           (1U)
+#define PWR_CR4_WP2_Msk           (0x1UL << PWR_CR4_WP2_Pos)                   /*!< 0x00000002 */
+#define PWR_CR4_WP2               PWR_CR4_WP2_Msk                              /*!< Wake-Up Pin 2 polarity */
+#define PWR_CR4_WP4_Pos           (3U)
+#define PWR_CR4_WP4_Msk           (0x1UL << PWR_CR4_WP4_Pos)                   /*!< 0x00000008 */
+#define PWR_CR4_WP4               PWR_CR4_WP4_Msk                              /*!< Wake-Up Pin 4 polarity */
+#define PWR_CR4_WP6_Pos           (5U)
+#define PWR_CR4_WP6_Msk           (0x1UL << PWR_CR4_WP6_Pos)                   /*!< 0x00000020 */
+#define PWR_CR4_WP6               PWR_CR4_WP6_Msk                              /*!< Wake-Up Pin 6 polarity */
+#define PWR_CR4_VBE_Pos           (8U)
+#define PWR_CR4_VBE_Msk           (0x1UL << PWR_CR4_VBE_Pos)                   /*!< 0x00000100 */
+#define PWR_CR4_VBE               PWR_CR4_VBE_Msk                              /*!< VBAT Battery charging Enable  */
+#define PWR_CR4_VBRS_Pos          (9U)
+#define PWR_CR4_VBRS_Msk          (0x1UL << PWR_CR4_VBRS_Pos)                  /*!< 0x00000200 */
+#define PWR_CR4_VBRS              PWR_CR4_VBRS_Msk                             /*!< VBAT Battery charging Resistor Selection */
+
+/********************  Bit definition for PWR_SR1 register  ********************/
+#define PWR_SR1_WUF_Pos           (0U)
+#define PWR_SR1_WUF_Msk           (0x2BUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000002B */
+#define PWR_SR1_WUF               PWR_SR1_WUF_Msk                              /*!< Wakeup Flags  */
+#define PWR_SR1_WUF1_Pos          (0U)
+#define PWR_SR1_WUF1_Msk          (0x1UL << PWR_SR1_WUF1_Pos)                  /*!< 0x00000001 */
+#define PWR_SR1_WUF1              PWR_SR1_WUF1_Msk                             /*!< Wakeup Flag 1 */
+#define PWR_SR1_WUF2_Pos          (1U)
+#define PWR_SR1_WUF2_Msk          (0x1UL << PWR_SR1_WUF2_Pos)                  /*!< 0x00000002 */
+#define PWR_SR1_WUF2              PWR_SR1_WUF2_Msk                             /*!< Wakeup Flag 2 */
+#define PWR_SR1_WUF4_Pos          (3U)
+#define PWR_SR1_WUF4_Msk          (0x1UL << PWR_SR1_WUF4_Pos)                  /*!< 0x00000008 */
+#define PWR_SR1_WUF4              PWR_SR1_WUF4_Msk                             /*!< Wakeup Flag 4 */
+#define PWR_SR1_WUF6_Pos          (5U)
+#define PWR_SR1_WUF6_Msk          (0x1UL << PWR_SR1_WUF6_Pos)                  /*!< 0x00000020 */
+#define PWR_SR1_WUF6              PWR_SR1_WUF6_Msk                             /*!< Wakeup Flag 6 */
+#define PWR_SR1_SBF_Pos           (8U)
+#define PWR_SR1_SBF_Msk           (0x1UL << PWR_SR1_SBF_Pos)                   /*!< 0x00000100 */
+#define PWR_SR1_SBF               PWR_SR1_SBF_Msk                              /*!< Standby Flag  */
+#define PWR_SR1_WUFI_Pos          (15U)
+#define PWR_SR1_WUFI_Msk          (0x1UL << PWR_SR1_WUFI_Pos)                  /*!< 0x00008000 */
+#define PWR_SR1_WUFI              PWR_SR1_WUFI_Msk                             /*!< Wakeup Flag Internal */
+
+/********************  Bit definition for PWR_SR2 register  ********************/
+#define PWR_SR2_FLASH_RDY_Pos     (7U)
+#define PWR_SR2_FLASH_RDY_Msk     (0x1UL << PWR_SR2_FLASH_RDY_Pos)             /*!< 0x00000080 */
+#define PWR_SR2_FLASH_RDY         PWR_SR2_FLASH_RDY_Msk                        /*!< Flash Ready */
+#define PWR_SR2_REGLPS_Pos        (8U)
+#define PWR_SR2_REGLPS_Msk        (0x1UL << PWR_SR2_REGLPS_Pos)                /*!< 0x00000100 */
+#define PWR_SR2_REGLPS            PWR_SR2_REGLPS_Msk                           /*!< Regulator Low Power started */
+#define PWR_SR2_REGLPF_Pos        (9U)
+#define PWR_SR2_REGLPF_Msk        (0x1UL << PWR_SR2_REGLPF_Pos)                /*!< 0x00000200 */
+#define PWR_SR2_REGLPF            PWR_SR2_REGLPF_Msk                           /*!< Regulator Low Power flag    */
+#define PWR_SR2_VOSF_Pos          (10U)
+#define PWR_SR2_VOSF_Msk          (0x1UL << PWR_SR2_VOSF_Pos)                  /*!< 0x00000400 */
+#define PWR_SR2_VOSF              PWR_SR2_VOSF_Msk                             /*!< Voltage Scaling Flag */
+
+/********************  Bit definition for PWR_SCR register  ********************/
+#define PWR_SCR_CWUF_Pos          (0U)
+#define PWR_SCR_CWUF_Msk          (0x2BUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000002B */
+#define PWR_SCR_CWUF              PWR_SCR_CWUF_Msk                             /*!< Clear Wake-up Flags  */
+#define PWR_SCR_CWUF1_Pos         (0U)
+#define PWR_SCR_CWUF1_Msk         (0x1UL << PWR_SCR_CWUF1_Pos)                 /*!< 0x00000001 */
+#define PWR_SCR_CWUF1             PWR_SCR_CWUF1_Msk                            /*!< Clear Wake-up Flag 1 */
+#define PWR_SCR_CWUF2_Pos         (1U)
+#define PWR_SCR_CWUF2_Msk         (0x1UL << PWR_SCR_CWUF2_Pos)                 /*!< 0x00000002 */
+#define PWR_SCR_CWUF2             PWR_SCR_CWUF2_Msk                            /*!< Clear Wake-up Flag 2 */
+#define PWR_SCR_CWUF4_Pos         (3U)
+#define PWR_SCR_CWUF4_Msk         (0x1UL << PWR_SCR_CWUF4_Pos)                 /*!< 0x00000008 */
+#define PWR_SCR_CWUF4             PWR_SCR_CWUF4_Msk                            /*!< Clear Wake-up Flag 4 */
+#define PWR_SCR_CWUF6_Pos         (5U)
+#define PWR_SCR_CWUF6_Msk         (0x1UL << PWR_SCR_CWUF6_Pos)                 /*!< 0x00000020 */
+#define PWR_SCR_CWUF6             PWR_SCR_CWUF6_Msk                            /*!< Clear Wake-up Flag 6 */
+#define PWR_SCR_CSBF_Pos          (8U)
+#define PWR_SCR_CSBF_Msk          (0x1UL << PWR_SCR_CSBF_Pos)                  /*!< 0x00000100 */
+#define PWR_SCR_CSBF              PWR_SCR_CSBF_Msk                             /*!< Clear Standby Flag  */
+
+/********************  Bit definition for PWR_PUCRA register  *****************/
+#define PWR_PUCRA_PU0_Pos         (0U)
+#define PWR_PUCRA_PU0_Msk         (0x1UL << PWR_PUCRA_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRA_PU0             PWR_PUCRA_PU0_Msk                            /*!< Pin PA0 Pull-Up set */
+#define PWR_PUCRA_PU1_Pos         (1U)
+#define PWR_PUCRA_PU1_Msk         (0x1UL << PWR_PUCRA_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRA_PU1             PWR_PUCRA_PU1_Msk                            /*!< Pin PA1 Pull-Up set */
+#define PWR_PUCRA_PU2_Pos         (2U)
+#define PWR_PUCRA_PU2_Msk         (0x1UL << PWR_PUCRA_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRA_PU2             PWR_PUCRA_PU2_Msk                            /*!< Pin PA2 Pull-Up set */
+#define PWR_PUCRA_PU3_Pos         (3U)
+#define PWR_PUCRA_PU3_Msk         (0x1UL << PWR_PUCRA_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRA_PU3             PWR_PUCRA_PU3_Msk                            /*!< Pin PA3 Pull-Up set */
+#define PWR_PUCRA_PU4_Pos         (4U)
+#define PWR_PUCRA_PU4_Msk         (0x1UL << PWR_PUCRA_PU4_Pos)                 /*!< 0x00000010 */
+#define PWR_PUCRA_PU4             PWR_PUCRA_PU4_Msk                            /*!< Pin PA4 Pull-Up set */
+#define PWR_PUCRA_PU5_Pos         (5U)
+#define PWR_PUCRA_PU5_Msk         (0x1UL << PWR_PUCRA_PU5_Pos)                 /*!< 0x00000020 */
+#define PWR_PUCRA_PU5             PWR_PUCRA_PU5_Msk                            /*!< Pin PA5 Pull-Up set */
+#define PWR_PUCRA_PU6_Pos         (6U)
+#define PWR_PUCRA_PU6_Msk         (0x1UL << PWR_PUCRA_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRA_PU6             PWR_PUCRA_PU6_Msk                            /*!< Pin PA6 Pull-Up set */
+#define PWR_PUCRA_PU7_Pos         (7U)
+#define PWR_PUCRA_PU7_Msk         (0x1UL << PWR_PUCRA_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRA_PU7             PWR_PUCRA_PU7_Msk                            /*!< Pin PA7 Pull-Up set */
+#define PWR_PUCRA_PU8_Pos         (8U)
+#define PWR_PUCRA_PU8_Msk         (0x1UL << PWR_PUCRA_PU8_Pos)                 /*!< 0x00000100 */
+#define PWR_PUCRA_PU8             PWR_PUCRA_PU8_Msk                            /*!< Pin PA8 Pull-Up set */
+#define PWR_PUCRA_PU9_Pos         (9U)
+#define PWR_PUCRA_PU9_Msk         (0x1UL << PWR_PUCRA_PU9_Pos)                 /*!< 0x00000200 */
+#define PWR_PUCRA_PU9             PWR_PUCRA_PU9_Msk                            /*!< Pin PA9 Pull-Up set */
+#define PWR_PUCRA_PU10_Pos        (10U)
+#define PWR_PUCRA_PU10_Msk        (0x1UL << PWR_PUCRA_PU10_Pos)                /*!< 0x00000400 */
+#define PWR_PUCRA_PU10            PWR_PUCRA_PU10_Msk                           /*!< Pin PA10 Pull-Up set */
+#define PWR_PUCRA_PU11_Pos        (11U)
+#define PWR_PUCRA_PU11_Msk        (0x1UL << PWR_PUCRA_PU11_Pos)                /*!< 0x00000800 */
+#define PWR_PUCRA_PU11            PWR_PUCRA_PU11_Msk                           /*!< Pin PA11 Pull-Up set */
+#define PWR_PUCRA_PU12_Pos        (12U)
+#define PWR_PUCRA_PU12_Msk        (0x1UL << PWR_PUCRA_PU12_Pos)                /*!< 0x00001000 */
+#define PWR_PUCRA_PU12            PWR_PUCRA_PU12_Msk                           /*!< Pin PA12 Pull-Up set */
+#define PWR_PUCRA_PU13_Pos        (13U)
+#define PWR_PUCRA_PU13_Msk        (0x1UL << PWR_PUCRA_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRA_PU13            PWR_PUCRA_PU13_Msk                           /*!< Pin PA13 Pull-Up set */
+#define PWR_PUCRA_PU14_Pos        (14U)
+#define PWR_PUCRA_PU14_Msk        (0x1UL << PWR_PUCRA_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRA_PU14            PWR_PUCRA_PU14_Msk                           /*!< Pin PA14 Pull-Up set */
+#define PWR_PUCRA_PU15_Pos        (15U)
+#define PWR_PUCRA_PU15_Msk        (0x1UL << PWR_PUCRA_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRA_PU15            PWR_PUCRA_PU15_Msk                           /*!< Pin PA15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRA register  *****************/
+#define PWR_PDCRA_PD0_Pos         (0U)
+#define PWR_PDCRA_PD0_Msk         (0x1UL << PWR_PDCRA_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRA_PD0             PWR_PDCRA_PD0_Msk                            /*!< Pin PA0 Pull-Down set */
+#define PWR_PDCRA_PD1_Pos         (1U)
+#define PWR_PDCRA_PD1_Msk         (0x1UL << PWR_PDCRA_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRA_PD1             PWR_PDCRA_PD1_Msk                            /*!< Pin PA1 Pull-Down set */
+#define PWR_PDCRA_PD2_Pos         (2U)
+#define PWR_PDCRA_PD2_Msk         (0x1UL << PWR_PDCRA_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRA_PD2             PWR_PDCRA_PD2_Msk                            /*!< Pin PA2 Pull-Down set */
+#define PWR_PDCRA_PD3_Pos         (3U)
+#define PWR_PDCRA_PD3_Msk         (0x1UL << PWR_PDCRA_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRA_PD3             PWR_PDCRA_PD3_Msk                            /*!< Pin PA3 Pull-Down set */
+#define PWR_PDCRA_PD4_Pos         (4U)
+#define PWR_PDCRA_PD4_Msk         (0x1UL << PWR_PDCRA_PD4_Pos)                 /*!< 0x00000010 */
+#define PWR_PDCRA_PD4             PWR_PDCRA_PD4_Msk                            /*!< Pin PA4 Pull-Down set */
+#define PWR_PDCRA_PD5_Pos         (5U)
+#define PWR_PDCRA_PD5_Msk         (0x1UL << PWR_PDCRA_PD5_Pos)                 /*!< 0x00000020 */
+#define PWR_PDCRA_PD5             PWR_PDCRA_PD5_Msk                            /*!< Pin PA5 Pull-Down set */
+#define PWR_PDCRA_PD6_Pos         (6U)
+#define PWR_PDCRA_PD6_Msk         (0x1UL << PWR_PDCRA_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRA_PD6             PWR_PDCRA_PD6_Msk                            /*!< Pin PA6 Pull-Down set */
+#define PWR_PDCRA_PD7_Pos         (7U)
+#define PWR_PDCRA_PD7_Msk         (0x1UL << PWR_PDCRA_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRA_PD7             PWR_PDCRA_PD7_Msk                            /*!< Pin PA7 Pull-Down set */
+#define PWR_PDCRA_PD8_Pos         (8U)
+#define PWR_PDCRA_PD8_Msk         (0x1UL << PWR_PDCRA_PD8_Pos)                 /*!< 0x00000100 */
+#define PWR_PDCRA_PD8             PWR_PDCRA_PD8_Msk                            /*!< Pin PA8 Pull-Down set */
+#define PWR_PDCRA_PD9_Pos         (9U)
+#define PWR_PDCRA_PD9_Msk         (0x1UL << PWR_PDCRA_PD9_Pos)                 /*!< 0x00000200 */
+#define PWR_PDCRA_PD9             PWR_PDCRA_PD9_Msk                            /*!< Pin PA9 Pull-Down set */
+#define PWR_PDCRA_PD10_Pos        (10U)
+#define PWR_PDCRA_PD10_Msk        (0x1UL << PWR_PDCRA_PD10_Pos)                /*!< 0x00000400 */
+#define PWR_PDCRA_PD10            PWR_PDCRA_PD10_Msk                           /*!< Pin PA10 Pull-Down set */
+#define PWR_PDCRA_PD11_Pos        (11U)
+#define PWR_PDCRA_PD11_Msk        (0x1UL << PWR_PDCRA_PD11_Pos)                /*!< 0x00000800 */
+#define PWR_PDCRA_PD11            PWR_PDCRA_PD11_Msk                           /*!< Pin PA11 Pull-Down set */
+#define PWR_PDCRA_PD12_Pos        (12U)
+#define PWR_PDCRA_PD12_Msk        (0x1UL << PWR_PDCRA_PD12_Pos)                /*!< 0x00001000 */
+#define PWR_PDCRA_PD12            PWR_PDCRA_PD12_Msk                           /*!< Pin PA12 Pull-Down set */
+#define PWR_PDCRA_PD13_Pos        (13U)
+#define PWR_PDCRA_PD13_Msk        (0x1UL << PWR_PDCRA_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRA_PD13            PWR_PDCRA_PD13_Msk                           /*!< Pin PA13 Pull-Down set */
+#define PWR_PDCRA_PD14_Pos        (14U)
+#define PWR_PDCRA_PD14_Msk        (0x1UL << PWR_PDCRA_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRA_PD14            PWR_PDCRA_PD14_Msk                           /*!< Pin PA14 Pull-Down set */
+#define PWR_PDCRA_PD15_Pos        (15U)
+#define PWR_PDCRA_PD15_Msk        (0x1UL << PWR_PDCRA_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRA_PD15            PWR_PDCRA_PD15_Msk                           /*!< Pin PA15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRB register  *****************/
+#define PWR_PUCRB_PU0_Pos         (0U)
+#define PWR_PUCRB_PU0_Msk         (0x1UL << PWR_PUCRB_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRB_PU0             PWR_PUCRB_PU0_Msk                            /*!< Pin PB0 Pull-Up set */
+#define PWR_PUCRB_PU1_Pos         (1U)
+#define PWR_PUCRB_PU1_Msk         (0x1UL << PWR_PUCRB_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRB_PU1             PWR_PUCRB_PU1_Msk                            /*!< Pin PB1 Pull-Up set */
+#define PWR_PUCRB_PU2_Pos         (2U)
+#define PWR_PUCRB_PU2_Msk         (0x1UL << PWR_PUCRB_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRB_PU2             PWR_PUCRB_PU2_Msk                            /*!< Pin PB2 Pull-Up set */
+#define PWR_PUCRB_PU3_Pos         (3U)
+#define PWR_PUCRB_PU3_Msk         (0x1UL << PWR_PUCRB_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRB_PU3             PWR_PUCRB_PU3_Msk                            /*!< Pin PB3 Pull-Up set */
+#define PWR_PUCRB_PU4_Pos         (4U)
+#define PWR_PUCRB_PU4_Msk         (0x1UL << PWR_PUCRB_PU4_Pos)                 /*!< 0x00000010 */
+#define PWR_PUCRB_PU4             PWR_PUCRB_PU4_Msk                            /*!< Pin PB4 Pull-Up set */
+#define PWR_PUCRB_PU5_Pos         (5U)
+#define PWR_PUCRB_PU5_Msk         (0x1UL << PWR_PUCRB_PU5_Pos)                 /*!< 0x00000020 */
+#define PWR_PUCRB_PU5             PWR_PUCRB_PU5_Msk                            /*!< Pin PB5 Pull-Up set */
+#define PWR_PUCRB_PU6_Pos         (6U)
+#define PWR_PUCRB_PU6_Msk         (0x1UL << PWR_PUCRB_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRB_PU6             PWR_PUCRB_PU6_Msk                            /*!< Pin PB6 Pull-Up set */
+#define PWR_PUCRB_PU7_Pos         (7U)
+#define PWR_PUCRB_PU7_Msk         (0x1UL << PWR_PUCRB_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRB_PU7             PWR_PUCRB_PU7_Msk                            /*!< Pin PB7 Pull-Up set */
+#define PWR_PUCRB_PU8_Pos         (8U)
+#define PWR_PUCRB_PU8_Msk         (0x1UL << PWR_PUCRB_PU8_Pos)                 /*!< 0x00000100 */
+#define PWR_PUCRB_PU8             PWR_PUCRB_PU8_Msk                            /*!< Pin PB8 Pull-Up set */
+#define PWR_PUCRB_PU9_Pos         (9U)
+#define PWR_PUCRB_PU9_Msk         (0x1UL << PWR_PUCRB_PU9_Pos)                 /*!< 0x00000200 */
+#define PWR_PUCRB_PU9             PWR_PUCRB_PU9_Msk                            /*!< Pin PB9 Pull-Up set */
+#define PWR_PUCRB_PU10_Pos        (10U)
+#define PWR_PUCRB_PU10_Msk        (0x1UL << PWR_PUCRB_PU10_Pos)                /*!< 0x00000400 */
+#define PWR_PUCRB_PU10            PWR_PUCRB_PU10_Msk                           /*!< Pin PB10 Pull-Up set */
+#define PWR_PUCRB_PU11_Pos        (11U)
+#define PWR_PUCRB_PU11_Msk        (0x1UL << PWR_PUCRB_PU11_Pos)                /*!< 0x00000800 */
+#define PWR_PUCRB_PU11            PWR_PUCRB_PU11_Msk                           /*!< Pin PB11 Pull-Up set */
+#define PWR_PUCRB_PU12_Pos        (12U)
+#define PWR_PUCRB_PU12_Msk        (0x1UL << PWR_PUCRB_PU12_Pos)                /*!< 0x00001000 */
+#define PWR_PUCRB_PU12            PWR_PUCRB_PU12_Msk                           /*!< Pin PB12 Pull-Up set */
+#define PWR_PUCRB_PU13_Pos        (13U)
+#define PWR_PUCRB_PU13_Msk        (0x1UL << PWR_PUCRB_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRB_PU13            PWR_PUCRB_PU13_Msk                           /*!< Pin PB13 Pull-Up set */
+#define PWR_PUCRB_PU14_Pos        (14U)
+#define PWR_PUCRB_PU14_Msk        (0x1UL << PWR_PUCRB_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRB_PU14            PWR_PUCRB_PU14_Msk                           /*!< Pin PB14 Pull-Up set */
+#define PWR_PUCRB_PU15_Pos        (15U)
+#define PWR_PUCRB_PU15_Msk        (0x1UL << PWR_PUCRB_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRB_PU15            PWR_PUCRB_PU15_Msk                           /*!< Pin PB15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRB register  *****************/
+#define PWR_PDCRB_PD0_Pos         (0U)
+#define PWR_PDCRB_PD0_Msk         (0x1UL << PWR_PDCRB_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRB_PD0             PWR_PDCRB_PD0_Msk                            /*!< Pin PB0 Pull-Down set */
+#define PWR_PDCRB_PD1_Pos         (1U)
+#define PWR_PDCRB_PD1_Msk         (0x1UL << PWR_PDCRB_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRB_PD1             PWR_PDCRB_PD1_Msk                            /*!< Pin PB1 Pull-Down set */
+#define PWR_PDCRB_PD2_Pos         (2U)
+#define PWR_PDCRB_PD2_Msk         (0x1UL << PWR_PDCRB_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRB_PD2             PWR_PDCRB_PD2_Msk                            /*!< Pin PB2 Pull-Down set */
+#define PWR_PDCRB_PD3_Pos         (3U)
+#define PWR_PDCRB_PD3_Msk         (0x1UL << PWR_PDCRB_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRB_PD3             PWR_PDCRB_PD3_Msk                            /*!< Pin PB3 Pull-Down set */
+#define PWR_PDCRB_PD4_Pos         (4U)
+#define PWR_PDCRB_PD4_Msk         (0x1UL << PWR_PDCRB_PD4_Pos)                 /*!< 0x00000010 */
+#define PWR_PDCRB_PD4             PWR_PDCRB_PD4_Msk                            /*!< Pin PB4 Pull-Down set */
+#define PWR_PDCRB_PD5_Pos         (5U)
+#define PWR_PDCRB_PD5_Msk         (0x1UL << PWR_PDCRB_PD5_Pos)                 /*!< 0x00000020 */
+#define PWR_PDCRB_PD5             PWR_PDCRB_PD5_Msk                            /*!< Pin PB5 Pull-Down set */
+#define PWR_PDCRB_PD6_Pos         (6U)
+#define PWR_PDCRB_PD6_Msk         (0x1UL << PWR_PDCRB_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRB_PD6             PWR_PDCRB_PD6_Msk                            /*!< Pin PB6 Pull-Down set */
+#define PWR_PDCRB_PD7_Pos         (7U)
+#define PWR_PDCRB_PD7_Msk         (0x1UL << PWR_PDCRB_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRB_PD7             PWR_PDCRB_PD7_Msk                            /*!< Pin PB7 Pull-Down set */
+#define PWR_PDCRB_PD8_Pos         (8U)
+#define PWR_PDCRB_PD8_Msk         (0x1UL << PWR_PDCRB_PD8_Pos)                 /*!< 0x00000100 */
+#define PWR_PDCRB_PD8             PWR_PDCRB_PD8_Msk                            /*!< Pin PB8 Pull-Down set */
+#define PWR_PDCRB_PD9_Pos         (9U)
+#define PWR_PDCRB_PD9_Msk         (0x1UL << PWR_PDCRB_PD9_Pos)                 /*!< 0x00000200 */
+#define PWR_PDCRB_PD9             PWR_PDCRB_PD9_Msk                            /*!< Pin PB9 Pull-Down set */
+#define PWR_PDCRB_PD10_Pos        (10U)
+#define PWR_PDCRB_PD10_Msk        (0x1UL << PWR_PDCRB_PD10_Pos)                /*!< 0x00000400 */
+#define PWR_PDCRB_PD10            PWR_PDCRB_PD10_Msk                           /*!< Pin PB10 Pull-Down set */
+#define PWR_PDCRB_PD11_Pos        (11U)
+#define PWR_PDCRB_PD11_Msk        (0x1UL << PWR_PDCRB_PD11_Pos)                /*!< 0x00000800 */
+#define PWR_PDCRB_PD11            PWR_PDCRB_PD11_Msk                           /*!< Pin PB11 Pull-Down set */
+#define PWR_PDCRB_PD12_Pos        (12U)
+#define PWR_PDCRB_PD12_Msk        (0x1UL << PWR_PDCRB_PD12_Pos)                /*!< 0x00001000 */
+#define PWR_PDCRB_PD12            PWR_PDCRB_PD12_Msk                           /*!< Pin PB12 Pull-Down set */
+#define PWR_PDCRB_PD13_Pos        (13U)
+#define PWR_PDCRB_PD13_Msk        (0x1UL << PWR_PDCRB_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRB_PD13            PWR_PDCRB_PD13_Msk                           /*!< Pin PB13 Pull-Down set */
+#define PWR_PDCRB_PD14_Pos        (14U)
+#define PWR_PDCRB_PD14_Msk        (0x1UL << PWR_PDCRB_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRB_PD14            PWR_PDCRB_PD14_Msk                           /*!< Pin PB14 Pull-Down set */
+#define PWR_PDCRB_PD15_Pos        (15U)
+#define PWR_PDCRB_PD15_Msk        (0x1UL << PWR_PDCRB_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRB_PD15            PWR_PDCRB_PD15_Msk                           /*!< Pin PB15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRC register  *****************/
+#define PWR_PUCRC_PU6_Pos         (6U)
+#define PWR_PUCRC_PU6_Msk         (0x1UL << PWR_PUCRC_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRC_PU6             PWR_PUCRC_PU6_Msk                            /*!< Pin PC6 Pull-Up set */
+#define PWR_PUCRC_PU7_Pos         (7U)
+#define PWR_PUCRC_PU7_Msk         (0x1UL << PWR_PUCRC_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRC_PU7             PWR_PUCRC_PU7_Msk                            /*!< Pin PC7 Pull-Up set */
+#define PWR_PUCRC_PU13_Pos        (13U)
+#define PWR_PUCRC_PU13_Msk        (0x1UL << PWR_PUCRC_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRC_PU13            PWR_PUCRC_PU13_Msk                           /*!< Pin PC13 Pull-Up set */
+#define PWR_PUCRC_PU14_Pos        (14U)
+#define PWR_PUCRC_PU14_Msk        (0x1UL << PWR_PUCRC_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRC_PU14            PWR_PUCRC_PU14_Msk                           /*!< Pin PC14 Pull-Up set */
+#define PWR_PUCRC_PU15_Pos        (15U)
+#define PWR_PUCRC_PU15_Msk        (0x1UL << PWR_PUCRC_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRC_PU15            PWR_PUCRC_PU15_Msk                           /*!< Pin PC15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRC register  *****************/
+#define PWR_PDCRC_PD6_Pos         (6U)
+#define PWR_PDCRC_PD6_Msk         (0x1UL << PWR_PDCRC_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRC_PD6             PWR_PDCRC_PD6_Msk                            /*!< Pin PC6 Pull-Down set */
+#define PWR_PDCRC_PD7_Pos         (7U)
+#define PWR_PDCRC_PD7_Msk         (0x1UL << PWR_PDCRC_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRC_PD7             PWR_PDCRC_PD7_Msk                            /*!< Pin PC7 Pull-Down set */
+#define PWR_PDCRC_PD13_Pos        (13U)
+#define PWR_PDCRC_PD13_Msk        (0x1UL << PWR_PDCRC_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRC_PD13            PWR_PDCRC_PD13_Msk                           /*!< Pin PC13 Pull-Down set */
+#define PWR_PDCRC_PD14_Pos        (14U)
+#define PWR_PDCRC_PD14_Msk        (0x1UL << PWR_PDCRC_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRC_PD14            PWR_PDCRC_PD14_Msk                           /*!< Pin PC14 Pull-Down set */
+#define PWR_PDCRC_PD15_Pos        (15U)
+#define PWR_PDCRC_PD15_Msk        (0x1UL << PWR_PDCRC_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRC_PD15            PWR_PDCRC_PD15_Msk                           /*!< Pin PC15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRD register  *****************/
+#define PWR_PUCRD_PU0_Pos         (0U)
+#define PWR_PUCRD_PU0_Msk         (0x1UL << PWR_PUCRD_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRD_PU0             PWR_PUCRD_PU0_Msk                            /*!< Pin PD0 Pull-Up set */
+#define PWR_PUCRD_PU1_Pos         (1U)
+#define PWR_PUCRD_PU1_Msk         (0x1UL << PWR_PUCRD_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRD_PU1             PWR_PUCRD_PU1_Msk                            /*!< Pin PD1 Pull-Up set */
+#define PWR_PUCRD_PU2_Pos         (2U)
+#define PWR_PUCRD_PU2_Msk         (0x1UL << PWR_PUCRD_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRD_PU2             PWR_PUCRD_PU2_Msk                            /*!< Pin PD2 Pull-Up set */
+#define PWR_PUCRD_PU3_Pos         (3U)
+#define PWR_PUCRD_PU3_Msk         (0x1UL << PWR_PUCRD_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRD_PU3             PWR_PUCRD_PU3_Msk                            /*!< Pin PD3 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRD register  *****************/
+#define PWR_PDCRD_PD0_Pos         (0U)
+#define PWR_PDCRD_PD0_Msk         (0x1UL << PWR_PDCRD_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRD_PD0             PWR_PDCRD_PD0_Msk                            /*!< Pin PD0 Pull-Down set */
+#define PWR_PDCRD_PD1_Pos         (1U)
+#define PWR_PDCRD_PD1_Msk         (0x1UL << PWR_PDCRD_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRD_PD1             PWR_PDCRD_PD1_Msk                            /*!< Pin PD1 Pull-Down set */
+#define PWR_PDCRD_PD2_Pos         (2U)
+#define PWR_PDCRD_PD2_Msk         (0x1UL << PWR_PDCRD_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRD_PD2             PWR_PDCRD_PD2_Msk                            /*!< Pin PD2 Pull-Down set */
+#define PWR_PDCRD_PD3_Pos         (3U)
+#define PWR_PDCRD_PD3_Msk         (0x1UL << PWR_PDCRD_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRD_PD3             PWR_PDCRD_PD3_Msk                            /*!< Pin PD3 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRF register  *****************/
+#define PWR_PUCRF_PU0_Pos         (0U)
+#define PWR_PUCRF_PU0_Msk         (0x1UL << PWR_PUCRF_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRF_PU0             PWR_PUCRF_PU0_Msk                            /*!< Pin PF0 Pull-Up set */
+#define PWR_PUCRF_PU1_Pos         (1U)
+#define PWR_PUCRF_PU1_Msk         (0x1UL << PWR_PUCRF_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRF_PU1             PWR_PUCRF_PU1_Msk                            /*!< Pin PF1 Pull-Up set */
+#define PWR_PUCRF_PU2_Pos         (2U)
+#define PWR_PUCRF_PU2_Msk         (0x1UL << PWR_PUCRF_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRF_PU2             PWR_PUCRF_PU2_Msk                            /*!< Pin PF2 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRF register  *****************/
+#define PWR_PDCRF_PD0_Pos         (0U)
+#define PWR_PDCRF_PD0_Msk         (0x1UL << PWR_PDCRF_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRF_PD0             PWR_PDCRF_PD0_Msk                            /*!< Pin PF0 Pull-Down set */
+#define PWR_PDCRF_PD1_Pos         (1U)
+#define PWR_PDCRF_PD1_Msk         (0x1UL << PWR_PDCRF_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRF_PD1             PWR_PDCRF_PD1_Msk                            /*!< Pin PF1 Pull-Down set */
+#define PWR_PDCRF_PD2_Pos         (2U)
+#define PWR_PDCRF_PD2_Msk         (0x1UL << PWR_PDCRF_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRF_PD2             PWR_PDCRF_PD2_Msk                            /*!< Pin PF2 Pull-Down set */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Reset and Clock Control                          */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
+*/
+
+/********************  Bit definition for RCC_CR register  *****************/
+#define RCC_CR_HSION_Pos                 (8U)
+#define RCC_CR_HSION_Msk                 (0x1UL << RCC_CR_HSION_Pos)           /*!< 0x00000100 */
+#define RCC_CR_HSION                     RCC_CR_HSION_Msk                      /*!< Internal High Speed clock enable */
+#define RCC_CR_HSIKERON_Pos              (9U)
+#define RCC_CR_HSIKERON_Msk              (0x1UL << RCC_CR_HSIKERON_Pos)        /*!< 0x00000200 */
+#define RCC_CR_HSIKERON                  RCC_CR_HSIKERON_Msk                   /*!< Internal High Speed clock enable for some IPs Kernel */
+#define RCC_CR_HSIRDY_Pos                (10U)
+#define RCC_CR_HSIRDY_Msk                (0x1UL << RCC_CR_HSIRDY_Pos)          /*!< 0x00000400 */
+#define RCC_CR_HSIRDY                    RCC_CR_HSIRDY_Msk                     /*!< Internal High Speed clock ready flag */
+#define RCC_CR_HSIDIV_Pos                (11U)
+#define RCC_CR_HSIDIV_Msk                (0x7UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00003800 */
+#define RCC_CR_HSIDIV                    RCC_CR_HSIDIV_Msk                     /*!< HSIDIV[13:11] Internal High Speed clock division factor */
+#define RCC_CR_HSIDIV_0                  (0x1UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00000800 */
+#define RCC_CR_HSIDIV_1                  (0x2UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00001000 */
+#define RCC_CR_HSIDIV_2                  (0x4UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00002000 */
+#define RCC_CR_HSEON_Pos                 (16U)
+#define RCC_CR_HSEON_Msk                 (0x1UL << RCC_CR_HSEON_Pos)           /*!< 0x00010000 */
+#define RCC_CR_HSEON                     RCC_CR_HSEON_Msk                      /*!< External High Speed clock enable */
+#define RCC_CR_HSERDY_Pos                (17U)
+#define RCC_CR_HSERDY_Msk                (0x1UL << RCC_CR_HSERDY_Pos)          /*!< 0x00020000 */
+#define RCC_CR_HSERDY                    RCC_CR_HSERDY_Msk                     /*!< External High Speed clock ready */
+#define RCC_CR_HSEBYP_Pos                (18U)
+#define RCC_CR_HSEBYP_Msk                (0x1UL << RCC_CR_HSEBYP_Pos)          /*!< 0x00040000 */
+#define RCC_CR_HSEBYP                    RCC_CR_HSEBYP_Msk                     /*!< External High Speed clock Bypass */
+#define RCC_CR_CSSON_Pos                 (19U)
+#define RCC_CR_CSSON_Msk                 (0x1UL << RCC_CR_CSSON_Pos)           /*!< 0x00080000 */
+#define RCC_CR_CSSON                     RCC_CR_CSSON_Msk                      /*!< HSE Clock Security System enable */
+
+#define RCC_CR_PLLON_Pos                 (24U)
+#define RCC_CR_PLLON_Msk                 (0x1UL << RCC_CR_PLLON_Pos)           /*!< 0x01000000 */
+#define RCC_CR_PLLON                     RCC_CR_PLLON_Msk                      /*!< System PLL clock enable */
+#define RCC_CR_PLLRDY_Pos                (25U)
+#define RCC_CR_PLLRDY_Msk                (0x1UL << RCC_CR_PLLRDY_Pos)          /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                    RCC_CR_PLLRDY_Msk                     /*!< System PLL clock ready */
+
+/********************  Bit definition for RCC_ICSCR register  ***************/
+/*!< HSICAL configuration */
+#define RCC_ICSCR_HSICAL_Pos             (0U)
+#define RCC_ICSCR_HSICAL_Msk             (0xFFUL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x000000FF */
+#define RCC_ICSCR_HSICAL                 RCC_ICSCR_HSICAL_Msk                  /*!< HSICAL[7:0] bits */
+#define RCC_ICSCR_HSICAL_0               (0x01UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000001 */
+#define RCC_ICSCR_HSICAL_1               (0x02UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000002 */
+#define RCC_ICSCR_HSICAL_2               (0x04UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000004 */
+#define RCC_ICSCR_HSICAL_3               (0x08UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000008 */
+#define RCC_ICSCR_HSICAL_4               (0x10UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000010 */
+#define RCC_ICSCR_HSICAL_5               (0x20UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000020 */
+#define RCC_ICSCR_HSICAL_6               (0x40UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000040 */
+#define RCC_ICSCR_HSICAL_7               (0x80UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000080 */
+
+/*!< HSITRIM configuration */
+#define RCC_ICSCR_HSITRIM_Pos            (8U)
+#define RCC_ICSCR_HSITRIM_Msk            (0x7FUL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00007F00 */
+#define RCC_ICSCR_HSITRIM                RCC_ICSCR_HSITRIM_Msk                 /*!< HSITRIM[14:8] bits */
+#define RCC_ICSCR_HSITRIM_0              (0x01UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000100 */
+#define RCC_ICSCR_HSITRIM_1              (0x02UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000200 */
+#define RCC_ICSCR_HSITRIM_2              (0x04UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000400 */
+#define RCC_ICSCR_HSITRIM_3              (0x08UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000800 */
+#define RCC_ICSCR_HSITRIM_4              (0x10UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00001000 */
+#define RCC_ICSCR_HSITRIM_5              (0x20UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00002000 */
+#define RCC_ICSCR_HSITRIM_6              (0x40UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00004000 */
+
+/********************  Bit definition for RCC_CFGR register  ***************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                (0U)
+#define RCC_CFGR_SW_Msk                (0x7UL << RCC_CFGR_SW_Pos)              /*!< 0x00000007 */
+#define RCC_CFGR_SW                    RCC_CFGR_SW_Msk                         /*!< SW[2:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                  (0x1UL << RCC_CFGR_SW_Pos)              /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                  (0x2UL << RCC_CFGR_SW_Pos)              /*!< 0x00000002 */
+#define RCC_CFGR_SW_2                  (0x4UL << RCC_CFGR_SW_Pos)              /*!< 0x00000004 */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos               (3U)
+#define RCC_CFGR_SWS_Msk               (0x7UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000038 */
+#define RCC_CFGR_SWS                   RCC_CFGR_SWS_Msk                        /*!< SWS[2:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                 (0x1UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000008 */
+#define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
+#define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos              (8U)
+#define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
+#define RCC_CFGR_HPRE                  RCC_CFGR_HPRE_Msk                       /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                (0x1UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000100 */
+#define RCC_CFGR_HPRE_1                (0x2UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000200 */
+#define RCC_CFGR_HPRE_2                (0x4UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000400 */
+#define RCC_CFGR_HPRE_3                (0x8UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000800 */
+
+/*!< PPRE configuration */
+#define RCC_CFGR_PPRE_Pos              (12U)
+#define RCC_CFGR_PPRE_Msk              (0x7UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00007000 */
+#define RCC_CFGR_PPRE                  RCC_CFGR_PPRE_Msk                       /*!< PRE1[2:0] bits (APB prescaler) */
+#define RCC_CFGR_PPRE_0                (0x1UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00001000 */
+#define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
+#define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
+
+
+/*!< MCOSEL configuration */
+#define RCC_CFGR_MCOSEL_Pos            (24U)
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
+#define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
+#define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
+#define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
+#define RCC_CFGR_MCOSEL_2              (0x4UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x04000000 */
+
+/*!< MCO Prescaler configuration */
+#define RCC_CFGR_MCOPRE_Pos            (28U)
+#define RCC_CFGR_MCOPRE_Msk            (0x7UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE                RCC_CFGR_MCOPRE_Msk                     /*!< MCO prescaler [2:0] */
+#define RCC_CFGR_MCOPRE_0              (0x1UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x10000000 */
+#define RCC_CFGR_MCOPRE_1              (0x2UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x20000000 */
+#define RCC_CFGR_MCOPRE_2              (0x4UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLSRC_Pos           (0U)
+#define RCC_PLLCFGR_PLLSRC_Msk           (0x3UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC               RCC_PLLCFGR_PLLSRC_Msk
+#define RCC_PLLCFGR_PLLSRC_0             (0x1UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLSRC_1             (0x2UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000002 */
+
+#define RCC_PLLCFGR_PLLSRC_NONE          (0x00000000UL)                        /*!< No clock sent to PLL      */
+#define RCC_PLLCFGR_PLLSRC_HSI_Pos       (1U)
+#define RCC_PLLCFGR_PLLSRC_HSI_Msk       (0x1UL << RCC_PLLCFGR_PLLSRC_HSI_Pos) /*!< 0x00000002 */
+#define RCC_PLLCFGR_PLLSRC_HSI           RCC_PLLCFGR_PLLSRC_HSI_Msk            /*!< HSI source clock selected */
+#define RCC_PLLCFGR_PLLSRC_HSE_Pos       (0U)
+#define RCC_PLLCFGR_PLLSRC_HSE_Msk       (0x3UL << RCC_PLLCFGR_PLLSRC_HSE_Pos) /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC_HSE           RCC_PLLCFGR_PLLSRC_HSE_Msk            /*!< HSE source clock selected */
+
+#define RCC_PLLCFGR_PLLM_Pos             (4U)
+#define RCC_PLLCFGR_PLLM_Msk             (0x7UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000070 */
+#define RCC_PLLCFGR_PLLM                 RCC_PLLCFGR_PLLM_Msk
+#define RCC_PLLCFGR_PLLM_0               (0x1UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_1               (0x2UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000020 */
+#define RCC_PLLCFGR_PLLM_2               (0x4UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000040 */
+
+#define RCC_PLLCFGR_PLLN_Pos             (8U)
+#define RCC_PLLCFGR_PLLN_Msk             (0x7FUL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00007F00 */
+#define RCC_PLLCFGR_PLLN                 RCC_PLLCFGR_PLLN_Msk
+#define RCC_PLLCFGR_PLLN_0               (0x01UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_1               (0x02UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_2               (0x04UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_3               (0x08UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_4               (0x10UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_5               (0x20UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_6               (0x40UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLPEN_Pos           (16U)
+#define RCC_PLLCFGR_PLLPEN_Msk           (0x1UL << RCC_PLLCFGR_PLLPEN_Pos)     /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLPEN               RCC_PLLCFGR_PLLPEN_Msk
+
+#define RCC_PLLCFGR_PLLP_Pos              (17U)
+#define RCC_PLLCFGR_PLLP_Msk              (0x1FUL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x003E0000 */
+#define RCC_PLLCFGR_PLLP                  RCC_PLLCFGR_PLLP_Msk
+#define RCC_PLLCFGR_PLLP_0                (0x01UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00020000 */
+#define RCC_PLLCFGR_PLLP_1                (0x02UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00040000 */
+#define RCC_PLLCFGR_PLLP_2                (0x04UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00080000 */
+#define RCC_PLLCFGR_PLLP_3                (0x08UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00100000 */
+#define RCC_PLLCFGR_PLLP_4                (0x10UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00200000 */
+
+
+#define RCC_PLLCFGR_PLLREN_Pos           (28U)
+#define RCC_PLLCFGR_PLLREN_Msk           (0x1UL << RCC_PLLCFGR_PLLREN_Pos)     /*!< 0x10000000 */
+#define RCC_PLLCFGR_PLLREN               RCC_PLLCFGR_PLLREN_Msk
+
+#define RCC_PLLCFGR_PLLR_Pos             (29U)
+#define RCC_PLLCFGR_PLLR_Msk             (0x7UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0xE0000000 */
+#define RCC_PLLCFGR_PLLR                 RCC_PLLCFGR_PLLR_Msk
+#define RCC_PLLCFGR_PLLR_0               (0x1UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x20000000 */
+#define RCC_PLLCFGR_PLLR_1               (0x2UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x40000000 */
+#define RCC_PLLCFGR_PLLR_2               (0x4UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIER register  ******************/
+#define RCC_CIER_LSIRDYIE_Pos            (0U)
+#define RCC_CIER_LSIRDYIE_Msk            (0x1UL << RCC_CIER_LSIRDYIE_Pos)      /*!< 0x00000001 */
+#define RCC_CIER_LSIRDYIE                RCC_CIER_LSIRDYIE_Msk
+#define RCC_CIER_LSERDYIE_Pos            (1U)
+#define RCC_CIER_LSERDYIE_Msk            (0x1UL << RCC_CIER_LSERDYIE_Pos)      /*!< 0x00000002 */
+#define RCC_CIER_LSERDYIE                RCC_CIER_LSERDYIE_Msk
+#define RCC_CIER_HSIRDYIE_Pos            (3U)
+#define RCC_CIER_HSIRDYIE_Msk            (0x1UL << RCC_CIER_HSIRDYIE_Pos)      /*!< 0x00000008 */
+#define RCC_CIER_HSIRDYIE                RCC_CIER_HSIRDYIE_Msk
+#define RCC_CIER_HSERDYIE_Pos            (4U)
+#define RCC_CIER_HSERDYIE_Msk            (0x1UL << RCC_CIER_HSERDYIE_Pos)      /*!< 0x00000010 */
+#define RCC_CIER_HSERDYIE                RCC_CIER_HSERDYIE_Msk
+#define RCC_CIER_PLLRDYIE_Pos            (5U)
+#define RCC_CIER_PLLRDYIE_Msk            (0x1UL << RCC_CIER_PLLRDYIE_Pos)      /*!< 0x00000020 */
+#define RCC_CIER_PLLRDYIE                RCC_CIER_PLLRDYIE_Msk
+
+/********************  Bit definition for RCC_CIFR register  ******************/
+#define RCC_CIFR_LSIRDYF_Pos             (0U)
+#define RCC_CIFR_LSIRDYF_Msk             (0x1UL << RCC_CIFR_LSIRDYF_Pos)       /*!< 0x00000001 */
+#define RCC_CIFR_LSIRDYF                 RCC_CIFR_LSIRDYF_Msk
+#define RCC_CIFR_LSERDYF_Pos             (1U)
+#define RCC_CIFR_LSERDYF_Msk             (0x1UL << RCC_CIFR_LSERDYF_Pos)       /*!< 0x00000002 */
+#define RCC_CIFR_LSERDYF                 RCC_CIFR_LSERDYF_Msk
+#define RCC_CIFR_HSIRDYF_Pos             (3U)
+#define RCC_CIFR_HSIRDYF_Msk             (0x1UL << RCC_CIFR_HSIRDYF_Pos)       /*!< 0x00000008 */
+#define RCC_CIFR_HSIRDYF                 RCC_CIFR_HSIRDYF_Msk
+#define RCC_CIFR_HSERDYF_Pos             (4U)
+#define RCC_CIFR_HSERDYF_Msk             (0x1UL << RCC_CIFR_HSERDYF_Pos)       /*!< 0x00000010 */
+#define RCC_CIFR_HSERDYF                 RCC_CIFR_HSERDYF_Msk
+#define RCC_CIFR_PLLRDYF_Pos             (5U)
+#define RCC_CIFR_PLLRDYF_Msk             (0x1UL << RCC_CIFR_PLLRDYF_Pos)       /*!< 0x00000020 */
+#define RCC_CIFR_PLLRDYF                 RCC_CIFR_PLLRDYF_Msk
+#define RCC_CIFR_CSSF_Pos                (8U)
+#define RCC_CIFR_CSSF_Msk                (0x1UL << RCC_CIFR_CSSF_Pos)          /*!< 0x00000100 */
+#define RCC_CIFR_CSSF                    RCC_CIFR_CSSF_Msk
+#define RCC_CIFR_LSECSSF_Pos             (9U)
+#define RCC_CIFR_LSECSSF_Msk             (0x1UL << RCC_CIFR_LSECSSF_Pos)       /*!< 0x00000200 */
+#define RCC_CIFR_LSECSSF                 RCC_CIFR_LSECSSF_Msk
+
+/********************  Bit definition for RCC_CICR register  ******************/
+#define RCC_CICR_LSIRDYC_Pos             (0U)
+#define RCC_CICR_LSIRDYC_Msk             (0x1UL << RCC_CICR_LSIRDYC_Pos)       /*!< 0x00000001 */
+#define RCC_CICR_LSIRDYC                 RCC_CICR_LSIRDYC_Msk
+#define RCC_CICR_LSERDYC_Pos             (1U)
+#define RCC_CICR_LSERDYC_Msk             (0x1UL << RCC_CICR_LSERDYC_Pos)       /*!< 0x00000002 */
+#define RCC_CICR_LSERDYC                 RCC_CICR_LSERDYC_Msk
+#define RCC_CICR_HSIRDYC_Pos             (3U)
+#define RCC_CICR_HSIRDYC_Msk             (0x1UL << RCC_CICR_HSIRDYC_Pos)       /*!< 0x00000008 */
+#define RCC_CICR_HSIRDYC                 RCC_CICR_HSIRDYC_Msk
+#define RCC_CICR_HSERDYC_Pos             (4U)
+#define RCC_CICR_HSERDYC_Msk             (0x1UL << RCC_CICR_HSERDYC_Pos)       /*!< 0x00000010 */
+#define RCC_CICR_HSERDYC                 RCC_CICR_HSERDYC_Msk
+#define RCC_CICR_PLLRDYC_Pos             (5U)
+#define RCC_CICR_PLLRDYC_Msk             (0x1UL << RCC_CICR_PLLRDYC_Pos)       /*!< 0x00000020 */
+#define RCC_CICR_PLLRDYC                 RCC_CICR_PLLRDYC_Msk
+#define RCC_CICR_CSSC_Pos                (8U)
+#define RCC_CICR_CSSC_Msk                (0x1UL << RCC_CICR_CSSC_Pos)          /*!< 0x00000100 */
+#define RCC_CICR_CSSC                    RCC_CICR_CSSC_Msk
+#define RCC_CICR_LSECSSC_Pos             (9U)
+#define RCC_CICR_LSECSSC_Msk             (0x1UL << RCC_CICR_LSECSSC_Pos)       /*!< 0x00000200 */
+#define RCC_CICR_LSECSSC                 RCC_CICR_LSECSSC_Msk
+
+/********************  Bit definition for RCC_IOPRSTR register  ****************/
+#define RCC_IOPRSTR_GPIOARST_Pos         (0U)
+#define RCC_IOPRSTR_GPIOARST_Msk         (0x1UL << RCC_IOPRSTR_GPIOARST_Pos)   /*!< 0x00000001 */
+#define RCC_IOPRSTR_GPIOARST             RCC_IOPRSTR_GPIOARST_Msk
+#define RCC_IOPRSTR_GPIOBRST_Pos         (1U)
+#define RCC_IOPRSTR_GPIOBRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOBRST_Pos)   /*!< 0x00000002 */
+#define RCC_IOPRSTR_GPIOBRST             RCC_IOPRSTR_GPIOBRST_Msk
+#define RCC_IOPRSTR_GPIOCRST_Pos         (2U)
+#define RCC_IOPRSTR_GPIOCRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOCRST_Pos)   /*!< 0x00000004 */
+#define RCC_IOPRSTR_GPIOCRST             RCC_IOPRSTR_GPIOCRST_Msk
+#define RCC_IOPRSTR_GPIODRST_Pos         (3U)
+#define RCC_IOPRSTR_GPIODRST_Msk         (0x1UL << RCC_IOPRSTR_GPIODRST_Pos)   /*!< 0x00000008 */
+#define RCC_IOPRSTR_GPIODRST             RCC_IOPRSTR_GPIODRST_Msk
+#define RCC_IOPRSTR_GPIOFRST_Pos         (5U)
+#define RCC_IOPRSTR_GPIOFRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOFRST_Pos)   /*!< 0x00000020 */
+#define RCC_IOPRSTR_GPIOFRST             RCC_IOPRSTR_GPIOFRST_Msk
+
+/********************  Bit definition for RCC_AHBRSTR register  ***************/
+#define RCC_AHBRSTR_DMA1RST_Pos          (0U)
+#define RCC_AHBRSTR_DMA1RST_Msk          (0x1UL << RCC_AHBRSTR_DMA1RST_Pos)    /*!< 0x00000001 */
+#define RCC_AHBRSTR_DMA1RST              RCC_AHBRSTR_DMA1RST_Msk
+#define RCC_AHBRSTR_FLASHRST_Pos         (8U)
+#define RCC_AHBRSTR_FLASHRST_Msk         (0x1UL << RCC_AHBRSTR_FLASHRST_Pos)   /*!< 0x00000100 */
+#define RCC_AHBRSTR_FLASHRST             RCC_AHBRSTR_FLASHRST_Msk
+#define RCC_AHBRSTR_CRCRST_Pos           (12U)
+#define RCC_AHBRSTR_CRCRST_Msk           (0x1UL << RCC_AHBRSTR_CRCRST_Pos)     /*!< 0x00001000 */
+#define RCC_AHBRSTR_CRCRST               RCC_AHBRSTR_CRCRST_Msk
+
+/********************  Bit definition for RCC_APBRSTR1 register  **************/
+#define RCC_APBRSTR1_TIM3RST_Pos         (1U)
+#define RCC_APBRSTR1_TIM3RST_Msk         (0x1UL << RCC_APBRSTR1_TIM3RST_Pos)   /*!< 0x00000002 */
+#define RCC_APBRSTR1_TIM3RST             RCC_APBRSTR1_TIM3RST_Msk
+#define RCC_APBRSTR1_TIM6RST_Pos         (4U)
+#define RCC_APBRSTR1_TIM6RST_Msk         (0x1UL << RCC_APBRSTR1_TIM6RST_Pos)   /*!< 0x00000010 */
+#define RCC_APBRSTR1_TIM6RST             RCC_APBRSTR1_TIM6RST_Msk
+#define RCC_APBRSTR1_TIM7RST_Pos         (5U)
+#define RCC_APBRSTR1_TIM7RST_Msk         (0x1UL << RCC_APBRSTR1_TIM7RST_Pos)   /*!< 0x00000020 */
+#define RCC_APBRSTR1_TIM7RST             RCC_APBRSTR1_TIM7RST_Msk
+#define RCC_APBRSTR1_SPI2RST_Pos         (14U)
+#define RCC_APBRSTR1_SPI2RST_Msk         (0x1UL << RCC_APBRSTR1_SPI2RST_Pos)   /*!< 0x00004000 */
+#define RCC_APBRSTR1_SPI2RST             RCC_APBRSTR1_SPI2RST_Msk
+#define RCC_APBRSTR1_USART2RST_Pos       (17U)
+#define RCC_APBRSTR1_USART2RST_Msk       (0x1UL << RCC_APBRSTR1_USART2RST_Pos) /*!< 0x00020000 */
+#define RCC_APBRSTR1_USART2RST           RCC_APBRSTR1_USART2RST_Msk
+#define RCC_APBRSTR1_I2C1RST_Pos         (21U)
+#define RCC_APBRSTR1_I2C1RST_Msk         (0x1UL << RCC_APBRSTR1_I2C1RST_Pos)    /*!< 0x00200000 */
+#define RCC_APBRSTR1_I2C1RST             RCC_APBRSTR1_I2C1RST_Msk
+#define RCC_APBRSTR1_I2C2RST_Pos         (22U)
+#define RCC_APBRSTR1_I2C2RST_Msk         (0x1UL << RCC_APBRSTR1_I2C2RST_Pos)    /*!< 0x00400000 */
+#define RCC_APBRSTR1_I2C2RST             RCC_APBRSTR1_I2C2RST_Msk
+#define RCC_APBRSTR1_DBGRST_Pos          (27U)
+#define RCC_APBRSTR1_DBGRST_Msk          (0x1UL << RCC_APBRSTR1_DBGRST_Pos)     /*!< 0x08000000 */
+#define RCC_APBRSTR1_DBGRST              RCC_APBRSTR1_DBGRST_Msk
+#define RCC_APBRSTR1_PWRRST_Pos          (28U)
+#define RCC_APBRSTR1_PWRRST_Msk          (0x1UL << RCC_APBRSTR1_PWRRST_Pos)     /*!< 0x10000000 */
+#define RCC_APBRSTR1_PWRRST              RCC_APBRSTR1_PWRRST_Msk
+
+/********************  Bit definition for RCC_APBRSTR2 register  **************/
+#define RCC_APBRSTR2_SYSCFGRST_Pos       (0U)
+#define RCC_APBRSTR2_SYSCFGRST_Msk       (0x1UL << RCC_APBRSTR2_SYSCFGRST_Pos)  /*!< 0x00000001 */
+#define RCC_APBRSTR2_SYSCFGRST           RCC_APBRSTR2_SYSCFGRST_Msk
+#define RCC_APBRSTR2_TIM1RST_Pos         (11U)
+#define RCC_APBRSTR2_TIM1RST_Msk         (0x1UL << RCC_APBRSTR2_TIM1RST_Pos)    /*!< 0x00000800 */
+#define RCC_APBRSTR2_TIM1RST             RCC_APBRSTR2_TIM1RST_Msk
+#define RCC_APBRSTR2_SPI1RST_Pos         (12U)
+#define RCC_APBRSTR2_SPI1RST_Msk         (0x1UL << RCC_APBRSTR2_SPI1RST_Pos)    /*!< 0x00001000 */
+#define RCC_APBRSTR2_SPI1RST             RCC_APBRSTR2_SPI1RST_Msk
+#define RCC_APBRSTR2_USART1RST_Pos       (14U)
+#define RCC_APBRSTR2_USART1RST_Msk       (0x1UL << RCC_APBRSTR2_USART1RST_Pos)  /*!< 0x00004000 */
+#define RCC_APBRSTR2_USART1RST           RCC_APBRSTR2_USART1RST_Msk
+#define RCC_APBRSTR2_TIM14RST_Pos        (15U)
+#define RCC_APBRSTR2_TIM14RST_Msk        (0x1UL << RCC_APBRSTR2_TIM14RST_Pos)   /*!< 0x00008000 */
+#define RCC_APBRSTR2_TIM14RST            RCC_APBRSTR2_TIM14RST_Msk
+#define RCC_APBRSTR2_TIM15RST_Pos        (16U)
+#define RCC_APBRSTR2_TIM15RST_Msk        (0x1UL << RCC_APBRSTR2_TIM15RST_Pos)   /*!< 0x00010000 */
+#define RCC_APBRSTR2_TIM15RST            RCC_APBRSTR2_TIM15RST_Msk
+#define RCC_APBRSTR2_TIM16RST_Pos        (17U)
+#define RCC_APBRSTR2_TIM16RST_Msk        (0x1UL << RCC_APBRSTR2_TIM16RST_Pos)   /*!< 0x00020000 */
+#define RCC_APBRSTR2_TIM16RST            RCC_APBRSTR2_TIM16RST_Msk
+#define RCC_APBRSTR2_TIM17RST_Pos        (18U)
+#define RCC_APBRSTR2_TIM17RST_Msk        (0x1UL << RCC_APBRSTR2_TIM17RST_Pos)   /*!< 0x00040000 */
+#define RCC_APBRSTR2_TIM17RST            RCC_APBRSTR2_TIM17RST_Msk
+#define RCC_APBRSTR2_ADCRST_Pos          (20U)
+#define RCC_APBRSTR2_ADCRST_Msk          (0x1UL << RCC_APBRSTR2_ADCRST_Pos)     /*!< 0x00100000 */
+#define RCC_APBRSTR2_ADCRST              RCC_APBRSTR2_ADCRST_Msk
+
+/********************  Bit definition for RCC_IOPENR register  ****************/
+#define RCC_IOPENR_GPIOAEN_Pos           (0U)
+#define RCC_IOPENR_GPIOAEN_Msk           (0x1UL << RCC_IOPENR_GPIOAEN_Pos)      /*!< 0x00000001 */
+#define RCC_IOPENR_GPIOAEN               RCC_IOPENR_GPIOAEN_Msk
+#define RCC_IOPENR_GPIOBEN_Pos           (1U)
+#define RCC_IOPENR_GPIOBEN_Msk           (0x1UL << RCC_IOPENR_GPIOBEN_Pos)      /*!< 0x00000002 */
+#define RCC_IOPENR_GPIOBEN               RCC_IOPENR_GPIOBEN_Msk
+#define RCC_IOPENR_GPIOCEN_Pos           (2U)
+#define RCC_IOPENR_GPIOCEN_Msk           (0x1UL << RCC_IOPENR_GPIOCEN_Pos)      /*!< 0x00000004 */
+#define RCC_IOPENR_GPIOCEN               RCC_IOPENR_GPIOCEN_Msk
+#define RCC_IOPENR_GPIODEN_Pos           (3U)
+#define RCC_IOPENR_GPIODEN_Msk           (0x1UL << RCC_IOPENR_GPIODEN_Pos)      /*!< 0x00000008 */
+#define RCC_IOPENR_GPIODEN               RCC_IOPENR_GPIODEN_Msk
+#define RCC_IOPENR_GPIOFEN_Pos           (5U)
+#define RCC_IOPENR_GPIOFEN_Msk           (0x1UL << RCC_IOPENR_GPIOFEN_Pos)      /*!< 0x00000020 */
+#define RCC_IOPENR_GPIOFEN               RCC_IOPENR_GPIOFEN_Msk
+
+/********************  Bit definition for RCC_AHBENR register  ****************/
+#define RCC_AHBENR_DMA1EN_Pos            (0U)
+#define RCC_AHBENR_DMA1EN_Msk            (0x1UL << RCC_AHBENR_DMA1EN_Pos)       /*!< 0x00000001 */
+#define RCC_AHBENR_DMA1EN                RCC_AHBENR_DMA1EN_Msk
+#define RCC_AHBENR_FLASHEN_Pos           (8U)
+#define RCC_AHBENR_FLASHEN_Msk           (0x1UL << RCC_AHBENR_FLASHEN_Pos)      /*!< 0x00000100 */
+#define RCC_AHBENR_FLASHEN               RCC_AHBENR_FLASHEN_Msk
+#define RCC_AHBENR_CRCEN_Pos             (12U)
+#define RCC_AHBENR_CRCEN_Msk             (0x1UL << RCC_AHBENR_CRCEN_Pos)        /*!< 0x00001000 */
+#define RCC_AHBENR_CRCEN                 RCC_AHBENR_CRCEN_Msk
+
+/********************  Bit definition for RCC_APBENR1 register  ***************/
+#define RCC_APBENR1_TIM3EN_Pos           (1U)
+#define RCC_APBENR1_TIM3EN_Msk           (0x1UL << RCC_APBENR1_TIM3EN_Pos)      /*!< 0x00000002 */
+#define RCC_APBENR1_TIM3EN               RCC_APBENR1_TIM3EN_Msk
+#define RCC_APBENR1_TIM6EN_Pos           (4U)
+#define RCC_APBENR1_TIM6EN_Msk           (0x1UL << RCC_APBENR1_TIM6EN_Pos)      /*!< 0x00000010 */
+#define RCC_APBENR1_TIM6EN               RCC_APBENR1_TIM6EN_Msk
+#define RCC_APBENR1_TIM7EN_Pos           (5U)
+#define RCC_APBENR1_TIM7EN_Msk           (0x1UL << RCC_APBENR1_TIM7EN_Pos)      /*!< 0x00000020 */
+#define RCC_APBENR1_TIM7EN               RCC_APBENR1_TIM7EN_Msk
+#define RCC_APBENR1_RTCAPBEN_Pos         (10U)
+#define RCC_APBENR1_RTCAPBEN_Msk         (0x1UL << RCC_APBENR1_RTCAPBEN_Pos)    /*!< 0x00000400 */
+#define RCC_APBENR1_RTCAPBEN             RCC_APBENR1_RTCAPBEN_Msk
+#define RCC_APBENR1_WWDGEN_Pos           (11U)
+#define RCC_APBENR1_WWDGEN_Msk           (0x1UL << RCC_APBENR1_WWDGEN_Pos)      /*!< 0x00000800 */
+#define RCC_APBENR1_WWDGEN               RCC_APBENR1_WWDGEN_Msk
+#define RCC_APBENR1_SPI2EN_Pos           (14U)
+#define RCC_APBENR1_SPI2EN_Msk           (0x1UL << RCC_APBENR1_SPI2EN_Pos)      /*!< 0x00004000 */
+#define RCC_APBENR1_SPI2EN               RCC_APBENR1_SPI2EN_Msk
+#define RCC_APBENR1_USART2EN_Pos         (17U)
+#define RCC_APBENR1_USART2EN_Msk         (0x1UL << RCC_APBENR1_USART2EN_Pos)    /*!< 0x00020000 */
+#define RCC_APBENR1_USART2EN             RCC_APBENR1_USART2EN_Msk
+#define RCC_APBENR1_I2C1EN_Pos           (21U)
+#define RCC_APBENR1_I2C1EN_Msk           (0x1UL << RCC_APBENR1_I2C1EN_Pos)      /*!< 0x00200000 */
+#define RCC_APBENR1_I2C1EN               RCC_APBENR1_I2C1EN_Msk
+#define RCC_APBENR1_I2C2EN_Pos           (22U)
+#define RCC_APBENR1_I2C2EN_Msk           (0x1UL << RCC_APBENR1_I2C2EN_Pos)      /*!< 0x00400000 */
+#define RCC_APBENR1_I2C2EN               RCC_APBENR1_I2C2EN_Msk
+#define RCC_APBENR1_DBGEN_Pos            (27U)
+#define RCC_APBENR1_DBGEN_Msk            (0x1UL << RCC_APBENR1_DBGEN_Pos)       /*!< 0x08000000 */
+#define RCC_APBENR1_DBGEN                RCC_APBENR1_DBGEN_Msk
+#define RCC_APBENR1_PWREN_Pos            (28U)
+#define RCC_APBENR1_PWREN_Msk            (0x1UL << RCC_APBENR1_PWREN_Pos)       /*!< 0x10000000 */
+#define RCC_APBENR1_PWREN                RCC_APBENR1_PWREN_Msk
+
+/********************  Bit definition for RCC_APBENR2 register  **************/
+#define RCC_APBENR2_SYSCFGEN_Pos         (0U)
+#define RCC_APBENR2_SYSCFGEN_Msk         (0x1UL << RCC_APBENR2_SYSCFGEN_Pos)    /*!< 0x00000001 */
+#define RCC_APBENR2_SYSCFGEN             RCC_APBENR2_SYSCFGEN_Msk
+#define RCC_APBENR2_TIM1EN_Pos           (11U)
+#define RCC_APBENR2_TIM1EN_Msk           (0x1UL << RCC_APBENR2_TIM1EN_Pos)      /*!< 0x00000800 */
+#define RCC_APBENR2_TIM1EN               RCC_APBENR2_TIM1EN_Msk
+#define RCC_APBENR2_SPI1EN_Pos           (12U)
+#define RCC_APBENR2_SPI1EN_Msk           (0x1UL << RCC_APBENR2_SPI1EN_Pos)      /*!< 0x00001000 */
+#define RCC_APBENR2_SPI1EN               RCC_APBENR2_SPI1EN_Msk
+#define RCC_APBENR2_USART1EN_Pos         (14U)
+#define RCC_APBENR2_USART1EN_Msk         (0x1UL << RCC_APBENR2_USART1EN_Pos)    /*!< 0x00004000 */
+#define RCC_APBENR2_USART1EN             RCC_APBENR2_USART1EN_Msk
+#define RCC_APBENR2_TIM14EN_Pos          (15U)
+#define RCC_APBENR2_TIM14EN_Msk          (0x1UL << RCC_APBENR2_TIM14EN_Pos)     /*!< 0x00008000 */
+#define RCC_APBENR2_TIM14EN              RCC_APBENR2_TIM14EN_Msk
+#define RCC_APBENR2_TIM15EN_Pos          (16U)
+#define RCC_APBENR2_TIM15EN_Msk          (0x1UL << RCC_APBENR2_TIM15EN_Pos)     /*!< 0x00010000 */
+#define RCC_APBENR2_TIM15EN              RCC_APBENR2_TIM15EN_Msk
+#define RCC_APBENR2_TIM16EN_Pos          (17U)
+#define RCC_APBENR2_TIM16EN_Msk          (0x1UL << RCC_APBENR2_TIM16EN_Pos)     /*!< 0x00020000 */
+#define RCC_APBENR2_TIM16EN              RCC_APBENR2_TIM16EN_Msk
+#define RCC_APBENR2_TIM17EN_Pos          (18U)
+#define RCC_APBENR2_TIM17EN_Msk          (0x1UL << RCC_APBENR2_TIM17EN_Pos)     /*!< 0x00040000 */
+#define RCC_APBENR2_TIM17EN              RCC_APBENR2_TIM17EN_Msk
+#define RCC_APBENR2_ADCEN_Pos            (20U)
+#define RCC_APBENR2_ADCEN_Msk            (0x1UL << RCC_APBENR2_ADCEN_Pos)       /*!< 0x00100000 */
+#define RCC_APBENR2_ADCEN                RCC_APBENR2_ADCEN_Msk
+
+/********************  Bit definition for RCC_IOPSMENR register  *************/
+#define RCC_IOPSMENR_GPIOASMEN_Pos       (0U)
+#define RCC_IOPSMENR_GPIOASMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOASMEN_Pos)  /*!< 0x00000001 */
+#define RCC_IOPSMENR_GPIOASMEN           RCC_IOPSMENR_GPIOASMEN_Msk
+#define RCC_IOPSMENR_GPIOBSMEN_Pos       (1U)
+#define RCC_IOPSMENR_GPIOBSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOBSMEN_Pos)  /*!< 0x00000002 */
+#define RCC_IOPSMENR_GPIOBSMEN           RCC_IOPSMENR_GPIOBSMEN_Msk
+#define RCC_IOPSMENR_GPIOCSMEN_Pos       (2U)
+#define RCC_IOPSMENR_GPIOCSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOCSMEN_Pos)  /*!< 0x00000004 */
+#define RCC_IOPSMENR_GPIOCSMEN           RCC_IOPSMENR_GPIOCSMEN_Msk
+#define RCC_IOPSMENR_GPIODSMEN_Pos       (3U)
+#define RCC_IOPSMENR_GPIODSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIODSMEN_Pos)  /*!< 0x00000008 */
+#define RCC_IOPSMENR_GPIODSMEN           RCC_IOPSMENR_GPIODSMEN_Msk
+#define RCC_IOPSMENR_GPIOFSMEN_Pos       (5U)
+#define RCC_IOPSMENR_GPIOFSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOFSMEN_Pos)  /*!< 0x00000020 */
+#define RCC_IOPSMENR_GPIOFSMEN           RCC_IOPSMENR_GPIOFSMEN_Msk
+
+/********************  Bit definition for RCC_AHBSMENR register  *************/
+#define RCC_AHBSMENR_DMA1SMEN_Pos        (0U)
+#define RCC_AHBSMENR_DMA1SMEN_Msk        (0x1UL << RCC_AHBSMENR_DMA1SMEN_Pos)   /*!< 0x00000001 */
+#define RCC_AHBSMENR_DMA1SMEN            RCC_AHBSMENR_DMA1SMEN_Msk
+#define RCC_AHBSMENR_FLASHSMEN_Pos       (8U)
+#define RCC_AHBSMENR_FLASHSMEN_Msk       (0x1UL << RCC_AHBSMENR_FLASHSMEN_Pos)  /*!< 0x00000100 */
+#define RCC_AHBSMENR_FLASHSMEN           RCC_AHBSMENR_FLASHSMEN_Msk
+#define RCC_AHBSMENR_SRAMSMEN_Pos        (9U)
+#define RCC_AHBSMENR_SRAMSMEN_Msk        (0x1UL << RCC_AHBSMENR_SRAMSMEN_Pos)   /*!< 0x00000200 */
+#define RCC_AHBSMENR_SRAMSMEN            RCC_AHBSMENR_SRAMSMEN_Msk
+#define RCC_AHBSMENR_CRCSMEN_Pos         (12U)
+#define RCC_AHBSMENR_CRCSMEN_Msk         (0x1UL << RCC_AHBSMENR_CRCSMEN_Pos)    /*!< 0x00001000 */
+#define RCC_AHBSMENR_CRCSMEN             RCC_AHBSMENR_CRCSMEN_Msk
+
+/********************  Bit definition for RCC_APBSMENR1 register  *************/
+#define RCC_APBSMENR1_TIM3SMEN_Pos       (1U)
+#define RCC_APBSMENR1_TIM3SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM3SMEN_Pos)  /*!< 0x00000002 */
+#define RCC_APBSMENR1_TIM3SMEN           RCC_APBSMENR1_TIM3SMEN_Msk
+#define RCC_APBSMENR1_TIM6SMEN_Pos       (4U)
+#define RCC_APBSMENR1_TIM6SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM6SMEN_Pos)  /*!< 0x00000010 */
+#define RCC_APBSMENR1_TIM6SMEN           RCC_APBSMENR1_TIM6SMEN_Msk
+#define RCC_APBSMENR1_TIM7SMEN_Pos       (5U)
+#define RCC_APBSMENR1_TIM7SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM7SMEN_Pos)  /*!< 0x00000020 */
+#define RCC_APBSMENR1_TIM7SMEN           RCC_APBSMENR1_TIM7SMEN_Msk
+#define RCC_APBSMENR1_RTCAPBSMEN_Pos     (10U)
+#define RCC_APBSMENR1_RTCAPBSMEN_Msk     (0x1UL << RCC_APBSMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_APBSMENR1_RTCAPBSMEN         RCC_APBSMENR1_RTCAPBSMEN_Msk
+#define RCC_APBSMENR1_WWDGSMEN_Pos       (11U)
+#define RCC_APBSMENR1_WWDGSMEN_Msk       (0x1UL << RCC_APBSMENR1_WWDGSMEN_Pos)   /*!< 0x00000800 */
+#define RCC_APBSMENR1_WWDGSMEN           RCC_APBSMENR1_WWDGSMEN_Msk
+#define RCC_APBSMENR1_SPI2SMEN_Pos       (14U)
+#define RCC_APBSMENR1_SPI2SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI2SMEN_Pos)   /*!< 0x00004000 */
+#define RCC_APBSMENR1_SPI2SMEN           RCC_APBSMENR1_SPI2SMEN_Msk
+#define RCC_APBSMENR1_USART2SMEN_Pos     (17U)
+#define RCC_APBSMENR1_USART2SMEN_Msk     (0x1UL << RCC_APBSMENR1_USART2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_APBSMENR1_USART2SMEN         RCC_APBSMENR1_USART2SMEN_Msk
+#define RCC_APBSMENR1_I2C1SMEN_Pos       (21U)
+#define RCC_APBSMENR1_I2C1SMEN_Msk       (0x1UL << RCC_APBSMENR1_I2C1SMEN_Pos)   /*!< 0x00200000 */
+#define RCC_APBSMENR1_I2C1SMEN           RCC_APBSMENR1_I2C1SMEN_Msk
+#define RCC_APBSMENR1_I2C2SMEN_Pos       (22U)
+#define RCC_APBSMENR1_I2C2SMEN_Msk       (0x1UL << RCC_APBSMENR1_I2C2SMEN_Pos)   /*!< 0x00400000 */
+#define RCC_APBSMENR1_I2C2SMEN           RCC_APBSMENR1_I2C2SMEN_Msk
+#define RCC_APBSMENR1_DBGSMEN_Pos        (27U)
+#define RCC_APBSMENR1_DBGSMEN_Msk        (0x1UL << RCC_APBSMENR1_DBGSMEN_Pos)    /*!< 0x08000000 */
+#define RCC_APBSMENR1_DBGSMEN            RCC_APBSMENR1_DBGSMEN_Msk
+#define RCC_APBSMENR1_PWRSMEN_Pos        (28U)
+#define RCC_APBSMENR1_PWRSMEN_Msk        (0x1UL << RCC_APBSMENR1_PWRSMEN_Pos)    /*!< 0x10000000 */
+#define RCC_APBSMENR1_PWRSMEN            RCC_APBSMENR1_PWRSMEN_Msk
+
+/********************  Bit definition for RCC_APBSMENR2 register  *************/
+#define RCC_APBSMENR2_SYSCFGSMEN_Pos     (0U)
+#define RCC_APBSMENR2_SYSCFGSMEN_Msk     (0x1UL << RCC_APBSMENR2_SYSCFGSMEN_Pos) /*!< 0x00000001 */
+#define RCC_APBSMENR2_SYSCFGSMEN         RCC_APBSMENR2_SYSCFGSMEN_Msk
+#define RCC_APBSMENR2_TIM1SMEN_Pos       (11U)
+#define RCC_APBSMENR2_TIM1SMEN_Msk       (0x1UL << RCC_APBSMENR2_TIM1SMEN_Pos)  /*!< 0x00000800 */
+#define RCC_APBSMENR2_TIM1SMEN           RCC_APBSMENR2_TIM1SMEN_Msk
+#define RCC_APBSMENR2_SPI1SMEN_Pos       (12U)
+#define RCC_APBSMENR2_SPI1SMEN_Msk       (0x1UL << RCC_APBSMENR2_SPI1SMEN_Pos)  /*!< 0x00001000 */
+#define RCC_APBSMENR2_SPI1SMEN           RCC_APBSMENR2_SPI1SMEN_Msk
+#define RCC_APBSMENR2_USART1SMEN_Pos     (14U)
+#define RCC_APBSMENR2_USART1SMEN_Msk     (0x1UL << RCC_APBSMENR2_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_APBSMENR2_USART1SMEN         RCC_APBSMENR2_USART1SMEN_Msk
+#define RCC_APBSMENR2_TIM14SMEN_Pos      (15U)
+#define RCC_APBSMENR2_TIM14SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM14SMEN_Pos) /*!< 0x00008000 */
+#define RCC_APBSMENR2_TIM14SMEN          RCC_APBSMENR2_TIM14SMEN_Msk
+#define RCC_APBSMENR2_TIM15SMEN_Pos      (16U)
+#define RCC_APBSMENR2_TIM15SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM15SMEN_Pos) /*!< 0x00010000 */
+#define RCC_APBSMENR2_TIM15SMEN          RCC_APBSMENR2_TIM15SMEN_Msk
+#define RCC_APBSMENR2_TIM16SMEN_Pos      (17U)
+#define RCC_APBSMENR2_TIM16SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM16SMEN_Pos) /*!< 0x00020000 */
+#define RCC_APBSMENR2_TIM16SMEN          RCC_APBSMENR2_TIM16SMEN_Msk
+#define RCC_APBSMENR2_TIM17SMEN_Pos      (18U)
+#define RCC_APBSMENR2_TIM17SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM17SMEN_Pos) /*!< 0x00040000 */
+#define RCC_APBSMENR2_TIM17SMEN          RCC_APBSMENR2_TIM17SMEN_Msk
+#define RCC_APBSMENR2_ADCSMEN_Pos        (20U)
+#define RCC_APBSMENR2_ADCSMEN_Msk        (0x1UL << RCC_APBSMENR2_ADCSMEN_Pos)   /*!< 0x00100000 */
+#define RCC_APBSMENR2_ADCSMEN            RCC_APBSMENR2_ADCSMEN_Msk
+
+/********************  Bit definition for RCC_CCIPR register  ******************/
+#define RCC_CCIPR_USART1SEL_Pos          (0U)
+#define RCC_CCIPR_USART1SEL_Msk          (0x3UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000003 */
+#define RCC_CCIPR_USART1SEL              RCC_CCIPR_USART1SEL_Msk
+#define RCC_CCIPR_USART1SEL_0            (0x1UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000001 */
+#define RCC_CCIPR_USART1SEL_1            (0x2UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000002 */
+
+
+
+
+#define RCC_CCIPR_I2C1SEL_Pos            (12U)
+#define RCC_CCIPR_I2C1SEL_Msk            (0x3UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00003000 */
+#define RCC_CCIPR_I2C1SEL                RCC_CCIPR_I2C1SEL_Msk
+#define RCC_CCIPR_I2C1SEL_0              (0x1UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00001000 */
+#define RCC_CCIPR_I2C1SEL_1              (0x2UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00002000 */
+
+#define RCC_CCIPR_I2S1SEL_Pos            (14U)
+#define RCC_CCIPR_I2S1SEL_Msk            (0x3UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x0000C000 */
+#define RCC_CCIPR_I2S1SEL                RCC_CCIPR_I2S1SEL_Msk
+#define RCC_CCIPR_I2S1SEL_0              (0x1UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x00004000 */
+#define RCC_CCIPR_I2S1SEL_1              (0x2UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x00008000 */
+
+
+
+
+#define RCC_CCIPR_ADCSEL_Pos             (30U)
+#define RCC_CCIPR_ADCSEL_Msk             (0x3UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0xC0000000 */
+#define RCC_CCIPR_ADCSEL                 RCC_CCIPR_ADCSEL_Msk
+#define RCC_CCIPR_ADCSEL_0               (0x1UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0x40000000 */
+#define RCC_CCIPR_ADCSEL_1               (0x2UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos               (0U)
+#define RCC_BDCR_LSEON_Msk               (0x1UL << RCC_BDCR_LSEON_Pos)          /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                   RCC_BDCR_LSEON_Msk
+#define RCC_BDCR_LSERDY_Pos              (1U)
+#define RCC_BDCR_LSERDY_Msk              (0x1UL << RCC_BDCR_LSERDY_Pos)         /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                  RCC_BDCR_LSERDY_Msk
+#define RCC_BDCR_LSEBYP_Pos              (2U)
+#define RCC_BDCR_LSEBYP_Msk              (0x1UL << RCC_BDCR_LSEBYP_Pos)         /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                  RCC_BDCR_LSEBYP_Msk
+
+#define RCC_BDCR_LSEDRV_Pos              (3U)
+#define RCC_BDCR_LSEDRV_Msk              (0x3UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000018 */
+#define RCC_BDCR_LSEDRV                  RCC_BDCR_LSEDRV_Msk
+#define RCC_BDCR_LSEDRV_0                (0x1UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000008 */
+#define RCC_BDCR_LSEDRV_1                (0x2UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000010 */
+
+#define RCC_BDCR_LSECSSON_Pos            (5U)
+#define RCC_BDCR_LSECSSON_Msk            (0x1UL << RCC_BDCR_LSECSSON_Pos)       /*!< 0x00000020 */
+#define RCC_BDCR_LSECSSON                RCC_BDCR_LSECSSON_Msk
+#define RCC_BDCR_LSECSSD_Pos             (6U)
+#define RCC_BDCR_LSECSSD_Msk             (0x1UL << RCC_BDCR_LSECSSD_Pos)        /*!< 0x00000040 */
+#define RCC_BDCR_LSECSSD                 RCC_BDCR_LSECSSD_Msk
+
+#define RCC_BDCR_RTCSEL_Pos              (8U)
+#define RCC_BDCR_RTCSEL_Msk              (0x3UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                  RCC_BDCR_RTCSEL_Msk
+#define RCC_BDCR_RTCSEL_0                (0x1UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                (0x2UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos               (15U)
+#define RCC_BDCR_RTCEN_Msk               (0x1UL << RCC_BDCR_RTCEN_Pos)          /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                   RCC_BDCR_RTCEN_Msk
+#define RCC_BDCR_BDRST_Pos               (16U)
+#define RCC_BDCR_BDRST_Msk               (0x1UL << RCC_BDCR_BDRST_Pos)          /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                   RCC_BDCR_BDRST_Msk
+
+#define RCC_BDCR_LSCOEN_Pos              (24U)
+#define RCC_BDCR_LSCOEN_Msk              (0x1UL << RCC_BDCR_LSCOEN_Pos)         /*!< 0x01000000 */
+#define RCC_BDCR_LSCOEN                  RCC_BDCR_LSCOEN_Msk
+#define RCC_BDCR_LSCOSEL_Pos             (25U)
+#define RCC_BDCR_LSCOSEL_Msk             (0x1UL << RCC_BDCR_LSCOSEL_Pos)        /*!< 0x02000000 */
+#define RCC_BDCR_LSCOSEL                 RCC_BDCR_LSCOSEL_Msk
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSION_Pos                (0U)
+#define RCC_CSR_LSION_Msk                (0x1UL << RCC_CSR_LSION_Pos)           /*!< 0x00000001 */
+#define RCC_CSR_LSION                    RCC_CSR_LSION_Msk
+#define RCC_CSR_LSIRDY_Pos               (1U)
+#define RCC_CSR_LSIRDY_Msk               (0x1UL << RCC_CSR_LSIRDY_Pos)          /*!< 0x00000002 */
+#define RCC_CSR_LSIRDY                   RCC_CSR_LSIRDY_Msk
+
+#define RCC_CSR_RMVF_Pos                 (23U)
+#define RCC_CSR_RMVF_Msk                 (0x1UL << RCC_CSR_RMVF_Pos)            /*!< 0x00800000 */
+#define RCC_CSR_RMVF                     RCC_CSR_RMVF_Msk
+#define RCC_CSR_OBLRSTF_Pos              (25U)
+#define RCC_CSR_OBLRSTF_Msk              (0x1UL << RCC_CSR_OBLRSTF_Pos)         /*!< 0x02000000 */
+#define RCC_CSR_OBLRSTF                  RCC_CSR_OBLRSTF_Msk
+#define RCC_CSR_PINRSTF_Pos              (26U)
+#define RCC_CSR_PINRSTF_Msk              (0x1UL << RCC_CSR_PINRSTF_Pos)         /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                  RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_PWRRSTF_Pos              (27U)
+#define RCC_CSR_PWRRSTF_Msk              (0x1UL << RCC_CSR_PWRRSTF_Pos)         /*!< 0x08000000 */
+#define RCC_CSR_PWRRSTF                  RCC_CSR_PWRRSTF_Msk
+#define RCC_CSR_SFTRSTF_Pos              (28U)
+#define RCC_CSR_SFTRSTF_Msk              (0x1UL << RCC_CSR_SFTRSTF_Pos)         /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                  RCC_CSR_SFTRSTF_Msk
+#define RCC_CSR_IWDGRSTF_Pos             (29U)
+#define RCC_CSR_IWDGRSTF_Msk             (0x1UL << RCC_CSR_IWDGRSTF_Pos)        /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                 RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos             (30U)
+#define RCC_CSR_WWDGRSTF_Msk             (0x1UL << RCC_CSR_WWDGRSTF_Pos)        /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                 RCC_CSR_WWDGRSTF_Msk
+#define RCC_CSR_LPWRRSTF_Pos             (31U)
+#define RCC_CSR_LPWRRSTF_Msk             (0x1UL << RCC_CSR_LPWRRSTF_Pos)        /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                 RCC_CSR_LPWRRSTF_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions
+*/
+#define RTC_WAKEUP_SUPPORT
+#define RTC_BACKUP_SUPPORT
+
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                (22U)
+#define RTC_TR_PM_Msk                (0x1UL << RTC_TR_PM_Pos)                   /*!< 0x00400000 */
+#define RTC_TR_PM                    RTC_TR_PM_Msk
+#define RTC_TR_HT_Pos                (20U)
+#define RTC_TR_HT_Msk                (0x3UL << RTC_TR_HT_Pos)                   /*!< 0x00300000 */
+#define RTC_TR_HT                    RTC_TR_HT_Msk
+#define RTC_TR_HT_0                  (0x1UL << RTC_TR_HT_Pos)                   /*!< 0x00100000 */
+#define RTC_TR_HT_1                  (0x2UL << RTC_TR_HT_Pos)                   /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                (16U)
+#define RTC_TR_HU_Msk                (0xFUL << RTC_TR_HU_Pos)                   /*!< 0x000F0000 */
+#define RTC_TR_HU                    RTC_TR_HU_Msk
+#define RTC_TR_HU_0                  (0x1UL << RTC_TR_HU_Pos)                   /*!< 0x00010000 */
+#define RTC_TR_HU_1                  (0x2UL << RTC_TR_HU_Pos)                   /*!< 0x00020000 */
+#define RTC_TR_HU_2                  (0x4UL << RTC_TR_HU_Pos)                   /*!< 0x00040000 */
+#define RTC_TR_HU_3                  (0x8UL << RTC_TR_HU_Pos)                   /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos               (12U)
+#define RTC_TR_MNT_Msk               (0x7UL << RTC_TR_MNT_Pos)                  /*!< 0x00007000 */
+#define RTC_TR_MNT                   RTC_TR_MNT_Msk
+#define RTC_TR_MNT_0                 (0x1UL << RTC_TR_MNT_Pos)                  /*!< 0x00001000 */
+#define RTC_TR_MNT_1                 (0x2UL << RTC_TR_MNT_Pos)                  /*!< 0x00002000 */
+#define RTC_TR_MNT_2                 (0x4UL << RTC_TR_MNT_Pos)                  /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos               (8U)
+#define RTC_TR_MNU_Msk               (0xFUL << RTC_TR_MNU_Pos)                  /*!< 0x00000F00 */
+#define RTC_TR_MNU                   RTC_TR_MNU_Msk
+#define RTC_TR_MNU_0                 (0x1UL << RTC_TR_MNU_Pos)                  /*!< 0x00000100 */
+#define RTC_TR_MNU_1                 (0x2UL << RTC_TR_MNU_Pos)                  /*!< 0x00000200 */
+#define RTC_TR_MNU_2                 (0x4UL << RTC_TR_MNU_Pos)                  /*!< 0x00000400 */
+#define RTC_TR_MNU_3                 (0x8UL << RTC_TR_MNU_Pos)                  /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                (4U)
+#define RTC_TR_ST_Msk                (0x7UL << RTC_TR_ST_Pos)                   /*!< 0x00000070 */
+#define RTC_TR_ST                    RTC_TR_ST_Msk
+#define RTC_TR_ST_0                  (0x1UL << RTC_TR_ST_Pos)                   /*!< 0x00000010 */
+#define RTC_TR_ST_1                  (0x2UL << RTC_TR_ST_Pos)                   /*!< 0x00000020 */
+#define RTC_TR_ST_2                  (0x4UL << RTC_TR_ST_Pos)                   /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                (0U)
+#define RTC_TR_SU_Msk                (0xFUL << RTC_TR_SU_Pos)                   /*!< 0x0000000F */
+#define RTC_TR_SU                    RTC_TR_SU_Msk
+#define RTC_TR_SU_0                  (0x1UL << RTC_TR_SU_Pos)                   /*!< 0x00000001 */
+#define RTC_TR_SU_1                  (0x2UL << RTC_TR_SU_Pos)                   /*!< 0x00000002 */
+#define RTC_TR_SU_2                  (0x4UL << RTC_TR_SU_Pos)                   /*!< 0x00000004 */
+#define RTC_TR_SU_3                  (0x8UL << RTC_TR_SU_Pos)                   /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                (20U)
+#define RTC_DR_YT_Msk                (0xFUL << RTC_DR_YT_Pos)                   /*!< 0x00F00000 */
+#define RTC_DR_YT                    RTC_DR_YT_Msk
+#define RTC_DR_YT_0                  (0x1UL << RTC_DR_YT_Pos)                   /*!< 0x00100000 */
+#define RTC_DR_YT_1                  (0x2UL << RTC_DR_YT_Pos)                   /*!< 0x00200000 */
+#define RTC_DR_YT_2                  (0x4UL << RTC_DR_YT_Pos)                   /*!< 0x00400000 */
+#define RTC_DR_YT_3                  (0x8UL << RTC_DR_YT_Pos)                   /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                (16U)
+#define RTC_DR_YU_Msk                (0xFUL << RTC_DR_YU_Pos)                   /*!< 0x000F0000 */
+#define RTC_DR_YU                    RTC_DR_YU_Msk
+#define RTC_DR_YU_0                  (0x1UL << RTC_DR_YU_Pos)                   /*!< 0x00010000 */
+#define RTC_DR_YU_1                  (0x2UL << RTC_DR_YU_Pos)                   /*!< 0x00020000 */
+#define RTC_DR_YU_2                  (0x4UL << RTC_DR_YU_Pos)                   /*!< 0x00040000 */
+#define RTC_DR_YU_3                  (0x8UL << RTC_DR_YU_Pos)                   /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos               (13U)
+#define RTC_DR_WDU_Msk               (0x7UL << RTC_DR_WDU_Pos)                  /*!< 0x0000E000 */
+#define RTC_DR_WDU                   RTC_DR_WDU_Msk
+#define RTC_DR_WDU_0                 (0x1UL << RTC_DR_WDU_Pos)                  /*!< 0x00002000 */
+#define RTC_DR_WDU_1                 (0x2UL << RTC_DR_WDU_Pos)                  /*!< 0x00004000 */
+#define RTC_DR_WDU_2                 (0x4UL << RTC_DR_WDU_Pos)                  /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                (12U)
+#define RTC_DR_MT_Msk                (0x1UL << RTC_DR_MT_Pos)                   /*!< 0x00001000 */
+#define RTC_DR_MT                    RTC_DR_MT_Msk
+#define RTC_DR_MU_Pos                (8U)
+#define RTC_DR_MU_Msk                (0xFUL << RTC_DR_MU_Pos)                   /*!< 0x00000F00 */
+#define RTC_DR_MU                    RTC_DR_MU_Msk
+#define RTC_DR_MU_0                  (0x1UL << RTC_DR_MU_Pos)                   /*!< 0x00000100 */
+#define RTC_DR_MU_1                  (0x2UL << RTC_DR_MU_Pos)                   /*!< 0x00000200 */
+#define RTC_DR_MU_2                  (0x4UL << RTC_DR_MU_Pos)                   /*!< 0x00000400 */
+#define RTC_DR_MU_3                  (0x8UL << RTC_DR_MU_Pos)                   /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                (4U)
+#define RTC_DR_DT_Msk                (0x3UL << RTC_DR_DT_Pos)                   /*!< 0x00000030 */
+#define RTC_DR_DT                    RTC_DR_DT_Msk
+#define RTC_DR_DT_0                  (0x1UL << RTC_DR_DT_Pos)                   /*!< 0x00000010 */
+#define RTC_DR_DT_1                  (0x2UL << RTC_DR_DT_Pos)                   /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                (0U)
+#define RTC_DR_DU_Msk                (0xFUL << RTC_DR_DU_Pos)                   /*!< 0x0000000F */
+#define RTC_DR_DU                    RTC_DR_DU_Msk
+#define RTC_DR_DU_0                  (0x1UL << RTC_DR_DU_Pos)                   /*!< 0x00000001 */
+#define RTC_DR_DU_1                  (0x2UL << RTC_DR_DU_Pos)                   /*!< 0x00000002 */
+#define RTC_DR_DU_2                  (0x4UL << RTC_DR_DU_Pos)                   /*!< 0x00000004 */
+#define RTC_DR_DU_3                  (0x8UL << RTC_DR_DU_Pos)                   /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos               (0U)
+#define RTC_SSR_SS_Msk               (0xFFFFUL << RTC_SSR_SS_Pos)               /*!< 0x0000FFFF */
+#define RTC_SSR_SS                   RTC_SSR_SS_Msk
+
+/********************  Bits definition for RTC_ICSR register  ******************/
+#define RTC_ICSR_RECALPF_Pos         (16U)
+#define RTC_ICSR_RECALPF_Msk         (0x1UL << RTC_ICSR_RECALPF_Pos)            /*!< 0x00010000 */
+#define RTC_ICSR_RECALPF             RTC_ICSR_RECALPF_Msk
+#define RTC_ICSR_INIT_Pos            (7U)
+#define RTC_ICSR_INIT_Msk            (0x1UL << RTC_ICSR_INIT_Pos)               /*!< 0x00000080 */
+#define RTC_ICSR_INIT                RTC_ICSR_INIT_Msk
+#define RTC_ICSR_INITF_Pos           (6U)
+#define RTC_ICSR_INITF_Msk           (0x1UL << RTC_ICSR_INITF_Pos)              /*!< 0x00000040 */
+#define RTC_ICSR_INITF               RTC_ICSR_INITF_Msk
+#define RTC_ICSR_RSF_Pos             (5U)
+#define RTC_ICSR_RSF_Msk             (0x1UL << RTC_ICSR_RSF_Pos)                /*!< 0x00000020 */
+#define RTC_ICSR_RSF                 RTC_ICSR_RSF_Msk
+#define RTC_ICSR_INITS_Pos           (4U)
+#define RTC_ICSR_INITS_Msk           (0x1UL << RTC_ICSR_INITS_Pos)              /*!< 0x00000010 */
+#define RTC_ICSR_INITS               RTC_ICSR_INITS_Msk
+#define RTC_ICSR_SHPF_Pos            (3U)
+#define RTC_ICSR_SHPF_Msk            (0x1UL << RTC_ICSR_SHPF_Pos)               /*!< 0x00000008 */
+#define RTC_ICSR_SHPF                RTC_ICSR_SHPF_Msk
+#define RTC_ICSR_WUTWF_Pos           (2U)
+#define RTC_ICSR_WUTWF_Msk           (0x1UL << RTC_ICSR_WUTWF_Pos)              /*!< 0x00000004 */
+#define RTC_ICSR_WUTWF               RTC_ICSR_WUTWF_Msk                         /*!< Wakeup timer write flag > */
+#define RTC_ICSR_ALRBWF_Pos          (1U)
+#define RTC_ICSR_ALRBWF_Msk          (0x1UL << RTC_ICSR_ALRBWF_Pos)             /*!< 0x00000002 */
+#define RTC_ICSR_ALRBWF              RTC_ICSR_ALRBWF_Msk
+#define RTC_ICSR_ALRAWF_Pos          (0U)
+#define RTC_ICSR_ALRAWF_Msk          (0x1UL << RTC_ICSR_ALRAWF_Pos)             /*!< 0x00000001 */
+#define RTC_ICSR_ALRAWF              RTC_ICSR_ALRAWF_Msk
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos        (16U)
+#define RTC_PRER_PREDIV_A_Msk        (0x7FUL << RTC_PRER_PREDIV_A_Pos)          /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A            RTC_PRER_PREDIV_A_Msk
+#define RTC_PRER_PREDIV_S_Pos        (0U)
+#define RTC_PRER_PREDIV_S_Msk        (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)        /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S            RTC_PRER_PREDIV_S_Msk
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos             (0U)
+#define RTC_WUTR_WUT_Msk             (0xFFFFUL << RTC_WUTR_WUT_Pos)            /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                 RTC_WUTR_WUT_Msk                          /*!< Wakeup auto-reload value bits > */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_OUT2EN_Pos            (31U)
+#define RTC_CR_OUT2EN_Msk            (0x1UL << RTC_CR_OUT2EN_Pos)              /*!< 0x80000000 */
+#define RTC_CR_OUT2EN                RTC_CR_OUT2EN_Msk                         /*!< RTC_OUT2 output enable */
+#define RTC_CR_TAMPALRM_TYPE_Pos     (30U)
+#define RTC_CR_TAMPALRM_TYPE_Msk     (0x1UL << RTC_CR_TAMPALRM_TYPE_Pos)       /*!< 0x40000000 */
+#define RTC_CR_TAMPALRM_TYPE         RTC_CR_TAMPALRM_TYPE_Msk                  /*!< TAMPALARM output type  */
+#define RTC_CR_TAMPALRM_PU_Pos       (29U)
+#define RTC_CR_TAMPALRM_PU_Msk       (0x1UL << RTC_CR_TAMPALRM_PU_Pos)         /*!< 0x20000000 */
+#define RTC_CR_TAMPALRM_PU           RTC_CR_TAMPALRM_PU_Msk                    /*!< TAMPALARM output pull-up config */
+#define RTC_CR_TAMPOE_Pos            (26U)
+#define RTC_CR_TAMPOE_Msk            (0x1UL << RTC_CR_TAMPOE_Pos)              /*!< 0x04000000 */
+#define RTC_CR_TAMPOE                RTC_CR_TAMPOE_Msk                         /*!< Tamper detection output enable on TAMPALARM  */
+#define RTC_CR_TAMPTS_Pos            (25U)
+#define RTC_CR_TAMPTS_Msk            (0x1UL << RTC_CR_TAMPTS_Pos)              /*!< 0x02000000 */
+#define RTC_CR_TAMPTS                RTC_CR_TAMPTS_Msk                         /*!< Activate timestamp on tamper detection event  */
+#define RTC_CR_ITSE_Pos              (24U)
+#define RTC_CR_ITSE_Msk              (0x1UL << RTC_CR_ITSE_Pos)                /*!< 0x01000000 */
+#define RTC_CR_ITSE                  RTC_CR_ITSE_Msk                           /*!< Timestamp on internal event enable  */
+#define RTC_CR_COE_Pos               (23U)
+#define RTC_CR_COE_Msk               (0x1UL << RTC_CR_COE_Pos)                 /*!< 0x00800000 */
+#define RTC_CR_COE                   RTC_CR_COE_Msk
+#define RTC_CR_OSEL_Pos              (21U)
+#define RTC_CR_OSEL_Msk              (0x3UL << RTC_CR_OSEL_Pos)                 /*!< 0x00600000 */
+#define RTC_CR_OSEL                  RTC_CR_OSEL_Msk
+#define RTC_CR_OSEL_0                (0x1UL << RTC_CR_OSEL_Pos)                 /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                (0x2UL << RTC_CR_OSEL_Pos)                 /*!< 0x00400000 */
+#define RTC_CR_POL_Pos               (20U)
+#define RTC_CR_POL_Msk               (0x1UL << RTC_CR_POL_Pos)                  /*!< 0x00100000 */
+#define RTC_CR_POL                   RTC_CR_POL_Msk
+#define RTC_CR_COSEL_Pos             (19U)
+#define RTC_CR_COSEL_Msk             (0x1UL << RTC_CR_COSEL_Pos)                /*!< 0x00080000 */
+#define RTC_CR_COSEL                 RTC_CR_COSEL_Msk
+#define RTC_CR_BKP_Pos               (18U)
+#define RTC_CR_BKP_Msk               (0x1UL << RTC_CR_BKP_Pos)                  /*!< 0x00040000 */
+#define RTC_CR_BKP                   RTC_CR_BKP_Msk
+#define RTC_CR_SUB1H_Pos             (17U)
+#define RTC_CR_SUB1H_Msk             (0x1UL << RTC_CR_SUB1H_Pos)                /*!< 0x00020000 */
+#define RTC_CR_SUB1H                 RTC_CR_SUB1H_Msk
+#define RTC_CR_ADD1H_Pos             (16U)
+#define RTC_CR_ADD1H_Msk             (0x1UL << RTC_CR_ADD1H_Pos)                /*!< 0x00010000 */
+#define RTC_CR_ADD1H                 RTC_CR_ADD1H_Msk
+#define RTC_CR_TSIE_Pos              (15U)
+#define RTC_CR_TSIE_Msk              (0x1UL << RTC_CR_TSIE_Pos)                /*!< 0x00008000 */
+#define RTC_CR_TSIE                  RTC_CR_TSIE_Msk                           /*!< Timestamp interrupt enable > */
+#define RTC_CR_WUTIE_Pos             (14U)
+#define RTC_CR_WUTIE_Msk             (0x1UL << RTC_CR_WUTIE_Pos)               /*!< 0x00004000 */
+#define RTC_CR_WUTIE                 RTC_CR_WUTIE_Msk                          /*!< Wakeup timer interrupt enable > */
+#define RTC_CR_ALRBIE_Pos            (13U)
+#define RTC_CR_ALRBIE_Msk            (0x1UL << RTC_CR_ALRBIE_Pos)              /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                RTC_CR_ALRBIE_Msk
+#define RTC_CR_ALRAIE_Pos            (12U)
+#define RTC_CR_ALRAIE_Msk            (0x1UL << RTC_CR_ALRAIE_Pos)              /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                RTC_CR_ALRAIE_Msk
+#define RTC_CR_TSE_Pos               (11U)
+#define RTC_CR_TSE_Msk               (0x1UL << RTC_CR_TSE_Pos)                 /*!< 0x00000800 */
+#define RTC_CR_TSE                   RTC_CR_TSE_Msk                            /*!< timestamp enable > */
+#define RTC_CR_WUTE_Pos              (10U)
+#define RTC_CR_WUTE_Msk              (0x1UL << RTC_CR_WUTE_Pos)                /*!< 0x00000400 */
+#define RTC_CR_WUTE                  RTC_CR_WUTE_Msk                           /*!< Wakeup timer enable > */
+#define RTC_CR_ALRBE_Pos             (9U)
+#define RTC_CR_ALRBE_Msk             (0x1UL << RTC_CR_ALRBE_Pos)               /*!< 0x00000200 */
+#define RTC_CR_ALRBE                 RTC_CR_ALRBE_Msk
+#define RTC_CR_ALRAE_Pos             (8U)
+#define RTC_CR_ALRAE_Msk             (0x1UL << RTC_CR_ALRAE_Pos)                /*!< 0x00000100 */
+#define RTC_CR_ALRAE                 RTC_CR_ALRAE_Msk
+#define RTC_CR_FMT_Pos               (6U)
+#define RTC_CR_FMT_Msk               (0x1UL << RTC_CR_FMT_Pos)                  /*!< 0x00000040 */
+#define RTC_CR_FMT                   RTC_CR_FMT_Msk
+#define RTC_CR_BYPSHAD_Pos           (5U)
+#define RTC_CR_BYPSHAD_Msk           (0x1UL << RTC_CR_BYPSHAD_Pos)              /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD               RTC_CR_BYPSHAD_Msk
+#define RTC_CR_REFCKON_Pos           (4U)
+#define RTC_CR_REFCKON_Msk           (0x1UL << RTC_CR_REFCKON_Pos)              /*!< 0x00000010 */
+#define RTC_CR_REFCKON               RTC_CR_REFCKON_Msk
+#define RTC_CR_TSEDGE_Pos            (3U)
+#define RTC_CR_TSEDGE_Msk            (0x1UL << RTC_CR_TSEDGE_Pos)              /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                RTC_CR_TSEDGE_Msk                         /*!< Timestamp event active edge > */
+#define RTC_CR_WUCKSEL_Pos           (0U)
+#define RTC_CR_WUCKSEL_Msk           (0x7UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL               RTC_CR_WUCKSEL_Msk                        /*!< Wakeup clock selection > */
+#define RTC_CR_WUCKSEL_0             (0x1UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1             (0x2UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2             (0x4UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000004 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos              (0U)
+#define RTC_WPR_KEY_Msk              (0xFFUL << RTC_WPR_KEY_Pos)                /*!< 0x000000FF */
+#define RTC_WPR_KEY                  RTC_WPR_KEY_Msk
+
+/********************  Bits definition for RTC_CALR register  *****************/
+#define RTC_CALR_CALP_Pos            (15U)
+#define RTC_CALR_CALP_Msk            (0x1UL << RTC_CALR_CALP_Pos)               /*!< 0x00008000 */
+#define RTC_CALR_CALP                RTC_CALR_CALP_Msk
+#define RTC_CALR_CALW8_Pos           (14U)
+#define RTC_CALR_CALW8_Msk           (0x1UL << RTC_CALR_CALW8_Pos)              /*!< 0x00004000 */
+#define RTC_CALR_CALW8               RTC_CALR_CALW8_Msk
+#define RTC_CALR_CALW16_Pos          (13U)
+#define RTC_CALR_CALW16_Msk          (0x1UL << RTC_CALR_CALW16_Pos)             /*!< 0x00002000 */
+#define RTC_CALR_CALW16              RTC_CALR_CALW16_Msk
+#define RTC_CALR_CALM_Pos            (0U)
+#define RTC_CALR_CALM_Msk            (0x1FFUL << RTC_CALR_CALM_Pos)             /*!< 0x000001FF */
+#define RTC_CALR_CALM                RTC_CALR_CALM_Msk
+#define RTC_CALR_CALM_0              (0x001UL << RTC_CALR_CALM_Pos)             /*!< 0x00000001 */
+#define RTC_CALR_CALM_1              (0x002UL << RTC_CALR_CALM_Pos)             /*!< 0x00000002 */
+#define RTC_CALR_CALM_2              (0x004UL << RTC_CALR_CALM_Pos)             /*!< 0x00000004 */
+#define RTC_CALR_CALM_3              (0x008UL << RTC_CALR_CALM_Pos)             /*!< 0x00000008 */
+#define RTC_CALR_CALM_4              (0x010UL << RTC_CALR_CALM_Pos)             /*!< 0x00000010 */
+#define RTC_CALR_CALM_5              (0x020UL << RTC_CALR_CALM_Pos)             /*!< 0x00000020 */
+#define RTC_CALR_CALM_6              (0x040UL << RTC_CALR_CALM_Pos)             /*!< 0x00000040 */
+#define RTC_CALR_CALM_7              (0x080UL << RTC_CALR_CALM_Pos)             /*!< 0x00000080 */
+#define RTC_CALR_CALM_8              (0x100UL << RTC_CALR_CALM_Pos)             /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos         (0U)
+#define RTC_SHIFTR_SUBFS_Msk         (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)         /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS             RTC_SHIFTR_SUBFS_Msk
+#define RTC_SHIFTR_ADD1S_Pos         (31U)
+#define RTC_SHIFTR_ADD1S_Msk         (0x1UL << RTC_SHIFTR_ADD1S_Pos)            /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S             RTC_SHIFTR_ADD1S_Msk
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos              (22U)
+#define RTC_TSTR_PM_Msk              (0x1UL << RTC_TSTR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TSTR_PM                  RTC_TSTR_PM_Msk                           /*!< AM-PM notation > */
+#define RTC_TSTR_HT_Pos              (20U)
+#define RTC_TSTR_HT_Msk              (0x3UL << RTC_TSTR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TSTR_HT                  RTC_TSTR_HT_Msk
+#define RTC_TSTR_HT_0                (0x1UL << RTC_TSTR_HT_Pos)                /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                (0x2UL << RTC_TSTR_HT_Pos)                /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos              (16U)
+#define RTC_TSTR_HU_Msk              (0xFUL << RTC_TSTR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TSTR_HU                  RTC_TSTR_HU_Msk
+#define RTC_TSTR_HU_0                (0x1UL << RTC_TSTR_HU_Pos)                /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                (0x2UL << RTC_TSTR_HU_Pos)                /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                (0x4UL << RTC_TSTR_HU_Pos)                /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                (0x8UL << RTC_TSTR_HU_Pos)                /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos             (12U)
+#define RTC_TSTR_MNT_Msk             (0x7UL << RTC_TSTR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TSTR_MNT                 RTC_TSTR_MNT_Msk
+#define RTC_TSTR_MNT_0               (0x1UL << RTC_TSTR_MNT_Pos)               /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1               (0x2UL << RTC_TSTR_MNT_Pos)               /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2               (0x4UL << RTC_TSTR_MNT_Pos)                /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos             (8U)
+#define RTC_TSTR_MNU_Msk             (0xFUL << RTC_TSTR_MNU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                 RTC_TSTR_MNU_Msk
+#define RTC_TSTR_MNU_0               (0x1UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1               (0x2UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2               (0x4UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3               (0x8UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos              (4U)
+#define RTC_TSTR_ST_Msk              (0x7UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000070 */
+#define RTC_TSTR_ST                  RTC_TSTR_ST_Msk
+#define RTC_TSTR_ST_0                (0x1UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                (0x2UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                (0x4UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos              (0U)
+#define RTC_TSTR_SU_Msk              (0xFUL << RTC_TSTR_SU_Pos)                 /*!< 0x0000000F */
+#define RTC_TSTR_SU                  RTC_TSTR_SU_Msk
+#define RTC_TSTR_SU_0                (0x1UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                (0x2UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                (0x4UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                (0x8UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos             (13U)
+#define RTC_TSDR_WDU_Msk             (0x7UL << RTC_TSDR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                 RTC_TSDR_WDU_Msk                          /*!< Week day units > */
+#define RTC_TSDR_WDU_0               (0x1UL << RTC_TSDR_WDU_Pos)               /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1               (0x2UL << RTC_TSDR_WDU_Pos)               /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2               (0x4UL << RTC_TSDR_WDU_Pos)               /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos              (12U)
+#define RTC_TSDR_MT_Msk              (0x1UL << RTC_TSDR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_TSDR_MT                  RTC_TSDR_MT_Msk
+#define RTC_TSDR_MU_Pos              (8U)
+#define RTC_TSDR_MU_Msk              (0xFUL << RTC_TSDR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSDR_MU                  RTC_TSDR_MU_Msk
+#define RTC_TSDR_MU_0                (0x1UL << RTC_TSDR_MU_Pos)                /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                (0x2UL << RTC_TSDR_MU_Pos)                /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                (0x4UL << RTC_TSDR_MU_Pos)                /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                (0x8UL << RTC_TSDR_MU_Pos)                /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos              (4U)
+#define RTC_TSDR_DT_Msk              (0x3UL << RTC_TSDR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_TSDR_DT                  RTC_TSDR_DT_Msk
+#define RTC_TSDR_DT_0                (0x1UL << RTC_TSDR_DT_Pos)                /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                (0x2UL << RTC_TSDR_DT_Pos)                /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos              (0U)
+#define RTC_TSDR_DU_Msk              (0xFUL << RTC_TSDR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_TSDR_DU                  RTC_TSDR_DU_Msk
+#define RTC_TSDR_DU_0                (0x1UL << RTC_TSDR_DU_Pos)                /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                (0x2UL << RTC_TSDR_DU_Pos)                /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                (0x4UL << RTC_TSDR_DU_Pos)                /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                (0x8UL << RTC_TSDR_DU_Pos)                /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos             (0U)
+#define RTC_TSSSR_SS_Msk             (0xFFFFUL << RTC_TSSSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                 RTC_TSSSR_SS_Msk                          /*!< Sub second value > */
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos          (31U)
+#define RTC_ALRMAR_MSK4_Msk          (0x1UL << RTC_ALRMAR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4              RTC_ALRMAR_MSK4_Msk
+#define RTC_ALRMAR_WDSEL_Pos         (30U)
+#define RTC_ALRMAR_WDSEL_Msk         (0x1UL << RTC_ALRMAR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL             RTC_ALRMAR_WDSEL_Msk
+#define RTC_ALRMAR_DT_Pos            (28U)
+#define RTC_ALRMAR_DT_Msk            (0x3UL << RTC_ALRMAR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                RTC_ALRMAR_DT_Msk
+#define RTC_ALRMAR_DT_0              (0x1UL << RTC_ALRMAR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1              (0x2UL << RTC_ALRMAR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos            (24U)
+#define RTC_ALRMAR_DU_Msk            (0xFUL << RTC_ALRMAR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                RTC_ALRMAR_DU_Msk
+#define RTC_ALRMAR_DU_0              (0x1UL << RTC_ALRMAR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1              (0x2UL << RTC_ALRMAR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2              (0x4UL << RTC_ALRMAR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3              (0x8UL << RTC_ALRMAR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos          (23U)
+#define RTC_ALRMAR_MSK3_Msk          (0x1UL << RTC_ALRMAR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3              RTC_ALRMAR_MSK3_Msk
+#define RTC_ALRMAR_PM_Pos            (22U)
+#define RTC_ALRMAR_PM_Msk            (0x1UL << RTC_ALRMAR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                RTC_ALRMAR_PM_Msk
+#define RTC_ALRMAR_HT_Pos            (20U)
+#define RTC_ALRMAR_HT_Msk            (0x3UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                RTC_ALRMAR_HT_Msk
+#define RTC_ALRMAR_HT_0              (0x1UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1              (0x2UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos            (16U)
+#define RTC_ALRMAR_HU_Msk            (0xFUL << RTC_ALRMAR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                RTC_ALRMAR_HU_Msk
+#define RTC_ALRMAR_HU_0              (0x1UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1              (0x2UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2              (0x4UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3              (0x8UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos          (15U)
+#define RTC_ALRMAR_MSK2_Msk          (0x1UL << RTC_ALRMAR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2              RTC_ALRMAR_MSK2_Msk
+#define RTC_ALRMAR_MNT_Pos           (12U)
+#define RTC_ALRMAR_MNT_Msk           (0x7UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT               RTC_ALRMAR_MNT_Msk
+#define RTC_ALRMAR_MNT_0             (0x1UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1             (0x2UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2             (0x4UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos           (8U)
+#define RTC_ALRMAR_MNU_Msk           (0xFUL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU               RTC_ALRMAR_MNU_Msk
+#define RTC_ALRMAR_MNU_0             (0x1UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1             (0x2UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2             (0x4UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3             (0x8UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos          (7U)
+#define RTC_ALRMAR_MSK1_Msk          (0x1UL << RTC_ALRMAR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1              RTC_ALRMAR_MSK1_Msk
+#define RTC_ALRMAR_ST_Pos            (4U)
+#define RTC_ALRMAR_ST_Msk            (0x7UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                RTC_ALRMAR_ST_Msk
+#define RTC_ALRMAR_ST_0              (0x1UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1              (0x2UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2              (0x4UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos            (0U)
+#define RTC_ALRMAR_SU_Msk            (0xFUL << RTC_ALRMAR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                RTC_ALRMAR_SU_Msk
+#define RTC_ALRMAR_SU_0              (0x1UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1              (0x2UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2              (0x4UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3              (0x8UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos      (24U)
+#define RTC_ALRMASSR_MASKSS_Msk      (0xFUL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS          RTC_ALRMASSR_MASKSS_Msk
+#define RTC_ALRMASSR_MASKSS_0        (0x1UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1        (0x2UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2        (0x4UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3        (0x8UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos          (0U)
+#define RTC_ALRMASSR_SS_Msk          (0x7FFFUL << RTC_ALRMASSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS              RTC_ALRMASSR_SS_Msk
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos          (31U)
+#define RTC_ALRMBR_MSK4_Msk          (0x1UL << RTC_ALRMBR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4              RTC_ALRMBR_MSK4_Msk
+#define RTC_ALRMBR_WDSEL_Pos         (30U)
+#define RTC_ALRMBR_WDSEL_Msk         (0x1UL << RTC_ALRMBR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL             RTC_ALRMBR_WDSEL_Msk
+#define RTC_ALRMBR_DT_Pos            (28U)
+#define RTC_ALRMBR_DT_Msk            (0x3UL << RTC_ALRMBR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                RTC_ALRMBR_DT_Msk
+#define RTC_ALRMBR_DT_0              (0x1UL << RTC_ALRMBR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1              (0x2UL << RTC_ALRMBR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos            (24U)
+#define RTC_ALRMBR_DU_Msk            (0xFUL << RTC_ALRMBR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                RTC_ALRMBR_DU_Msk
+#define RTC_ALRMBR_DU_0              (0x1UL << RTC_ALRMBR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1              (0x2UL << RTC_ALRMBR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2              (0x4UL << RTC_ALRMBR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3              (0x8UL << RTC_ALRMBR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos          (23U)
+#define RTC_ALRMBR_MSK3_Msk          (0x1UL << RTC_ALRMBR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3              RTC_ALRMBR_MSK3_Msk
+#define RTC_ALRMBR_PM_Pos            (22U)
+#define RTC_ALRMBR_PM_Msk            (0x1UL << RTC_ALRMBR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                RTC_ALRMBR_PM_Msk
+#define RTC_ALRMBR_HT_Pos            (20U)
+#define RTC_ALRMBR_HT_Msk            (0x3UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                RTC_ALRMBR_HT_Msk
+#define RTC_ALRMBR_HT_0              (0x1UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1              (0x2UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos            (16U)
+#define RTC_ALRMBR_HU_Msk            (0xFUL << RTC_ALRMBR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                RTC_ALRMBR_HU_Msk
+#define RTC_ALRMBR_HU_0              (0x1UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1              (0x2UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2              (0x4UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3              (0x8UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos          (15U)
+#define RTC_ALRMBR_MSK2_Msk          (0x1UL << RTC_ALRMBR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2              RTC_ALRMBR_MSK2_Msk
+#define RTC_ALRMBR_MNT_Pos           (12U)
+#define RTC_ALRMBR_MNT_Msk           (0x7UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT               RTC_ALRMBR_MNT_Msk
+#define RTC_ALRMBR_MNT_0             (0x1UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1             (0x2UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2             (0x4UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos           (8U)
+#define RTC_ALRMBR_MNU_Msk           (0xFUL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU               RTC_ALRMBR_MNU_Msk
+#define RTC_ALRMBR_MNU_0             (0x1UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1             (0x2UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2             (0x4UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3             (0x8UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos          (7U)
+#define RTC_ALRMBR_MSK1_Msk          (0x1UL << RTC_ALRMBR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1              RTC_ALRMBR_MSK1_Msk
+#define RTC_ALRMBR_ST_Pos            (4U)
+#define RTC_ALRMBR_ST_Msk            (0x7UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                RTC_ALRMBR_ST_Msk
+#define RTC_ALRMBR_ST_0              (0x1UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1              (0x2UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2              (0x4UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos            (0U)
+#define RTC_ALRMBR_SU_Msk            (0xFUL << RTC_ALRMBR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                RTC_ALRMBR_SU_Msk
+#define RTC_ALRMBR_SU_0              (0x1UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1              (0x2UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2              (0x4UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3              (0x8UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos      (24U)
+#define RTC_ALRMBSSR_MASKSS_Msk      (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS          RTC_ALRMBSSR_MASKSS_Msk
+#define RTC_ALRMBSSR_MASKSS_0        (0x1UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1        (0x2UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2        (0x4UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3        (0x8UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos          (0U)
+#define RTC_ALRMBSSR_SS_Msk          (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS              RTC_ALRMBSSR_SS_Msk
+
+/********************  Bits definition for RTC_SR register  *******************/
+#define RTC_SR_ITSF_Pos              (5U)
+#define RTC_SR_ITSF_Msk              (0x1UL << RTC_SR_ITSF_Pos)                /*!< 0x00000020 */
+#define RTC_SR_ITSF                  RTC_SR_ITSF_Msk
+#define RTC_SR_TSOVF_Pos             (4U)
+#define RTC_SR_TSOVF_Msk             (0x1UL << RTC_SR_TSOVF_Pos)               /*!< 0x00000010 */
+#define RTC_SR_TSOVF                 RTC_SR_TSOVF_Msk                          /*!< Timestamp overflow flag > */
+#define RTC_SR_TSF_Pos               (3U)
+#define RTC_SR_TSF_Msk               (0x1UL << RTC_SR_TSF_Pos)                 /*!< 0x00000008 */
+#define RTC_SR_TSF                   RTC_SR_TSF_Msk                            /*!< Timestamp flag > */
+#define RTC_SR_WUTF_Pos              (2U)
+#define RTC_SR_WUTF_Msk              (0x1UL << RTC_SR_WUTF_Pos)                /*!< 0x00000004 */
+#define RTC_SR_WUTF                  RTC_SR_WUTF_Msk                           /*!< Wakeup timer flag > */
+#define RTC_SR_ALRBF_Pos             (1U)
+#define RTC_SR_ALRBF_Msk             (0x1UL << RTC_SR_ALRBF_Pos)               /*!< 0x00000002 */
+#define RTC_SR_ALRBF                 RTC_SR_ALRBF_Msk
+#define RTC_SR_ALRAF_Pos             (0U)
+#define RTC_SR_ALRAF_Msk             (0x1UL << RTC_SR_ALRAF_Pos)               /*!< 0x00000001 */
+#define RTC_SR_ALRAF                 RTC_SR_ALRAF_Msk
+
+/********************  Bits definition for RTC_MISR register  *****************/
+#define RTC_MISR_ITSMF_Pos           (5U)
+#define RTC_MISR_ITSMF_Msk           (0x1UL << RTC_MISR_ITSMF_Pos)             /*!< 0x00000020 */
+#define RTC_MISR_ITSMF               RTC_MISR_ITSMF_Msk
+#define RTC_MISR_TSOVMF_Pos          (4U)
+#define RTC_MISR_TSOVMF_Msk          (0x1UL << RTC_MISR_TSOVMF_Pos)            /*!< 0x00000010 */
+#define RTC_MISR_TSOVMF              RTC_MISR_TSOVMF_Msk                       /*!< Timestamp overflow masked flag > */
+#define RTC_MISR_TSMF_Pos            (3U)
+#define RTC_MISR_TSMF_Msk            (0x1UL << RTC_MISR_TSMF_Pos)              /*!< 0x00000008 */
+#define RTC_MISR_TSMF                RTC_MISR_TSMF_Msk                         /*!< Timestamp masked flag > */
+#define RTC_MISR_WUTMF_Pos           (2U)
+#define RTC_MISR_WUTMF_Msk           (0x1UL << RTC_MISR_WUTMF_Pos)             /*!< 0x00000004 */
+#define RTC_MISR_WUTMF               RTC_MISR_WUTMF_Msk                        /*!< Wakeup timer masked flag > */
+#define RTC_MISR_ALRBMF_Pos          (1U)
+#define RTC_MISR_ALRBMF_Msk          (0x1UL << RTC_MISR_ALRBMF_Pos)            /*!< 0x00000002 */
+#define RTC_MISR_ALRBMF              RTC_MISR_ALRBMF_Msk
+#define RTC_MISR_ALRAMF_Pos          (0U)
+#define RTC_MISR_ALRAMF_Msk          (0x1UL << RTC_MISR_ALRAMF_Pos)            /*!< 0x00000001 */
+#define RTC_MISR_ALRAMF              RTC_MISR_ALRAMF_Msk
+
+/********************  Bits definition for RTC_SCR register  ******************/
+#define RTC_SCR_CITSF_Pos            (5U)
+#define RTC_SCR_CITSF_Msk            (0x1UL << RTC_SCR_CITSF_Pos)              /*!< 0x00000020 */
+#define RTC_SCR_CITSF                RTC_SCR_CITSF_Msk
+#define RTC_SCR_CTSOVF_Pos           (4U)
+#define RTC_SCR_CTSOVF_Msk           (0x1UL << RTC_SCR_CTSOVF_Pos)             /*!< 0x00000010 */
+#define RTC_SCR_CTSOVF               RTC_SCR_CTSOVF_Msk                        /*!< Clear timestamp overflow flag > */
+#define RTC_SCR_CTSF_Pos             (3U)
+#define RTC_SCR_CTSF_Msk             (0x1UL << RTC_SCR_CTSF_Pos)               /*!< 0x00000008 */
+#define RTC_SCR_CTSF                 RTC_SCR_CTSF_Msk                          /*!< Clear timestamp flag > */
+#define RTC_SCR_CWUTF_Pos            (2U)
+#define RTC_SCR_CWUTF_Msk            (0x1UL << RTC_SCR_CWUTF_Pos)              /*!< 0x00000004 */
+#define RTC_SCR_CWUTF                RTC_SCR_CWUTF_Msk                         /*!< Clear wakeup timer flag > */
+#define RTC_SCR_CALRBF_Pos           (1U)
+#define RTC_SCR_CALRBF_Msk           (0x1UL << RTC_SCR_CALRBF_Pos)             /*!< 0x00000002 */
+#define RTC_SCR_CALRBF               RTC_SCR_CALRBF_Msk
+#define RTC_SCR_CALRAF_Pos           (0U)
+#define RTC_SCR_CALRAF_Msk           (0x1UL << RTC_SCR_CALRAF_Pos)             /*!< 0x00000001 */
+#define RTC_SCR_CALRAF               RTC_SCR_CALRAF_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                     Tamper and backup register (TAMP)                      */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for TAMP_CR1 register  *****************/
+#define TAMP_CR1_TAMP1E_Pos          (0U)
+#define TAMP_CR1_TAMP1E_Msk          (0x1UL << TAMP_CR1_TAMP1E_Pos)             /*!< 0x00000001 */
+#define TAMP_CR1_TAMP1E              TAMP_CR1_TAMP1E_Msk
+#define TAMP_CR1_TAMP2E_Pos          (1U)
+#define TAMP_CR1_TAMP2E_Msk          (0x1UL << TAMP_CR1_TAMP2E_Pos)             /*!< 0x00000002 */
+#define TAMP_CR1_TAMP2E              TAMP_CR1_TAMP2E_Msk
+#define TAMP_CR1_ITAMP3E_Pos         (18U)
+#define TAMP_CR1_ITAMP3E_Msk         (0x1UL << TAMP_CR1_ITAMP3E_Pos)            /*!< 0x00040000 */
+#define TAMP_CR1_ITAMP3E             TAMP_CR1_ITAMP3E_Msk
+#define TAMP_CR1_ITAMP4E_Pos         (19U)
+#define TAMP_CR1_ITAMP4E_Msk         (0x1UL << TAMP_CR1_ITAMP4E_Pos)            /*!< 0x00080000 */
+#define TAMP_CR1_ITAMP4E             TAMP_CR1_ITAMP4E_Msk
+#define TAMP_CR1_ITAMP5E_Pos         (20U)
+#define TAMP_CR1_ITAMP5E_Msk         (0x1UL << TAMP_CR1_ITAMP5E_Pos)            /*!< 0x00100000 */
+#define TAMP_CR1_ITAMP5E             TAMP_CR1_ITAMP5E_Msk
+#define TAMP_CR1_ITAMP6E_Pos         (21U)
+#define TAMP_CR1_ITAMP6E_Msk         (0x1UL << TAMP_CR1_ITAMP6E_Pos)            /*!< 0x00200000 */
+#define TAMP_CR1_ITAMP6E             TAMP_CR1_ITAMP6E_Msk
+
+/********************  Bits definition for TAMP_CR2 register  *****************/
+#define TAMP_CR2_TAMP1NOERASE_Pos    (0U)
+#define TAMP_CR2_TAMP1NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP1NOERASE_Pos)       /*!< 0x00000001 */
+#define TAMP_CR2_TAMP1NOERASE        TAMP_CR2_TAMP1NOERASE_Msk
+#define TAMP_CR2_TAMP2NOERASE_Pos    (1U)
+#define TAMP_CR2_TAMP2NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP2NOERASE_Pos)       /*!< 0x00000002 */
+#define TAMP_CR2_TAMP2NOERASE        TAMP_CR2_TAMP2NOERASE_Msk
+#define TAMP_CR2_TAMP1MSK_Pos        (16U)
+#define TAMP_CR2_TAMP1MSK_Msk        (0x1UL << TAMP_CR2_TAMP1MSK_Pos)           /*!< 0x00010000 */
+#define TAMP_CR2_TAMP1MSK            TAMP_CR2_TAMP1MSK_Msk
+#define TAMP_CR2_TAMP2MSK_Pos        (17U)
+#define TAMP_CR2_TAMP2MSK_Msk        (0x1UL << TAMP_CR2_TAMP2MSK_Pos)           /*!< 0x00020000 */
+#define TAMP_CR2_TAMP2MSK            TAMP_CR2_TAMP2MSK_Msk
+#define TAMP_CR2_TAMP1TRG_Pos        (24U)
+#define TAMP_CR2_TAMP1TRG_Msk        (0x1UL << TAMP_CR2_TAMP1TRG_Pos)           /*!< 0x01000000 */
+#define TAMP_CR2_TAMP1TRG            TAMP_CR2_TAMP1TRG_Msk
+#define TAMP_CR2_TAMP2TRG_Pos        (25U)
+#define TAMP_CR2_TAMP2TRG_Msk        (0x1UL << TAMP_CR2_TAMP2TRG_Pos)           /*!< 0x02000000 */
+#define TAMP_CR2_TAMP2TRG            TAMP_CR2_TAMP2TRG_Msk
+
+/********************  Bits definition for TAMP_FLTCR register  ***************/
+#define TAMP_FLTCR_TAMPFREQ_0        0x00000001U
+#define TAMP_FLTCR_TAMPFREQ_1        0x00000002U
+#define TAMP_FLTCR_TAMPFREQ_2        0x00000004U
+#define TAMP_FLTCR_TAMPFREQ_Pos      (0U)
+#define TAMP_FLTCR_TAMPFREQ_Msk      (0x7UL << TAMP_FLTCR_TAMPFREQ_Pos)         /*!< 0x00000007 */
+#define TAMP_FLTCR_TAMPFREQ          TAMP_FLTCR_TAMPFREQ_Msk
+#define TAMP_FLTCR_TAMPFLT_0         0x00000008U
+#define TAMP_FLTCR_TAMPFLT_1         0x00000010U
+#define TAMP_FLTCR_TAMPFLT_Pos       (3U)
+#define TAMP_FLTCR_TAMPFLT_Msk       (0x3UL << TAMP_FLTCR_TAMPFLT_Pos)          /*!< 0x00000018 */
+#define TAMP_FLTCR_TAMPFLT           TAMP_FLTCR_TAMPFLT_Msk
+#define TAMP_FLTCR_TAMPPRCH_0        0x00000020U
+#define TAMP_FLTCR_TAMPPRCH_1        0x00000040U
+#define TAMP_FLTCR_TAMPPRCH_Pos      (5U)
+#define TAMP_FLTCR_TAMPPRCH_Msk      (0x3UL << TAMP_FLTCR_TAMPPRCH_Pos)         /*!< 0x00000060 */
+#define TAMP_FLTCR_TAMPPRCH          TAMP_FLTCR_TAMPPRCH_Msk
+#define TAMP_FLTCR_TAMPPUDIS_Pos     (7U)
+#define TAMP_FLTCR_TAMPPUDIS_Msk     (0x1UL << TAMP_FLTCR_TAMPPUDIS_Pos)        /*!< 0x00000080 */
+#define TAMP_FLTCR_TAMPPUDIS         TAMP_FLTCR_TAMPPUDIS_Msk
+
+/********************  Bits definition for TAMP_IER register  *****************/
+#define TAMP_IER_TAMP1IE_Pos         (0U)
+#define TAMP_IER_TAMP1IE_Msk         (0x1UL << TAMP_IER_TAMP1IE_Pos)            /*!< 0x00000001 */
+#define TAMP_IER_TAMP1IE             TAMP_IER_TAMP1IE_Msk
+#define TAMP_IER_TAMP2IE_Pos         (1U)
+#define TAMP_IER_TAMP2IE_Msk         (0x1UL << TAMP_IER_TAMP2IE_Pos)            /*!< 0x00000002 */
+#define TAMP_IER_TAMP2IE             TAMP_IER_TAMP2IE_Msk
+#define TAMP_IER_ITAMP3IE_Pos        (18U)
+#define TAMP_IER_ITAMP3IE_Msk        (0x1UL << TAMP_IER_ITAMP3IE_Pos)           /*!< 0x00040000 */
+#define TAMP_IER_ITAMP3IE            TAMP_IER_ITAMP3IE_Msk
+#define TAMP_IER_ITAMP4IE_Pos        (19U)
+#define TAMP_IER_ITAMP4IE_Msk        (0x1UL << TAMP_IER_ITAMP4IE_Pos)           /*!< 0x00080000 */
+#define TAMP_IER_ITAMP4IE            TAMP_IER_ITAMP4IE_Msk
+#define TAMP_IER_ITAMP5IE_Pos        (20U)
+#define TAMP_IER_ITAMP5IE_Msk        (0x1UL << TAMP_IER_ITAMP5IE_Pos)           /*!< 0x00100000 */
+#define TAMP_IER_ITAMP5IE            TAMP_IER_ITAMP5IE_Msk
+#define TAMP_IER_ITAMP6IE_Pos        (21U)
+#define TAMP_IER_ITAMP6IE_Msk        (0x1UL << TAMP_IER_ITAMP6IE_Pos)           /*!< 0x00200000 */
+#define TAMP_IER_ITAMP6IE            TAMP_IER_ITAMP6IE_Msk
+
+/********************  Bits definition for TAMP_SR register  ******************/
+#define TAMP_SR_TAMP1F_Pos           (0U)
+#define TAMP_SR_TAMP1F_Msk           (0x1UL << TAMP_SR_TAMP1F_Pos)              /*!< 0x00000001 */
+#define TAMP_SR_TAMP1F               TAMP_SR_TAMP1F_Msk
+#define TAMP_SR_TAMP2F_Pos           (1U)
+#define TAMP_SR_TAMP2F_Msk           (0x1UL << TAMP_SR_TAMP2F_Pos)              /*!< 0x00000002 */
+#define TAMP_SR_TAMP2F               TAMP_SR_TAMP2F_Msk
+#define TAMP_SR_ITAMP3F_Pos          (18U)
+#define TAMP_SR_ITAMP3F_Msk          (0x1UL << TAMP_SR_ITAMP3F_Pos)             /*!< 0x00040000 */
+#define TAMP_SR_ITAMP3F              TAMP_SR_ITAMP3F_Msk
+#define TAMP_SR_ITAMP4F_Pos          (19U)
+#define TAMP_SR_ITAMP4F_Msk          (0x1UL << TAMP_SR_ITAMP4F_Pos)             /*!< 0x00080000 */
+#define TAMP_SR_ITAMP4F              TAMP_SR_ITAMP4F_Msk
+#define TAMP_SR_ITAMP5F_Pos          (20U)
+#define TAMP_SR_ITAMP5F_Msk          (0x1UL << TAMP_SR_ITAMP5F_Pos)             /*!< 0x00100000 */
+#define TAMP_SR_ITAMP5F              TAMP_SR_ITAMP5F_Msk
+#define TAMP_SR_ITAMP6F_Pos          (21U)
+#define TAMP_SR_ITAMP6F_Msk          (0x1UL << TAMP_SR_ITAMP6F_Pos)             /*!< 0x00200000 */
+#define TAMP_SR_ITAMP6F              TAMP_SR_ITAMP6F_Msk
+
+/********************  Bits definition for TAMP_MISR register  ****************/
+#define TAMP_MISR_TAMP1MF_Pos        (0U)
+#define TAMP_MISR_TAMP1MF_Msk        (0x1UL << TAMP_MISR_TAMP1MF_Pos)           /*!< 0x00000001 */
+#define TAMP_MISR_TAMP1MF            TAMP_MISR_TAMP1MF_Msk
+#define TAMP_MISR_TAMP2MF_Pos        (1U)
+#define TAMP_MISR_TAMP2MF_Msk        (0x1UL << TAMP_MISR_TAMP2MF_Pos)           /*!< 0x00000002 */
+#define TAMP_MISR_TAMP2MF            TAMP_MISR_TAMP2MF_Msk
+#define TAMP_MISR_ITAMP3MF_Pos       (18U)
+#define TAMP_MISR_ITAMP3MF_Msk       (0x1UL << TAMP_MISR_ITAMP3MF_Pos)          /*!< 0x00040000 */
+#define TAMP_MISR_ITAMP3MF           TAMP_MISR_ITAMP3MF_Msk
+#define TAMP_MISR_ITAMP4MF_Pos       (19U)
+#define TAMP_MISR_ITAMP4MF_Msk       (0x1UL << TAMP_MISR_ITAMP4MF_Pos)          /*!< 0x00080000 */
+#define TAMP_MISR_ITAMP4MF           TAMP_MISR_ITAMP4MF_Msk
+#define TAMP_MISR_ITAMP5MF_Pos       (20U)
+#define TAMP_MISR_ITAMP5MF_Msk       (0x1UL << TAMP_MISR_ITAMP5MF_Pos)          /*!< 0x00100000 */
+#define TAMP_MISR_ITAMP5MF           TAMP_MISR_ITAMP5MF_Msk
+#define TAMP_MISR_ITAMP6MF_Pos       (21U)
+#define TAMP_MISR_ITAMP6MF_Msk       (0x1UL << TAMP_MISR_ITAMP6MF_Pos)          /*!< 0x00200000 */
+#define TAMP_MISR_ITAMP6MF           TAMP_MISR_ITAMP6MF_Msk
+
+/********************  Bits definition for TAMP_SCR register  *****************/
+#define TAMP_SCR_CTAMP1F_Pos         (0U)
+#define TAMP_SCR_CTAMP1F_Msk         (0x1UL << TAMP_SCR_CTAMP1F_Pos)            /*!< 0x00000001 */
+#define TAMP_SCR_CTAMP1F             TAMP_SCR_CTAMP1F_Msk
+#define TAMP_SCR_CTAMP2F_Pos         (1U)
+#define TAMP_SCR_CTAMP2F_Msk         (0x1UL << TAMP_SCR_CTAMP2F_Pos)            /*!< 0x00000002 */
+#define TAMP_SCR_CTAMP2F             TAMP_SCR_CTAMP2F_Msk
+#define TAMP_SCR_CITAMP3F_Pos        (18U)
+#define TAMP_SCR_CITAMP3F_Msk        (0x1UL << TAMP_SCR_CITAMP3F_Pos)           /*!< 0x00040000 */
+#define TAMP_SCR_CITAMP3F            TAMP_SCR_CITAMP3F_Msk
+#define TAMP_SCR_CITAMP4F_Pos        (19U)
+#define TAMP_SCR_CITAMP4F_Msk        (0x1UL << TAMP_SCR_CITAMP4F_Pos)           /*!< 0x00080000 */
+#define TAMP_SCR_CITAMP4F            TAMP_SCR_CITAMP4F_Msk
+#define TAMP_SCR_CITAMP5F_Pos        (20U)
+#define TAMP_SCR_CITAMP5F_Msk        (0x1UL << TAMP_SCR_CITAMP5F_Pos)           /*!< 0x00100000 */
+#define TAMP_SCR_CITAMP5F            TAMP_SCR_CITAMP5F_Msk
+#define TAMP_SCR_CITAMP6F_Pos        (21U)
+#define TAMP_SCR_CITAMP6F_Msk        (0x1UL << TAMP_SCR_CITAMP6F_Pos)           /*!< 0x00200000 */
+#define TAMP_SCR_CITAMP6F            TAMP_SCR_CITAMP6F_Msk
+
+/********************  Bits definition for TAMP_BKP0R register  ***************/
+#define TAMP_BKP0R_Pos               (0U)
+#define TAMP_BKP0R_Msk               (0xFFFFFFFFUL << TAMP_BKP0R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP0R                   TAMP_BKP0R_Msk
+
+/********************  Bits definition for TAMP_BKP1R register  ***************/
+#define TAMP_BKP1R_Pos               (0U)
+#define TAMP_BKP1R_Msk               (0xFFFFFFFFUL << TAMP_BKP1R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP1R                   TAMP_BKP1R_Msk
+
+/********************  Bits definition for TAMP_BKP2R register  ***************/
+#define TAMP_BKP2R_Pos               (0U)
+#define TAMP_BKP2R_Msk               (0xFFFFFFFFUL << TAMP_BKP2R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP2R                   TAMP_BKP2R_Msk
+
+/********************  Bits definition for TAMP_BKP3R register  ***************/
+#define TAMP_BKP3R_Pos               (0U)
+#define TAMP_BKP3R_Msk               (0xFFFFFFFFUL << TAMP_BKP3R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP3R                   TAMP_BKP3R_Msk
+
+/********************  Bits definition for TAMP_BKP4R register  ***************/
+#define TAMP_BKP4R_Pos               (0U)
+#define TAMP_BKP4R_Msk               (0xFFFFFFFFUL << TAMP_BKP4R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP4R                   TAMP_BKP4R_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
+ */
+#define SPI_I2S_SUPPORT                       /*!< I2S support */
+
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                  /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                  /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                  /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                  /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                 /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)            /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                 /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                 /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)              /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_CRCL_Pos            (11U)
+#define SPI_CR1_CRCL_Msk            (0x1UL << SPI_CR1_CRCL_Pos)                /*!< 0x00000800 */
+#define SPI_CR1_CRCL                SPI_CR1_CRCL_Msk                           /*!< CRC Length */
+#define SPI_CR1_CRCNEXT_Pos         (12U)
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)             /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)               /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)              /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)            /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)             /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!< Rx Buffer DMA Enable */
+#define SPI_CR2_TXDMAEN_Pos         (1U)
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)             /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!< Tx Buffer DMA Enable */
+#define SPI_CR2_SSOE_Pos            (2U)
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!< SS Output Enable */
+#define SPI_CR2_NSSP_Pos            (3U)
+#define SPI_CR2_NSSP_Msk            (0x1UL << SPI_CR2_NSSP_Pos)                /*!< 0x00000008 */
+#define SPI_CR2_NSSP                SPI_CR2_NSSP_Msk                           /*!< NSS pulse management Enable */
+#define SPI_CR2_FRF_Pos             (4U)
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                 /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!< Frame Format Enable */
+#define SPI_CR2_ERRIE_Pos           (5U)
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)               /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!< Error Interrupt Enable */
+#define SPI_CR2_RXNEIE_Pos          (6U)
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)              /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!< RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)               /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!< Tx buffer Empty Interrupt Enable */
+#define SPI_CR2_DS_Pos              (8U)
+#define SPI_CR2_DS_Msk              (0xFUL << SPI_CR2_DS_Pos)                  /*!< 0x00000F00 */
+#define SPI_CR2_DS                  SPI_CR2_DS_Msk                             /*!< DS[3:0] Data Size */
+#define SPI_CR2_DS_0                (0x1UL << SPI_CR2_DS_Pos)                  /*!< 0x00000100 */
+#define SPI_CR2_DS_1                (0x2UL << SPI_CR2_DS_Pos)                  /*!< 0x00000200 */
+#define SPI_CR2_DS_2                (0x4UL << SPI_CR2_DS_Pos)                  /*!< 0x00000400 */
+#define SPI_CR2_DS_3                (0x8UL << SPI_CR2_DS_Pos)                  /*!< 0x00000800 */
+#define SPI_CR2_FRXTH_Pos           (12U)
+#define SPI_CR2_FRXTH_Msk           (0x1UL << SPI_CR2_FRXTH_Pos)               /*!< 0x00001000 */
+#define SPI_CR2_FRXTH               SPI_CR2_FRXTH_Msk                          /*!< FIFO reception Threshold */
+#define SPI_CR2_LDMARX_Pos          (13U)
+#define SPI_CR2_LDMARX_Msk          (0x1UL << SPI_CR2_LDMARX_Pos)              /*!< 0x00002000 */
+#define SPI_CR2_LDMARX              SPI_CR2_LDMARX_Msk                         /*!< Last DMA transfer for reception */
+#define SPI_CR2_LDMATX_Pos          (14U)
+#define SPI_CR2_LDMATX_Msk          (0x1UL << SPI_CR2_LDMATX_Pos)              /*!< 0x00004000 */
+#define SPI_CR2_LDMATX              SPI_CR2_LDMATX_Msk                         /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                 /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!< Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                  /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!< Transmit buffer Empty */
+#define SPI_SR_CHSIDE_Pos           (2U)
+#define SPI_SR_CHSIDE_Msk           (0x1UL << SPI_SR_CHSIDE_Pos)               /*!< 0x00000004 */
+#define SPI_SR_CHSIDE               SPI_SR_CHSIDE_Msk                          /*!< Channel side */
+#define SPI_SR_UDR_Pos              (3U)
+#define SPI_SR_UDR_Msk              (0x1UL << SPI_SR_UDR_Pos)                  /*!< 0x00000008 */
+#define SPI_SR_UDR                  SPI_SR_UDR_Msk                             /*!< Underrun flag */
+#define SPI_SR_CRCERR_Pos           (4U)
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)               /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!< CRC Error flag */
+#define SPI_SR_MODF_Pos             (5U)
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                 /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!< Mode fault */
+#define SPI_SR_OVR_Pos              (6U)
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                  /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!< Overrun flag */
+#define SPI_SR_BSY_Pos              (7U)
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                  /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!< Busy flag */
+#define SPI_SR_FRE_Pos              (8U)
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                  /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!< TI frame format error */
+#define SPI_SR_FRLVL_Pos            (9U)
+#define SPI_SR_FRLVL_Msk            (0x3UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000600 */
+#define SPI_SR_FRLVL                SPI_SR_FRLVL_Msk                           /*!< FIFO Reception Level */
+#define SPI_SR_FRLVL_0              (0x1UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000200 */
+#define SPI_SR_FRLVL_1              (0x2UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000400 */
+#define SPI_SR_FTLVL_Pos            (11U)
+#define SPI_SR_FTLVL_Msk            (0x3UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001800 */
+#define SPI_SR_FTLVL                SPI_SR_FTLVL_Msk                           /*!< FIFO Transmission Level */
+#define SPI_SR_FTLVL_0              (0x1UL << SPI_SR_FTLVL_Pos)                /*!< 0x00000800 */
+#define SPI_SR_FTLVL_1              (0x2UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001000 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)        /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN_Pos       (0U)
+#define SPI_I2SCFGR_CHLEN_Msk       (0x1UL << SPI_I2SCFGR_CHLEN_Pos)           /*!< 0x00000001 */
+#define SPI_I2SCFGR_CHLEN           SPI_I2SCFGR_CHLEN_Msk                      /*!<Channel length (number of bits per audio channel) */
+#define SPI_I2SCFGR_DATLEN_Pos      (1U)
+#define SPI_I2SCFGR_DATLEN_Msk      (0x3UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000006 */
+#define SPI_I2SCFGR_DATLEN          SPI_I2SCFGR_DATLEN_Msk                     /*!<DATLEN[1:0] bits (Data length to be transferred) */
+#define SPI_I2SCFGR_DATLEN_0        (0x1UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000002 */
+#define SPI_I2SCFGR_DATLEN_1        (0x2UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000004 */
+#define SPI_I2SCFGR_CKPOL_Pos       (3U)
+#define SPI_I2SCFGR_CKPOL_Msk       (0x1UL << SPI_I2SCFGR_CKPOL_Pos)           /*!< 0x00000008 */
+#define SPI_I2SCFGR_CKPOL           SPI_I2SCFGR_CKPOL_Msk                      /*!<steady state clock polarity */
+#define SPI_I2SCFGR_I2SSTD_Pos      (4U)
+#define SPI_I2SCFGR_I2SSTD_Msk      (0x3UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000030 */
+#define SPI_I2SCFGR_I2SSTD          SPI_I2SCFGR_I2SSTD_Msk                     /*!<I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0        (0x1UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000010 */
+#define SPI_I2SCFGR_I2SSTD_1        (0x2UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000020 */
+#define SPI_I2SCFGR_PCMSYNC_Pos     (7U)
+#define SPI_I2SCFGR_PCMSYNC_Msk     (0x1UL << SPI_I2SCFGR_PCMSYNC_Pos)         /*!< 0x00000080 */
+#define SPI_I2SCFGR_PCMSYNC         SPI_I2SCFGR_PCMSYNC_Msk                    /*!<PCM frame synchronization */
+#define SPI_I2SCFGR_I2SCFG_Pos      (8U)
+#define SPI_I2SCFGR_I2SCFG_Msk      (0x3UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000300 */
+#define SPI_I2SCFGR_I2SCFG          SPI_I2SCFGR_I2SCFG_Msk                     /*!<I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0        (0x1UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000100 */
+#define SPI_I2SCFGR_I2SCFG_1        (0x2UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000200 */
+#define SPI_I2SCFGR_I2SE_Pos        (10U)
+#define SPI_I2SCFGR_I2SE_Msk        (0x1UL << SPI_I2SCFGR_I2SE_Pos)            /*!< 0x00000400 */
+#define SPI_I2SCFGR_I2SE            SPI_I2SCFGR_I2SE_Msk                       /*!<I2S Enable */
+#define SPI_I2SCFGR_I2SMOD_Pos      (11U)
+#define SPI_I2SCFGR_I2SMOD_Msk      (0x1UL << SPI_I2SCFGR_I2SMOD_Pos)          /*!< 0x00000800 */
+#define SPI_I2SCFGR_I2SMOD          SPI_I2SCFGR_I2SMOD_Msk                     /*!<I2S mode selection */
+#define SPI_I2SCFGR_ASTRTEN_Pos     (12U)
+#define SPI_I2SCFGR_ASTRTEN_Msk     (0x1UL << SPI_I2SCFGR_ASTRTEN_Pos)         /*!< 0x00001000 */
+#define SPI_I2SCFGR_ASTRTEN         SPI_I2SCFGR_ASTRTEN_Msk                    /*!<Asynchronous start enable */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV_Pos        (0U)
+#define SPI_I2SPR_I2SDIV_Msk        (0xFFUL << SPI_I2SPR_I2SDIV_Pos)           /*!< 0x000000FF */
+#define SPI_I2SPR_I2SDIV            SPI_I2SPR_I2SDIV_Msk                       /*!<I2S Linear prescaler */
+#define SPI_I2SPR_ODD_Pos           (8U)
+#define SPI_I2SPR_ODD_Msk           (0x1UL << SPI_I2SPR_ODD_Pos)               /*!< 0x00000100 */
+#define SPI_I2SPR_ODD               SPI_I2SPR_ODD_Msk                          /*!<Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE_Pos         (9U)
+#define SPI_I2SPR_MCKOE_Msk         (0x1UL << SPI_I2SPR_MCKOE_Pos)             /*!< 0x00000200 */
+#define SPI_I2SPR_MCKOE             SPI_I2SPR_MCKOE_Msk                        /*!<Master Clock Output Enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
+/*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
+#define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
+#define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
+#define SYSCFG_CFGR1_MEM_MODE                 SYSCFG_CFGR1_MEM_MODE_Msk            /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_CFGR1_MEM_MODE_0               (0x1UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000001 */
+#define SYSCFG_CFGR1_MEM_MODE_1               (0x2UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000002 */
+#define SYSCFG_CFGR1_PA11_RMP_Pos             (3U)
+#define SYSCFG_CFGR1_PA11_RMP_Msk             (0x1UL << SYSCFG_CFGR1_PA11_RMP_Pos) /*!< 0x00000008 */
+#define SYSCFG_CFGR1_PA11_RMP                 SYSCFG_CFGR1_PA11_RMP_Msk            /*!< PA11 Remap */
+#define SYSCFG_CFGR1_PA12_RMP_Pos             (4U)
+#define SYSCFG_CFGR1_PA12_RMP_Msk             (0x1UL << SYSCFG_CFGR1_PA12_RMP_Pos) /*!< 0x00000010 */
+#define SYSCFG_CFGR1_PA12_RMP                 SYSCFG_CFGR1_PA12_RMP_Msk            /*!< PA12 Remap */
+#define SYSCFG_CFGR1_IR_POL_Pos               (5U)
+#define SYSCFG_CFGR1_IR_POL_Msk               (0x1UL << SYSCFG_CFGR1_IR_POL_Pos) /*!< 0x00000020 */
+#define SYSCFG_CFGR1_IR_POL                   SYSCFG_CFGR1_IR_POL_Msk            /*!< IROut Polarity Selection */
+#define SYSCFG_CFGR1_IR_MOD_Pos               (6U)
+#define SYSCFG_CFGR1_IR_MOD_Msk               (0x3UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x000000C0 */
+#define SYSCFG_CFGR1_IR_MOD                   SYSCFG_CFGR1_IR_MOD_Msk            /*!< IRDA Modulation Envelope signal source selection */
+#define SYSCFG_CFGR1_IR_MOD_0                 (0x1UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x00000040 */
+#define SYSCFG_CFGR1_IR_MOD_1                 (0x2UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x00000080 */
+#define SYSCFG_CFGR1_BOOSTEN_Pos              (8U)
+#define SYSCFG_CFGR1_BOOSTEN_Msk              (0x1UL << SYSCFG_CFGR1_BOOSTEN_Pos) /*!< 0x00000100 */
+#define SYSCFG_CFGR1_BOOSTEN                  SYSCFG_CFGR1_BOOSTEN_Msk            /*!< I/O analog switch voltage booster enable */
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Pos          (16U)
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB6_FMP_Pos)  /*!< 0x00010000 */
+#define SYSCFG_CFGR1_I2C_PB6_FMP              SYSCFG_CFGR1_I2C_PB6_FMP_Msk             /*!< I2C PB6 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Pos          (17U)
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB7_FMP_Pos)  /*!< 0x00020000 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP              SYSCFG_CFGR1_I2C_PB7_FMP_Msk             /*!< I2C PB7 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Pos          (18U)
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB8_FMP_Pos)  /*!< 0x00040000 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP              SYSCFG_CFGR1_I2C_PB8_FMP_Msk             /*!< I2C PB8 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Pos          (19U)
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB9_FMP_Pos)  /*!< 0x00080000 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP              SYSCFG_CFGR1_I2C_PB9_FMP_Msk             /*!< I2C PB9 Fast mode plus */
+#define SYSCFG_CFGR1_I2C1_FMP_Pos             (20U)
+#define SYSCFG_CFGR1_I2C1_FMP_Msk             (0x1UL << SYSCFG_CFGR1_I2C1_FMP_Pos)     /*!< 0x00100000 */
+#define SYSCFG_CFGR1_I2C1_FMP                 SYSCFG_CFGR1_I2C1_FMP_Msk                /*!< Enable Fast Mode Plus on PB10, PB11, PF6 and PF7  */
+#define SYSCFG_CFGR1_I2C2_FMP_Pos             (21U)
+#define SYSCFG_CFGR1_I2C2_FMP_Msk             (0x1UL << SYSCFG_CFGR1_I2C2_FMP_Pos)     /*!< 0x00200000 */
+#define SYSCFG_CFGR1_I2C2_FMP                 SYSCFG_CFGR1_I2C2_FMP_Msk                /*!< Enable I2C2 Fast mode plus  */
+#define SYSCFG_CFGR1_I2C_PA9_FMP_Pos          (22U)
+#define SYSCFG_CFGR1_I2C_PA9_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PA9_FMP_Pos)  /*!< 0x00400000 */
+#define SYSCFG_CFGR1_I2C_PA9_FMP              SYSCFG_CFGR1_I2C_PA9_FMP_Msk             /*!< Enable Fast Mode Plus on PA9  */
+#define SYSCFG_CFGR1_I2C_PA10_FMP_Pos         (23U)
+#define SYSCFG_CFGR1_I2C_PA10_FMP_Msk         (0x1UL << SYSCFG_CFGR1_I2C_PA10_FMP_Pos) /*!< 0x00800000 */
+#define SYSCFG_CFGR1_I2C_PA10_FMP             SYSCFG_CFGR1_I2C_PA10_FMP_Msk            /*!< Enable Fast Mode Plus on PA10 */
+
+/******************  Bit definition for SYSCFG_CFGR2 register  ****************/
+#define SYSCFG_CFGR2_CLL_Pos                  (0U)
+#define SYSCFG_CFGR2_CLL_Msk                  (0x1UL << SYSCFG_CFGR2_CLL_Pos)   /*!< 0x00000001 */
+#define SYSCFG_CFGR2_CLL                      SYSCFG_CFGR2_CLL_Msk              /*!< Enables and locks the LOCKUP (Hardfault) output of CortexM0 with Break Input of TIMER1 */
+#define SYSCFG_CFGR2_SPL_Pos                  (1U)
+#define SYSCFG_CFGR2_SPL_Msk                  (0x1UL << SYSCFG_CFGR2_SPL_Pos)   /*!< 0x00000002 */
+#define SYSCFG_CFGR2_SPL                      SYSCFG_CFGR2_SPL_Msk              /*!< Enables and locks the SRAM_PARITY error signal with Break Input of TIMER1 */
+#define SYSCFG_CFGR2_ECCL_Pos                 (3U)
+#define SYSCFG_CFGR2_ECCL_Msk                 (0x1UL << SYSCFG_CFGR2_ECCL_Pos)  /*!< 0x00000008 */
+#define SYSCFG_CFGR2_ECCL                     SYSCFG_CFGR2_ECCL_Msk             /*!< ECCL */
+#define SYSCFG_CFGR2_SPF_Pos                  (8U)
+#define SYSCFG_CFGR2_SPF_Msk                  (0x1UL << SYSCFG_CFGR2_SPF_Pos)   /*!< 0x00000100 */
+#define SYSCFG_CFGR2_SPF                      SYSCFG_CFGR2_SPF_Msk              /*!< SRAM Parity error flag */
+#define SYSCFG_CFGR2_SRAM_PE                  SYSCFG_CFGR2_SPF                  /*!< SRAM Parity error flag (define maintained for legacy purpose) */
+
+#define SYSCFG_CFGR2_PA1_CDEN_Pos             (16U)
+#define SYSCFG_CFGR2_PA1_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA1_CDEN_Pos)   /* 0x00010000 */
+#define SYSCFG_CFGR2_PA1_CDEN                 SYSCFG_CFGR2_PA1_CDEN_Msk              /*!< PA[1] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA3_CDEN_Pos             (17U)
+#define SYSCFG_CFGR2_PA3_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA3_CDEN_Pos)   /* 0x00020000 */
+#define SYSCFG_CFGR2_PA3_CDEN                 SYSCFG_CFGR2_PA3_CDEN_Msk              /*!< PA[3] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA5_CDEN_Pos             (18U)
+#define SYSCFG_CFGR2_PA5_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA5_CDEN_Pos)   /* 0x00040000 */
+#define SYSCFG_CFGR2_PA5_CDEN                 SYSCFG_CFGR2_PA5_CDEN_Msk              /*!< PA[5] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA6_CDEN_Pos             (19U)
+#define SYSCFG_CFGR2_PA6_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA6_CDEN_Pos)   /* 0x00080000 */
+#define SYSCFG_CFGR2_PA6_CDEN                 SYSCFG_CFGR2_PA6_CDEN_Msk              /*!< PA[6] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA13_CDEN_Pos            (20U)
+#define SYSCFG_CFGR2_PA13_CDEN_Msk            (0x1UL << SYSCFG_CFGR2_PA13_CDEN_Pos)  /* 0x00100000 */
+#define SYSCFG_CFGR2_PA13_CDEN                 SYSCFG_CFGR2_PA13_CDEN_Msk            /*!< PA[13] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB0_CDEN_Pos             (21U)
+#define SYSCFG_CFGR2_PB0_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB0_CDEN_Pos)   /* 0x00200000 */
+#define SYSCFG_CFGR2_PB0_CDEN                 SYSCFG_CFGR2_PB0_CDEN_Msk              /*!< PB[0] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB1_CDEN_Pos             (22U)
+#define SYSCFG_CFGR2_PB1_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB1_CDEN_Pos)   /* 0x00400000 */
+#define SYSCFG_CFGR2_PB1_CDEN                 SYSCFG_CFGR2_PB1_CDEN_Msk              /*!< PB[1] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB2_CDEN_Pos             (23U)
+#define SYSCFG_CFGR2_PB2_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB2_CDEN_Pos)   /* 0x00800000 */
+#define SYSCFG_CFGR2_PB2_CDEN                 SYSCFG_CFGR2_PB2_CDEN_Msk              /*!< PB[2] Clamping Diode Enable */
+/*****************  Bit definition for SYSCFG_ITLINEx ISR Wrapper register  ****************/
+#define SYSCFG_ITLINE0_SR_EWDG_Pos            (0U)
+#define SYSCFG_ITLINE0_SR_EWDG_Msk            (0x1UL << SYSCFG_ITLINE0_SR_EWDG_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE0_SR_EWDG                SYSCFG_ITLINE0_SR_EWDG_Msk       /*!< EWDG interrupt */
+#define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
+#define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
+#define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
+#define SYSCFG_ITLINE3_SR_FLASH_ITF_Pos       (1U)
+#define SYSCFG_ITLINE3_SR_FLASH_ITF_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ITF_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE3_SR_FLASH_ITF           SYSCFG_ITLINE3_SR_FLASH_ITF_Msk  /*!< FLASH ITF interrupt */
+#define SYSCFG_ITLINE4_SR_CLK_CTRL_Pos        (0U)
+#define SYSCFG_ITLINE4_SR_CLK_CTRL_Msk        (0x1UL << SYSCFG_ITLINE4_SR_CLK_CTRL_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE4_SR_CLK_CTRL            SYSCFG_ITLINE4_SR_CLK_CTRL_Msk   /*!< RCC interrupt */
+#define SYSCFG_ITLINE5_SR_EXTI0_Pos           (0U)
+#define SYSCFG_ITLINE5_SR_EXTI0_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI0_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE5_SR_EXTI0               SYSCFG_ITLINE5_SR_EXTI0_Msk      /*!< External Interrupt 0 */
+#define SYSCFG_ITLINE5_SR_EXTI1_Pos           (1U)
+#define SYSCFG_ITLINE5_SR_EXTI1_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE5_SR_EXTI1               SYSCFG_ITLINE5_SR_EXTI1_Msk      /*!< External Interrupt 1 */
+#define SYSCFG_ITLINE6_SR_EXTI2_Pos           (0U)
+#define SYSCFG_ITLINE6_SR_EXTI2_Msk           (0x1UL << SYSCFG_ITLINE6_SR_EXTI2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE6_SR_EXTI2               SYSCFG_ITLINE6_SR_EXTI2_Msk      /*!< External Interrupt 2 */
+#define SYSCFG_ITLINE6_SR_EXTI3_Pos           (1U)
+#define SYSCFG_ITLINE6_SR_EXTI3_Msk           (0x1UL << SYSCFG_ITLINE6_SR_EXTI3_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE6_SR_EXTI3               SYSCFG_ITLINE6_SR_EXTI3_Msk      /*!< External Interrupt 3 */
+#define SYSCFG_ITLINE7_SR_EXTI4_Pos           (0U)
+#define SYSCFG_ITLINE7_SR_EXTI4_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI4_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE7_SR_EXTI4               SYSCFG_ITLINE7_SR_EXTI4_Msk      /*!< External Interrupt 4 */
+#define SYSCFG_ITLINE7_SR_EXTI5_Pos           (1U)
+#define SYSCFG_ITLINE7_SR_EXTI5_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI5_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE7_SR_EXTI5               SYSCFG_ITLINE7_SR_EXTI5_Msk      /*!< External Interrupt 5 */
+#define SYSCFG_ITLINE7_SR_EXTI6_Pos           (2U)
+#define SYSCFG_ITLINE7_SR_EXTI6_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI6_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE7_SR_EXTI6               SYSCFG_ITLINE7_SR_EXTI6_Msk      /*!< External Interrupt 6 */
+#define SYSCFG_ITLINE7_SR_EXTI7_Pos           (3U)
+#define SYSCFG_ITLINE7_SR_EXTI7_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI7_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE7_SR_EXTI7               SYSCFG_ITLINE7_SR_EXTI7_Msk      /*!< External Interrupt 7 */
+#define SYSCFG_ITLINE7_SR_EXTI8_Pos           (4U)
+#define SYSCFG_ITLINE7_SR_EXTI8_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI8_Pos) /*!< 0x00000010 */
+#define SYSCFG_ITLINE7_SR_EXTI8               SYSCFG_ITLINE7_SR_EXTI8_Msk      /*!< External Interrupt 8 */
+#define SYSCFG_ITLINE7_SR_EXTI9_Pos           (5U)
+#define SYSCFG_ITLINE7_SR_EXTI9_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI9_Pos) /*!< 0x00000020 */
+#define SYSCFG_ITLINE7_SR_EXTI9               SYSCFG_ITLINE7_SR_EXTI9_Msk      /*!< External Interrupt 9 */
+#define SYSCFG_ITLINE7_SR_EXTI10_Pos          (6U)
+#define SYSCFG_ITLINE7_SR_EXTI10_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI10_Pos) /*!< 0x00000040 */
+#define SYSCFG_ITLINE7_SR_EXTI10              SYSCFG_ITLINE7_SR_EXTI10_Msk     /*!< External Interrupt 10 */
+#define SYSCFG_ITLINE7_SR_EXTI11_Pos          (7U)
+#define SYSCFG_ITLINE7_SR_EXTI11_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI11_Pos) /*!< 0x00000080 */
+#define SYSCFG_ITLINE7_SR_EXTI11              SYSCFG_ITLINE7_SR_EXTI11_Msk     /*!< External Interrupt 11 */
+#define SYSCFG_ITLINE7_SR_EXTI12_Pos          (8U)
+#define SYSCFG_ITLINE7_SR_EXTI12_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI12_Pos) /*!< 0x00000100 */
+#define SYSCFG_ITLINE7_SR_EXTI12              SYSCFG_ITLINE7_SR_EXTI12_Msk     /*!< External Interrupt 12 */
+#define SYSCFG_ITLINE7_SR_EXTI13_Pos          (9U)
+#define SYSCFG_ITLINE7_SR_EXTI13_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI13_Pos) /*!< 0x00000200 */
+#define SYSCFG_ITLINE7_SR_EXTI13              SYSCFG_ITLINE7_SR_EXTI13_Msk     /*!< External Interrupt 13 */
+#define SYSCFG_ITLINE7_SR_EXTI14_Pos          (10U)
+#define SYSCFG_ITLINE7_SR_EXTI14_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI14_Pos) /*!< 0x00000400 */
+#define SYSCFG_ITLINE7_SR_EXTI14              SYSCFG_ITLINE7_SR_EXTI14_Msk     /*!< External Interrupt 14 */
+#define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
+#define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
+#define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
+#define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
+#define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
+#define SYSCFG_ITLINE10_SR_DMA1_CH2_Pos       (0U)
+#define SYSCFG_ITLINE10_SR_DMA1_CH2_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE10_SR_DMA1_CH2           SYSCFG_ITLINE10_SR_DMA1_CH2_Msk  /*!< DMA1 Channel 2 Interrupt */
+#define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
+#define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH5_Pos       (2U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH5_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH5_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH5           SYSCFG_ITLINE11_SR_DMA1_CH5_Msk  /*!< DMA1 Channel 5 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH6_Pos       (3U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH6_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH6_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH6           SYSCFG_ITLINE11_SR_DMA1_CH6_Msk  /*!< DMA1 Channel 6 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH7_Pos       (4U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH7_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH7_Pos) /*!< 0x00000010 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH7           SYSCFG_ITLINE11_SR_DMA1_CH7_Msk  /*!< DMA1 Channel 7 Interrupt */
+#define SYSCFG_ITLINE12_SR_ADC_Pos            (0U)
+#define SYSCFG_ITLINE12_SR_ADC_Msk            (0x1UL << SYSCFG_ITLINE12_SR_ADC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE12_SR_ADC                SYSCFG_ITLINE12_SR_ADC_Msk       /*!< ADC Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_CCU_Pos       (0U)
+#define SYSCFG_ITLINE13_SR_TIM1_CCU_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_CCU_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE13_SR_TIM1_CCU           SYSCFG_ITLINE13_SR_TIM1_CCU_Msk  /*!< TIM1 CCU Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_TRG_Pos       (1U)
+#define SYSCFG_ITLINE13_SR_TIM1_TRG_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_TRG_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE13_SR_TIM1_TRG           SYSCFG_ITLINE13_SR_TIM1_TRG_Msk  /*!< TIM1 TRG Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_UPD_Pos       (2U)
+#define SYSCFG_ITLINE13_SR_TIM1_UPD_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_UPD_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE13_SR_TIM1_UPD           SYSCFG_ITLINE13_SR_TIM1_UPD_Msk  /*!< TIM1 UPD Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_BRK_Pos       (3U)
+#define SYSCFG_ITLINE13_SR_TIM1_BRK_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_BRK_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE13_SR_TIM1_BRK           SYSCFG_ITLINE13_SR_TIM1_BRK_Msk  /*!< TIM1 BRK Interrupt */
+#define SYSCFG_ITLINE14_SR_TIM1_CC_Pos        (0U)
+#define SYSCFG_ITLINE14_SR_TIM1_CC_Msk        (0x1UL << SYSCFG_ITLINE14_SR_TIM1_CC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE14_SR_TIM1_CC            SYSCFG_ITLINE14_SR_TIM1_CC_Msk   /*!< TIM1 CC Interrupt */
+#define SYSCFG_ITLINE16_SR_TIM3_GLB_Pos       (0U)
+#define SYSCFG_ITLINE16_SR_TIM3_GLB_Msk       (0x1UL << SYSCFG_ITLINE16_SR_TIM3_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE16_SR_TIM3_GLB           SYSCFG_ITLINE16_SR_TIM3_GLB_Msk  /*!< TIM3 GLB Interrupt */
+#define SYSCFG_ITLINE17_SR_TIM6_GLB_Pos       (0U)
+#define SYSCFG_ITLINE17_SR_TIM6_GLB_Msk       (0x1UL << SYSCFG_ITLINE17_SR_TIM6_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE17_SR_TIM6_GLB           SYSCFG_ITLINE17_SR_TIM6_GLB_Msk  /*!< TIM6 GLB Interrupt */
+#define SYSCFG_ITLINE18_SR_TIM7_GLB_Pos       (0U)
+#define SYSCFG_ITLINE18_SR_TIM7_GLB_Msk       (0x1UL << SYSCFG_ITLINE18_SR_TIM7_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE18_SR_TIM7_GLB           SYSCFG_ITLINE18_SR_TIM7_GLB_Msk  /*!< TIM7 GLB Interrupt */
+#define SYSCFG_ITLINE19_SR_TIM14_GLB_Pos      (0U)
+#define SYSCFG_ITLINE19_SR_TIM14_GLB_Msk      (0x1UL << SYSCFG_ITLINE19_SR_TIM14_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE19_SR_TIM14_GLB          SYSCFG_ITLINE19_SR_TIM14_GLB_Msk /*!< TIM14 GLB Interrupt */
+#define SYSCFG_ITLINE20_SR_TIM15_GLB_Pos      (0U)
+#define SYSCFG_ITLINE20_SR_TIM15_GLB_Msk      (0x1UL << SYSCFG_ITLINE20_SR_TIM15_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE20_SR_TIM15_GLB          SYSCFG_ITLINE20_SR_TIM15_GLB_Msk /*!< TIM15 GLB Interrupt */
+#define SYSCFG_ITLINE21_SR_TIM16_GLB_Pos      (0U)
+#define SYSCFG_ITLINE21_SR_TIM16_GLB_Msk      (0x1UL << SYSCFG_ITLINE21_SR_TIM16_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE21_SR_TIM16_GLB          SYSCFG_ITLINE21_SR_TIM16_GLB_Msk /*!< TIM16 GLB Interrupt */
+#define SYSCFG_ITLINE22_SR_TIM17_GLB_Pos      (0U)
+#define SYSCFG_ITLINE22_SR_TIM17_GLB_Msk      (0x1UL << SYSCFG_ITLINE22_SR_TIM17_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE22_SR_TIM17_GLB          SYSCFG_ITLINE22_SR_TIM17_GLB_Msk /*!< TIM17 GLB Interrupt */
+#define SYSCFG_ITLINE23_SR_I2C1_GLB_Pos       (0U)
+#define SYSCFG_ITLINE23_SR_I2C1_GLB_Msk       (0x1UL << SYSCFG_ITLINE23_SR_I2C1_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
+#define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
+#define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
+#define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
+#define SYSCFG_ITLINE26_SR_SPI2_Pos           (0U)
+#define SYSCFG_ITLINE26_SR_SPI2_Msk           (0x1UL << SYSCFG_ITLINE26_SR_SPI2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE26_SR_SPI2               SYSCFG_ITLINE26_SR_SPI2_Msk      /*!< SPI2  Interrupt */
+#define SYSCFG_ITLINE27_SR_USART1_GLB_Pos     (0U)
+#define SYSCFG_ITLINE27_SR_USART1_GLB_Msk     (0x1UL << SYSCFG_ITLINE27_SR_USART1_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE27_SR_USART1_GLB         SYSCFG_ITLINE27_SR_USART1_GLB_Msk /*!< USART1 GLB Interrupt -> exti[25] */
+#define SYSCFG_ITLINE28_SR_USART2_GLB_Pos     (0U)
+#define SYSCFG_ITLINE28_SR_USART2_GLB_Msk     (0x1UL << SYSCFG_ITLINE28_SR_USART2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE28_SR_USART2_GLB         SYSCFG_ITLINE28_SR_USART2_GLB_Msk /*!< USART2 GLB Interrupt -> exti[26] */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                   /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable */
+#define TIM_CR1_UDIS_Pos          (1U)
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                  /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable */
+#define TIM_CR1_URS_Pos           (2U)
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                   /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode */
+#define TIM_CR1_DIR_Pos           (4U)
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                   /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction */
+
+#define TIM_CR1_CMS_Pos           (5U)
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000020 */
+#define TIM_CR1_CMS_1             (0x2UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                  /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable */
+
+#define TIM_CR1_CKD_Pos           (8U)
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000100 */
+#define TIM_CR1_CKD_1             (0x2UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000200 */
+
+#define TIM_CR1_UIFREMAP_Pos      (11U)
+#define TIM_CR1_UIFREMAP_Msk      (0x1UL << TIM_CR1_UIFREMAP_Pos)              /*!< 0x00000800 */
+#define TIM_CR1_UIFREMAP          TIM_CR1_UIFREMAP_Msk                         /*!<Update interrupt flag remap */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                  /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control */
+#define TIM_CR2_CCUS_Pos          (2U)
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                  /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                  /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection */
+
+#define TIM_CR2_MMS_Pos           (4U)
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000010 */
+#define TIM_CR2_MMS_1             (0x2UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000020 */
+#define TIM_CR2_MMS_2             (0x4UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                  /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                  /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output) */
+#define TIM_CR2_OIS1N_Pos         (9U)
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                 /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                  /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output) */
+#define TIM_CR2_OIS2N_Pos         (11U)
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                 /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                  /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output) */
+#define TIM_CR2_OIS3N_Pos         (13U)
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                 /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                  /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output) */
+#define TIM_CR2_OIS5_Pos          (16U)
+#define TIM_CR2_OIS5_Msk          (0x1UL << TIM_CR2_OIS5_Pos)                  /*!< 0x00010000 */
+#define TIM_CR2_OIS5              TIM_CR2_OIS5_Msk                             /*!<Output Idle state 5 (OC5 output) */
+#define TIM_CR2_OIS6_Pos          (18U)
+#define TIM_CR2_OIS6_Msk          (0x1UL << TIM_CR2_OIS6_Pos)                  /*!< 0x00040000 */
+#define TIM_CR2_OIS6              TIM_CR2_OIS6_Msk                             /*!<Output Idle state 6 (OC6 output) */
+
+#define TIM_CR2_MMS2_Pos          (20U)
+#define TIM_CR2_MMS2_Msk          (0xFUL << TIM_CR2_MMS2_Pos)                  /*!< 0x00F00000 */
+#define TIM_CR2_MMS2              TIM_CR2_MMS2_Msk                             /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS2_0            (0x1UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00100000 */
+#define TIM_CR2_MMS2_1            (0x2UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00200000 */
+#define TIM_CR2_MMS2_2            (0x4UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00400000 */
+#define TIM_CR2_MMS2_3            (0x8UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00800000 */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)
+#define TIM_SMCR_SMS_Msk          (0x10007UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMCR_SMS_0            (0x00001UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000001 */
+#define TIM_SMCR_SMS_1            (0x00002UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000002 */
+#define TIM_SMCR_SMS_2            (0x00004UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000004 */
+#define TIM_SMCR_SMS_3            (0x10000UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010000 */
+
+#define TIM_SMCR_OCCS_Pos         (3U)
+#define TIM_SMCR_OCCS_Msk         (0x1UL << TIM_SMCR_OCCS_Pos)                 /*!< 0x00000008 */
+#define TIM_SMCR_OCCS             TIM_SMCR_OCCS_Msk                            /*!< OCREF clear selection */
+
+#define TIM_SMCR_TS_Pos           (4U)
+#define TIM_SMCR_TS_Msk           (0x30007UL << TIM_SMCR_TS_Pos)               /*!< 0x00300070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection) */
+#define TIM_SMCR_TS_0             (0x00001UL << TIM_SMCR_TS_Pos)               /*!< 0x00000010 */
+#define TIM_SMCR_TS_1             (0x00002UL << TIM_SMCR_TS_Pos)               /*!< 0x00000020 */
+#define TIM_SMCR_TS_2             (0x00004UL << TIM_SMCR_TS_Pos)               /*!< 0x00000040 */
+#define TIM_SMCR_TS_3             (0x10000UL << TIM_SMCR_TS_Pos)               /*!< 0x00100000 */
+#define TIM_SMCR_TS_4             (0x20000UL << TIM_SMCR_TS_Pos)               /*!< 0x00200000 */
+
+#define TIM_SMCR_MSM_Pos          (7U)
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                  /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode */
+
+#define TIM_SMCR_ETF_Pos          (8U)
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000100 */
+#define TIM_SMCR_ETF_1            (0x2UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000200 */
+#define TIM_SMCR_ETF_2            (0x4UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000400 */
+#define TIM_SMCR_ETF_3            (0x8UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00001000 */
+#define TIM_SMCR_ETPS_1           (0x2UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00002000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                  /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable */
+#define TIM_SMCR_ETP_Pos          (15U)
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                  /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                  /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable */
+#define TIM_DIER_CC2IE_Pos        (2U)
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable */
+#define TIM_DIER_CC3IE_Pos        (3U)
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable */
+#define TIM_DIER_CC4IE_Pos        (4U)
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable */
+#define TIM_DIER_COMIE_Pos        (5U)
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable */
+#define TIM_DIER_TIE_Pos          (6U)
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                  /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable */
+#define TIM_DIER_BIE_Pos          (7U)
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                  /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable */
+#define TIM_DIER_UDE_Pos          (8U)
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                  /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable */
+#define TIM_DIER_CC1DE_Pos        (9U)
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable */
+#define TIM_DIER_TDE_Pos          (14U)
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                  /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                    /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag */
+#define TIM_SR_CC1IF_Pos          (1U)
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                  /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag */
+#define TIM_SR_CC2IF_Pos          (2U)
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                  /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag */
+#define TIM_SR_CC3IF_Pos          (3U)
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                  /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag */
+#define TIM_SR_CC4IF_Pos          (4U)
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                  /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag */
+#define TIM_SR_COMIF_Pos          (5U)
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                  /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag */
+#define TIM_SR_TIF_Pos            (6U)
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                    /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag */
+#define TIM_SR_BIF_Pos            (7U)
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                    /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag */
+#define TIM_SR_B2IF_Pos           (8U)
+#define TIM_SR_B2IF_Msk           (0x1UL << TIM_SR_B2IF_Pos)                   /*!< 0x00000100 */
+#define TIM_SR_B2IF               TIM_SR_B2IF_Msk                              /*!<Break 2 interrupt Flag */
+#define TIM_SR_CC1OF_Pos          (9U)
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                  /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                  /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                  /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                  /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+#define TIM_SR_SBIF_Pos           (13U)
+#define TIM_SR_SBIF_Msk           (0x1UL << TIM_SR_SBIF_Pos)                   /*!< 0x00002000 */
+#define TIM_SR_SBIF               TIM_SR_SBIF_Msk                              /*!<System Break interrupt Flag */
+#define TIM_SR_CC5IF_Pos          (16U)
+#define TIM_SR_CC5IF_Msk          (0x1UL << TIM_SR_CC5IF_Pos)                  /*!< 0x00010000 */
+#define TIM_SR_CC5IF              TIM_SR_CC5IF_Msk                             /*!<Capture/Compare 5 interrupt Flag */
+#define TIM_SR_CC6IF_Pos          (17U)
+#define TIM_SR_CC6IF_Msk          (0x1UL << TIM_SR_CC6IF_Pos)                  /*!< 0x00020000 */
+#define TIM_SR_CC6IF              TIM_SR_CC6IF_Msk                             /*!<Capture/Compare 6 interrupt Flag */
+
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                    /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation */
+#define TIM_EGR_CC1G_Pos          (1U)
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                  /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation */
+#define TIM_EGR_CC2G_Pos          (2U)
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                  /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation */
+#define TIM_EGR_CC3G_Pos          (3U)
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                  /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation */
+#define TIM_EGR_CC4G_Pos          (4U)
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                  /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation */
+#define TIM_EGR_COMG_Pos          (5U)
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                  /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                    /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation */
+#define TIM_EGR_BG_Pos            (7U)
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                    /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation */
+#define TIM_EGR_B2G_Pos           (8U)
+#define TIM_EGR_B2G_Msk           (0x1UL << TIM_EGR_B2G_Pos)                   /*!< 0x00000100 */
+#define TIM_EGR_B2G               TIM_EGR_B2G_Msk                              /*!<Break 2 Generation */
+
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000001 */
+#define TIM_CCMR1_CC1S_1          (0x2UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable */
+#define TIM_CCMR1_OC1PE_Pos       (3U)
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)
+#define TIM_CCMR1_OC1M_Msk        (0x1007UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_CCMR1_OC1M_0          (0x0001UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR1_OC1M_1          (0x0002UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR1_OC1M_2          (0x0004UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR1_OC1M_3          (0x1000UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1 Clear Enable */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000100 */
+#define TIM_CCMR1_CC2S_1          (0x2UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable */
+#define TIM_CCMR1_OC2PE_Pos       (11U)
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)
+#define TIM_CCMR1_OC2M_Msk        (0x1007UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_CCMR1_OC2M_0          (0x0001UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR1_OC2M_1          (0x0002UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR1_OC2M_2          (0x0004UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR1_OC2M_3          (0x1000UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR1_IC1PSC_Pos      (2U)
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x00000004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x00000008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_CCMR1_IC1F_0          (0x1UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000010 */
+#define TIM_CCMR1_IC1F_1          (0x2UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000020 */
+#define TIM_CCMR1_IC1F_2          (0x4UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000040 */
+#define TIM_CCMR1_IC1F_3          (0x8UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_CCMR1_IC2PSC_0        (0x1UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_CCMR1_IC2F_0          (0x1UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00001000 */
+#define TIM_CCMR1_IC2F_1          (0x2UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00002000 */
+#define TIM_CCMR1_IC2F_2          (0x4UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00004000 */
+#define TIM_CCMR1_IC2F_3          (0x8UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CCMR2_CC3S_0          (0x1UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000001 */
+#define TIM_CCMR2_CC3S_1          (0x2UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable */
+#define TIM_CCMR2_OC3PE_Pos       (3U)
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)
+#define TIM_CCMR2_OC3M_Msk        (0x1007UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x0001UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR2_OC3M_1          (0x0002UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR2_OC3M_2          (0x0004UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR2_OC3M_3          (0x1000UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000100 */
+#define TIM_CCMR2_CC4S_1          (0x2UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable */
+#define TIM_CCMR2_OC4PE_Pos       (11U)
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)
+#define TIM_CCMR2_OC4M_Msk        (0x1007UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x0001UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR2_OC4M_1          (0x0002UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR2_OC4M_2          (0x0004UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR2_OC4M_3          (0x1000UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR2_IC3PSC_Pos      (2U)
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x00000004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x00000008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000010 */
+#define TIM_CCMR2_IC3F_1          (0x2UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000020 */
+#define TIM_CCMR2_IC3F_2          (0x4UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000040 */
+#define TIM_CCMR2_IC3F_3          (0x8UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00001000 */
+#define TIM_CCMR2_IC4F_1          (0x2UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00002000 */
+#define TIM_CCMR2_IC4F_2          (0x4UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00004000 */
+#define TIM_CCMR2_IC4F_3          (0x8UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define TIM_CCMR3_OC5FE_Pos       (2U)
+#define TIM_CCMR3_OC5FE_Msk       (0x1UL << TIM_CCMR3_OC5FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR3_OC5FE           TIM_CCMR3_OC5FE_Msk                          /*!<Output Compare 5 Fast enable */
+#define TIM_CCMR3_OC5PE_Pos       (3U)
+#define TIM_CCMR3_OC5PE_Msk       (0x1UL << TIM_CCMR3_OC5PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR3_OC5PE           TIM_CCMR3_OC5PE_Msk                          /*!<Output Compare 5 Preload enable */
+
+#define TIM_CCMR3_OC5M_Pos        (4U)
+#define TIM_CCMR3_OC5M_Msk        (0x1007UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR3_OC5M            TIM_CCMR3_OC5M_Msk                           /*!<OC5M[3:0] bits (Output Compare 5 Mode) */
+#define TIM_CCMR3_OC5M_0          (0x0001UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR3_OC5M_1          (0x0002UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR3_OC5M_2          (0x0004UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR3_OC5M_3          (0x1000UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR3_OC5CE_Pos       (7U)
+#define TIM_CCMR3_OC5CE_Msk       (0x1UL << TIM_CCMR3_OC5CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR3_OC5CE           TIM_CCMR3_OC5CE_Msk                          /*!<Output Compare 5 Clear Enable */
+
+#define TIM_CCMR3_OC6FE_Pos       (10U)
+#define TIM_CCMR3_OC6FE_Msk       (0x1UL << TIM_CCMR3_OC6FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR3_OC6FE           TIM_CCMR3_OC6FE_Msk                          /*!<Output Compare 6 Fast enable */
+#define TIM_CCMR3_OC6PE_Pos       (11U)
+#define TIM_CCMR3_OC6PE_Msk       (0x1UL << TIM_CCMR3_OC6PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR3_OC6PE           TIM_CCMR3_OC6PE_Msk                          /*!<Output Compare 6 Preload enable */
+
+#define TIM_CCMR3_OC6M_Pos        (12U)
+#define TIM_CCMR3_OC6M_Msk        (0x1007UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR3_OC6M            TIM_CCMR3_OC6M_Msk                           /*!<OC6M[3:0] bits (Output Compare 6 Mode) */
+#define TIM_CCMR3_OC6M_0          (0x0001UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR3_OC6M_1          (0x0002UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR3_OC6M_2          (0x0004UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR3_OC6M_3          (0x1000UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR3_OC6CE_Pos       (15U)
+#define TIM_CCMR3_OC6CE_Msk       (0x1UL << TIM_CCMR3_OC6CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR3_OC6CE           TIM_CCMR3_OC6CE_Msk                          /*!<Output Compare 6 Clear Enable */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                 /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable */
+#define TIM_CCER_CC1P_Pos         (1U)
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                 /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity */
+#define TIM_CCER_CC1NE_Pos        (2U)
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable */
+#define TIM_CCER_CC1NP_Pos        (3U)
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                 /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable */
+#define TIM_CCER_CC2P_Pos         (5U)
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                 /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity */
+#define TIM_CCER_CC2NE_Pos        (6U)
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable */
+#define TIM_CCER_CC2NP_Pos        (7U)
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                 /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable */
+#define TIM_CCER_CC3P_Pos         (9U)
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                 /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity */
+#define TIM_CCER_CC3NE_Pos        (10U)
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable */
+#define TIM_CCER_CC3NP_Pos        (11U)
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                 /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable */
+#define TIM_CCER_CC4P_Pos         (13U)
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                 /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity */
+#define TIM_CCER_CC4NP_Pos        (15U)
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+#define TIM_CCER_CC5E_Pos         (16U)
+#define TIM_CCER_CC5E_Msk         (0x1UL << TIM_CCER_CC5E_Pos)                 /*!< 0x00010000 */
+#define TIM_CCER_CC5E             TIM_CCER_CC5E_Msk                            /*!<Capture/Compare 5 output enable */
+#define TIM_CCER_CC5P_Pos         (17U)
+#define TIM_CCER_CC5P_Msk         (0x1UL << TIM_CCER_CC5P_Pos)                 /*!< 0x00020000 */
+#define TIM_CCER_CC5P             TIM_CCER_CC5P_Msk                            /*!<Capture/Compare 5 output Polarity */
+#define TIM_CCER_CC6E_Pos         (20U)
+#define TIM_CCER_CC6E_Msk         (0x1UL << TIM_CCER_CC6E_Pos)                 /*!< 0x00100000 */
+#define TIM_CCER_CC6E             TIM_CCER_CC6E_Msk                            /*!<Capture/Compare 6 output enable */
+#define TIM_CCER_CC6P_Pos         (21U)
+#define TIM_CCER_CC6P_Msk         (0x1UL << TIM_CCER_CC6P_Pos)                 /*!< 0x00200000 */
+#define TIM_CCER_CC6P             TIM_CCER_CC6P_Msk                            /*!<Capture/Compare 6 output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                              /*!<Counter Value */
+#define TIM_CNT_UIFCPY_Pos        (31U)
+#define TIM_CNT_UIFCPY_Msk        (0x1UL << TIM_CNT_UIFCPY_Pos)                /*!< 0x80000000 */
+#define TIM_CNT_UIFCPY            TIM_CNT_UIFCPY_Msk                           /*!<Update interrupt flag copy (if UIFREMAP=1) */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<Actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)
+#define TIM_RCR_REP_Msk           (0xFFFFUL << TIM_RCR_REP_Pos)                /*!< 0x0000FFFF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define TIM_CCR5_CCR5_Pos         (0U)
+#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
+#define TIM_CCR5_GC5C1_Pos        (29U)
+#define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
+#define TIM_CCR5_GC5C1            TIM_CCR5_GC5C1_Msk                           /*!<Group Channel 5 and Channel 1 */
+#define TIM_CCR5_GC5C2_Pos        (30U)
+#define TIM_CCR5_GC5C2_Msk        (0x1UL << TIM_CCR5_GC5C2_Pos)                /*!< 0x40000000 */
+#define TIM_CCR5_GC5C2            TIM_CCR5_GC5C2_Msk                           /*!<Group Channel 5 and Channel 2 */
+#define TIM_CCR5_GC5C3_Pos        (31U)
+#define TIM_CCR5_GC5C3_Msk        (0x1UL << TIM_CCR5_GC5C3_Pos)                /*!< 0x80000000 */
+#define TIM_CCR5_GC5C3            TIM_CCR5_GC5C3_Msk                           /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define TIM_CCR6_CCR6_Pos         (0U)
+#define TIM_CCR6_CCR6_Msk         (0xFFFFUL << TIM_CCR6_CCR6_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6             TIM_CCR6_CCR6_Msk                            /*!<Capture/Compare 6 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                 /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000001 */
+#define TIM_BDTR_DTG_1            (0x02UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000002 */
+#define TIM_BDTR_DTG_2            (0x04UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000004 */
+#define TIM_BDTR_DTG_3            (0x08UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000008 */
+#define TIM_BDTR_DTG_4            (0x10UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000010 */
+#define TIM_BDTR_DTG_5            (0x20UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000020 */
+#define TIM_BDTR_DTG_6            (0x40UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000040 */
+#define TIM_BDTR_DTG_7            (0x80UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000100 */
+#define TIM_BDTR_LOCK_1           (0x2UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                 /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                 /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode */
+#define TIM_BDTR_BKE_Pos          (12U)
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                  /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable for Break 1 */
+#define TIM_BDTR_BKP_Pos          (13U)
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                  /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity for Break 1 */
+#define TIM_BDTR_AOE_Pos          (14U)
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                  /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable */
+#define TIM_BDTR_MOE_Pos          (15U)
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                  /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable */
+
+#define TIM_BDTR_BKF_Pos          (16U)
+#define TIM_BDTR_BKF_Msk          (0xFUL << TIM_BDTR_BKF_Pos)                  /*!< 0x000F0000 */
+#define TIM_BDTR_BKF              TIM_BDTR_BKF_Msk                             /*!<Break Filter for Break 1 */
+#define TIM_BDTR_BK2F_Pos         (20U)
+#define TIM_BDTR_BK2F_Msk         (0xFUL << TIM_BDTR_BK2F_Pos)                 /*!< 0x00F00000 */
+#define TIM_BDTR_BK2F             TIM_BDTR_BK2F_Msk                            /*!<Break Filter for Break 2 */
+
+#define TIM_BDTR_BK2E_Pos         (24U)
+#define TIM_BDTR_BK2E_Msk         (0x1UL << TIM_BDTR_BK2E_Pos)                 /*!< 0x01000000 */
+#define TIM_BDTR_BK2E             TIM_BDTR_BK2E_Msk                            /*!<Break enable for Break 2 */
+#define TIM_BDTR_BK2P_Pos         (25U)
+#define TIM_BDTR_BK2P_Msk         (0x1UL << TIM_BDTR_BK2P_Pos)                 /*!< 0x02000000 */
+#define TIM_BDTR_BK2P             TIM_BDTR_BK2P_Msk                            /*!<Break Polarity for Break 2 */
+
+#define TIM_BDTR_BKDSRM_Pos       (26U)
+#define TIM_BDTR_BKDSRM_Msk       (0x1UL << TIM_BDTR_BKDSRM_Pos)               /*!< 0x04000000 */
+#define TIM_BDTR_BKDSRM           TIM_BDTR_BKDSRM_Msk                          /*!<Break disarming/re-arming */
+#define TIM_BDTR_BK2DSRM_Pos      (27U)
+#define TIM_BDTR_BK2DSRM_Msk      (0x1UL << TIM_BDTR_BK2DSRM_Pos)              /*!< 0x08000000 */
+#define TIM_BDTR_BK2DSRM          TIM_BDTR_BK2DSRM_Msk                         /*!<Break2 disarming/re-arming */
+
+#define TIM_BDTR_BKBID_Pos        (28U)
+#define TIM_BDTR_BKBID_Msk        (0x1UL << TIM_BDTR_BKBID_Pos)                /*!< 0x10000000 */
+#define TIM_BDTR_BKBID            TIM_BDTR_BKBID_Msk                           /*!<Break BIDirectional */
+#define TIM_BDTR_BK2BID_Pos       (29U)
+#define TIM_BDTR_BK2BID_Msk       (0x1UL << TIM_BDTR_BK2BID_Pos)               /*!< 0x20000000 */
+#define TIM_BDTR_BK2BID           TIM_BDTR_BK2BID_Msk                          /*!<Break2 BIDirectional */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                  /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000001 */
+#define TIM_DCR_DBA_1             (0x02UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000002 */
+#define TIM_DCR_DBA_2             (0x04UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000004 */
+#define TIM_DCR_DBA_3             (0x08UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000008 */
+#define TIM_DCR_DBA_4             (0x10UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000010 */
+
+#define TIM_DCR_DBL_Pos           (8U)
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                  /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000100 */
+#define TIM_DCR_DBL_1             (0x02UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000200 */
+#define TIM_DCR_DBL_2             (0x04UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000400 */
+#define TIM_DCR_DBL_3             (0x08UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000800 */
+#define TIM_DCR_DBL_4             (0x10UL << TIM_DCR_DBL_Pos)                  /*!< 0x00001000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)              /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM1_OR1 register  *******************/
+#define TIM1_OR1_OCREF_CLR_Pos     (0U)
+#define TIM1_OR1_OCREF_CLR_Msk     (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM1_AF1 register  *******************/
+#define TIM1_AF1_BKINE_Pos        (0U)
+#define TIM1_AF1_BKINE_Msk        (0x1UL << TIM1_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM1_AF1_BKINE            TIM1_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM1_AF1_BKCMP1E_Pos      (1U)
+#define TIM1_AF1_BKCMP1E_Msk      (0x1UL << TIM1_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM1_AF1_BKCMP1E          TIM1_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM1_AF1_BKCMP2E_Pos      (2U)
+#define TIM1_AF1_BKCMP2E_Msk      (0x1UL << TIM1_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM1_AF1_BKCMP2E          TIM1_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM1_AF1_BKINP_Pos        (9U)
+#define TIM1_AF1_BKINP_Msk        (0x1UL << TIM1_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM1_AF1_BKINP            TIM1_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM1_AF1_BKCMP1P_Pos      (10U)
+#define TIM1_AF1_BKCMP1P_Msk      (0x1UL << TIM1_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM1_AF1_BKCMP1P          TIM1_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM1_AF1_BKCMP2P_Pos      (11U)
+#define TIM1_AF1_BKCMP2P_Msk      (0x1UL << TIM1_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM1_AF1_BKCMP2P          TIM1_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+#define TIM1_AF1_ETRSEL_Pos       (14U)
+#define TIM1_AF1_ETRSEL_Msk       (0xFUL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM1_AF1_ETRSEL           TIM1_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM1 ETR source selection) */
+#define TIM1_AF1_ETRSEL_0         (0x1UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM1_AF1_ETRSEL_1         (0x2UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM1_AF1_ETRSEL_2         (0x4UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM1_AF1_ETRSEL_3         (0x8UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM1_AF2 register  *******************/
+#define TIM1_AF2_BK2INE_Pos       (0U)
+#define TIM1_AF2_BK2INE_Msk       (0x1UL << TIM1_AF2_BK2INE_Pos)               /*!< 0x00000001 */
+#define TIM1_AF2_BK2INE           TIM1_AF2_BK2INE_Msk                          /*!<BRK2 BKIN2 input enable */
+#define TIM1_AF2_BK2CMP1E_Pos     (1U)
+#define TIM1_AF2_BK2CMP1E_Msk     (0x1UL << TIM1_AF2_BK2CMP1E_Pos)             /*!< 0x00000002 */
+#define TIM1_AF2_BK2CMP1E         TIM1_AF2_BK2CMP1E_Msk                        /*!<BRK2 COMP1 enable */
+#define TIM1_AF2_BK2CMP2E_Pos     (2U)
+#define TIM1_AF2_BK2CMP2E_Msk     (0x1UL << TIM1_AF2_BK2CMP2E_Pos)             /*!< 0x00000004 */
+#define TIM1_AF2_BK2CMP2E         TIM1_AF2_BK2CMP2E_Msk                        /*!<BRK2 COMP2 enable */
+#define TIM1_AF2_BK2INP_Pos       (9U)
+#define TIM1_AF2_BK2INP_Msk       (0x1UL << TIM1_AF2_BK2INP_Pos)               /*!< 0x00000200 */
+#define TIM1_AF2_BK2INP           TIM1_AF2_BK2INP_Msk                          /*!<BRK2 BKIN2 input polarity */
+#define TIM1_AF2_BK2CMP1P_Pos     (10U)
+#define TIM1_AF2_BK2CMP1P_Msk     (0x1UL << TIM1_AF2_BK2CMP1P_Pos)             /*!< 0x00000400 */
+#define TIM1_AF2_BK2CMP1P         TIM1_AF2_BK2CMP1P_Msk                        /*!<BRK2 COMP1 input polarity */
+#define TIM1_AF2_BK2CMP2P_Pos     (11U)
+#define TIM1_AF2_BK2CMP2P_Msk     (0x1UL << TIM1_AF2_BK2CMP2P_Pos)             /*!< 0x00000800 */
+#define TIM1_AF2_BK2CMP2P         TIM1_AF2_BK2CMP2P_Msk                        /*!<BRK2 COMP2 input polarity */
+
+
+/*******************  Bit definition for TIM3_OR1 register  *******************/
+#define TIM3_OR1_OCREF_CLR_Pos     (0U)
+#define TIM3_OR1_OCREF_CLR_Msk     (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM3_AF1 register  *******************/
+#define TIM3_AF1_ETRSEL_Pos       (14U)
+#define TIM3_AF1_ETRSEL_Msk       (0xFUL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM3_AF1_ETRSEL           TIM3_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM3_AF1_ETRSEL_0         (0x1UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM3_AF1_ETRSEL_1         (0x2UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM3_AF1_ETRSEL_2         (0x4UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM3_AF1_ETRSEL_3         (0x8UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM14_AF1 register  *******************/
+#define TIM14_AF1_ETRSEL_Pos      (14U)
+#define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
+#define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
+#define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
+#define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
+#define TIM14_AF1_ETRSEL_3        (0x8UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM15_AF1 register  ******************/
+#define TIM15_AF1_BKINE_Pos      (0U)
+#define TIM15_AF1_BKINE_Msk      (0x1UL << TIM15_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM15_AF1_BKINE          TIM15_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM15_AF1_BKCMP1E_Pos    (1U)
+#define TIM15_AF1_BKCMP1E_Msk    (0x1UL << TIM15_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM15_AF1_BKCMP1E        TIM15_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM15_AF1_BKCMP2E_Pos    (2U)
+#define TIM15_AF1_BKCMP2E_Msk    (0x1UL << TIM15_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM15_AF1_BKCMP2E        TIM15_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM15_AF1_BKINP_Pos      (9U)
+#define TIM15_AF1_BKINP_Msk      (0x1UL << TIM15_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM15_AF1_BKINP          TIM15_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM15_AF1_BKCMP1P_Pos    (10U)
+#define TIM15_AF1_BKCMP1P_Msk    (0x1UL << TIM15_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM15_AF1_BKCMP1P        TIM15_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM15_AF1_BKCMP2P_Pos    (11U)
+#define TIM15_AF1_BKCMP2P_Msk    (0x1UL << TIM15_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM15_AF1_BKCMP2P        TIM15_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM16_AF1 register  ******************/
+#define TIM16_AF1_BKINE_Pos      (0U)
+#define TIM16_AF1_BKINE_Msk      (0x1UL << TIM16_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM16_AF1_BKINE          TIM16_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM16_AF1_BKCMP1E_Pos    (1U)
+#define TIM16_AF1_BKCMP1E_Msk    (0x1UL << TIM16_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM16_AF1_BKCMP1E        TIM16_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM16_AF1_BKCMP2E_Pos    (2U)
+#define TIM16_AF1_BKCMP2E_Msk    (0x1UL << TIM16_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM16_AF1_BKCMP2E        TIM16_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM16_AF1_BKINP_Pos      (9U)
+#define TIM16_AF1_BKINP_Msk      (0x1UL << TIM16_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM16_AF1_BKINP          TIM16_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM16_AF1_BKCMP1P_Pos    (10U)
+#define TIM16_AF1_BKCMP1P_Msk    (0x1UL << TIM16_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM16_AF1_BKCMP1P        TIM16_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM16_AF1_BKCMP2P_Pos    (11U)
+#define TIM16_AF1_BKCMP2P_Msk    (0x1UL << TIM16_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM16_AF1_BKCMP2P        TIM16_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM17_AF1 register  ******************/
+#define TIM17_AF1_BKINE_Pos      (0U)
+#define TIM17_AF1_BKINE_Msk      (0x1UL << TIM17_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM17_AF1_BKINE          TIM17_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM17_AF1_BKCMP1E_Pos    (1U)
+#define TIM17_AF1_BKCMP1E_Msk    (0x1UL << TIM17_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM17_AF1_BKCMP1E        TIM17_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM17_AF1_BKCMP2E_Pos    (2U)
+#define TIM17_AF1_BKCMP2E_Msk    (0x1UL << TIM17_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM17_AF1_BKCMP2E        TIM17_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM17_AF1_BKINP_Pos      (9U)
+#define TIM17_AF1_BKINP_Msk      (0x1UL << TIM17_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM17_AF1_BKINP          TIM17_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM17_AF1_BKCMP1P_Pos    (10U)
+#define TIM17_AF1_BKCMP1P_Msk    (0x1UL << TIM17_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM17_AF1_BKCMP1P        TIM17_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM17_AF1_BKCMP2P_Pos    (11U)
+#define TIM17_AF1_BKCMP2P_Msk    (0x1UL << TIM17_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM17_AF1_BKCMP2P        TIM17_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM_TISEL register  *********************/
+#define TIM_TISEL_TI1SEL_Pos      (0U)
+#define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
+#define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
+#define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
+#define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
+#define TIM_TISEL_TI1SEL_3        (0x8UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000008 */
+
+#define TIM_TISEL_TI2SEL_Pos      (8U)
+#define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
+#define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
+#define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
+#define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
+#define TIM_TISEL_TI2SEL_3        (0x8UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000800 */
+
+#define TIM_TISEL_TI3SEL_Pos      (16U)
+#define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
+#define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
+#define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
+#define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
+#define TIM_TISEL_TI3SEL_3        (0x8UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00080000 */
+
+#define TIM_TISEL_TI4SEL_Pos      (24U)
+#define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
+#define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
+#define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
+#define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
+#define TIM_TISEL_TI4SEL_3        (0x8UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x08000000 */
+
+
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_UE_Pos             (0U)
+#define USART_CR1_UE_Msk             (0x1UL << USART_CR1_UE_Pos)               /*!< 0x00000001 */
+#define USART_CR1_UE                 USART_CR1_UE_Msk                          /*!< USART Enable */
+#define USART_CR1_UESM_Pos           (1U)
+#define USART_CR1_UESM_Msk           (0x1UL << USART_CR1_UESM_Pos)             /*!< 0x00000002 */
+#define USART_CR1_UESM               USART_CR1_UESM_Msk                        /*!< USART Enable in STOP Mode */
+#define USART_CR1_RE_Pos             (2U)
+#define USART_CR1_RE_Msk             (0x1UL << USART_CR1_RE_Pos)               /*!< 0x00000004 */
+#define USART_CR1_RE                 USART_CR1_RE_Msk                          /*!< Receiver Enable */
+#define USART_CR1_TE_Pos             (3U)
+#define USART_CR1_TE_Msk             (0x1UL << USART_CR1_TE_Pos)               /*!< 0x00000008 */
+#define USART_CR1_TE                 USART_CR1_TE_Msk                          /*!< Transmitter Enable */
+#define USART_CR1_IDLEIE_Pos         (4U)
+#define USART_CR1_IDLEIE_Msk         (0x1UL << USART_CR1_IDLEIE_Pos)           /*!< 0x00000010 */
+#define USART_CR1_IDLEIE             USART_CR1_IDLEIE_Msk                      /*!< IDLE Interrupt Enable */
+#define USART_CR1_RXNEIE_RXFNEIE_Pos   (5U)
+#define USART_CR1_RXNEIE_RXFNEIE_Msk   (0x1UL << USART_CR1_RXNEIE_RXFNEIE_Pos) /*!< 0x00000020 */
+#define USART_CR1_RXNEIE_RXFNEIE       USART_CR1_RXNEIE_RXFNEIE_Msk            /*!< RXNE/RXFIFO not empty Interrupt Enable */
+#define USART_CR1_TCIE_Pos           (6U)
+#define USART_CR1_TCIE_Msk           (0x1UL << USART_CR1_TCIE_Pos)             /*!< 0x00000040 */
+#define USART_CR1_TCIE               USART_CR1_TCIE_Msk                        /*!< Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_TXFNFIE_Pos  (7U)
+#define USART_CR1_TXEIE_TXFNFIE_Msk   (0x1UL << USART_CR1_TXEIE_TXFNFIE_Pos)   /*!< 0x00000080 */
+#define USART_CR1_TXEIE_TXFNFIE       USART_CR1_TXEIE_TXFNFIE_Msk              /*!< TXE/TXFIFO not full Interrupt Enable */
+#define USART_CR1_PEIE_Pos           (8U)
+#define USART_CR1_PEIE_Msk           (0x1UL << USART_CR1_PEIE_Pos)             /*!< 0x00000100 */
+#define USART_CR1_PEIE               USART_CR1_PEIE_Msk                        /*!< PE Interrupt Enable */
+#define USART_CR1_PS_Pos             (9U)
+#define USART_CR1_PS_Msk             (0x1UL << USART_CR1_PS_Pos)               /*!< 0x00000200 */
+#define USART_CR1_PS                 USART_CR1_PS_Msk                          /*!< Parity Selection */
+#define USART_CR1_PCE_Pos            (10U)
+#define USART_CR1_PCE_Msk            (0x1UL << USART_CR1_PCE_Pos)              /*!< 0x00000400 */
+#define USART_CR1_PCE                USART_CR1_PCE_Msk                         /*!< Parity Control Enable */
+#define USART_CR1_WAKE_Pos           (11U)
+#define USART_CR1_WAKE_Msk           (0x1UL << USART_CR1_WAKE_Pos)             /*!< 0x00000800 */
+#define USART_CR1_WAKE               USART_CR1_WAKE_Msk                        /*!< Receiver Wakeup method */
+#define USART_CR1_M_Pos              (12U)
+#define USART_CR1_M_Msk              (0x10001UL << USART_CR1_M_Pos)            /*!< 0x10001000 */
+#define USART_CR1_M                  USART_CR1_M_Msk                           /*!< Word length */
+#define USART_CR1_M0_Pos             (12U)
+#define USART_CR1_M0_Msk             (0x1UL << USART_CR1_M0_Pos)               /*!< 0x00001000 */
+#define USART_CR1_M0                 USART_CR1_M0_Msk                          /*!< Word length - Bit 0 */
+#define USART_CR1_MME_Pos            (13U)
+#define USART_CR1_MME_Msk            (0x1UL << USART_CR1_MME_Pos)              /*!< 0x00002000 */
+#define USART_CR1_MME                USART_CR1_MME_Msk                         /*!< Mute Mode Enable */
+#define USART_CR1_CMIE_Pos           (14U)
+#define USART_CR1_CMIE_Msk           (0x1UL << USART_CR1_CMIE_Pos)             /*!< 0x00004000 */
+#define USART_CR1_CMIE               USART_CR1_CMIE_Msk                        /*!< Character match interrupt enable */
+#define USART_CR1_OVER8_Pos          (15U)
+#define USART_CR1_OVER8_Msk          (0x1UL << USART_CR1_OVER8_Pos)            /*!< 0x00008000 */
+#define USART_CR1_OVER8              USART_CR1_OVER8_Msk                       /*!< Oversampling by 8-bit or 16-bit mode */
+#define USART_CR1_DEDT_Pos           (16U)
+#define USART_CR1_DEDT_Msk           (0x1FUL << USART_CR1_DEDT_Pos)            /*!< 0x001F0000 */
+#define USART_CR1_DEDT               USART_CR1_DEDT_Msk                        /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define USART_CR1_DEDT_0             (0x01UL << USART_CR1_DEDT_Pos)            /*!< 0x00010000 */
+#define USART_CR1_DEDT_1             (0x02UL << USART_CR1_DEDT_Pos)            /*!< 0x00020000 */
+#define USART_CR1_DEDT_2             (0x04UL << USART_CR1_DEDT_Pos)            /*!< 0x00040000 */
+#define USART_CR1_DEDT_3             (0x08UL << USART_CR1_DEDT_Pos)            /*!< 0x00080000 */
+#define USART_CR1_DEDT_4             (0x10UL << USART_CR1_DEDT_Pos)            /*!< 0x00100000 */
+#define USART_CR1_DEAT_Pos           (21U)
+#define USART_CR1_DEAT_Msk           (0x1FUL << USART_CR1_DEAT_Pos)            /*!< 0x03E00000 */
+#define USART_CR1_DEAT               USART_CR1_DEAT_Msk                        /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define USART_CR1_DEAT_0             (0x01UL << USART_CR1_DEAT_Pos)            /*!< 0x00200000 */
+#define USART_CR1_DEAT_1             (0x02UL << USART_CR1_DEAT_Pos)            /*!< 0x00400000 */
+#define USART_CR1_DEAT_2             (0x04UL << USART_CR1_DEAT_Pos)            /*!< 0x00800000 */
+#define USART_CR1_DEAT_3             (0x08UL << USART_CR1_DEAT_Pos)            /*!< 0x01000000 */
+#define USART_CR1_DEAT_4             (0x10UL << USART_CR1_DEAT_Pos)            /*!< 0x02000000 */
+#define USART_CR1_RTOIE_Pos          (26U)
+#define USART_CR1_RTOIE_Msk          (0x1UL << USART_CR1_RTOIE_Pos)            /*!< 0x04000000 */
+#define USART_CR1_RTOIE              USART_CR1_RTOIE_Msk                       /*!< Receive Time Out interrupt enable */
+#define USART_CR1_EOBIE_Pos          (27U)
+#define USART_CR1_EOBIE_Msk          (0x1UL << USART_CR1_EOBIE_Pos)            /*!< 0x08000000 */
+#define USART_CR1_EOBIE              USART_CR1_EOBIE_Msk                       /*!< End of Block interrupt enable */
+#define USART_CR1_M1_Pos             (28U)
+#define USART_CR1_M1_Msk             (0x1UL << USART_CR1_M1_Pos)               /*!< 0x10000000 */
+#define USART_CR1_M1                 USART_CR1_M1_Msk                          /*!< Word length - Bit 1 */
+#define USART_CR1_FIFOEN_Pos         (29U)
+#define USART_CR1_FIFOEN_Msk         (0x1UL << USART_CR1_FIFOEN_Pos)           /*!< 0x20000000 */
+#define USART_CR1_FIFOEN             USART_CR1_FIFOEN_Msk                      /*!< FIFO mode enable */
+#define USART_CR1_TXFEIE_Pos         (30U)
+#define USART_CR1_TXFEIE_Msk         (0x1UL << USART_CR1_TXFEIE_Pos)           /*!< 0x40000000 */
+#define USART_CR1_TXFEIE             USART_CR1_TXFEIE_Msk                      /*!< TXFIFO empty interrupt enable */
+#define USART_CR1_RXFFIE_Pos         (31U)
+#define USART_CR1_RXFFIE_Msk         (0x1UL << USART_CR1_RXFFIE_Pos)           /*!< 0x80000000 */
+#define USART_CR1_RXFFIE             USART_CR1_RXFFIE_Msk                      /*!< RXFIFO Full interrupt enable */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_SLVEN_Pos          (0U)
+#define USART_CR2_SLVEN_Msk          (0x1UL << USART_CR2_SLVEN_Pos)            /*!< 0x00000001 */
+#define USART_CR2_SLVEN              USART_CR2_SLVEN_Msk                       /*!< Synchronous Slave mode enable */
+#define USART_CR2_DIS_NSS_Pos        (3U)
+#define USART_CR2_DIS_NSS_Msk        (0x1UL << USART_CR2_DIS_NSS_Pos)          /*!< 0x00000008 */
+#define USART_CR2_DIS_NSS            USART_CR2_DIS_NSS_Msk                     /*!< NSS input pin disable for SPI slave selection */
+#define USART_CR2_ADDM7_Pos          (4U)
+#define USART_CR2_ADDM7_Msk          (0x1UL << USART_CR2_ADDM7_Pos)            /*!< 0x00000010 */
+#define USART_CR2_ADDM7              USART_CR2_ADDM7_Msk                       /*!< 7-bit or 4-bit Address Detection */
+#define USART_CR2_LBDL_Pos           (5U)
+#define USART_CR2_LBDL_Msk           (0x1UL << USART_CR2_LBDL_Pos)             /*!< 0x00000020 */
+#define USART_CR2_LBDL               USART_CR2_LBDL_Msk                        /*!< LIN Break Detection Length */
+#define USART_CR2_LBDIE_Pos          (6U)
+#define USART_CR2_LBDIE_Msk          (0x1UL << USART_CR2_LBDIE_Pos)            /*!< 0x00000040 */
+#define USART_CR2_LBDIE              USART_CR2_LBDIE_Msk                       /*!< LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos           (8U)
+#define USART_CR2_LBCL_Msk           (0x1UL << USART_CR2_LBCL_Pos)             /*!< 0x00000100 */
+#define USART_CR2_LBCL               USART_CR2_LBCL_Msk                        /*!< Last Bit Clock pulse */
+#define USART_CR2_CPHA_Pos           (9U)
+#define USART_CR2_CPHA_Msk           (0x1UL << USART_CR2_CPHA_Pos)             /*!< 0x00000200 */
+#define USART_CR2_CPHA               USART_CR2_CPHA_Msk                        /*!< Clock Phase */
+#define USART_CR2_CPOL_Pos           (10U)
+#define USART_CR2_CPOL_Msk           (0x1UL << USART_CR2_CPOL_Pos)             /*!< 0x00000400 */
+#define USART_CR2_CPOL               USART_CR2_CPOL_Msk                        /*!< Clock Polarity */
+#define USART_CR2_CLKEN_Pos          (11U)
+#define USART_CR2_CLKEN_Msk          (0x1UL << USART_CR2_CLKEN_Pos)            /*!< 0x00000800 */
+#define USART_CR2_CLKEN              USART_CR2_CLKEN_Msk                       /*!< Clock Enable */
+#define USART_CR2_STOP_Pos           (12U)
+#define USART_CR2_STOP_Msk           (0x3UL << USART_CR2_STOP_Pos)             /*!< 0x00003000 */
+#define USART_CR2_STOP               USART_CR2_STOP_Msk                        /*!< STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0             (0x1UL << USART_CR2_STOP_Pos)             /*!< 0x00001000 */
+#define USART_CR2_STOP_1             (0x2UL << USART_CR2_STOP_Pos)             /*!< 0x00002000 */
+#define USART_CR2_LINEN_Pos          (14U)
+#define USART_CR2_LINEN_Msk          (0x1UL << USART_CR2_LINEN_Pos)            /*!< 0x00004000 */
+#define USART_CR2_LINEN              USART_CR2_LINEN_Msk                       /*!< LIN mode enable */
+#define USART_CR2_SWAP_Pos           (15U)
+#define USART_CR2_SWAP_Msk           (0x1UL << USART_CR2_SWAP_Pos)             /*!< 0x00008000 */
+#define USART_CR2_SWAP               USART_CR2_SWAP_Msk                        /*!< SWAP TX/RX pins */
+#define USART_CR2_RXINV_Pos          (16U)
+#define USART_CR2_RXINV_Msk          (0x1UL << USART_CR2_RXINV_Pos)            /*!< 0x00010000 */
+#define USART_CR2_RXINV              USART_CR2_RXINV_Msk                       /*!< RX pin active level inversion */
+#define USART_CR2_TXINV_Pos          (17U)
+#define USART_CR2_TXINV_Msk          (0x1UL << USART_CR2_TXINV_Pos)            /*!< 0x00020000 */
+#define USART_CR2_TXINV              USART_CR2_TXINV_Msk                       /*!< TX pin active level inversion */
+#define USART_CR2_DATAINV_Pos        (18U)
+#define USART_CR2_DATAINV_Msk        (0x1UL << USART_CR2_DATAINV_Pos)          /*!< 0x00040000 */
+#define USART_CR2_DATAINV            USART_CR2_DATAINV_Msk                     /*!< Binary data inversion */
+#define USART_CR2_MSBFIRST_Pos       (19U)
+#define USART_CR2_MSBFIRST_Msk       (0x1UL << USART_CR2_MSBFIRST_Pos)         /*!< 0x00080000 */
+#define USART_CR2_MSBFIRST           USART_CR2_MSBFIRST_Msk                    /*!< Most Significant Bit First */
+#define USART_CR2_ABREN_Pos          (20U)
+#define USART_CR2_ABREN_Msk          (0x1UL << USART_CR2_ABREN_Pos)            /*!< 0x00100000 */
+#define USART_CR2_ABREN              USART_CR2_ABREN_Msk                       /*!< Auto Baud-Rate Enable*/
+#define USART_CR2_ABRMODE_Pos        (21U)
+#define USART_CR2_ABRMODE_Msk        (0x3UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00600000 */
+#define USART_CR2_ABRMODE            USART_CR2_ABRMODE_Msk                     /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define USART_CR2_ABRMODE_0          (0x1UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00200000 */
+#define USART_CR2_ABRMODE_1          (0x2UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00400000 */
+#define USART_CR2_RTOEN_Pos          (23U)
+#define USART_CR2_RTOEN_Msk          (0x1UL << USART_CR2_RTOEN_Pos)            /*!< 0x00800000 */
+#define USART_CR2_RTOEN              USART_CR2_RTOEN_Msk                       /*!< Receiver Time-Out enable */
+#define USART_CR2_ADD_Pos            (24U)
+#define USART_CR2_ADD_Msk            (0xFFUL << USART_CR2_ADD_Pos)             /*!< 0xFF000000 */
+#define USART_CR2_ADD                USART_CR2_ADD_Msk                         /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos            (0U)
+#define USART_CR3_EIE_Msk            (0x1UL << USART_CR3_EIE_Pos)              /*!< 0x00000001 */
+#define USART_CR3_EIE                USART_CR3_EIE_Msk                         /*!< Error Interrupt Enable */
+#define USART_CR3_IREN_Pos           (1U)
+#define USART_CR3_IREN_Msk           (0x1UL << USART_CR3_IREN_Pos)             /*!< 0x00000002 */
+#define USART_CR3_IREN               USART_CR3_IREN_Msk                        /*!< IrDA mode Enable */
+#define USART_CR3_IRLP_Pos           (2U)
+#define USART_CR3_IRLP_Msk           (0x1UL << USART_CR3_IRLP_Pos)             /*!< 0x00000004 */
+#define USART_CR3_IRLP               USART_CR3_IRLP_Msk                        /*!< IrDA Low-Power */
+#define USART_CR3_HDSEL_Pos          (3U)
+#define USART_CR3_HDSEL_Msk          (0x1UL << USART_CR3_HDSEL_Pos)            /*!< 0x00000008 */
+#define USART_CR3_HDSEL              USART_CR3_HDSEL_Msk                       /*!< Half-Duplex Selection */
+#define USART_CR3_NACK_Pos           (4U)
+#define USART_CR3_NACK_Msk           (0x1UL << USART_CR3_NACK_Pos)             /*!< 0x00000010 */
+#define USART_CR3_NACK               USART_CR3_NACK_Msk                        /*!< SmartCard NACK enable */
+#define USART_CR3_SCEN_Pos           (5U)
+#define USART_CR3_SCEN_Msk           (0x1UL << USART_CR3_SCEN_Pos)             /*!< 0x00000020 */
+#define USART_CR3_SCEN               USART_CR3_SCEN_Msk                        /*!< SmartCard mode enable */
+#define USART_CR3_DMAR_Pos           (6U)
+#define USART_CR3_DMAR_Msk           (0x1UL << USART_CR3_DMAR_Pos)             /*!< 0x00000040 */
+#define USART_CR3_DMAR               USART_CR3_DMAR_Msk                        /*!< DMA Enable Receiver */
+#define USART_CR3_DMAT_Pos           (7U)
+#define USART_CR3_DMAT_Msk           (0x1UL << USART_CR3_DMAT_Pos)             /*!< 0x00000080 */
+#define USART_CR3_DMAT               USART_CR3_DMAT_Msk                        /*!< DMA Enable Transmitter */
+#define USART_CR3_RTSE_Pos           (8U)
+#define USART_CR3_RTSE_Msk           (0x1UL << USART_CR3_RTSE_Pos)             /*!< 0x00000100 */
+#define USART_CR3_RTSE               USART_CR3_RTSE_Msk                        /*!< RTS Enable */
+#define USART_CR3_CTSE_Pos           (9U)
+#define USART_CR3_CTSE_Msk           (0x1UL << USART_CR3_CTSE_Pos)             /*!< 0x00000200 */
+#define USART_CR3_CTSE               USART_CR3_CTSE_Msk                        /*!< CTS Enable */
+#define USART_CR3_CTSIE_Pos          (10U)
+#define USART_CR3_CTSIE_Msk          (0x1UL << USART_CR3_CTSIE_Pos)            /*!< 0x00000400 */
+#define USART_CR3_CTSIE              USART_CR3_CTSIE_Msk                       /*!< CTS Interrupt Enable */
+#define USART_CR3_ONEBIT_Pos         (11U)
+#define USART_CR3_ONEBIT_Msk         (0x1UL << USART_CR3_ONEBIT_Pos)           /*!< 0x00000800 */
+#define USART_CR3_ONEBIT             USART_CR3_ONEBIT_Msk                      /*!< One sample bit method enable */
+#define USART_CR3_OVRDIS_Pos         (12U)
+#define USART_CR3_OVRDIS_Msk         (0x1UL << USART_CR3_OVRDIS_Pos)           /*!< 0x00001000 */
+#define USART_CR3_OVRDIS             USART_CR3_OVRDIS_Msk                      /*!< Overrun Disable */
+#define USART_CR3_DDRE_Pos           (13U)
+#define USART_CR3_DDRE_Msk           (0x1UL << USART_CR3_DDRE_Pos)             /*!< 0x00002000 */
+#define USART_CR3_DDRE               USART_CR3_DDRE_Msk                        /*!< DMA Disable on Reception Error */
+#define USART_CR3_DEM_Pos            (14U)
+#define USART_CR3_DEM_Msk            (0x1UL << USART_CR3_DEM_Pos)              /*!< 0x00004000 */
+#define USART_CR3_DEM                USART_CR3_DEM_Msk                         /*!< Driver Enable Mode */
+#define USART_CR3_DEP_Pos            (15U)
+#define USART_CR3_DEP_Msk            (0x1UL << USART_CR3_DEP_Pos)              /*!< 0x00008000 */
+#define USART_CR3_DEP                USART_CR3_DEP_Msk                         /*!< Driver Enable Polarity Selection */
+#define USART_CR3_SCARCNT_Pos        (17U)
+#define USART_CR3_SCARCNT_Msk        (0x7UL << USART_CR3_SCARCNT_Pos)          /*!< 0x000E0000 */
+#define USART_CR3_SCARCNT            USART_CR3_SCARCNT_Msk                     /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define USART_CR3_SCARCNT_0          (0x1UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00020000 */
+#define USART_CR3_SCARCNT_1          (0x2UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00040000 */
+#define USART_CR3_SCARCNT_2          (0x4UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00080000 */
+#define USART_CR3_WUS_Pos            (20U)
+#define USART_CR3_WUS_Msk            (0x3UL << USART_CR3_WUS_Pos)              /*!< 0x00300000 */
+#define USART_CR3_WUS                USART_CR3_WUS_Msk                         /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define USART_CR3_WUS_0              (0x1UL << USART_CR3_WUS_Pos)              /*!< 0x00100000 */
+#define USART_CR3_WUS_1              (0x2UL << USART_CR3_WUS_Pos)              /*!< 0x00200000 */
+#define USART_CR3_WUFIE_Pos          (22U)
+#define USART_CR3_WUFIE_Msk          (0x1UL << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
+#define USART_CR3_WUFIE              USART_CR3_WUFIE_Msk                       /*!< Wake Up Interrupt Enable */
+#define USART_CR3_TXFTIE_Pos         (23U)
+#define USART_CR3_TXFTIE_Msk         (0x1UL << USART_CR3_TXFTIE_Pos)           /*!< 0x00800000 */
+#define USART_CR3_TXFTIE             USART_CR3_TXFTIE_Msk                      /*!< TXFIFO threshold interrupt enable */
+#define USART_CR3_TCBGTIE_Pos        (24U)
+#define USART_CR3_TCBGTIE_Msk        (0x1UL << USART_CR3_TCBGTIE_Pos)          /*!< 0x01000000 */
+#define USART_CR3_TCBGTIE            USART_CR3_TCBGTIE_Msk                     /*!< Transmission Complete Before Guard Time Interrupt Enable */
+#define USART_CR3_RXFTCFG_Pos        (25U)
+#define USART_CR3_RXFTCFG_Msk        (0x7UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x0E000000 */
+#define USART_CR3_RXFTCFG            USART_CR3_RXFTCFG_Msk                     /*!< RXFIFO FIFO threshold configuration */
+#define USART_CR3_RXFTCFG_0          (0x1UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x02000000 */
+#define USART_CR3_RXFTCFG_1          (0x2UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x04000000 */
+#define USART_CR3_RXFTCFG_2          (0x4UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x08000000 */
+#define USART_CR3_RXFTIE_Pos         (28U)
+#define USART_CR3_RXFTIE_Msk         (0x1UL << USART_CR3_RXFTIE_Pos)           /*!< 0x10000000 */
+#define USART_CR3_RXFTIE             USART_CR3_RXFTIE_Msk                      /*!< RXFIFO threshold interrupt enable */
+#define USART_CR3_TXFTCFG_Pos        (29U)
+#define USART_CR3_TXFTCFG_Msk        (0x7UL << USART_CR3_TXFTCFG_Pos)          /*!< 0xE0000000 */
+#define USART_CR3_TXFTCFG            USART_CR3_TXFTCFG_Msk                     /*!< TXFIFO threshold configuration */
+#define USART_CR3_TXFTCFG_0          (0x1UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x20000000 */
+#define USART_CR3_TXFTCFG_1          (0x2UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x40000000 */
+#define USART_CR3_TXFTCFG_2          (0x4UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x80000000 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_BRR                ((uint16_t)0xFFFF)                        /*!< USART  Baud rate register [15:0] */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos           (0U)
+#define USART_GTPR_PSC_Msk           (0xFFUL << USART_GTPR_PSC_Pos)            /*!< 0x000000FF */
+#define USART_GTPR_PSC               USART_GTPR_PSC_Msk                        /*!< PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_GT_Pos            (8U)
+#define USART_GTPR_GT_Msk            (0xFFUL << USART_GTPR_GT_Pos)             /*!< 0x0000FF00 */
+#define USART_GTPR_GT                USART_GTPR_GT_Msk                         /*!< GT[7:0] bits (Guard time value) */
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define USART_RTOR_RTO_Pos           (0U)
+#define USART_RTOR_RTO_Msk           (0xFFFFFFUL << USART_RTOR_RTO_Pos)        /*!< 0x00FFFFFF */
+#define USART_RTOR_RTO               USART_RTOR_RTO_Msk                        /*!< Receiver Time Out Value */
+#define USART_RTOR_BLEN_Pos          (24U)
+#define USART_RTOR_BLEN_Msk          (0xFFUL << USART_RTOR_BLEN_Pos)           /*!< 0xFF000000 */
+#define USART_RTOR_BLEN              USART_RTOR_BLEN_Msk                       /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define USART_RQR_ABRRQ        ((uint16_t)0x0001)                              /*!< Auto-Baud Rate Request */
+#define USART_RQR_SBKRQ        ((uint16_t)0x0002)                              /*!< Send Break Request */
+#define USART_RQR_MMRQ         ((uint16_t)0x0004)                              /*!< Mute Mode Request */
+#define USART_RQR_RXFRQ        ((uint16_t)0x0008)                              /*!< Receive Data flush Request */
+#define USART_RQR_TXFRQ        ((uint16_t)0x0010)                              /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define USART_ISR_PE_Pos             (0U)
+#define USART_ISR_PE_Msk             (0x1UL << USART_ISR_PE_Pos)               /*!< 0x00000001 */
+#define USART_ISR_PE                 USART_ISR_PE_Msk                          /*!< Parity Error */
+#define USART_ISR_FE_Pos             (1U)
+#define USART_ISR_FE_Msk             (0x1UL << USART_ISR_FE_Pos)               /*!< 0x00000002 */
+#define USART_ISR_FE                 USART_ISR_FE_Msk                          /*!< Framing Error */
+#define USART_ISR_NE_Pos             (2U)
+#define USART_ISR_NE_Msk             (0x1UL << USART_ISR_NE_Pos)               /*!< 0x00000004 */
+#define USART_ISR_NE                 USART_ISR_NE_Msk                          /*!< Noise detected Flag */
+#define USART_ISR_ORE_Pos            (3U)
+#define USART_ISR_ORE_Msk            (0x1UL << USART_ISR_ORE_Pos)              /*!< 0x00000008 */
+#define USART_ISR_ORE                USART_ISR_ORE_Msk                         /*!< OverRun Error */
+#define USART_ISR_IDLE_Pos           (4U)
+#define USART_ISR_IDLE_Msk           (0x1UL << USART_ISR_IDLE_Pos)             /*!< 0x00000010 */
+#define USART_ISR_IDLE               USART_ISR_IDLE_Msk                        /*!< IDLE line detected */
+#define USART_ISR_RXNE_RXFNE_Pos     (5U)
+#define USART_ISR_RXNE_RXFNE_Msk     (0x1UL << USART_ISR_RXNE_RXFNE_Pos)       /*!< 0x00000020 */
+#define USART_ISR_RXNE_RXFNE         USART_ISR_RXNE_RXFNE_Msk                  /*!< Read Data Register Not Empty/RXFIFO Not Empty */
+#define USART_ISR_TC_Pos             (6U)
+#define USART_ISR_TC_Msk             (0x1UL << USART_ISR_TC_Pos)               /*!< 0x00000040 */
+#define USART_ISR_TC                 USART_ISR_TC_Msk                          /*!< Transmission Complete */
+#define USART_ISR_TXE_TXFNF_Pos      (7U)
+#define USART_ISR_TXE_TXFNF_Msk      (0x1UL << USART_ISR_TXE_TXFNF_Pos)        /*!< 0x00000080 */
+#define USART_ISR_TXE_TXFNF          USART_ISR_TXE_TXFNF_Msk                   /*!< Transmit Data Register Empty/TXFIFO Not Full */
+#define USART_ISR_LBDF_Pos           (8U)
+#define USART_ISR_LBDF_Msk           (0x1UL << USART_ISR_LBDF_Pos)             /*!< 0x00000100 */
+#define USART_ISR_LBDF               USART_ISR_LBDF_Msk                        /*!< LIN Break Detection Flag */
+#define USART_ISR_CTSIF_Pos          (9U)
+#define USART_ISR_CTSIF_Msk          (0x1UL << USART_ISR_CTSIF_Pos)            /*!< 0x00000200 */
+#define USART_ISR_CTSIF              USART_ISR_CTSIF_Msk                       /*!< CTS interrupt flag */
+#define USART_ISR_CTS_Pos            (10U)
+#define USART_ISR_CTS_Msk            (0x1UL << USART_ISR_CTS_Pos)              /*!< 0x00000400 */
+#define USART_ISR_CTS                USART_ISR_CTS_Msk                         /*!< CTS flag */
+#define USART_ISR_RTOF_Pos           (11U)
+#define USART_ISR_RTOF_Msk           (0x1UL << USART_ISR_RTOF_Pos)             /*!< 0x00000800 */
+#define USART_ISR_RTOF               USART_ISR_RTOF_Msk                        /*!< Receiver Time Out */
+#define USART_ISR_EOBF_Pos           (12U)
+#define USART_ISR_EOBF_Msk           (0x1UL << USART_ISR_EOBF_Pos)             /*!< 0x00001000 */
+#define USART_ISR_EOBF               USART_ISR_EOBF_Msk                        /*!< End Of Block Flag */
+#define USART_ISR_UDR_Pos            (13U)
+#define USART_ISR_UDR_Msk            (0x1UL << USART_ISR_UDR_Pos)              /*!< 0x00002000 */
+#define USART_ISR_UDR                 USART_ISR_UDR_Msk                        /*!< SPI Slave Underrun Error Flag */
+#define USART_ISR_ABRE_Pos           (14U)
+#define USART_ISR_ABRE_Msk           (0x1UL << USART_ISR_ABRE_Pos)             /*!< 0x00004000 */
+#define USART_ISR_ABRE               USART_ISR_ABRE_Msk                        /*!< Auto-Baud Rate Error */
+#define USART_ISR_ABRF_Pos           (15U)
+#define USART_ISR_ABRF_Msk           (0x1UL << USART_ISR_ABRF_Pos)             /*!< 0x00008000 */
+#define USART_ISR_ABRF               USART_ISR_ABRF_Msk                        /*!< Auto-Baud Rate Flag */
+#define USART_ISR_BUSY_Pos           (16U)
+#define USART_ISR_BUSY_Msk           (0x1UL << USART_ISR_BUSY_Pos)             /*!< 0x00010000 */
+#define USART_ISR_BUSY               USART_ISR_BUSY_Msk                        /*!< Busy Flag */
+#define USART_ISR_CMF_Pos            (17U)
+#define USART_ISR_CMF_Msk            (0x1UL << USART_ISR_CMF_Pos)              /*!< 0x00020000 */
+#define USART_ISR_CMF                USART_ISR_CMF_Msk                         /*!< Character Match Flag */
+#define USART_ISR_SBKF_Pos           (18U)
+#define USART_ISR_SBKF_Msk           (0x1UL << USART_ISR_SBKF_Pos)             /*!< 0x00040000 */
+#define USART_ISR_SBKF               USART_ISR_SBKF_Msk                        /*!< Send Break Flag */
+#define USART_ISR_RWU_Pos            (19U)
+#define USART_ISR_RWU_Msk            (0x1UL << USART_ISR_RWU_Pos)              /*!< 0x00080000 */
+#define USART_ISR_RWU                USART_ISR_RWU_Msk                         /*!< Receive Wake Up from mute mode Flag */
+#define USART_ISR_WUF_Pos            (20U)
+#define USART_ISR_WUF_Msk            (0x1UL << USART_ISR_WUF_Pos)              /*!< 0x00100000 */
+#define USART_ISR_WUF                USART_ISR_WUF_Msk                         /*!< Wake Up from stop mode Flag */
+#define USART_ISR_TEACK_Pos          (21U)
+#define USART_ISR_TEACK_Msk          (0x1UL << USART_ISR_TEACK_Pos)            /*!< 0x00200000 */
+#define USART_ISR_TEACK              USART_ISR_TEACK_Msk                       /*!< Transmit Enable Acknowledge Flag */
+#define USART_ISR_REACK_Pos          (22U)
+#define USART_ISR_REACK_Msk          (0x1UL << USART_ISR_REACK_Pos)            /*!< 0x00400000 */
+#define USART_ISR_REACK              USART_ISR_REACK_Msk                       /*!< Receive Enable Acknowledge Flag */
+#define USART_ISR_TXFE_Pos           (23U)
+#define USART_ISR_TXFE_Msk           (0x1UL << USART_ISR_TXFE_Pos)             /*!< 0x00800000 */
+#define USART_ISR_TXFE               USART_ISR_TXFE_Msk                        /*!< TXFIFO Empty Flag */
+#define USART_ISR_RXFF_Pos           (24U)
+#define USART_ISR_RXFF_Msk           (0x1UL << USART_ISR_RXFF_Pos)             /*!< 0x01000000 */
+#define USART_ISR_RXFF               USART_ISR_RXFF_Msk                        /*!< RXFIFO Full Flag */
+#define USART_ISR_TCBGT_Pos          (25U)
+#define USART_ISR_TCBGT_Msk          (0x1UL << USART_ISR_TCBGT_Pos)            /*!< 0x02000000 */
+#define USART_ISR_TCBGT              USART_ISR_TCBGT_Msk                       /*!< Transmission Complete Before Guard Time Completion Flag */
+#define USART_ISR_RXFT_Pos           (26U)
+#define USART_ISR_RXFT_Msk           (0x1UL << USART_ISR_RXFT_Pos)             /*!< 0x04000000 */
+#define USART_ISR_RXFT               USART_ISR_RXFT_Msk                        /*!< RXFIFO Threshold Flag */
+#define USART_ISR_TXFT_Pos           (27U)
+#define USART_ISR_TXFT_Msk           (0x1UL << USART_ISR_TXFT_Pos)             /*!< 0x08000000 */
+#define USART_ISR_TXFT               USART_ISR_TXFT_Msk                        /*!< TXFIFO Threshold Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define USART_ICR_PECF_Pos           (0U)
+#define USART_ICR_PECF_Msk           (0x1UL << USART_ICR_PECF_Pos)             /*!< 0x00000001 */
+#define USART_ICR_PECF               USART_ICR_PECF_Msk                        /*!< Parity Error Clear Flag */
+#define USART_ICR_FECF_Pos           (1U)
+#define USART_ICR_FECF_Msk           (0x1UL << USART_ICR_FECF_Pos)             /*!< 0x00000002 */
+#define USART_ICR_FECF               USART_ICR_FECF_Msk                        /*!< Framing Error Clear Flag */
+#define USART_ICR_NECF_Pos           (2U)
+#define USART_ICR_NECF_Msk           (0x1UL << USART_ICR_NECF_Pos)             /*!< 0x00000004 */
+#define USART_ICR_NECF               USART_ICR_NECF_Msk                        /*!< Noise Error detected Clear Flag */
+#define USART_ICR_ORECF_Pos          (3U)
+#define USART_ICR_ORECF_Msk          (0x1UL << USART_ICR_ORECF_Pos)            /*!< 0x00000008 */
+#define USART_ICR_ORECF              USART_ICR_ORECF_Msk                       /*!< OverRun Error Clear Flag */
+#define USART_ICR_IDLECF_Pos         (4U)
+#define USART_ICR_IDLECF_Msk         (0x1UL << USART_ICR_IDLECF_Pos)           /*!< 0x00000010 */
+#define USART_ICR_IDLECF             USART_ICR_IDLECF_Msk                      /*!< IDLE line detected Clear Flag */
+#define USART_ICR_TXFECF_Pos         (5U)
+#define USART_ICR_TXFECF_Msk         (0x1UL << USART_ICR_TXFECF_Pos)           /*!< 0x00000020 */
+#define USART_ICR_TXFECF             USART_ICR_TXFECF_Msk                      /*!< TXFIFO Empty Clear Flag */
+#define USART_ICR_TCCF_Pos           (6U)
+#define USART_ICR_TCCF_Msk           (0x1UL << USART_ICR_TCCF_Pos)             /*!< 0x00000040 */
+#define USART_ICR_TCCF               USART_ICR_TCCF_Msk                        /*!< Transmission Complete Clear Flag */
+#define USART_ICR_TCBGTCF_Pos        (7U)
+#define USART_ICR_TCBGTCF_Msk        (0x1UL << USART_ICR_TCBGTCF_Pos)          /*!< 0x00000080 */
+#define USART_ICR_TCBGTCF            USART_ICR_TCBGTCF_Msk                     /*!< Transmission Complete Before Guard Time Clear Flag */
+#define USART_ICR_LBDCF_Pos          (8U)
+#define USART_ICR_LBDCF_Msk          (0x1UL << USART_ICR_LBDCF_Pos)            /*!< 0x00000100 */
+#define USART_ICR_LBDCF              USART_ICR_LBDCF_Msk                       /*!< LIN Break Detection Clear Flag */
+#define USART_ICR_CTSCF_Pos          (9U)
+#define USART_ICR_CTSCF_Msk          (0x1UL << USART_ICR_CTSCF_Pos)            /*!< 0x00000200 */
+#define USART_ICR_CTSCF              USART_ICR_CTSCF_Msk                       /*!< CTS Interrupt Clear Flag */
+#define USART_ICR_RTOCF_Pos          (11U)
+#define USART_ICR_RTOCF_Msk          (0x1UL << USART_ICR_RTOCF_Pos)            /*!< 0x00000800 */
+#define USART_ICR_RTOCF              USART_ICR_RTOCF_Msk                       /*!< Receiver Time Out Clear Flag */
+#define USART_ICR_EOBCF_Pos          (12U)
+#define USART_ICR_EOBCF_Msk          (0x1UL << USART_ICR_EOBCF_Pos)            /*!< 0x00001000 */
+#define USART_ICR_EOBCF              USART_ICR_EOBCF_Msk                       /*!< End Of Block Clear Flag */
+#define USART_ICR_UDRCF_Pos          (13U)
+#define USART_ICR_UDRCF_Msk          (0x1UL << USART_ICR_UDRCF_Pos)            /*!< 0x00002000 */
+#define USART_ICR_UDRCF              USART_ICR_UDRCF_Msk                       /*!< SPI Slave Underrun Clear Flag */
+#define USART_ICR_CMCF_Pos           (17U)
+#define USART_ICR_CMCF_Msk           (0x1UL << USART_ICR_CMCF_Pos)             /*!< 0x00020000 */
+#define USART_ICR_CMCF               USART_ICR_CMCF_Msk                        /*!< Character Match Clear Flag */
+#define USART_ICR_WUCF_Pos           (20U)
+#define USART_ICR_WUCF_Msk           (0x1UL << USART_ICR_WUCF_Pos)             /*!< 0x00100000 */
+#define USART_ICR_WUCF               USART_ICR_WUCF_Msk                        /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define USART_RDR_RDR_Pos             (0U)
+#define USART_RDR_RDR_Msk             (0x1FFUL << USART_RDR_RDR_Pos)           /*!< 0x000001FF */
+#define USART_RDR_RDR                 USART_RDR_RDR_Msk                        /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define USART_TDR_TDR_Pos             (0U)
+#define USART_TDR_TDR_Msk             (0x1FFUL << USART_TDR_TDR_Pos)           /*!< 0x000001FF */
+#define USART_TDR_TDR                 USART_TDR_TDR_Msk                        /*!< TDR[8:0] bits (Transmit Data value) */
+
+/*******************  Bit definition for USART_PRESC register  ****************/
+#define USART_PRESC_PRESCALER_Pos    (0U)
+#define USART_PRESC_PRESCALER_Msk    (0xFUL << USART_PRESC_PRESCALER_Pos)      /*!< 0x0000000F */
+#define USART_PRESC_PRESCALER        USART_PRESC_PRESCALER_Msk                 /*!< PRESCALER[3:0] bits (Clock prescaler) */
+#define USART_PRESC_PRESCALER_0      (0x1UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000001 */
+#define USART_PRESC_PRESCALER_1      (0x2UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000002 */
+#define USART_PRESC_PRESCALER_2      (0x4UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000004 */
+#define USART_PRESC_PRESCALER_3      (0x8UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000008 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                      /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01UL << WWDG_CR_T_Pos)                      /*!< 0x00000001 */
+#define WWDG_CR_T_1             (0x02UL << WWDG_CR_T_Pos)                      /*!< 0x00000002 */
+#define WWDG_CR_T_2             (0x04UL << WWDG_CR_T_Pos)                      /*!< 0x00000004 */
+#define WWDG_CR_T_3             (0x08UL << WWDG_CR_T_Pos)                      /*!< 0x00000008 */
+#define WWDG_CR_T_4             (0x10UL << WWDG_CR_T_Pos)                      /*!< 0x00000010 */
+#define WWDG_CR_T_5             (0x20UL << WWDG_CR_T_Pos)                      /*!< 0x00000020 */
+#define WWDG_CR_T_6             (0x40UL << WWDG_CR_T_Pos)                      /*!< 0x00000040 */
+
+#define WWDG_CR_WDGA_Pos        (7U)
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                    /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                     /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01UL << WWDG_CFR_W_Pos)                     /*!< 0x00000001 */
+#define WWDG_CFR_W_1            (0x02UL << WWDG_CFR_W_Pos)                     /*!< 0x00000002 */
+#define WWDG_CFR_W_2            (0x04UL << WWDG_CFR_W_Pos)                     /*!< 0x00000004 */
+#define WWDG_CFR_W_3            (0x08UL << WWDG_CFR_W_Pos)                     /*!< 0x00000008 */
+#define WWDG_CFR_W_4            (0x10UL << WWDG_CFR_W_Pos)                     /*!< 0x00000010 */
+#define WWDG_CFR_W_5            (0x20UL << WWDG_CFR_W_Pos)                     /*!< 0x00000020 */
+#define WWDG_CFR_W_6            (0x40UL << WWDG_CFR_W_Pos)                     /*!< 0x00000040 */
+
+#define WWDG_CFR_WDGTB_Pos      (11U)
+#define WWDG_CFR_WDGTB_Msk      (0x7UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00003800 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[2:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00000800 */
+#define WWDG_CFR_WDGTB_1        (0x2UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00001000 */
+#define WWDG_CFR_WDGTB_2        (0x4UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00002000 */
+
+#define WWDG_CFR_EWI_Pos        (9U)
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                    /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                    /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                Debug MCU                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBG_IDCODE register  *************/
+#define DBG_IDCODE_DEV_ID_Pos                          (0U)
+#define DBG_IDCODE_DEV_ID_Msk                          (0xFFFUL << DBG_IDCODE_DEV_ID_Pos)  /*!< 0x00000FFF */
+#define DBG_IDCODE_DEV_ID                              DBG_IDCODE_DEV_ID_Msk
+#define DBG_IDCODE_REV_ID_Pos                          (16U)
+#define DBG_IDCODE_REV_ID_Msk                          (0xFFFFUL << DBG_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBG_IDCODE_REV_ID                              DBG_IDCODE_REV_ID_Msk
+
+/********************  Bit definition for DBG_CR register  *****************/
+#define DBG_CR_DBG_STOP_Pos                            (1U)
+#define DBG_CR_DBG_STOP_Msk                            (0x1UL << DBG_CR_DBG_STOP_Pos)      /*!< 0x00000002 */
+#define DBG_CR_DBG_STOP                                DBG_CR_DBG_STOP_Msk
+#define DBG_CR_DBG_STANDBY_Pos                         (2U)
+#define DBG_CR_DBG_STANDBY_Msk                         (0x1UL << DBG_CR_DBG_STANDBY_Pos)   /*!< 0x00000004 */
+#define DBG_CR_DBG_STANDBY                             DBG_CR_DBG_STANDBY_Msk
+
+
+/********************  Bit definition for DBG_APB_FZ1 register  ***********/
+#define DBG_APB_FZ1_DBG_TIM3_STOP_Pos                  (1U)
+#define DBG_APB_FZ1_DBG_TIM3_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
+#define DBG_APB_FZ1_DBG_TIM3_STOP                      DBG_APB_FZ1_DBG_TIM3_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM6_STOP_Pos                  (4U)
+#define DBG_APB_FZ1_DBG_TIM6_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM6_STOP_Pos) /*!< 0x00000010 */
+#define DBG_APB_FZ1_DBG_TIM6_STOP                      DBG_APB_FZ1_DBG_TIM6_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM7_STOP_Pos                  (5U)
+#define DBG_APB_FZ1_DBG_TIM7_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM7_STOP_Pos) /*!< 0x00000020 */
+#define DBG_APB_FZ1_DBG_TIM7_STOP                      DBG_APB_FZ1_DBG_TIM7_STOP_Msk
+#define DBG_APB_FZ1_DBG_RTC_STOP_Pos                   (10U)
+#define DBG_APB_FZ1_DBG_RTC_STOP_Msk                   (0x1UL << DBG_APB_FZ1_DBG_RTC_STOP_Pos)  /*!< 0x00000400 */
+#define DBG_APB_FZ1_DBG_RTC_STOP                       DBG_APB_FZ1_DBG_RTC_STOP_Msk
+#define DBG_APB_FZ1_DBG_WWDG_STOP_Pos                  (11U)
+#define DBG_APB_FZ1_DBG_WWDG_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_WWDG_STOP_Pos) /*!< 0x00000800 */
+#define DBG_APB_FZ1_DBG_WWDG_STOP                      DBG_APB_FZ1_DBG_WWDG_STOP_Msk
+#define DBG_APB_FZ1_DBG_IWDG_STOP_Pos                  (12U)
+#define DBG_APB_FZ1_DBG_IWDG_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_IWDG_STOP_Pos) /*!< 0x00001000 */
+#define DBG_APB_FZ1_DBG_IWDG_STOP                      DBG_APB_FZ1_DBG_IWDG_STOP_Msk
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Pos    (21U)
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00200000 */
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Msk
+
+/********************  Bit definition for DBG_APB_FZ2 register  ************/
+#define DBG_APB_FZ2_DBG_TIM1_STOP_Pos                  (11U)
+#define DBG_APB_FZ2_DBG_TIM1_STOP_Msk                  (0x1UL << DBG_APB_FZ2_DBG_TIM1_STOP_Pos)  /*!< 0x00000800 */
+#define DBG_APB_FZ2_DBG_TIM1_STOP                      DBG_APB_FZ2_DBG_TIM1_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM14_STOP_Pos                 (15U)
+#define DBG_APB_FZ2_DBG_TIM14_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM14_STOP_Pos) /*!< 0x00008000 */
+#define DBG_APB_FZ2_DBG_TIM14_STOP                     DBG_APB_FZ2_DBG_TIM14_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM15_STOP_Pos                 (16U)
+#define DBG_APB_FZ2_DBG_TIM15_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM15_STOP_Pos) /*!< 0x00010000 */
+#define DBG_APB_FZ2_DBG_TIM15_STOP                     DBG_APB_FZ2_DBG_TIM15_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM16_STOP_Pos                 (17U)
+#define DBG_APB_FZ2_DBG_TIM16_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM16_STOP_Pos) /*!< 0x00020000 */
+#define DBG_APB_FZ2_DBG_TIM16_STOP                     DBG_APB_FZ2_DBG_TIM16_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM17_STOP_Pos                 (18U)
+#define DBG_APB_FZ2_DBG_TIM17_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM17_STOP_Pos) /*!< 0x00040000 */
+#define DBG_APB_FZ2_DBG_TIM17_STOP                     DBG_APB_FZ2_DBG_TIM17_STOP_Msk
+
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+
+
+
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Channel1) || \
+                                       ((INSTANCE) == DMA1_Channel2) || \
+                                       ((INSTANCE) == DMA1_Channel3) || \
+                                       ((INSTANCE) == DMA1_Channel4) || \
+                                       ((INSTANCE) == DMA1_Channel5) || \
+                                       ((INSTANCE) == DMA1_Channel6) || \
+                                       ((INSTANCE) == DMA1_Channel7))
+
+/******************************** DMAMUX Instances ****************************/
+#define IS_DMAMUX_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DMAMUX1)
+
+#define IS_DMAMUX_REQUEST_GEN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMAMUX1_RequestGenerator0) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator1) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator2) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator3))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOD) || \
+                                        ((INSTANCE) == GPIOF))
+/******************************* GPIO AF Instances ****************************/
+#define IS_GPIO_AF_INSTANCE(INSTANCE)   IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/**************************** GPIO Lock Instances *****************************/
+#define IS_GPIO_LOCK_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                         ((INSTANCE) == GPIOB) || \
+                                         ((INSTANCE) == GPIOC))
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1) || \
+                                       ((INSTANCE) == I2C2))
+
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/****************************** SMBUS Instances *******************************/
+#define IS_SMBUS_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1))
+
+/****************************** WAKEUP_FROMSTOP Instances *******************************/
+#define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) (((INSTANCE) == I2C1))
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
+                                       ((INSTANCE) == SPI2))
+
+/******************************** SPI Instances *******************************/
+#define IS_I2S_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == SPI1)
+
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM6)   || \
+                                         ((INSTANCE) == TIM7)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting 32 bits counter ****************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) (0)
+
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)    || \
+                                            ((INSTANCE) == TIM15)   || \
+                                            ((INSTANCE) == TIM16)   || \
+                                            ((INSTANCE) == TIM17))
+
+/************** TIM Instances : supporting Break source selection *************/
+#define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                               ((INSTANCE) == TIM15)  || \
+                                               ((INSTANCE) == TIM16)  || \
+                                               ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BKIN2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM15))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM3))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(INSTANCE)   ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(INSTANCE)   ((INSTANCE) == TIM1)
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.COMDE) *******/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : DMA requests generation (TIMx_DIER.UDE) ***/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM6)   || \
+                                            ((INSTANCE) == TIM7)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM14)  || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+    ((((INSTANCE) == TIM1) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4) ||          \
+      ((CHANNEL) == TIM_CHANNEL_5) ||          \
+      ((CHANNEL) == TIM_CHANNEL_6)))           \
+     ||                                        \
+     (((INSTANCE) == TIM3) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
+     (((INSTANCE) == TIM14) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+     ||                                        \
+     (((INSTANCE) == TIM15) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2)))           \
+     ||                                        \
+     (((INSTANCE) == TIM16) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+     ||                                        \
+     (((INSTANCE) == TIM17) &&                 \
+      (((CHANNEL) == TIM_CHANNEL_1))))
+
+/****************** TIM Instances : supporting complementary output(s) ********/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+   ((((INSTANCE) == TIM1) &&                    \
+     (((CHANNEL) == TIM_CHANNEL_1) ||           \
+      ((CHANNEL) == TIM_CHANNEL_2) ||           \
+      ((CHANNEL) == TIM_CHANNEL_3)))            \
+    ||                                          \
+    (((INSTANCE) == TIM15) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1))              \
+    ||                                          \
+    (((INSTANCE) == TIM16) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1))              \
+    ||                                          \
+    (((INSTANCE) == TIM17) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1)))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
+                                                    ((INSTANCE) == TIM3)    || \
+                                                    ((INSTANCE) == TIM14)   || \
+                                                    ((INSTANCE) == TIM15)   || \
+                                                    ((INSTANCE) == TIM16)   || \
+                                                    ((INSTANCE) == TIM17))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting commutation event generation ***/
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                     ((INSTANCE) == TIM15)  || \
+                                                     ((INSTANCE) == TIM16)  || \
+                                                     ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                      ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                         ((INSTANCE) == TIM3))
+
+/**************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM3))
+
+/************* TIM Instances : supporting ETR source selection ***************/
+#define IS_TIM_ETRSEL_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                             ((INSTANCE) == TIM3))
+
+/****** TIM Instances : Master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM3)  || \
+                                            ((INSTANCE) == TIM6)  || \
+                                            ((INSTANCE) == TIM7)  || \
+                                            ((INSTANCE) == TIM15))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM3)  || \
+                                            ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM15) || \
+                                                       ((INSTANCE) == TIM16) || \
+                                                       ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM15))
+
+/******************* TIM Instances : Timer input selection ********************/
+#define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/************ TIM Instances : Advanced timers  ********************************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                    ((INSTANCE) == USART2))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                     ((INSTANCE) == USART2))
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == USART2))
+
+/********************* USART Instances : Smard card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+/****************** UART Instances : Auto Baud Rate detection ****************/
+#define IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+/******************** UART Instances : Half-Duplex mode **********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                 ((INSTANCE) == USART2))
+
+/******************** UART Instances : LIN mode **********************/
+#define IS_UART_LIN_INSTANCE(INSTANCE)   ((INSTANCE) == USART1)
+/******************** UART Instances : Wake-up from Stop mode **********************/
+#define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   ((INSTANCE) == USART1)
+
+/****************** UART Instances : Driver Enable *****************/
+#define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE)     (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == USART2))
+
+/****************** UART Instances : SPI Slave selection mode ***************/
+#define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                              ((INSTANCE) == USART2))
+
+/****************** UART Instances : Driver Enable *****************/
+#define IS_UART_FIFO_INSTANCE(INSTANCE)     ((INSTANCE) == USART1)
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+#define IS_LPUART_INSTANCE(INSTANCE)    (0U)
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+
+/**
+  * @}
+  */
+
+ /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* STM32G050xx_H */
+
+/**
+  * @}
+  */
+
+  /**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/soc/stm32g051xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g051xx.h
@@ -1,0 +1,8405 @@
+/**
+  ******************************************************************************
+  * @file    stm32g051xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for stm32g051xx devices.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral's registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under Apache License, Version 2.0,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/Apache-2.0
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32g051xx
+  * @{
+  */
+
+#ifndef STM32G051xx_H
+#define STM32G051xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+  * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+   */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+ * @brief stm32g051xx Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
+ */
+
+/*!< Interrupt Number Definition */
+typedef enum
+{
+/******  Cortex-M0+ Processor Exceptions Numbers ***************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  HardFault_IRQn              = -13,    /*!< 3 Cortex-M Hard Fault Interrupt                                   */
+  SVC_IRQn                    = -5,     /*!< 11 Cortex-M SV Call Interrupt                                     */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M Pend SV Interrupt                                     */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
+/******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI line 16                                          */
+  RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
+  FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
+  EXTI0_1_IRQn                = 5,      /*!< EXTI 0 and 1 Interrupts                                           */
+  EXTI2_3_IRQn                = 6,      /*!< EXTI Line 2 and 3 Interrupts                                      */
+  EXTI4_15_IRQn               = 7,      /*!< EXTI Line 4 to 15 Interrupts                                      */
+  DMA1_Channel1_IRQn          = 9,      /*!< DMA1 Channel 1 Interrupt                                          */
+  DMA1_Channel2_3_IRQn        = 10,     /*!< DMA1 Channel 2 and Channel 3 Interrupts                           */
+  DMA1_Ch4_7_DMAMUX1_OVR_IRQn = 11,     /*!< DMA1 Channel 4 to Channel 7 and DMAMUX1 Overrun Interrupts        */
+  ADC1_COMP_IRQn              = 12,     /*!< ADC1, COMP1 and COMP2 Interrupts (combined with EXTI 17 & 18)     */
+  TIM1_BRK_UP_TRG_COM_IRQn    = 13,     /*!< TIM1 Break, Update, Trigger and Commutation Interrupts            */
+  TIM1_CC_IRQn                = 14,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 15,     /*!< TIM2 Interrupt                                                    */
+  TIM3_IRQn                   = 16,     /*!< TIM3 global Interrupt                                             */
+  TIM6_DAC_LPTIM1_IRQn        = 17,     /*!< TIM6, DAC and LPTIM1 global Interrupts                            */
+  TIM7_LPTIM2_IRQn            = 18,     /*!< TIM7 and LPTIM2 global Interrupt                                  */
+  TIM14_IRQn                  = 19,     /*!< TIM14 global Interrupt                                            */
+  TIM15_IRQn                  = 20,     /*!< TIM15 global Interrupt                                            */
+  TIM16_IRQn                  = 21,     /*!< TIM16 global Interrupt                                            */
+  TIM17_IRQn                  = 22,     /*!< TIM17 global Interrupt                                            */
+  I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt  (combined with EXTI 23)                           */
+  I2C2_IRQn                   = 24,     /*!< I2C2 Interrupt                                                    */
+  SPI1_IRQn                   = 25,     /*!< SPI1/I2S1 Interrupt                                               */
+  SPI2_IRQn                   = 26,     /*!< SPI2 Interrupt                                                    */
+  USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
+  USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                                  */
+  LPUART1_IRQn                = 29,     /*!< LPUART1 globlal Interrupts (combined with EXTI 28)                 */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+#include "core_cm0plus.h"               /* Cortex-M0+ processor and core peripherals */
+#include "system_stm32g0xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC interrupt and status register,             Address offset: 0x00 */
+  __IO uint32_t IER;          /*!< ADC interrupt enable register,                 Address offset: 0x04 */
+  __IO uint32_t CR;           /*!< ADC control register,                          Address offset: 0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC configuration register 1,                  Address offset: 0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC configuration register 2,                  Address offset: 0x10 */
+  __IO uint32_t SMPR;         /*!< ADC sampling time register,                    Address offset: 0x14 */
+       uint32_t RESERVED1;    /*!< Reserved,                                                      0x18 */
+       uint32_t RESERVED2;    /*!< Reserved,                                                      0x1C */
+  __IO uint32_t TR1;          /*!< ADC analog watchdog 1 threshold register,      Address offset: 0x20 */
+  __IO uint32_t TR2;          /*!< ADC analog watchdog 2 threshold register,      Address offset: 0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC group regular sequencer register,          Address offset: 0x28 */
+  __IO uint32_t TR3;          /*!< ADC analog watchdog 3 threshold register,      Address offset: 0x2C */
+       uint32_t RESERVED3[4]; /*!< Reserved,                                               0x30 - 0x3C */
+  __IO uint32_t DR;           /*!< ADC group regular data register,               Address offset: 0x40 */
+       uint32_t RESERVED4[23];/*!< Reserved,                                               0x44 - 0x9C */
+  __IO uint32_t AWD2CR;       /*!< ADC analog watchdog 2 configuration register,  Address offset: 0xA0 */
+  __IO uint32_t AWD3CR;       /*!< ADC analog watchdog 3 configuration register,  Address offset: 0xA4 */
+       uint32_t RESERVED5[3]; /*!< Reserved,                                               0xA8 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC Calibration factor register,               Address offset: 0xB4 */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CCR;          /*!< ADC common configuration register,             Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+
+
+/**
+  * @brief Comparator
+  */
+typedef struct
+{
+  __IO uint32_t CSR;         /*!< COMP control and status register,                                                 Address offset: 0x00 */
+} COMP_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSR_ODD;    /*!< COMP control and status register located in register of comparator instance odd, used for bits common to several COMP instances, Address offset: 0x00 */
+  __IO uint32_t CSR_EVEN;   /*!< COMP control and status register located in register of comparator instance even, used for bits common to several COMP instances, Address offset: 0x04 */
+} COMP_Common_TypeDef;
+
+/**
+  * @brief CRC calculation unit
+  */
+typedef struct
+{
+  __IO uint32_t DR;             /*!< CRC Data register,                         Address offset: 0x00 */
+  __IO uint32_t IDR;            /*!< CRC Independent data register,             Address offset: 0x04 */
+  __IO uint32_t CR;             /*!< CRC Control register,                      Address offset: 0x08 */
+       uint32_t RESERVED1;      /*!< Reserved,                                                  0x0C */
+  __IO uint32_t INIT;           /*!< Initial CRC value register,                Address offset: 0x10 */
+  __IO uint32_t POL;            /*!< CRC polynomial register,                   Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Digital to Analog Converter
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;     /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;     /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;     /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;      /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;     /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;     /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;      /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;     /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;     /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;      /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;        /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;        /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;          /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CCR;         /*!< DAC calibration control register,                        Address offset: 0x38 */
+  __IO uint32_t MCR;         /*!< DAC mode control register,                               Address offset: 0x3C */
+  __IO uint32_t SHSR1;       /*!< DAC Sample and Hold sample time register 1,              Address offset: 0x40 */
+  __IO uint32_t SHSR2;       /*!< DAC Sample and Hold sample time register 2,              Address offset: 0x44 */
+  __IO uint32_t SHHR;        /*!< DAC Sample and Hold hold time register,                  Address offset: 0x48 */
+  __IO uint32_t SHRR;        /*!< DAC Sample and Hold refresh time register,               Address offset: 0x4C */
+} DAC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+typedef struct
+{
+  __IO uint32_t IDCODE;      /*!< MCU device ID code,              Address offset: 0x00 */
+  __IO uint32_t CR;          /*!< Debug configuration register,    Address offset: 0x04 */
+  __IO uint32_t APBFZ1;      /*!< Debug APB freeze register 1,     Address offset: 0x08 */
+  __IO uint32_t APBFZ2;      /*!< Debug APB freeze register 2,     Address offset: 0x0C */
+} DBG_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+typedef struct
+{
+  __IO uint32_t CCR;         /*!< DMA channel x configuration register        */
+  __IO uint32_t CNDTR;       /*!< DMA channel x number of data register       */
+  __IO uint32_t CPAR;        /*!< DMA channel x peripheral address register   */
+  __IO uint32_t CMAR;        /*!< DMA channel x memory address register       */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< DMA interrupt status register,                 Address offset: 0x00 */
+  __IO uint32_t IFCR;        /*!< DMA interrupt flag clear register,             Address offset: 0x04 */
+} DMA_TypeDef;
+
+/**
+  * @brief DMA Multiplexer
+  */
+typedef struct
+{
+  __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
+}DMAMUX_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
+  __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
+}DMAMUX_ChannelStatus_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
+}DMAMUX_RequestGen_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
+  __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
+}DMAMUX_RequestGenStatus_TypeDef;
+
+/**
+  * @brief Asynch Interrupt/Event Controller (EXTI)
+  */
+typedef struct
+{
+  __IO uint32_t RTSR1;          /*!< EXTI Rising Trigger Selection Register 1,        Address offset:   0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI Falling Trigger Selection Register 1,       Address offset:   0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI Software Interrupt event Register 1,        Address offset:   0x08 */
+  __IO uint32_t RPR1;           /*!< EXTI Rising Pending Register 1,                  Address offset:   0x0C */
+  __IO uint32_t FPR1;           /*!< EXTI Falling Pending Register 1,                 Address offset:   0x10 */
+       uint32_t RESERVED1[3];   /*!< Reserved 1,                                                0x14 -- 0x1C */
+       uint32_t RESERVED2[5];   /*!< Reserved 2,                                                0x20 -- 0x30 */
+       uint32_t RESERVED3[11];  /*!< Reserved 3,                                                0x34 -- 0x5C */
+  __IO uint32_t EXTICR[4];      /*!< EXTI External Interrupt Configuration Register,            0x60 -- 0x6C */
+       uint32_t RESERVED4[4];   /*!< Reserved 4,                                                0x70 -- 0x7C */
+  __IO uint32_t IMR1;           /*!< EXTI Interrupt Mask Register 1,                  Address offset:   0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI Event Mask Register 1,                      Address offset:   0x84 */
+} EXTI_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;          /*!< FLASH Access Control register,                     Address offset: 0x00 */
+       uint32_t RESERVED1;    /*!< Reserved1,                                         Address offset: 0x04 */
+  __IO uint32_t KEYR;         /*!< FLASH Key register,                                Address offset: 0x08 */
+  __IO uint32_t OPTKEYR;      /*!< FLASH Option Key register,                         Address offset: 0x0C */
+  __IO uint32_t SR;           /*!< FLASH Status register,                             Address offset: 0x10 */
+  __IO uint32_t CR;           /*!< FLASH Control register,                            Address offset: 0x14 */
+  __IO uint32_t ECCR;         /*!< FLASH ECC register,                                Address offset: 0x18 */
+       uint32_t RESERVED2;    /*!< Reserved2,                                         Address offset: 0x1C */
+  __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
+  __IO uint32_t PCROP1ASR;    /*!< FLASH Bank PCROP area A Start address register,    Address offset: 0x24 */
+  __IO uint32_t PCROP1AER;    /*!< FLASH Bank PCROP area A End address register,      Address offset: 0x28 */
+  __IO uint32_t WRP1AR;       /*!< FLASH Bank WRP area A address register,            Address offset: 0x2C */
+  __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
+  __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
+  __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
+       uint32_t RESERVED8[17];/*!< Reserved8,                                         Address offset: 0x3C--0x7C */
+  __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
+} FLASH_TypeDef;
+
+/**
+  * @brief General Purpose I/O
+  */
+typedef struct
+{
+  __IO uint32_t MODER;       /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;      /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;     /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;       /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;         /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;         /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;        /*!< GPIO port bit set/reset  register,     Address offset: 0x18      */
+  __IO uint32_t LCKR;        /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];      /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;         /*!< GPIO Bit Reset register,               Address offset: 0x28      */
+} GPIO_TypeDef;
+
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;          /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;          /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;         /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;          /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR;        /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+/**
+  * @brief LPTIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;              /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;              /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;              /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;             /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;               /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;              /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;              /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;              /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t RESERVED1;        /*!< Reserved1,                                          Address offset: 0x20 */
+  __IO uint32_t CFGR2;            /*!< LPTIM Option register,                              Address offset: 0x24 */
+} LPTIM_TypeDef;
+
+
+/**
+  * @brief Power Control
+  */
+typedef struct
+{
+  __IO uint32_t CR1;          /*!< PWR Power Control Register 1,                     Address offset: 0x00 */
+  __IO uint32_t CR2;          /*!< PWR Power Control Register 2,                     Address offset: 0x04 */
+  __IO uint32_t CR3;          /*!< PWR Power Control Register 3,                     Address offset: 0x08 */
+  __IO uint32_t CR4;          /*!< PWR Power Control Register 4,                     Address offset: 0x0C */
+  __IO uint32_t SR1;          /*!< PWR Power Status Register 1,                      Address offset: 0x10 */
+  __IO uint32_t SR2;          /*!< PWR Power Status Register 2,                      Address offset: 0x14 */
+  __IO uint32_t SCR;          /*!< PWR Power Status Clear Register,                  Address offset: 0x18 */
+       uint32_t RESERVED1;    /*!< Reserved,                                         Address offset: 0x1C */
+  __IO uint32_t PUCRA;        /*!< PWR Pull-Up Control Register of port A,           Address offset: 0x20 */
+  __IO uint32_t PDCRA;        /*!< PWR Pull-Down Control Register of port A,         Address offset: 0x24 */
+  __IO uint32_t PUCRB;        /*!< PWR Pull-Up Control Register of port B,           Address offset: 0x28 */
+  __IO uint32_t PDCRB;        /*!< PWR Pull-Down Control Register of port B,         Address offset: 0x2C */
+  __IO uint32_t PUCRC;        /*!< PWR Pull-Up Control Register of port C,           Address offset: 0x30 */
+  __IO uint32_t PDCRC;        /*!< PWR Pull-Down Control Register of port C,         Address offset: 0x34 */
+  __IO uint32_t PUCRD;        /*!< PWR Pull-Up Control Register of port D,           Address offset: 0x38 */
+  __IO uint32_t PDCRD;        /*!< PWR Pull-Down Control Register of port D,         Address offset: 0x3C */
+       uint32_t RESERVED2;    /*!< Reserved,                                         Address offset: 0x40 */
+       uint32_t RESERVED3;    /*!< Reserved,                                         Address offset: 0x44 */
+  __IO uint32_t PUCRF;        /*!< PWR Pull-Up Control Register of port F,           Address offset: 0x48 */
+  __IO uint32_t PDCRF;        /*!< PWR Pull-Down Control Register of port F,         Address offset: 0x4C */
+} PWR_TypeDef;
+
+/**
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< RCC Clock Sources Control Register,                                     Address offset: 0x00 */
+  __IO uint32_t ICSCR;       /*!< RCC Internal Clock Sources Calibration Register,                        Address offset: 0x04 */
+  __IO uint32_t CFGR;        /*!< RCC Regulated Domain Clocks Configuration Register,                     Address offset: 0x08 */
+  __IO uint32_t PLLCFGR;     /*!< RCC System PLL configuration Register,                                  Address offset: 0x0C */
+  __IO uint32_t RESERVED0;   /*!< Reserved,                                                               Address offset: 0x10 */
+  __IO uint32_t RESERVED1;   /*!< Reserved,                                                               Address offset: 0x14 */
+  __IO uint32_t CIER;        /*!< RCC Clock Interrupt Enable Register,                                    Address offset: 0x18 */
+  __IO uint32_t CIFR;        /*!< RCC Clock Interrupt Flag Register,                                      Address offset: 0x1C */
+  __IO uint32_t CICR;        /*!< RCC Clock Interrupt Clear Register,                                     Address offset: 0x20 */
+  __IO uint32_t IOPRSTR;     /*!< RCC IO port reset register,                                             Address offset: 0x24 */
+  __IO uint32_t AHBRSTR;     /*!< RCC AHB peripherals reset register,                                     Address offset: 0x28 */
+  __IO uint32_t APBRSTR1;    /*!< RCC APB peripherals reset register 1,                                   Address offset: 0x2C */
+  __IO uint32_t APBRSTR2;    /*!< RCC APB peripherals reset register 2,                                   Address offset: 0x30 */
+  __IO uint32_t IOPENR;      /*!< RCC IO port enable register,                                            Address offset: 0x34 */
+  __IO uint32_t AHBENR;      /*!< RCC AHB peripherals clock enable register,                              Address offset: 0x38 */
+  __IO uint32_t APBENR1;     /*!< RCC APB peripherals clock enable register1,                             Address offset: 0x3C */
+  __IO uint32_t APBENR2;     /*!< RCC APB peripherals clock enable register2,                             Address offset: 0x40 */
+  __IO uint32_t IOPSMENR;    /*!< RCC IO port clocks enable in sleep mode register,                       Address offset: 0x44 */
+  __IO uint32_t AHBSMENR;    /*!< RCC AHB peripheral clocks enable in sleep mode register,                Address offset: 0x48 */
+  __IO uint32_t APBSMENR1;   /*!< RCC APB peripheral clocks enable in sleep mode register1,               Address offset: 0x4C */
+  __IO uint32_t APBSMENR2;   /*!< RCC APB peripheral clocks enable in sleep mode register2,               Address offset: 0x50 */
+  __IO uint32_t CCIPR;       /*!< RCC Peripherals Independent Clocks Configuration Register,              Address offset: 0x54 */
+  __IO uint32_t RESERVED2;   /*!< Reserved,                                                               Address offset: 0x58 */
+  __IO uint32_t BDCR;        /*!< RCC Backup Domain Control Register,                                     Address offset: 0x5C */
+  __IO uint32_t CSR;         /*!< RCC Unregulated Domain Clock Control and Status Register,               Address offset: 0x60 */
+} RCC_TypeDef;
+
+/**
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;          /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;          /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t SSR;         /*!< RTC sub second register,                                   Address offset: 0x08 */
+  __IO uint32_t ICSR;        /*!< RTC initialization control and status register,            Address offset: 0x0C */
+  __IO uint32_t PRER;        /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;        /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+  __IO uint32_t CR;          /*!< RTC control register,                                      Address offset: 0x18 */
+       uint32_t RESERVED0;   /*!< Reserved                                                   Address offset: 0x1C */
+       uint32_t RESERVED1;   /*!< Reserved                                                   Address offset: 0x20 */
+  __IO uint32_t WPR;         /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t CALR;        /*!< RTC calibration register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;      /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;        /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;        /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;       /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+       uint32_t RESERVED2;   /*!< Reserved                                                   Address offset: 0x1C */
+  __IO uint32_t ALRMAR;      /*!< RTC alarm A register,                                      Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;    /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBR;      /*!< RTC alarm B register,                                      Address offset: 0x48 */
+  __IO uint32_t ALRMBSSR;    /*!< RTC alarm B sub second register,                           Address offset: 0x4C */
+  __IO uint32_t SR;          /*!< RTC Status register,                                       Address offset: 0x50 */
+  __IO uint32_t MISR;        /*!< RTC Masked Interrupt Status register,                      Address offset: 0x54 */
+       uint32_t RESERVED3;   /*!< Reserved                                                   Address offset: 0x58 */
+  __IO uint32_t SCR;         /*!< RTC Status Clear register,                                 Address offset: 0x5C */
+  __IO uint32_t OR;          /*!< RTC option register,                                       Address offset: 0x60 */
+} RTC_TypeDef;
+
+/**
+  * @brief Tamper and backup registers
+  */
+typedef struct
+{
+  __IO uint32_t CR1;            /*!< TAMP configuration register 1,                             Address offset: 0x00 */
+  __IO uint32_t CR2;            /*!< TAMP configuration register 2,                             Address offset: 0x04 */
+       uint32_t RESERVED0;      /*!< Reserved                                                   Address offset: 0x08 */
+  __IO uint32_t FLTCR;          /*!< Reserved                                                   Address offset: 0x0C */
+       uint32_t RESERVED1[7];   /*!< Reserved                                                   Address offset: 0x10 -- 0x28 */
+  __IO uint32_t IER;            /*!< TAMP Interrupt enable register,                            Address offset: 0x2C */
+  __IO uint32_t SR;             /*!< TAMP Status register,                                      Address offset: 0x30 */
+  __IO uint32_t MISR;           /*!< TAMP Masked Interrupt Status register,                     Address offset: 0x34 */
+       uint32_t RESERVED2;      /*!< Reserved                                                   Address offset: 0x38 */
+  __IO uint32_t SCR;            /*!< TAMP Status clear register,                                Address offset: 0x3C */
+       uint32_t RESERVED3[48];  /*!< Reserved                                                   Address offset: 0x54 -- 0xFC */
+  __IO uint32_t BKP0R;          /*!< TAMP backup register 0,                                    Address offset: 0x100 */
+  __IO uint32_t BKP1R;          /*!< TAMP backup register 1,                                    Address offset: 0x104 */
+  __IO uint32_t BKP2R;          /*!< TAMP backup register 2,                                    Address offset: 0x108 */
+  __IO uint32_t BKP3R;          /*!< TAMP backup register 3,                                    Address offset: 0x10C */
+  __IO uint32_t BKP4R;          /*!< TAMP backup register 4,                                    Address offset: 0x110 */
+} TAMP_TypeDef;
+
+  /**
+  * @brief Serial Peripheral Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1 (not used in I2S mode),       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,                              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,                                 Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,                                   Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register (not used in I2S mode),  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register (not used in I2S mode),          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register (not used in I2S mode),          Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;  /*!< SPI_I2S configuration register,                      Address offset: 0x1C */
+  __IO uint32_t I2SPR;    /*!< SPI_I2S prescaler register,                          Address offset: 0x20 */
+} SPI_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+typedef struct
+{
+  __IO uint32_t CFGR1;          /*!< SYSCFG configuration register 1,                   Address offset: 0x00 */
+       uint32_t RESERVED0[5];   /*!< Reserved,                                                   0x04 --0x14 */
+  __IO uint32_t CFGR2;          /*!< SYSCFG configuration register 2,                   Address offset: 0x18 */
+       uint32_t RESERVED1[25];  /*!< Reserved                                                           0x1C */
+  __IO uint32_t IT_LINE_SR[32]; /*!< SYSCFG configuration IT_LINE register,             Address offset: 0x80 */
+} SYSCFG_TypeDef;
+
+/**
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,                   Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,                   Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,          Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,        Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                      Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,            Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1,      Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2,      Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register,      Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                     Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */
+  __IO uint32_t OR1;         /*!< TIM option register,                      Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare register5,            Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare register6,            Address offset: 0x5C */
+  __IO uint32_t AF1;         /*!< TIM alternate function register 1,        Address offset: 0x60 */
+  __IO uint32_t AF2;         /*!< TIM alternate function register 2,        Address offset: 0x64 */
+  __IO uint32_t TISEL;       /*!< TIM Input Selection register,             Address offset: 0x68 */
+} TIM_TypeDef;
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< USART Control register 1,                 Address offset: 0x00  */
+  __IO uint32_t CR2;         /*!< USART Control register 2,                 Address offset: 0x04  */
+  __IO uint32_t CR3;         /*!< USART Control register 3,                 Address offset: 0x08  */
+  __IO uint32_t BRR;         /*!< USART Baud rate register,                 Address offset: 0x0C  */
+  __IO uint32_t GTPR;        /*!< USART Guard time and prescaler register,  Address offset: 0x10  */
+  __IO uint32_t RTOR;        /*!< USART Receiver Time Out register,         Address offset: 0x14  */
+  __IO uint32_t RQR;         /*!< USART Request register,                   Address offset: 0x18  */
+  __IO uint32_t ISR;         /*!< USART Interrupt and status register,      Address offset: 0x1C  */
+  __IO uint32_t ICR;         /*!< USART Interrupt flag Clear register,      Address offset: 0x20  */
+  __IO uint32_t RDR;         /*!< USART Receive Data register,              Address offset: 0x24  */
+  __IO uint32_t TDR;         /*!< USART Transmit Data register,             Address offset: 0x28  */
+  __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C  */
+} USART_TypeDef;
+
+/**
+  * @brief VREFBUF
+  */
+typedef struct
+{
+  __IO uint32_t CSR;         /*!< VREFBUF control and status register,         Address offset: 0x00 */
+  __IO uint32_t CCR;         /*!< VREFBUF calibration and control register,    Address offset: 0x04 */
+} VREFBUF_TypeDef;
+
+/**
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;         /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+#define FLASH_BASE            (0x08000000UL)  /*!< FLASH base address */
+#define SRAM_BASE             (0x20000000UL)  /*!< SRAM base address */
+#define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
+#define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
+#define SRAM_SIZE_MAX         (0x00004000UL)  /*!< maximum SRAM size (up to 16 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x007FU)) << 10U)
+
+/*!< Peripheral memory map */
+#define APBPERIPH_BASE        (PERIPH_BASE)
+#define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
+
+/*!< APB peripherals */
+
+#define TIM2_BASE             (APBPERIPH_BASE + 0UL)
+#define TIM3_BASE             (APBPERIPH_BASE + 0x00000400UL)
+#define TIM6_BASE             (APBPERIPH_BASE + 0x00001000UL)
+#define TIM7_BASE             (APBPERIPH_BASE + 0x00001400UL)
+#define TIM14_BASE            (APBPERIPH_BASE + 0x00002000UL)
+#define RTC_BASE              (APBPERIPH_BASE + 0x00002800UL)
+#define WWDG_BASE             (APBPERIPH_BASE + 0x00002C00UL)
+#define IWDG_BASE             (APBPERIPH_BASE + 0x00003000UL)
+#define SPI2_BASE             (APBPERIPH_BASE + 0x00003800UL)
+#define USART2_BASE           (APBPERIPH_BASE + 0x00004400UL)
+#define I2C1_BASE             (APBPERIPH_BASE + 0x00005400UL)
+#define I2C2_BASE             (APBPERIPH_BASE + 0x00005800UL)
+#define PWR_BASE              (APBPERIPH_BASE + 0x00007000UL)
+#define DAC1_BASE             (APBPERIPH_BASE + 0x00007400UL)
+#define DAC_BASE              (APBPERIPH_BASE + 0x00007400UL) /* Kept for legacy purpose */
+#define LPTIM1_BASE           (APBPERIPH_BASE + 0x00007C00UL)
+#define LPUART1_BASE          (APBPERIPH_BASE + 0x00008000UL)
+#define LPTIM2_BASE           (APBPERIPH_BASE + 0x00009400UL)
+#define TAMP_BASE             (APBPERIPH_BASE + 0x0000B000UL)
+#define SYSCFG_BASE           (APBPERIPH_BASE + 0x00010000UL)
+#define VREFBUF_BASE          (APBPERIPH_BASE + 0x00010030UL)
+#define COMP1_BASE            (SYSCFG_BASE + 0x0200UL)
+#define COMP2_BASE            (SYSCFG_BASE + 0x0204UL)
+#define ADC1_BASE             (APBPERIPH_BASE + 0x00012400UL)
+#define ADC1_COMMON_BASE      (APBPERIPH_BASE + 0x00012708UL)
+#define ADC_BASE              (ADC1_COMMON_BASE) /* Kept for legacy purpose */
+#define TIM1_BASE             (APBPERIPH_BASE + 0x00012C00UL)
+#define SPI1_BASE             (APBPERIPH_BASE + 0x00013000UL)
+#define USART1_BASE           (APBPERIPH_BASE + 0x00013800UL)
+#define TIM15_BASE            (APBPERIPH_BASE + 0x00014000UL)
+#define TIM16_BASE            (APBPERIPH_BASE + 0x00014400UL)
+#define TIM17_BASE            (APBPERIPH_BASE + 0x00014800UL)
+#define DBG_BASE              (APBPERIPH_BASE + 0x00015800UL)
+
+
+/*!< AHB peripherals */
+#define DMA1_BASE             (AHBPERIPH_BASE)
+#define DMAMUX1_BASE          (AHBPERIPH_BASE + 0x00000800UL)
+#define RCC_BASE              (AHBPERIPH_BASE + 0x00001000UL)
+#define EXTI_BASE             (AHBPERIPH_BASE + 0x00001800UL)
+#define FLASH_R_BASE          (AHBPERIPH_BASE + 0x00002000UL)
+#define CRC_BASE              (AHBPERIPH_BASE + 0x00003000UL)
+
+
+#define DMA1_Channel1_BASE    (DMA1_BASE + 0x00000008UL)
+#define DMA1_Channel2_BASE    (DMA1_BASE + 0x0000001CUL)
+#define DMA1_Channel3_BASE    (DMA1_BASE + 0x00000030UL)
+#define DMA1_Channel4_BASE    (DMA1_BASE + 0x00000044UL)
+#define DMA1_Channel5_BASE    (DMA1_BASE + 0x00000058UL)
+#define DMA1_Channel6_BASE    (DMA1_BASE + 0x0000006CUL)
+#define DMA1_Channel7_BASE    (DMA1_BASE + 0x00000080UL)
+
+#define DMAMUX1_Channel0_BASE    (DMAMUX1_BASE)
+#define DMAMUX1_Channel1_BASE    (DMAMUX1_BASE + 0x00000004UL)
+#define DMAMUX1_Channel2_BASE    (DMAMUX1_BASE + 0x00000008UL)
+#define DMAMUX1_Channel3_BASE    (DMAMUX1_BASE + 0x0000000CUL)
+#define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
+#define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
+#define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+
+#define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
+#define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
+#define DMAMUX1_RequestGenerator2_BASE  (DMAMUX1_BASE + 0x00000108UL)
+#define DMAMUX1_RequestGenerator3_BASE  (DMAMUX1_BASE + 0x0000010CUL)
+
+#define DMAMUX1_ChannelStatus_BASE      (DMAMUX1_BASE + 0x00000080UL)
+#define DMAMUX1_RequestGenStatus_BASE   (DMAMUX1_BASE + 0x00000140UL)
+
+/*!< IOPORT */
+#define GPIOA_BASE            (IOPORT_BASE + 0x00000000UL)
+#define GPIOB_BASE            (IOPORT_BASE + 0x00000400UL)
+#define GPIOC_BASE            (IOPORT_BASE + 0x00000800UL)
+#define GPIOD_BASE            (IOPORT_BASE + 0x00000C00UL)
+#define GPIOF_BASE            (IOPORT_BASE + 0x00001400UL)
+
+/*!< Device Electronic Signature */
+#define PACKAGE_BASE          (0x1FFF7500UL)        /*!< Package data register base address     */
+#define UID_BASE              (0x1FFF7590UL)        /*!< Unique device ID register base address */
+#define FLASHSIZE_BASE        (0x1FFF75E0UL)        /*!< Flash size data register base address  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define TIM3                ((TIM_TypeDef *) TIM3_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                ((TIM_TypeDef *) TIM7_BASE)
+#define TIM14               ((TIM_TypeDef *) TIM14_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define TAMP                ((TAMP_TypeDef *) TAMP_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define DAC1                ((DAC_TypeDef *) DAC1_BASE)
+#define DAC                 ((DAC_TypeDef *) DAC_BASE) /* Kept for legacy purpose */
+#define LPUART1             ((USART_TypeDef *) LPUART1_BASE)
+#define LPTIM2              ((LPTIM_TypeDef *) LPTIM2_BASE)
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define VREFBUF             ((VREFBUF_TypeDef *) VREFBUF_BASE)
+#define COMP1               ((COMP_TypeDef *) COMP1_BASE)
+#define COMP2               ((COMP_TypeDef *) COMP2_BASE)
+#define COMP12_COMMON       ((COMP_Common_TypeDef *) COMP1_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define TIM15               ((TIM_TypeDef *) TIM15_BASE)
+#define TIM16               ((TIM_TypeDef *) TIM16_BASE)
+#define TIM17               ((TIM_TypeDef *) TIM17_BASE)
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOF               ((GPIO_TypeDef *) GPIOF_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) ADC1_COMMON_BASE)
+#define ADC                 (ADC1_COMMON) /* Kept for legacy purpose */
+
+
+
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+#define DMAMUX1                ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
+#define DMAMUX1_Channel0       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
+#define DMAMUX1_Channel1       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel1_BASE)
+#define DMAMUX1_Channel2       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel2_BASE)
+#define DMAMUX1_Channel3       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel3_BASE)
+#define DMAMUX1_Channel4       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
+#define DMAMUX1_Channel5       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
+#define DMAMUX1_Channel6       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+
+#define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
+#define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
+#define DMAMUX1_RequestGenerator2  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator2_BASE)
+#define DMAMUX1_RequestGenerator3  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator3_BASE)
+
+#define DMAMUX1_ChannelStatus      ((DMAMUX_ChannelStatus_TypeDef *) DMAMUX1_ChannelStatus_BASE)
+#define DMAMUX1_RequestGenStatus   ((DMAMUX_RequestGenStatus_TypeDef *) DMAMUX1_RequestGenStatus_BASE)
+
+#define DBG              ((DBG_TypeDef *) DBG_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for ADC_ISR register  *******************/
+#define ADC_ISR_ADRDY_Pos              (0U)
+#define ADC_ISR_ADRDY_Msk              (0x1UL << ADC_ISR_ADRDY_Pos)            /*!< 0x00000001 */
+#define ADC_ISR_ADRDY                  ADC_ISR_ADRDY_Msk                       /*!< ADC ready flag */
+#define ADC_ISR_EOSMP_Pos              (1U)
+#define ADC_ISR_EOSMP_Msk              (0x1UL << ADC_ISR_EOSMP_Pos)            /*!< 0x00000002 */
+#define ADC_ISR_EOSMP                  ADC_ISR_EOSMP_Msk                       /*!< ADC group regular end of sampling flag */
+#define ADC_ISR_EOC_Pos                (2U)
+#define ADC_ISR_EOC_Msk                (0x1UL << ADC_ISR_EOC_Pos)              /*!< 0x00000004 */
+#define ADC_ISR_EOC                    ADC_ISR_EOC_Msk                         /*!< ADC group regular end of unitary conversion flag */
+#define ADC_ISR_EOS_Pos                (3U)
+#define ADC_ISR_EOS_Msk                (0x1UL << ADC_ISR_EOS_Pos)              /*!< 0x00000008 */
+#define ADC_ISR_EOS                    ADC_ISR_EOS_Msk                         /*!< ADC group regular end of sequence conversions flag */
+#define ADC_ISR_OVR_Pos                (4U)
+#define ADC_ISR_OVR_Msk                (0x1UL << ADC_ISR_OVR_Pos)              /*!< 0x00000010 */
+#define ADC_ISR_OVR                    ADC_ISR_OVR_Msk                         /*!< ADC group regular overrun flag */
+#define ADC_ISR_AWD1_Pos               (7U)
+#define ADC_ISR_AWD1_Msk               (0x1UL << ADC_ISR_AWD1_Pos)             /*!< 0x00000080 */
+#define ADC_ISR_AWD1                   ADC_ISR_AWD1_Msk                        /*!< ADC analog watchdog 1 flag */
+#define ADC_ISR_AWD2_Pos               (8U)
+#define ADC_ISR_AWD2_Msk               (0x1UL << ADC_ISR_AWD2_Pos)             /*!< 0x00000100 */
+#define ADC_ISR_AWD2                   ADC_ISR_AWD2_Msk                        /*!< ADC analog watchdog 2 flag */
+#define ADC_ISR_AWD3_Pos               (9U)
+#define ADC_ISR_AWD3_Msk               (0x1UL << ADC_ISR_AWD3_Pos)             /*!< 0x00000200 */
+#define ADC_ISR_AWD3                   ADC_ISR_AWD3_Msk                        /*!< ADC analog watchdog 3 flag */
+#define ADC_ISR_EOCAL_Pos              (11U)
+#define ADC_ISR_EOCAL_Msk              (0x1UL << ADC_ISR_EOCAL_Pos)            /*!< 0x00000800 */
+#define ADC_ISR_EOCAL                  ADC_ISR_EOCAL_Msk                       /*!< ADC end of calibration flag */
+#define ADC_ISR_CCRDY_Pos              (13U)
+#define ADC_ISR_CCRDY_Msk              (0x1UL << ADC_ISR_CCRDY_Pos)            /*!< 0x00002000 */
+#define ADC_ISR_CCRDY                  ADC_ISR_CCRDY_Msk                       /*!< ADC channel configuration ready flag */
+
+/* Legacy defines */
+#define ADC_ISR_EOSEQ           (ADC_ISR_EOS)
+
+/********************  Bit definition for ADC_IER register  *******************/
+#define ADC_IER_ADRDYIE_Pos            (0U)
+#define ADC_IER_ADRDYIE_Msk            (0x1UL << ADC_IER_ADRDYIE_Pos)          /*!< 0x00000001 */
+#define ADC_IER_ADRDYIE                ADC_IER_ADRDYIE_Msk                     /*!< ADC ready interrupt */
+#define ADC_IER_EOSMPIE_Pos            (1U)
+#define ADC_IER_EOSMPIE_Msk            (0x1UL << ADC_IER_EOSMPIE_Pos)          /*!< 0x00000002 */
+#define ADC_IER_EOSMPIE                ADC_IER_EOSMPIE_Msk                     /*!< ADC group regular end of sampling interrupt */
+#define ADC_IER_EOCIE_Pos              (2U)
+#define ADC_IER_EOCIE_Msk              (0x1UL << ADC_IER_EOCIE_Pos)            /*!< 0x00000004 */
+#define ADC_IER_EOCIE                  ADC_IER_EOCIE_Msk                       /*!< ADC group regular end of unitary conversion interrupt */
+#define ADC_IER_EOSIE_Pos              (3U)
+#define ADC_IER_EOSIE_Msk              (0x1UL << ADC_IER_EOSIE_Pos)            /*!< 0x00000008 */
+#define ADC_IER_EOSIE                  ADC_IER_EOSIE_Msk                       /*!< ADC group regular end of sequence conversions interrupt */
+#define ADC_IER_OVRIE_Pos              (4U)
+#define ADC_IER_OVRIE_Msk              (0x1UL << ADC_IER_OVRIE_Pos)            /*!< 0x00000010 */
+#define ADC_IER_OVRIE                  ADC_IER_OVRIE_Msk                       /*!< ADC group regular overrun interrupt */
+#define ADC_IER_AWD1IE_Pos             (7U)
+#define ADC_IER_AWD1IE_Msk             (0x1UL << ADC_IER_AWD1IE_Pos)           /*!< 0x00000080 */
+#define ADC_IER_AWD1IE                 ADC_IER_AWD1IE_Msk                      /*!< ADC analog watchdog 1 interrupt */
+#define ADC_IER_AWD2IE_Pos             (8U)
+#define ADC_IER_AWD2IE_Msk             (0x1UL << ADC_IER_AWD2IE_Pos)           /*!< 0x00000100 */
+#define ADC_IER_AWD2IE                 ADC_IER_AWD2IE_Msk                      /*!< ADC analog watchdog 2 interrupt */
+#define ADC_IER_AWD3IE_Pos             (9U)
+#define ADC_IER_AWD3IE_Msk             (0x1UL << ADC_IER_AWD3IE_Pos)           /*!< 0x00000200 */
+#define ADC_IER_AWD3IE                 ADC_IER_AWD3IE_Msk                      /*!< ADC analog watchdog 3 interrupt */
+#define ADC_IER_EOCALIE_Pos            (11U)
+#define ADC_IER_EOCALIE_Msk            (0x1UL << ADC_IER_EOCALIE_Pos)          /*!< 0x00000800 */
+#define ADC_IER_EOCALIE                ADC_IER_EOCALIE_Msk                     /*!< ADC end of calibration interrupt */
+#define ADC_IER_CCRDYIE_Pos            (13U)
+#define ADC_IER_CCRDYIE_Msk            (0x1UL << ADC_IER_CCRDYIE_Pos)          /*!< 0x00002000 */
+#define ADC_IER_CCRDYIE                ADC_IER_CCRDYIE_Msk                     /*!< ADC channel configuration ready interrupt */
+
+/* Legacy defines */
+#define ADC_IER_EOSEQIE           (ADC_IER_EOSIE)
+
+/********************  Bit definition for ADC_CR register  ********************/
+#define ADC_CR_ADEN_Pos                (0U)
+#define ADC_CR_ADEN_Msk                (0x1UL << ADC_CR_ADEN_Pos)              /*!< 0x00000001 */
+#define ADC_CR_ADEN                    ADC_CR_ADEN_Msk                         /*!< ADC enable */
+#define ADC_CR_ADDIS_Pos               (1U)
+#define ADC_CR_ADDIS_Msk               (0x1UL << ADC_CR_ADDIS_Pos)             /*!< 0x00000002 */
+#define ADC_CR_ADDIS                   ADC_CR_ADDIS_Msk                        /*!< ADC disable */
+#define ADC_CR_ADSTART_Pos             (2U)
+#define ADC_CR_ADSTART_Msk             (0x1UL << ADC_CR_ADSTART_Pos)           /*!< 0x00000004 */
+#define ADC_CR_ADSTART                 ADC_CR_ADSTART_Msk                      /*!< ADC group regular conversion start */
+#define ADC_CR_ADSTP_Pos               (4U)
+#define ADC_CR_ADSTP_Msk               (0x1UL << ADC_CR_ADSTP_Pos)             /*!< 0x00000010 */
+#define ADC_CR_ADSTP                   ADC_CR_ADSTP_Msk                        /*!< ADC group regular conversion stop */
+#define ADC_CR_ADVREGEN_Pos            (28U)
+#define ADC_CR_ADVREGEN_Msk            (0x1UL << ADC_CR_ADVREGEN_Pos)          /*!< 0x10000000 */
+#define ADC_CR_ADVREGEN                ADC_CR_ADVREGEN_Msk                     /*!< ADC voltage regulator enable */
+#define ADC_CR_ADCAL_Pos               (31U)
+#define ADC_CR_ADCAL_Msk               (0x1UL << ADC_CR_ADCAL_Pos)             /*!< 0x80000000 */
+#define ADC_CR_ADCAL                   ADC_CR_ADCAL_Msk                        /*!< ADC calibration */
+
+/********************  Bit definition for ADC_CFGR1 register  *****************/
+#define ADC_CFGR1_DMAEN_Pos            (0U)
+#define ADC_CFGR1_DMAEN_Msk            (0x1UL << ADC_CFGR1_DMAEN_Pos)          /*!< 0x00000001 */
+#define ADC_CFGR1_DMAEN                ADC_CFGR1_DMAEN_Msk                     /*!< ADC DMA transfer enable */
+#define ADC_CFGR1_DMACFG_Pos           (1U)
+#define ADC_CFGR1_DMACFG_Msk           (0x1UL << ADC_CFGR1_DMACFG_Pos)         /*!< 0x00000002 */
+#define ADC_CFGR1_DMACFG               ADC_CFGR1_DMACFG_Msk                    /*!< ADC DMA transfer configuration */
+
+#define ADC_CFGR1_SCANDIR_Pos          (2U)
+#define ADC_CFGR1_SCANDIR_Msk          (0x1UL << ADC_CFGR1_SCANDIR_Pos)        /*!< 0x00000004 */
+#define ADC_CFGR1_SCANDIR              ADC_CFGR1_SCANDIR_Msk                   /*!< ADC group regular sequencer scan direction */
+
+#define ADC_CFGR1_RES_Pos              (3U)
+#define ADC_CFGR1_RES_Msk              (0x3UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000018 */
+#define ADC_CFGR1_RES                  ADC_CFGR1_RES_Msk                       /*!< ADC data resolution */
+#define ADC_CFGR1_RES_0                (0x1U << ADC_CFGR1_RES_Pos)             /*!< 0x00000008 */
+#define ADC_CFGR1_RES_1                (0x2U << ADC_CFGR1_RES_Pos)             /*!< 0x00000010 */
+
+#define ADC_CFGR1_ALIGN_Pos            (5U)
+#define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
+
+#define ADC_CFGR1_EXTSEL_Pos           (6U)
+#define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
+#define ADC_CFGR1_EXTSEL               ADC_CFGR1_EXTSEL_Msk                    /*!< ADC group regular external trigger source */
+#define ADC_CFGR1_EXTSEL_0             (0x1UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000040 */
+#define ADC_CFGR1_EXTSEL_1             (0x2UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000080 */
+#define ADC_CFGR1_EXTSEL_2             (0x4UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000100 */
+
+#define ADC_CFGR1_EXTEN_Pos            (10U)
+#define ADC_CFGR1_EXTEN_Msk            (0x3UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000C00 */
+#define ADC_CFGR1_EXTEN                ADC_CFGR1_EXTEN_Msk                     /*!< ADC group regular external trigger polarity */
+#define ADC_CFGR1_EXTEN_0              (0x1UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000400 */
+#define ADC_CFGR1_EXTEN_1              (0x2UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000800 */
+
+#define ADC_CFGR1_OVRMOD_Pos           (12U)
+#define ADC_CFGR1_OVRMOD_Msk           (0x1UL << ADC_CFGR1_OVRMOD_Pos)         /*!< 0x00001000 */
+#define ADC_CFGR1_OVRMOD               ADC_CFGR1_OVRMOD_Msk                    /*!< ADC group regular overrun configuration */
+#define ADC_CFGR1_CONT_Pos             (13U)
+#define ADC_CFGR1_CONT_Msk             (0x1UL << ADC_CFGR1_CONT_Pos)           /*!< 0x00002000 */
+#define ADC_CFGR1_CONT                 ADC_CFGR1_CONT_Msk                      /*!< ADC group regular continuous conversion mode */
+#define ADC_CFGR1_WAIT_Pos             (14U)
+#define ADC_CFGR1_WAIT_Msk             (0x1UL << ADC_CFGR1_WAIT_Pos)           /*!< 0x00004000 */
+#define ADC_CFGR1_WAIT                 ADC_CFGR1_WAIT_Msk                      /*!< ADC low power auto wait */
+#define ADC_CFGR1_AUTOFF_Pos           (15U)
+#define ADC_CFGR1_AUTOFF_Msk           (0x1UL << ADC_CFGR1_AUTOFF_Pos)         /*!< 0x00008000 */
+#define ADC_CFGR1_AUTOFF               ADC_CFGR1_AUTOFF_Msk                    /*!< ADC low power auto power off */
+#define ADC_CFGR1_DISCEN_Pos           (16U)
+#define ADC_CFGR1_DISCEN_Msk           (0x1UL << ADC_CFGR1_DISCEN_Pos)         /*!< 0x00010000 */
+#define ADC_CFGR1_DISCEN               ADC_CFGR1_DISCEN_Msk                    /*!< ADC group regular sequencer discontinuous mode */
+#define ADC_CFGR1_CHSELRMOD_Pos        (21U)
+#define ADC_CFGR1_CHSELRMOD_Msk        (0x1UL << ADC_CFGR1_CHSELRMOD_Pos)      /*!< 0x00200000 */
+#define ADC_CFGR1_CHSELRMOD            ADC_CFGR1_CHSELRMOD_Msk                 /*!< ADC group regular sequencer mode */
+
+#define ADC_CFGR1_AWD1SGL_Pos          (22U)
+#define ADC_CFGR1_AWD1SGL_Msk          (0x1UL << ADC_CFGR1_AWD1SGL_Pos)        /*!< 0x00400000 */
+#define ADC_CFGR1_AWD1SGL              ADC_CFGR1_AWD1SGL_Msk                   /*!< ADC analog watchdog 1 monitoring a single channel or all channels */
+#define ADC_CFGR1_AWD1EN_Pos           (23U)
+#define ADC_CFGR1_AWD1EN_Msk           (0x1UL << ADC_CFGR1_AWD1EN_Pos)         /*!< 0x00800000 */
+#define ADC_CFGR1_AWD1EN               ADC_CFGR1_AWD1EN_Msk                    /*!< ADC analog watchdog 1 enable on scope ADC group regular */
+
+#define ADC_CFGR1_AWD1CH_Pos           (26U)
+#define ADC_CFGR1_AWD1CH_Msk           (0x1FUL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x7C000000 */
+#define ADC_CFGR1_AWD1CH               ADC_CFGR1_AWD1CH_Msk                    /*!< ADC analog watchdog 1 monitored channel selection */
+#define ADC_CFGR1_AWD1CH_0             (0x01UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x04000000 */
+#define ADC_CFGR1_AWD1CH_1             (0x02UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x08000000 */
+#define ADC_CFGR1_AWD1CH_2             (0x04UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x10000000 */
+#define ADC_CFGR1_AWD1CH_3             (0x08UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x20000000 */
+#define ADC_CFGR1_AWD1CH_4             (0x10UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x40000000 */
+
+/* Legacy defines */
+#define ADC_CFGR1_AUTDLY          (ADC_CFGR1_WAIT)
+
+/********************  Bit definition for ADC_CFGR2 register  *****************/
+#define ADC_CFGR2_OVSE_Pos             (0U)
+#define ADC_CFGR2_OVSE_Msk             (0x1UL << ADC_CFGR2_OVSE_Pos)           /*!< 0x00000001 */
+#define ADC_CFGR2_OVSE                 ADC_CFGR2_OVSE_Msk                      /*!< ADC oversampler enable on scope ADC group regular */
+
+#define ADC_CFGR2_OVSR_Pos             (2U)
+#define ADC_CFGR2_OVSR_Msk             (0x7UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x0000001C */
+#define ADC_CFGR2_OVSR                 ADC_CFGR2_OVSR_Msk                      /*!< ADC oversampling ratio */
+#define ADC_CFGR2_OVSR_0               (0x1UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000004 */
+#define ADC_CFGR2_OVSR_1               (0x2UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000008 */
+#define ADC_CFGR2_OVSR_2               (0x4UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000010 */
+
+#define ADC_CFGR2_OVSS_Pos             (5U)
+#define ADC_CFGR2_OVSS_Msk             (0xFUL << ADC_CFGR2_OVSS_Pos)           /*!< 0x000001E0 */
+#define ADC_CFGR2_OVSS                 ADC_CFGR2_OVSS_Msk                      /*!< ADC oversampling shift */
+#define ADC_CFGR2_OVSS_0               (0x1UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000020 */
+#define ADC_CFGR2_OVSS_1               (0x2UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000040 */
+#define ADC_CFGR2_OVSS_2               (0x4UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000080 */
+#define ADC_CFGR2_OVSS_3               (0x8UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000100 */
+
+#define ADC_CFGR2_TOVS_Pos             (9U)
+#define ADC_CFGR2_TOVS_Msk             (0x1UL << ADC_CFGR2_TOVS_Pos)           /*!< 0x00000200 */
+#define ADC_CFGR2_TOVS                 ADC_CFGR2_TOVS_Msk                      /*!< ADC oversampling discontinuous mode (triggered mode) for ADC group regular */
+
+#define ADC_CFGR2_LFTRIG_Pos           (29U)
+#define ADC_CFGR2_LFTRIG_Msk           (0x1UL << ADC_CFGR2_LFTRIG_Pos)         /*!< 0x20000000 */
+#define ADC_CFGR2_LFTRIG               ADC_CFGR2_LFTRIG_Msk                    /*!< ADC low frequency trigger mode */
+
+#define ADC_CFGR2_CKMODE_Pos           (30U)
+#define ADC_CFGR2_CKMODE_Msk           (0x3UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0xC0000000 */
+#define ADC_CFGR2_CKMODE               ADC_CFGR2_CKMODE_Msk                    /*!< ADC clock source and prescaler (prescaler only for clock source synchronous) */
+#define ADC_CFGR2_CKMODE_1             (0x2UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x80000000 */
+#define ADC_CFGR2_CKMODE_0             (0x1UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x40000000 */
+
+/********************  Bit definition for ADC_SMPR register  ******************/
+#define ADC_SMPR_SMP1_Pos              (0U)
+#define ADC_SMPR_SMP1_Msk              (0x7UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000007 */
+#define ADC_SMPR_SMP1                  ADC_SMPR_SMP1_Msk                       /*!< ADC group of channels sampling time 1 */
+#define ADC_SMPR_SMP1_0                (0x1UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000001 */
+#define ADC_SMPR_SMP1_1                (0x2UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000002 */
+#define ADC_SMPR_SMP1_2                (0x4UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000004 */
+
+#define ADC_SMPR_SMP2_Pos              (4U)
+#define ADC_SMPR_SMP2_Msk              (0x7UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000070 */
+#define ADC_SMPR_SMP2                  ADC_SMPR_SMP2_Msk                       /*!< ADC group of channels sampling time 2 */
+#define ADC_SMPR_SMP2_0                (0x1UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000010 */
+#define ADC_SMPR_SMP2_1                (0x2UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000020 */
+#define ADC_SMPR_SMP2_2                (0x4UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000040 */
+
+#define ADC_SMPR_SMPSEL_Pos            (8U)
+#define ADC_SMPR_SMPSEL_Msk            (0x7FFFFUL << ADC_SMPR_SMPSEL_Pos)      /*!< 0x07FFFF00 */
+#define ADC_SMPR_SMPSEL                ADC_SMPR_SMPSEL_Msk                     /*!< ADC all channels sampling time selection */
+#define ADC_SMPR_SMPSEL0_Pos           (8U)
+#define ADC_SMPR_SMPSEL0_Msk           (0x1UL << ADC_SMPR_SMPSEL0_Pos)         /*!< 0x00000100 */
+#define ADC_SMPR_SMPSEL0               ADC_SMPR_SMPSEL0_Msk                    /*!< ADC channel 0 sampling time selection */
+#define ADC_SMPR_SMPSEL1_Pos           (9U)
+#define ADC_SMPR_SMPSEL1_Msk           (0x1UL << ADC_SMPR_SMPSEL1_Pos)         /*!< 0x00000200 */
+#define ADC_SMPR_SMPSEL1               ADC_SMPR_SMPSEL1_Msk                    /*!< ADC channel 1 sampling time selection */
+#define ADC_SMPR_SMPSEL2_Pos           (10U)
+#define ADC_SMPR_SMPSEL2_Msk           (0x1UL << ADC_SMPR_SMPSEL2_Pos)         /*!< 0x00000400 */
+#define ADC_SMPR_SMPSEL2               ADC_SMPR_SMPSEL2_Msk                    /*!< ADC channel 2 sampling time selection */
+#define ADC_SMPR_SMPSEL3_Pos           (11U)
+#define ADC_SMPR_SMPSEL3_Msk           (0x1UL << ADC_SMPR_SMPSEL3_Pos)         /*!< 0x00000800 */
+#define ADC_SMPR_SMPSEL3               ADC_SMPR_SMPSEL3_Msk                    /*!< ADC channel 3 sampling time selection */
+#define ADC_SMPR_SMPSEL4_Pos           (12U)
+#define ADC_SMPR_SMPSEL4_Msk           (0x1UL << ADC_SMPR_SMPSEL4_Pos)         /*!< 0x00001000 */
+#define ADC_SMPR_SMPSEL4               ADC_SMPR_SMPSEL4_Msk                    /*!< ADC channel 4 sampling time selection */
+#define ADC_SMPR_SMPSEL5_Pos           (13U)
+#define ADC_SMPR_SMPSEL5_Msk           (0x1UL << ADC_SMPR_SMPSEL5_Pos)         /*!< 0x00002000 */
+#define ADC_SMPR_SMPSEL5               ADC_SMPR_SMPSEL5_Msk                    /*!< ADC channel 5 sampling time selection */
+#define ADC_SMPR_SMPSEL6_Pos           (14U)
+#define ADC_SMPR_SMPSEL6_Msk           (0x1UL << ADC_SMPR_SMPSEL6_Pos)         /*!< 0x00004000 */
+#define ADC_SMPR_SMPSEL6               ADC_SMPR_SMPSEL6_Msk                    /*!< ADC channel 6 sampling time selection */
+#define ADC_SMPR_SMPSEL7_Pos           (15U)
+#define ADC_SMPR_SMPSEL7_Msk           (0x1UL << ADC_SMPR_SMPSEL7_Pos)         /*!< 0x00008000 */
+#define ADC_SMPR_SMPSEL7               ADC_SMPR_SMPSEL7_Msk                    /*!< ADC channel 7 sampling time selection */
+#define ADC_SMPR_SMPSEL8_Pos           (16U)
+#define ADC_SMPR_SMPSEL8_Msk           (0x1UL << ADC_SMPR_SMPSEL8_Pos)         /*!< 0x00010000 */
+#define ADC_SMPR_SMPSEL8               ADC_SMPR_SMPSEL8_Msk                    /*!< ADC channel 8 sampling time selection */
+#define ADC_SMPR_SMPSEL9_Pos           (17U)
+#define ADC_SMPR_SMPSEL9_Msk           (0x1UL << ADC_SMPR_SMPSEL9_Pos)         /*!< 0x00020000 */
+#define ADC_SMPR_SMPSEL9               ADC_SMPR_SMPSEL9_Msk                    /*!< ADC channel 9 sampling time selection */
+#define ADC_SMPR_SMPSEL10_Pos          (18U)
+#define ADC_SMPR_SMPSEL10_Msk          (0x1UL << ADC_SMPR_SMPSEL10_Pos)        /*!< 0x00040000 */
+#define ADC_SMPR_SMPSEL10              ADC_SMPR_SMPSEL10_Msk                   /*!< ADC channel 10 sampling time selection */
+#define ADC_SMPR_SMPSEL11_Pos          (19U)
+#define ADC_SMPR_SMPSEL11_Msk          (0x1UL << ADC_SMPR_SMPSEL11_Pos)        /*!< 0x00080000 */
+#define ADC_SMPR_SMPSEL11              ADC_SMPR_SMPSEL11_Msk                   /*!< ADC channel 11 sampling time selection */
+#define ADC_SMPR_SMPSEL12_Pos          (20U)
+#define ADC_SMPR_SMPSEL12_Msk          (0x1UL << ADC_SMPR_SMPSEL12_Pos)        /*!< 0x00100000 */
+#define ADC_SMPR_SMPSEL12              ADC_SMPR_SMPSEL12_Msk                   /*!< ADC channel 12 sampling time selection */
+#define ADC_SMPR_SMPSEL13_Pos          (21U)
+#define ADC_SMPR_SMPSEL13_Msk          (0x1UL << ADC_SMPR_SMPSEL13_Pos)        /*!< 0x00200000 */
+#define ADC_SMPR_SMPSEL13              ADC_SMPR_SMPSEL13_Msk                   /*!< ADC channel 13 sampling time selection */
+#define ADC_SMPR_SMPSEL14_Pos          (22U)
+#define ADC_SMPR_SMPSEL14_Msk          (0x1UL << ADC_SMPR_SMPSEL14_Pos)        /*!< 0x00400000 */
+#define ADC_SMPR_SMPSEL14              ADC_SMPR_SMPSEL14_Msk                   /*!< ADC channel 14 sampling time selection */
+#define ADC_SMPR_SMPSEL15_Pos          (23U)
+#define ADC_SMPR_SMPSEL15_Msk          (0x1UL << ADC_SMPR_SMPSEL15_Pos)        /*!< 0x00800000 */
+#define ADC_SMPR_SMPSEL15              ADC_SMPR_SMPSEL15_Msk                   /*!< ADC channel 15 sampling time selection */
+#define ADC_SMPR_SMPSEL16_Pos          (24U)
+#define ADC_SMPR_SMPSEL16_Msk          (0x1UL << ADC_SMPR_SMPSEL16_Pos)        /*!< 0x01000000 */
+#define ADC_SMPR_SMPSEL16              ADC_SMPR_SMPSEL16_Msk                   /*!< ADC channel 16 sampling time selection */
+#define ADC_SMPR_SMPSEL17_Pos          (25U)
+#define ADC_SMPR_SMPSEL17_Msk          (0x1UL << ADC_SMPR_SMPSEL17_Pos)        /*!< 0x02000000 */
+#define ADC_SMPR_SMPSEL17              ADC_SMPR_SMPSEL17_Msk                   /*!< ADC channel 17 sampling time selection */
+#define ADC_SMPR_SMPSEL18_Pos          (26U)
+#define ADC_SMPR_SMPSEL18_Msk          (0x1UL << ADC_SMPR_SMPSEL18_Pos)        /*!< 0x04000000 */
+#define ADC_SMPR_SMPSEL18              ADC_SMPR_SMPSEL18_Msk                   /*!< ADC channel 18 sampling time selection */
+
+/********************  Bit definition for ADC_TR1 register  *******************/
+#define ADC_TR1_LT1_Pos                (0U)
+#define ADC_TR1_LT1_Msk                (0xFFFUL << ADC_TR1_LT1_Pos)            /*!< 0x00000FFF */
+#define ADC_TR1_LT1                    ADC_TR1_LT1_Msk                         /*!< ADC analog watchdog 1 threshold low */
+#define ADC_TR1_LT1_0                  (0x001UL << ADC_TR1_LT1_Pos)            /*!< 0x00000001 */
+#define ADC_TR1_LT1_1                  (0x002UL << ADC_TR1_LT1_Pos)            /*!< 0x00000002 */
+#define ADC_TR1_LT1_2                  (0x004UL << ADC_TR1_LT1_Pos)            /*!< 0x00000004 */
+#define ADC_TR1_LT1_3                  (0x008UL << ADC_TR1_LT1_Pos)            /*!< 0x00000008 */
+#define ADC_TR1_LT1_4                  (0x010UL << ADC_TR1_LT1_Pos)            /*!< 0x00000010 */
+#define ADC_TR1_LT1_5                  (0x020UL << ADC_TR1_LT1_Pos)            /*!< 0x00000020 */
+#define ADC_TR1_LT1_6                  (0x040UL << ADC_TR1_LT1_Pos)            /*!< 0x00000040 */
+#define ADC_TR1_LT1_7                  (0x080UL << ADC_TR1_LT1_Pos)            /*!< 0x00000080 */
+#define ADC_TR1_LT1_8                  (0x100UL << ADC_TR1_LT1_Pos)            /*!< 0x00000100 */
+#define ADC_TR1_LT1_9                  (0x200UL << ADC_TR1_LT1_Pos)            /*!< 0x00000200 */
+#define ADC_TR1_LT1_10                 (0x400UL << ADC_TR1_LT1_Pos)            /*!< 0x00000400 */
+#define ADC_TR1_LT1_11                 (0x800UL << ADC_TR1_LT1_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR1_HT1_Pos                (16U)
+#define ADC_TR1_HT1_Msk                (0xFFFUL << ADC_TR1_HT1_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR1_HT1                    ADC_TR1_HT1_Msk                         /*!< ADC Analog watchdog 1 threshold high */
+#define ADC_TR1_HT1_0                  (0x001UL << ADC_TR1_HT1_Pos)            /*!< 0x00010000 */
+#define ADC_TR1_HT1_1                  (0x002UL << ADC_TR1_HT1_Pos)            /*!< 0x00020000 */
+#define ADC_TR1_HT1_2                  (0x004UL << ADC_TR1_HT1_Pos)            /*!< 0x00040000 */
+#define ADC_TR1_HT1_3                  (0x008UL << ADC_TR1_HT1_Pos)            /*!< 0x00080000 */
+#define ADC_TR1_HT1_4                  (0x010UL << ADC_TR1_HT1_Pos)            /*!< 0x00100000 */
+#define ADC_TR1_HT1_5                  (0x020UL << ADC_TR1_HT1_Pos)            /*!< 0x00200000 */
+#define ADC_TR1_HT1_6                  (0x040UL << ADC_TR1_HT1_Pos)            /*!< 0x00400000 */
+#define ADC_TR1_HT1_7                  (0x080UL << ADC_TR1_HT1_Pos)            /*!< 0x00800000 */
+#define ADC_TR1_HT1_8                  (0x100UL << ADC_TR1_HT1_Pos)            /*!< 0x01000000 */
+#define ADC_TR1_HT1_9                  (0x200UL << ADC_TR1_HT1_Pos)            /*!< 0x02000000 */
+#define ADC_TR1_HT1_10                 (0x400UL << ADC_TR1_HT1_Pos)            /*!< 0x04000000 */
+#define ADC_TR1_HT1_11                 (0x800UL << ADC_TR1_HT1_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_TR2 register  *******************/
+#define ADC_TR2_LT2_Pos                (0U)
+#define ADC_TR2_LT2_Msk                (0xFFFUL << ADC_TR2_LT2_Pos)            /*!< 0x00000FFF */
+#define ADC_TR2_LT2                    ADC_TR2_LT2_Msk                         /*!< ADC analog watchdog 2 threshold low */
+#define ADC_TR2_LT2_0                  (0x001UL << ADC_TR2_LT2_Pos)            /*!< 0x00000001 */
+#define ADC_TR2_LT2_1                  (0x002UL << ADC_TR2_LT2_Pos)            /*!< 0x00000002 */
+#define ADC_TR2_LT2_2                  (0x004UL << ADC_TR2_LT2_Pos)            /*!< 0x00000004 */
+#define ADC_TR2_LT2_3                  (0x008UL << ADC_TR2_LT2_Pos)            /*!< 0x00000008 */
+#define ADC_TR2_LT2_4                  (0x010UL << ADC_TR2_LT2_Pos)            /*!< 0x00000010 */
+#define ADC_TR2_LT2_5                  (0x020UL << ADC_TR2_LT2_Pos)            /*!< 0x00000020 */
+#define ADC_TR2_LT2_6                  (0x040UL << ADC_TR2_LT2_Pos)            /*!< 0x00000040 */
+#define ADC_TR2_LT2_7                  (0x080UL << ADC_TR2_LT2_Pos)            /*!< 0x00000080 */
+#define ADC_TR2_LT2_8                  (0x100UL << ADC_TR2_LT2_Pos)            /*!< 0x00000100 */
+#define ADC_TR2_LT2_9                  (0x200UL << ADC_TR2_LT2_Pos)            /*!< 0x00000200 */
+#define ADC_TR2_LT2_10                 (0x400UL << ADC_TR2_LT2_Pos)            /*!< 0x00000400 */
+#define ADC_TR2_LT2_11                 (0x800UL << ADC_TR2_LT2_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR2_HT2_Pos                (16U)
+#define ADC_TR2_HT2_Msk                (0xFFFUL << ADC_TR2_HT2_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR2_HT2                    ADC_TR2_HT2_Msk                         /*!< ADC analog watchdog 2 threshold high */
+#define ADC_TR2_HT2_0                  (0x001UL << ADC_TR2_HT2_Pos)            /*!< 0x00010000 */
+#define ADC_TR2_HT2_1                  (0x002UL << ADC_TR2_HT2_Pos)            /*!< 0x00020000 */
+#define ADC_TR2_HT2_2                  (0x004UL << ADC_TR2_HT2_Pos)            /*!< 0x00040000 */
+#define ADC_TR2_HT2_3                  (0x008UL << ADC_TR2_HT2_Pos)            /*!< 0x00080000 */
+#define ADC_TR2_HT2_4                  (0x010UL << ADC_TR2_HT2_Pos)            /*!< 0x00100000 */
+#define ADC_TR2_HT2_5                  (0x020UL << ADC_TR2_HT2_Pos)            /*!< 0x00200000 */
+#define ADC_TR2_HT2_6                  (0x040UL << ADC_TR2_HT2_Pos)            /*!< 0x00400000 */
+#define ADC_TR2_HT2_7                  (0x080UL << ADC_TR2_HT2_Pos)            /*!< 0x00800000 */
+#define ADC_TR2_HT2_8                  (0x100UL << ADC_TR2_HT2_Pos)            /*!< 0x01000000 */
+#define ADC_TR2_HT2_9                  (0x200UL << ADC_TR2_HT2_Pos)            /*!< 0x02000000 */
+#define ADC_TR2_HT2_10                 (0x400UL << ADC_TR2_HT2_Pos)            /*!< 0x04000000 */
+#define ADC_TR2_HT2_11                 (0x800UL << ADC_TR2_HT2_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_CHSELR register  ****************/
+#define ADC_CHSELR_CHSEL_Pos           (0U)
+#define ADC_CHSELR_CHSEL_Msk           (0x7FFFFUL << ADC_CHSELR_CHSEL_Pos)     /*!< 0x0007FFFF */
+#define ADC_CHSELR_CHSEL               ADC_CHSELR_CHSEL_Msk                    /*!< ADC group regular sequencer channels, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL18_Pos         (18U)
+#define ADC_CHSELR_CHSEL18_Msk         (0x1UL << ADC_CHSELR_CHSEL18_Pos)       /*!< 0x00040000 */
+#define ADC_CHSELR_CHSEL18             ADC_CHSELR_CHSEL18_Msk                  /*!< ADC group regular sequencer channel 18, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL17_Pos         (17U)
+#define ADC_CHSELR_CHSEL17_Msk         (0x1UL << ADC_CHSELR_CHSEL17_Pos)       /*!< 0x00020000 */
+#define ADC_CHSELR_CHSEL17             ADC_CHSELR_CHSEL17_Msk                  /*!< ADC group regular sequencer channel 17, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL16_Pos         (16U)
+#define ADC_CHSELR_CHSEL16_Msk         (0x1UL << ADC_CHSELR_CHSEL16_Pos)       /*!< 0x00010000 */
+#define ADC_CHSELR_CHSEL16             ADC_CHSELR_CHSEL16_Msk                  /*!< ADC group regular sequencer channel 16, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL15_Pos         (15U)
+#define ADC_CHSELR_CHSEL15_Msk         (0x1UL << ADC_CHSELR_CHSEL15_Pos)       /*!< 0x00008000 */
+#define ADC_CHSELR_CHSEL15             ADC_CHSELR_CHSEL15_Msk                  /*!< ADC group regular sequencer channel 15, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL14_Pos         (14U)
+#define ADC_CHSELR_CHSEL14_Msk         (0x1UL << ADC_CHSELR_CHSEL14_Pos)       /*!< 0x00004000 */
+#define ADC_CHSELR_CHSEL14             ADC_CHSELR_CHSEL14_Msk                  /*!< ADC group regular sequencer channel 14, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL13_Pos         (13U)
+#define ADC_CHSELR_CHSEL13_Msk         (0x1UL << ADC_CHSELR_CHSEL13_Pos)       /*!< 0x00002000 */
+#define ADC_CHSELR_CHSEL13             ADC_CHSELR_CHSEL13_Msk                  /*!< ADC group regular sequencer channel 13, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL12_Pos         (12U)
+#define ADC_CHSELR_CHSEL12_Msk         (0x1UL << ADC_CHSELR_CHSEL12_Pos)       /*!< 0x00001000 */
+#define ADC_CHSELR_CHSEL12             ADC_CHSELR_CHSEL12_Msk                  /*!< ADC group regular sequencer channel 12, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL11_Pos         (11U)
+#define ADC_CHSELR_CHSEL11_Msk         (0x1UL << ADC_CHSELR_CHSEL11_Pos)       /*!< 0x00000800 */
+#define ADC_CHSELR_CHSEL11             ADC_CHSELR_CHSEL11_Msk                  /*!< ADC group regular sequencer channel 11, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL10_Pos         (10U)
+#define ADC_CHSELR_CHSEL10_Msk         (0x1UL << ADC_CHSELR_CHSEL10_Pos)       /*!< 0x00000400 */
+#define ADC_CHSELR_CHSEL10             ADC_CHSELR_CHSEL10_Msk                  /*!< ADC group regular sequencer channel 10, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL9_Pos          (9U)
+#define ADC_CHSELR_CHSEL9_Msk          (0x1UL << ADC_CHSELR_CHSEL9_Pos)        /*!< 0x00000200 */
+#define ADC_CHSELR_CHSEL9              ADC_CHSELR_CHSEL9_Msk                   /*!< ADC group regular sequencer channel 9, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL8_Pos          (8U)
+#define ADC_CHSELR_CHSEL8_Msk          (0x1UL << ADC_CHSELR_CHSEL8_Pos)        /*!< 0x00000100 */
+#define ADC_CHSELR_CHSEL8              ADC_CHSELR_CHSEL8_Msk                   /*!< ADC group regular sequencer channel 8, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL7_Pos          (7U)
+#define ADC_CHSELR_CHSEL7_Msk          (0x1UL << ADC_CHSELR_CHSEL7_Pos)        /*!< 0x00000080 */
+#define ADC_CHSELR_CHSEL7              ADC_CHSELR_CHSEL7_Msk                   /*!< ADC group regular sequencer channel 7, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL6_Pos          (6U)
+#define ADC_CHSELR_CHSEL6_Msk          (0x1UL << ADC_CHSELR_CHSEL6_Pos)        /*!< 0x00000040 */
+#define ADC_CHSELR_CHSEL6              ADC_CHSELR_CHSEL6_Msk                   /*!< ADC group regular sequencer channel 6, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL5_Pos          (5U)
+#define ADC_CHSELR_CHSEL5_Msk          (0x1UL << ADC_CHSELR_CHSEL5_Pos)        /*!< 0x00000020 */
+#define ADC_CHSELR_CHSEL5              ADC_CHSELR_CHSEL5_Msk                   /*!< ADC group regular sequencer channel 5, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL4_Pos          (4U)
+#define ADC_CHSELR_CHSEL4_Msk          (0x1UL << ADC_CHSELR_CHSEL4_Pos)        /*!< 0x00000010 */
+#define ADC_CHSELR_CHSEL4              ADC_CHSELR_CHSEL4_Msk                   /*!< ADC group regular sequencer channel 4, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL3_Pos          (3U)
+#define ADC_CHSELR_CHSEL3_Msk          (0x1UL << ADC_CHSELR_CHSEL3_Pos)        /*!< 0x00000008 */
+#define ADC_CHSELR_CHSEL3              ADC_CHSELR_CHSEL3_Msk                   /*!< ADC group regular sequencer channel 3, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL2_Pos          (2U)
+#define ADC_CHSELR_CHSEL2_Msk          (0x1UL << ADC_CHSELR_CHSEL2_Pos)        /*!< 0x00000004 */
+#define ADC_CHSELR_CHSEL2              ADC_CHSELR_CHSEL2_Msk                   /*!< ADC group regular sequencer channel 2, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL1_Pos          (1U)
+#define ADC_CHSELR_CHSEL1_Msk          (0x1UL << ADC_CHSELR_CHSEL1_Pos)        /*!< 0x00000002 */
+#define ADC_CHSELR_CHSEL1              ADC_CHSELR_CHSEL1_Msk                   /*!< ADC group regular sequencer channel 1, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL0_Pos          (0U)
+#define ADC_CHSELR_CHSEL0_Msk          (0x1UL << ADC_CHSELR_CHSEL0_Pos)        /*!< 0x00000001 */
+#define ADC_CHSELR_CHSEL0              ADC_CHSELR_CHSEL0_Msk                   /*!< ADC group regular sequencer channel 0, available when ADC_CFGR1_CHSELRMOD is reset */
+
+#define ADC_CHSELR_SQ_ALL_Pos          (0U)
+#define ADC_CHSELR_SQ_ALL_Msk          (0xFFFFFFFFUL << ADC_CHSELR_SQ_ALL_Pos) /*!< 0xFFFFFFFF */
+#define ADC_CHSELR_SQ_ALL              ADC_CHSELR_SQ_ALL_Msk                   /*!< ADC group regular sequencer all ranks, available when ADC_CFGR1_CHSELRMOD is set */
+
+#define ADC_CHSELR_SQ8_Pos             (28U)
+#define ADC_CHSELR_SQ8_Msk             (0xFUL << ADC_CHSELR_SQ8_Pos)           /*!< 0xF0000000 */
+#define ADC_CHSELR_SQ8                 ADC_CHSELR_SQ8_Msk                      /*!< ADC group regular sequencer rank 8, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ8_0               (0x1UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x10000000 */
+#define ADC_CHSELR_SQ8_1               (0x2UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x20000000 */
+#define ADC_CHSELR_SQ8_2               (0x4UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x40000000 */
+#define ADC_CHSELR_SQ8_3               (0x8UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x80000000 */
+
+#define ADC_CHSELR_SQ7_Pos             (24U)
+#define ADC_CHSELR_SQ7_Msk             (0xFUL << ADC_CHSELR_SQ7_Pos)           /*!< 0x0F000000 */
+#define ADC_CHSELR_SQ7                 ADC_CHSELR_SQ7_Msk                      /*!< ADC group regular sequencer rank 7, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ7_0               (0x1UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x01000000 */
+#define ADC_CHSELR_SQ7_1               (0x2UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x02000000 */
+#define ADC_CHSELR_SQ7_2               (0x4UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x04000000 */
+#define ADC_CHSELR_SQ7_3               (0x8UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x08000000 */
+
+#define ADC_CHSELR_SQ6_Pos             (20U)
+#define ADC_CHSELR_SQ6_Msk             (0xFUL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00F00000 */
+#define ADC_CHSELR_SQ6                 ADC_CHSELR_SQ6_Msk                      /*!< ADC group regular sequencer rank 6, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ6_0               (0x1UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00100000 */
+#define ADC_CHSELR_SQ6_1               (0x2UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00200000 */
+#define ADC_CHSELR_SQ6_2               (0x4UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00400000 */
+#define ADC_CHSELR_SQ6_3               (0x8UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00800000 */
+
+#define ADC_CHSELR_SQ5_Pos             (16U)
+#define ADC_CHSELR_SQ5_Msk             (0xFUL << ADC_CHSELR_SQ5_Pos)           /*!< 0x000F0000 */
+#define ADC_CHSELR_SQ5                 ADC_CHSELR_SQ5_Msk                      /*!< ADC group regular sequencer rank 5, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ5_0               (0x1UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00010000 */
+#define ADC_CHSELR_SQ5_1               (0x2UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00020000 */
+#define ADC_CHSELR_SQ5_2               (0x4UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00040000 */
+#define ADC_CHSELR_SQ5_3               (0x8UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00080000 */
+
+#define ADC_CHSELR_SQ4_Pos             (12U)
+#define ADC_CHSELR_SQ4_Msk             (0xFUL << ADC_CHSELR_SQ4_Pos)           /*!< 0x0000F000 */
+#define ADC_CHSELR_SQ4                 ADC_CHSELR_SQ4_Msk                      /*!< ADC group regular sequencer rank 4, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ4_0               (0x1UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00001000 */
+#define ADC_CHSELR_SQ4_1               (0x2UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00002000 */
+#define ADC_CHSELR_SQ4_2               (0x4UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00004000 */
+#define ADC_CHSELR_SQ4_3               (0x8UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00008000 */
+
+#define ADC_CHSELR_SQ3_Pos             (8U)
+#define ADC_CHSELR_SQ3_Msk             (0xFUL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000F00 */
+#define ADC_CHSELR_SQ3                 ADC_CHSELR_SQ3_Msk                      /*!< ADC group regular sequencer rank 3, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ3_0               (0x1UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000100 */
+#define ADC_CHSELR_SQ3_1               (0x2UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000200 */
+#define ADC_CHSELR_SQ3_2               (0x4UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000400 */
+#define ADC_CHSELR_SQ3_3               (0x8UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000800 */
+
+#define ADC_CHSELR_SQ2_Pos             (4U)
+#define ADC_CHSELR_SQ2_Msk             (0xFUL << ADC_CHSELR_SQ2_Pos)           /*!< 0x000000F0 */
+#define ADC_CHSELR_SQ2                 ADC_CHSELR_SQ2_Msk                      /*!< ADC group regular sequencer rank 2, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ2_0               (0x1UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000010 */
+#define ADC_CHSELR_SQ2_1               (0x2UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000020 */
+#define ADC_CHSELR_SQ2_2               (0x4UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000040 */
+#define ADC_CHSELR_SQ2_3               (0x8UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000080 */
+
+#define ADC_CHSELR_SQ1_Pos             (0U)
+#define ADC_CHSELR_SQ1_Msk             (0xFUL << ADC_CHSELR_SQ1_Pos)           /*!< 0x0000000F */
+#define ADC_CHSELR_SQ1                 ADC_CHSELR_SQ1_Msk                      /*!< ADC group regular sequencer rank 1, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ1_0               (0x1UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000001 */
+#define ADC_CHSELR_SQ1_1               (0x2UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000002 */
+#define ADC_CHSELR_SQ1_2               (0x4UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000004 */
+#define ADC_CHSELR_SQ1_3               (0x8UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000008 */
+
+/********************  Bit definition for ADC_TR3 register  *******************/
+#define ADC_TR3_LT3_Pos                (0U)
+#define ADC_TR3_LT3_Msk                (0xFFFUL << ADC_TR3_LT3_Pos)            /*!< 0x00000FFF */
+#define ADC_TR3_LT3                    ADC_TR3_LT3_Msk                         /*!< ADC analog watchdog 3 threshold low */
+#define ADC_TR3_LT3_0                  (0x001UL << ADC_TR3_LT3_Pos)            /*!< 0x00000001 */
+#define ADC_TR3_LT3_1                  (0x002UL << ADC_TR3_LT3_Pos)            /*!< 0x00000002 */
+#define ADC_TR3_LT3_2                  (0x004UL << ADC_TR3_LT3_Pos)            /*!< 0x00000004 */
+#define ADC_TR3_LT3_3                  (0x008UL << ADC_TR3_LT3_Pos)            /*!< 0x00000008 */
+#define ADC_TR3_LT3_4                  (0x010UL << ADC_TR3_LT3_Pos)            /*!< 0x00000010 */
+#define ADC_TR3_LT3_5                  (0x020UL << ADC_TR3_LT3_Pos)            /*!< 0x00000020 */
+#define ADC_TR3_LT3_6                  (0x040UL << ADC_TR3_LT3_Pos)            /*!< 0x00000040 */
+#define ADC_TR3_LT3_7                  (0x080UL << ADC_TR3_LT3_Pos)            /*!< 0x00000080 */
+#define ADC_TR3_LT3_8                  (0x100UL << ADC_TR3_LT3_Pos)            /*!< 0x00000100 */
+#define ADC_TR3_LT3_9                  (0x200UL << ADC_TR3_LT3_Pos)            /*!< 0x00000200 */
+#define ADC_TR3_LT3_10                 (0x400UL << ADC_TR3_LT3_Pos)            /*!< 0x00000400 */
+#define ADC_TR3_LT3_11                 (0x800UL << ADC_TR3_LT3_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR3_HT3_Pos                (16U)
+#define ADC_TR3_HT3_Msk                (0xFFFUL << ADC_TR3_HT3_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR3_HT3                    ADC_TR3_HT3_Msk                         /*!< ADC analog watchdog 3 threshold high */
+#define ADC_TR3_HT3_0                  (0x001UL << ADC_TR3_HT3_Pos)            /*!< 0x00010000 */
+#define ADC_TR3_HT3_1                  (0x002UL << ADC_TR3_HT3_Pos)            /*!< 0x00020000 */
+#define ADC_TR3_HT3_2                  (0x004UL << ADC_TR3_HT3_Pos)            /*!< 0x00040000 */
+#define ADC_TR3_HT3_3                  (0x008UL << ADC_TR3_HT3_Pos)            /*!< 0x00080000 */
+#define ADC_TR3_HT3_4                  (0x010UL << ADC_TR3_HT3_Pos)            /*!< 0x00100000 */
+#define ADC_TR3_HT3_5                  (0x020UL << ADC_TR3_HT3_Pos)            /*!< 0x00200000 */
+#define ADC_TR3_HT3_6                  (0x040UL << ADC_TR3_HT3_Pos)            /*!< 0x00400000 */
+#define ADC_TR3_HT3_7                  (0x080UL << ADC_TR3_HT3_Pos)            /*!< 0x00800000 */
+#define ADC_TR3_HT3_8                  (0x100UL << ADC_TR3_HT3_Pos)            /*!< 0x01000000 */
+#define ADC_TR3_HT3_9                  (0x200UL << ADC_TR3_HT3_Pos)            /*!< 0x02000000 */
+#define ADC_TR3_HT3_10                 (0x400UL << ADC_TR3_HT3_Pos)            /*!< 0x04000000 */
+#define ADC_TR3_HT3_11                 (0x800UL << ADC_TR3_HT3_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos                (0U)
+#define ADC_DR_DATA_Msk                (0xFFFFUL << ADC_DR_DATA_Pos)           /*!< 0x0000FFFF */
+#define ADC_DR_DATA                    ADC_DR_DATA_Msk                         /*!< ADC group regular conversion data */
+#define ADC_DR_DATA_0                  (0x0001UL << ADC_DR_DATA_Pos)           /*!< 0x00000001 */
+#define ADC_DR_DATA_1                  (0x0002UL << ADC_DR_DATA_Pos)           /*!< 0x00000002 */
+#define ADC_DR_DATA_2                  (0x0004UL << ADC_DR_DATA_Pos)           /*!< 0x00000004 */
+#define ADC_DR_DATA_3                  (0x0008UL << ADC_DR_DATA_Pos)           /*!< 0x00000008 */
+#define ADC_DR_DATA_4                  (0x0010UL << ADC_DR_DATA_Pos)           /*!< 0x00000010 */
+#define ADC_DR_DATA_5                  (0x0020UL << ADC_DR_DATA_Pos)           /*!< 0x00000020 */
+#define ADC_DR_DATA_6                  (0x0040UL << ADC_DR_DATA_Pos)           /*!< 0x00000040 */
+#define ADC_DR_DATA_7                  (0x0080UL << ADC_DR_DATA_Pos)           /*!< 0x00000080 */
+#define ADC_DR_DATA_8                  (0x0100UL << ADC_DR_DATA_Pos)           /*!< 0x00000100 */
+#define ADC_DR_DATA_9                  (0x0200UL << ADC_DR_DATA_Pos)           /*!< 0x00000200 */
+#define ADC_DR_DATA_10                 (0x0400UL << ADC_DR_DATA_Pos)           /*!< 0x00000400 */
+#define ADC_DR_DATA_11                 (0x0800UL << ADC_DR_DATA_Pos)           /*!< 0x00000800 */
+#define ADC_DR_DATA_12                 (0x1000UL << ADC_DR_DATA_Pos)           /*!< 0x00001000 */
+#define ADC_DR_DATA_13                 (0x2000UL << ADC_DR_DATA_Pos)           /*!< 0x00002000 */
+#define ADC_DR_DATA_14                 (0x4000UL << ADC_DR_DATA_Pos)           /*!< 0x00004000 */
+#define ADC_DR_DATA_15                 (0x8000UL << ADC_DR_DATA_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for ADC_AWD2CR register  ****************/
+#define ADC_AWD2CR_AWD2CH_Pos          (0U)
+#define ADC_AWD2CR_AWD2CH_Msk          (0x7FFFFUL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x0007FFFF */
+#define ADC_AWD2CR_AWD2CH              ADC_AWD2CR_AWD2CH_Msk                   /*!< ADC analog watchdog 2 monitored channel selection */
+#define ADC_AWD2CR_AWD2CH_0            (0x00001UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000001 */
+#define ADC_AWD2CR_AWD2CH_1            (0x00002UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000002 */
+#define ADC_AWD2CR_AWD2CH_2            (0x00004UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000004 */
+#define ADC_AWD2CR_AWD2CH_3            (0x00008UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000008 */
+#define ADC_AWD2CR_AWD2CH_4            (0x00010UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000010 */
+#define ADC_AWD2CR_AWD2CH_5            (0x00020UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000020 */
+#define ADC_AWD2CR_AWD2CH_6            (0x00040UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000040 */
+#define ADC_AWD2CR_AWD2CH_7            (0x00080UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000080 */
+#define ADC_AWD2CR_AWD2CH_8            (0x00100UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000100 */
+#define ADC_AWD2CR_AWD2CH_9            (0x00200UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000200 */
+#define ADC_AWD2CR_AWD2CH_10           (0x00400UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000400 */
+#define ADC_AWD2CR_AWD2CH_11           (0x00800UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000800 */
+#define ADC_AWD2CR_AWD2CH_12           (0x01000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00001000 */
+#define ADC_AWD2CR_AWD2CH_13           (0x02000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00002000 */
+#define ADC_AWD2CR_AWD2CH_14           (0x04000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00004000 */
+#define ADC_AWD2CR_AWD2CH_15           (0x08000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00008000 */
+#define ADC_AWD2CR_AWD2CH_16           (0x10000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00010000 */
+#define ADC_AWD2CR_AWD2CH_17           (0x20000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00020000 */
+#define ADC_AWD2CR_AWD2CH_18           (0x40000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00040000 */
+
+/********************  Bit definition for ADC_AWD3CR register  ****************/
+#define ADC_AWD3CR_AWD3CH_Pos          (0U)
+#define ADC_AWD3CR_AWD3CH_Msk          (0x7FFFFUL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x0007FFFF */
+#define ADC_AWD3CR_AWD3CH              ADC_AWD3CR_AWD3CH_Msk                   /*!< ADC analog watchdog 3 monitored channel selection */
+#define ADC_AWD3CR_AWD3CH_0            (0x00001UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000001 */
+#define ADC_AWD3CR_AWD3CH_1            (0x00002UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000002 */
+#define ADC_AWD3CR_AWD3CH_2            (0x00004UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000004 */
+#define ADC_AWD3CR_AWD3CH_3            (0x00008UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000008 */
+#define ADC_AWD3CR_AWD3CH_4            (0x00010UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000010 */
+#define ADC_AWD3CR_AWD3CH_5            (0x00020UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000020 */
+#define ADC_AWD3CR_AWD3CH_6            (0x00040UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000040 */
+#define ADC_AWD3CR_AWD3CH_7            (0x00080UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000080 */
+#define ADC_AWD3CR_AWD3CH_8            (0x00100UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000100 */
+#define ADC_AWD3CR_AWD3CH_9            (0x00200UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000200 */
+#define ADC_AWD3CR_AWD3CH_10           (0x00400UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000400 */
+#define ADC_AWD3CR_AWD3CH_11           (0x00800UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000800 */
+#define ADC_AWD3CR_AWD3CH_12           (0x01000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00001000 */
+#define ADC_AWD3CR_AWD3CH_13           (0x02000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00002000 */
+#define ADC_AWD3CR_AWD3CH_14           (0x04000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00004000 */
+#define ADC_AWD3CR_AWD3CH_15           (0x08000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00008000 */
+#define ADC_AWD3CR_AWD3CH_16           (0x10000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00010000 */
+#define ADC_AWD3CR_AWD3CH_17           (0x20000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00020000 */
+#define ADC_AWD3CR_AWD3CH_18           (0x40000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00040000 */
+
+/********************  Bit definition for ADC_CALFACT register  ***************/
+#define ADC_CALFACT_CALFACT_Pos        (0U)
+#define ADC_CALFACT_CALFACT_Msk        (0x7FUL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x0000007F */
+#define ADC_CALFACT_CALFACT            ADC_CALFACT_CALFACT_Msk                 /*!< ADC calibration factor in single-ended mode */
+#define ADC_CALFACT_CALFACT_0          (0x01UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000001 */
+#define ADC_CALFACT_CALFACT_1          (0x02UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000002 */
+#define ADC_CALFACT_CALFACT_2          (0x04UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000004 */
+#define ADC_CALFACT_CALFACT_3          (0x08UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000008 */
+#define ADC_CALFACT_CALFACT_4          (0x10UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000010 */
+#define ADC_CALFACT_CALFACT_5          (0x20UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000020 */
+#define ADC_CALFACT_CALFACT_6          (0x40UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000040 */
+
+/*************************  ADC Common registers  *****************************/
+/********************  Bit definition for ADC_CCR register  *******************/
+#define ADC_CCR_PRESC_Pos              (18U)
+#define ADC_CCR_PRESC_Msk              (0xFUL << ADC_CCR_PRESC_Pos)            /*!< 0x003C0000 */
+#define ADC_CCR_PRESC                  ADC_CCR_PRESC_Msk                       /*!< ADC common clock prescaler, only for clock source asynchronous */
+#define ADC_CCR_PRESC_0                (0x1UL << ADC_CCR_PRESC_Pos)            /*!< 0x00040000 */
+#define ADC_CCR_PRESC_1                (0x2UL << ADC_CCR_PRESC_Pos)            /*!< 0x00080000 */
+#define ADC_CCR_PRESC_2                (0x4UL << ADC_CCR_PRESC_Pos)            /*!< 0x00100000 */
+#define ADC_CCR_PRESC_3                (0x8UL << ADC_CCR_PRESC_Pos)            /*!< 0x00200000 */
+
+#define ADC_CCR_VREFEN_Pos             (22U)
+#define ADC_CCR_VREFEN_Msk             (0x1UL << ADC_CCR_VREFEN_Pos)           /*!< 0x00400000 */
+#define ADC_CCR_VREFEN                 ADC_CCR_VREFEN_Msk                      /*!< ADC internal path to VrefInt enable */
+#define ADC_CCR_TSEN_Pos               (23U)
+#define ADC_CCR_TSEN_Msk               (0x1UL << ADC_CCR_TSEN_Pos)             /*!< 0x00800000 */
+#define ADC_CCR_TSEN                   ADC_CCR_TSEN_Msk                        /*!< ADC internal path to temperature sensor enable */
+#define ADC_CCR_VBATEN_Pos             (24U)
+#define ADC_CCR_VBATEN_Msk             (0x1UL << ADC_CCR_VBATEN_Pos)           /*!< 0x01000000 */
+#define ADC_CCR_VBATEN                 ADC_CCR_VBATEN_Msk                      /*!< ADC internal path to battery voltage enable */
+
+/* Legacy */
+#define ADC_CCR_LFMEN_Pos              (25U)
+#define ADC_CCR_LFMEN_Msk              (0x1UL << ADC_CCR_LFMEN_Pos)            /*!< 0x02000000 */
+#define ADC_CCR_LFMEN                  ADC_CCR_LFMEN_Msk                       /*!< Legacy feature, useless on STM32G0 (ADC common clock low frequency mode is automatically managed by ADC peripheral on STM32G0) */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos            (0U)
+#define CRC_DR_DR_Msk            (0xFFFFFFFFUL << CRC_DR_DR_Pos)                /*!< 0xFFFFFFFF */
+#define CRC_DR_DR                CRC_DR_DR_Msk                                  /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos          (0U)
+#define CRC_IDR_IDR_Msk          (0xFFFFFFFFUL << CRC_IDR_IDR_Pos)              /*!< 0xFFFFFFFF */
+#define CRC_IDR_IDR              CRC_IDR_IDR_Msk                                /*!< General-purpose 32-bits data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos         (0U)
+#define CRC_CR_RESET_Msk         (0x1UL << CRC_CR_RESET_Pos)                    /*!< 0x00000001 */
+#define CRC_CR_RESET             CRC_CR_RESET_Msk                               /*!< RESET the CRC computation unit bit */
+#define CRC_CR_POLYSIZE_Pos      (3U)
+#define CRC_CR_POLYSIZE_Msk      (0x3UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000018 */
+#define CRC_CR_POLYSIZE          CRC_CR_POLYSIZE_Msk                            /*!< Polynomial size bits */
+#define CRC_CR_POLYSIZE_0        (0x1UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000008 */
+#define CRC_CR_POLYSIZE_1        (0x2UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000010 */
+#define CRC_CR_REV_IN_Pos        (5U)
+#define CRC_CR_REV_IN_Msk        (0x3UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000060 */
+#define CRC_CR_REV_IN            CRC_CR_REV_IN_Msk                              /*!< REV_IN Reverse Input Data bits */
+#define CRC_CR_REV_IN_0          (0x1UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000020 */
+#define CRC_CR_REV_IN_1          (0x2UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000040 */
+#define CRC_CR_REV_OUT_Pos       (7U)
+#define CRC_CR_REV_OUT_Msk       (0x1UL << CRC_CR_REV_OUT_Pos)                  /*!< 0x00000080 */
+#define CRC_CR_REV_OUT           CRC_CR_REV_OUT_Msk                             /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define CRC_INIT_INIT_Pos        (0U)
+#define CRC_INIT_INIT_Msk        (0xFFFFFFFFUL << CRC_INIT_INIT_Pos)            /*!< 0xFFFFFFFF */
+#define CRC_INIT_INIT            CRC_INIT_INIT_Msk                              /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define CRC_POL_POL_Pos          (0U)
+#define CRC_POL_POL_Msk          (0xFFFFFFFFUL << CRC_POL_POL_Pos)              /*!< 0xFFFFFFFF */
+#define CRC_POL_POL              CRC_POL_POL_Msk                                /*!< Coefficients of the polynomial */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Digital to Analog Converter                           */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions
+*/
+#define DAC_ADDITIONAL_TRIGGERS_SUPPORT
+
+/********************  Bit definition for DAC_CR register  ********************/
+#define DAC_CR_EN1_Pos              (0U)
+#define DAC_CR_EN1_Msk              (0x1UL << DAC_CR_EN1_Pos)                  /*!< 0x00000001 */
+#define DAC_CR_EN1                  DAC_CR_EN1_Msk                             /*!<DAC channel1 enable */
+#define DAC_CR_TEN1_Pos             (1U)
+#define DAC_CR_TEN1_Msk             (0x1UL << DAC_CR_TEN1_Pos)                 /*!< 0x00000002 */
+#define DAC_CR_TEN1                 DAC_CR_TEN1_Msk                            /*!<DAC channel1 Trigger enable */
+
+#define DAC_CR_TSEL1_Pos            (2U)
+#define DAC_CR_TSEL1_Msk            (0xFUL << DAC_CR_TSEL1_Pos)                /*!< 0x0000003C */
+#define DAC_CR_TSEL1                DAC_CR_TSEL1_Msk                           /*!<TSEL1[3:0] (DAC channel1 Trigger selection) */
+#define DAC_CR_TSEL1_0              (0x1UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000004 */
+#define DAC_CR_TSEL1_1              (0x2UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000008 */
+#define DAC_CR_TSEL1_2              (0x4UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000010 */
+#define DAC_CR_TSEL1_3              (0x8UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000020 */
+
+#define DAC_CR_WAVE1_Pos            (6U)
+#define DAC_CR_WAVE1_Msk            (0x3UL << DAC_CR_WAVE1_Pos)                /*!< 0x000000C0 */
+#define DAC_CR_WAVE1                DAC_CR_WAVE1_Msk                           /*!<WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define DAC_CR_WAVE1_0              (0x1UL << DAC_CR_WAVE1_Pos)                /*!< 0x00000040 */
+#define DAC_CR_WAVE1_1              (0x2UL << DAC_CR_WAVE1_Pos)                /*!< 0x00000080 */
+
+#define DAC_CR_MAMP1_Pos            (8U)
+#define DAC_CR_MAMP1_Msk            (0xFUL << DAC_CR_MAMP1_Pos)                /*!< 0x00000F00 */
+#define DAC_CR_MAMP1                DAC_CR_MAMP1_Msk                           /*!<MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define DAC_CR_MAMP1_0              (0x1UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000100 */
+#define DAC_CR_MAMP1_1              (0x2UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000200 */
+#define DAC_CR_MAMP1_2              (0x4UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000400 */
+#define DAC_CR_MAMP1_3              (0x8UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000800 */
+
+#define DAC_CR_DMAEN1_Pos           (12U)
+#define DAC_CR_DMAEN1_Msk           (0x1UL << DAC_CR_DMAEN1_Pos)               /*!< 0x00001000 */
+#define DAC_CR_DMAEN1               DAC_CR_DMAEN1_Msk                          /*!<DAC channel1 DMA enable */
+#define DAC_CR_DMAUDRIE1_Pos        (13U)
+#define DAC_CR_DMAUDRIE1_Msk        (0x1UL << DAC_CR_DMAUDRIE1_Pos)            /*!< 0x00002000 */
+#define DAC_CR_DMAUDRIE1            DAC_CR_DMAUDRIE1_Msk                       /*!<DAC channel 1 DMA underrun interrupt enable  >*/
+#define DAC_CR_CEN1_Pos             (14U)
+#define DAC_CR_CEN1_Msk             (0x1UL << DAC_CR_CEN1_Pos)                 /*!< 0x00004000 */
+#define DAC_CR_CEN1                 DAC_CR_CEN1_Msk                            /*!<DAC channel 1 calibration enable >*/
+
+#define DAC_CR_EN2_Pos              (16U)
+#define DAC_CR_EN2_Msk              (0x1UL << DAC_CR_EN2_Pos)                  /*!< 0x00010000 */
+#define DAC_CR_EN2                  DAC_CR_EN2_Msk                             /*!<DAC channel2 enable */
+#define DAC_CR_TEN2_Pos             (17U)
+#define DAC_CR_TEN2_Msk             (0x1UL << DAC_CR_TEN2_Pos)                 /*!< 0x00020000 */
+#define DAC_CR_TEN2                 DAC_CR_TEN2_Msk                            /*!<DAC channel2 Trigger enable */
+
+#define DAC_CR_TSEL2_Pos            (18U)
+#define DAC_CR_TSEL2_Msk            (0xFUL << DAC_CR_TSEL2_Pos)                /*!< 0x003C0000 */
+#define DAC_CR_TSEL2                DAC_CR_TSEL2_Msk                           /*!<TSEL2[2:0] (DAC channel2 Trigger selection) */
+#define DAC_CR_TSEL2_0              (0x1UL << DAC_CR_TSEL2_Pos)                /*!< 0x00040000 */
+#define DAC_CR_TSEL2_1              (0x2UL << DAC_CR_TSEL2_Pos)                /*!< 0x00080000 */
+#define DAC_CR_TSEL2_2              (0x4UL << DAC_CR_TSEL2_Pos)                /*!< 0x00100000 */
+#define DAC_CR_TSEL2_3              (0x8UL << DAC_CR_TSEL2_Pos)                /*!< 0x00200000 */
+
+#define DAC_CR_WAVE2_Pos            (22U)
+#define DAC_CR_WAVE2_Msk            (0x3UL << DAC_CR_WAVE2_Pos)                /*!< 0x00C00000 */
+#define DAC_CR_WAVE2                DAC_CR_WAVE2_Msk                           /*!<WAVE2[1:0] (DAC channel2 noise/triangle wave generation enable) */
+#define DAC_CR_WAVE2_0              (0x1UL << DAC_CR_WAVE2_Pos)                /*!< 0x00400000 */
+#define DAC_CR_WAVE2_1              (0x2UL << DAC_CR_WAVE2_Pos)                /*!< 0x00800000 */
+
+#define DAC_CR_MAMP2_Pos            (24U)
+#define DAC_CR_MAMP2_Msk            (0xFUL << DAC_CR_MAMP2_Pos)                /*!< 0x0F000000 */
+#define DAC_CR_MAMP2                DAC_CR_MAMP2_Msk                           /*!<MAMP2[3:0] (DAC channel2 Mask/Amplitude selector) */
+#define DAC_CR_MAMP2_0              (0x1UL << DAC_CR_MAMP2_Pos)                /*!< 0x01000000 */
+#define DAC_CR_MAMP2_1              (0x2UL << DAC_CR_MAMP2_Pos)                /*!< 0x02000000 */
+#define DAC_CR_MAMP2_2              (0x4UL << DAC_CR_MAMP2_Pos)                /*!< 0x04000000 */
+#define DAC_CR_MAMP2_3              (0x8UL << DAC_CR_MAMP2_Pos)                /*!< 0x08000000 */
+
+#define DAC_CR_DMAEN2_Pos           (28U)
+#define DAC_CR_DMAEN2_Msk           (0x1UL << DAC_CR_DMAEN2_Pos)               /*!< 0x10000000 */
+#define DAC_CR_DMAEN2               DAC_CR_DMAEN2_Msk                          /*!<DAC channel2 DMA enabled */
+#define DAC_CR_DMAUDRIE2_Pos        (29U)
+#define DAC_CR_DMAUDRIE2_Msk        (0x1UL << DAC_CR_DMAUDRIE2_Pos)            /*!< 0x20000000 */
+#define DAC_CR_DMAUDRIE2            DAC_CR_DMAUDRIE2_Msk                       /*!<DAC channel2 DMA underrun interrupt enable  >*/
+#define DAC_CR_CEN2_Pos             (30U)
+#define DAC_CR_CEN2_Msk             (0x1UL << DAC_CR_CEN2_Pos)                 /*!< 0x40000000 */
+#define DAC_CR_CEN2                 DAC_CR_CEN2_Msk                            /*!<DAC channel2 calibration enable >*/
+
+/*****************  Bit definition for DAC_SWTRIGR register  ******************/
+#define DAC_SWTRIGR_SWTRIG1_Pos     (0U)
+#define DAC_SWTRIGR_SWTRIG1_Msk     (0x1UL << DAC_SWTRIGR_SWTRIG1_Pos)         /*!< 0x00000001 */
+#define DAC_SWTRIGR_SWTRIG1         DAC_SWTRIGR_SWTRIG1_Msk                    /*!<DAC channel1 software trigger */
+#define DAC_SWTRIGR_SWTRIG2_Pos     (1U)
+#define DAC_SWTRIGR_SWTRIG2_Msk     (0x1UL << DAC_SWTRIGR_SWTRIG2_Pos)         /*!< 0x00000002 */
+#define DAC_SWTRIGR_SWTRIG2         DAC_SWTRIGR_SWTRIG2_Msk                    /*!<DAC channel2 software trigger */
+
+/*****************  Bit definition for DAC_DHR12R1 register  ******************/
+#define DAC_DHR12R1_DACC1DHR_Pos    (0U)
+#define DAC_DHR12R1_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12R1_DACC1DHR_Pos)      /*!< 0x00000FFF */
+#define DAC_DHR12R1_DACC1DHR        DAC_DHR12R1_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L1 register  ******************/
+#define DAC_DHR12L1_DACC1DHR_Pos    (4U)
+#define DAC_DHR12L1_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12L1_DACC1DHR_Pos)      /*!< 0x0000FFF0 */
+#define DAC_DHR12L1_DACC1DHR        DAC_DHR12L1_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R1 register  ******************/
+#define DAC_DHR8R1_DACC1DHR_Pos     (0U)
+#define DAC_DHR8R1_DACC1DHR_Msk     (0xFFUL << DAC_DHR8R1_DACC1DHR_Pos)        /*!< 0x000000FF */
+#define DAC_DHR8R1_DACC1DHR         DAC_DHR8R1_DACC1DHR_Msk                    /*!<DAC channel1 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12R2 register  ******************/
+#define DAC_DHR12R2_DACC2DHR_Pos    (0U)
+#define DAC_DHR12R2_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12R2_DACC2DHR_Pos)      /*!< 0x00000FFF */
+#define DAC_DHR12R2_DACC2DHR        DAC_DHR12R2_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L2 register  ******************/
+#define DAC_DHR12L2_DACC2DHR_Pos    (4U)
+#define DAC_DHR12L2_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12L2_DACC2DHR_Pos)      /*!< 0x0000FFF0 */
+#define DAC_DHR12L2_DACC2DHR        DAC_DHR12L2_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R2 register  ******************/
+#define DAC_DHR8R2_DACC2DHR_Pos     (0U)
+#define DAC_DHR8R2_DACC2DHR_Msk     (0xFFUL << DAC_DHR8R2_DACC2DHR_Pos)        /*!< 0x000000FF */
+#define DAC_DHR8R2_DACC2DHR         DAC_DHR8R2_DACC2DHR_Msk                    /*!<DAC channel2 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12RD register  ******************/
+#define DAC_DHR12RD_DACC1DHR_Pos    (0U)
+#define DAC_DHR12RD_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12RD_DACC1DHR_Pos)      /*!< 0x00000FFF */
+#define DAC_DHR12RD_DACC1DHR        DAC_DHR12RD_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Right aligned data */
+#define DAC_DHR12RD_DACC2DHR_Pos    (16U)
+#define DAC_DHR12RD_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12RD_DACC2DHR_Pos)      /*!< 0x0FFF0000 */
+#define DAC_DHR12RD_DACC2DHR        DAC_DHR12RD_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12LD register  ******************/
+#define DAC_DHR12LD_DACC1DHR_Pos    (4U)
+#define DAC_DHR12LD_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12LD_DACC1DHR_Pos)      /*!< 0x0000FFF0 */
+#define DAC_DHR12LD_DACC1DHR        DAC_DHR12LD_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Left aligned data */
+#define DAC_DHR12LD_DACC2DHR_Pos    (20U)
+#define DAC_DHR12LD_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12LD_DACC2DHR_Pos)      /*!< 0xFFF00000 */
+#define DAC_DHR12LD_DACC2DHR        DAC_DHR12LD_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8RD register  ******************/
+#define DAC_DHR8RD_DACC1DHR_Pos     (0U)
+#define DAC_DHR8RD_DACC1DHR_Msk     (0xFFUL << DAC_DHR8RD_DACC1DHR_Pos)        /*!< 0x000000FF */
+#define DAC_DHR8RD_DACC1DHR         DAC_DHR8RD_DACC1DHR_Msk                    /*!<DAC channel1 8-bit Right aligned data */
+#define DAC_DHR8RD_DACC2DHR_Pos     (8U)
+#define DAC_DHR8RD_DACC2DHR_Msk     (0xFFUL << DAC_DHR8RD_DACC2DHR_Pos)        /*!< 0x0000FF00 */
+#define DAC_DHR8RD_DACC2DHR         DAC_DHR8RD_DACC2DHR_Msk                    /*!<DAC channel2 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define DAC_DOR1_DACC1DOR_Pos       (0U)
+#define DAC_DOR1_DACC1DOR_Msk       (0xFFFUL << DAC_DOR1_DACC1DOR_Pos)         /*!< 0x00000FFF */
+#define DAC_DOR1_DACC1DOR           DAC_DOR1_DACC1DOR_Msk                      /*!<DAC channel1 data output */
+
+/*******************  Bit definition for DAC_DOR2 register  *******************/
+#define DAC_DOR2_DACC2DOR_Pos       (0U)
+#define DAC_DOR2_DACC2DOR_Msk       (0xFFFUL << DAC_DOR2_DACC2DOR_Pos)         /*!< 0x00000FFF */
+#define DAC_DOR2_DACC2DOR           DAC_DOR2_DACC2DOR_Msk                      /*!<DAC channel2 data output */
+
+/********************  Bit definition for DAC_SR register  ********************/
+#define DAC_SR_DMAUDR1_Pos          (13U)
+#define DAC_SR_DMAUDR1_Msk          (0x1UL << DAC_SR_DMAUDR1_Pos)              /*!< 0x00002000 */
+#define DAC_SR_DMAUDR1              DAC_SR_DMAUDR1_Msk                         /*!<DAC channel1 DMA underrun flag */
+#define DAC_SR_CAL_FLAG1_Pos        (14U)
+#define DAC_SR_CAL_FLAG1_Msk        (0x1UL << DAC_SR_CAL_FLAG1_Pos)            /*!< 0x00004000 */
+#define DAC_SR_CAL_FLAG1            DAC_SR_CAL_FLAG1_Msk                       /*!<DAC channel1 calibration offset status */
+#define DAC_SR_BWST1_Pos            (15U)
+#define DAC_SR_BWST1_Msk            (0x1UL << DAC_SR_BWST1_Pos)                /*!< 0x00008000 */
+#define DAC_SR_BWST1                DAC_SR_BWST1_Msk                           /*!<DAC channel1 busy writing sample time flag */
+
+#define DAC_SR_DMAUDR2_Pos          (29U)
+#define DAC_SR_DMAUDR2_Msk          (0x1UL << DAC_SR_DMAUDR2_Pos)              /*!< 0x20000000 */
+#define DAC_SR_DMAUDR2              DAC_SR_DMAUDR2_Msk                         /*!<DAC channel2 DMA underrun flag */
+#define DAC_SR_CAL_FLAG2_Pos        (30U)
+#define DAC_SR_CAL_FLAG2_Msk        (0x1UL << DAC_SR_CAL_FLAG2_Pos)            /*!< 0x40000000 */
+#define DAC_SR_CAL_FLAG2            DAC_SR_CAL_FLAG2_Msk                       /*!<DAC channel2 calibration offset status */
+#define DAC_SR_BWST2_Pos            (31U)
+#define DAC_SR_BWST2_Msk            (0x1UL << DAC_SR_BWST2_Pos)                /*!< 0x80000000 */
+#define DAC_SR_BWST2                DAC_SR_BWST2_Msk                           /*!<DAC channel2 busy writing sample time flag */
+
+/*******************  Bit definition for DAC_CCR register  ********************/
+#define DAC_CCR_OTRIM1_Pos          (0U)
+#define DAC_CCR_OTRIM1_Msk          (0x1FUL << DAC_CCR_OTRIM1_Pos)             /*!< 0x0000001F */
+#define DAC_CCR_OTRIM1              DAC_CCR_OTRIM1_Msk                         /*!<DAC channel1 offset trimming value */
+#define DAC_CCR_OTRIM2_Pos          (16U)
+#define DAC_CCR_OTRIM2_Msk          (0x1FUL << DAC_CCR_OTRIM2_Pos)             /*!< 0x001F0000 */
+#define DAC_CCR_OTRIM2              DAC_CCR_OTRIM2_Msk                         /*!<DAC channel2 offset trimming value */
+
+/*******************  Bit definition for DAC_MCR register  *******************/
+#define DAC_MCR_MODE1_Pos           (0U)
+#define DAC_MCR_MODE1_Msk           (0x7UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000007 */
+#define DAC_MCR_MODE1               DAC_MCR_MODE1_Msk                          /*!<MODE1[2:0] (DAC channel1 mode) */
+#define DAC_MCR_MODE1_0             (0x1UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000001 */
+#define DAC_MCR_MODE1_1             (0x2UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000002 */
+#define DAC_MCR_MODE1_2             (0x4UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000004 */
+
+#define DAC_MCR_MODE2_Pos           (16U)
+#define DAC_MCR_MODE2_Msk           (0x7UL << DAC_MCR_MODE2_Pos)               /*!< 0x00070000 */
+#define DAC_MCR_MODE2               DAC_MCR_MODE2_Msk                          /*!<MODE2[2:0] (DAC channel2 mode) */
+#define DAC_MCR_MODE2_0             (0x1UL << DAC_MCR_MODE2_Pos)               /*!< 0x00010000 */
+#define DAC_MCR_MODE2_1             (0x2UL << DAC_MCR_MODE2_Pos)               /*!< 0x00020000 */
+#define DAC_MCR_MODE2_2             (0x4UL << DAC_MCR_MODE2_Pos)               /*!< 0x00040000 */
+
+/******************  Bit definition for DAC_SHSR1 register  ******************/
+#define DAC_SHSR1_TSAMPLE1_Pos      (0U)
+#define DAC_SHSR1_TSAMPLE1_Msk      (0x3FFUL << DAC_SHSR1_TSAMPLE1_Pos)        /*!< 0x000003FF */
+#define DAC_SHSR1_TSAMPLE1          DAC_SHSR1_TSAMPLE1_Msk                     /*!<DAC channel1 sample time */
+
+/******************  Bit definition for DAC_SHSR2 register  ******************/
+#define DAC_SHSR2_TSAMPLE2_Pos      (0U)
+#define DAC_SHSR2_TSAMPLE2_Msk      (0x3FFUL << DAC_SHSR2_TSAMPLE2_Pos)        /*!< 0x000003FF */
+#define DAC_SHSR2_TSAMPLE2          DAC_SHSR2_TSAMPLE2_Msk                     /*!<DAC channel2 sample time */
+
+/******************  Bit definition for DAC_SHHR register  ******************/
+#define DAC_SHHR_THOLD1_Pos         (0U)
+#define DAC_SHHR_THOLD1_Msk         (0x3FFUL << DAC_SHHR_THOLD1_Pos)           /*!< 0x000003FF */
+#define DAC_SHHR_THOLD1             DAC_SHHR_THOLD1_Msk                        /*!<DAC channel1 hold time */
+#define DAC_SHHR_THOLD2_Pos         (16U)
+#define DAC_SHHR_THOLD2_Msk         (0x3FFUL << DAC_SHHR_THOLD2_Pos)           /*!< 0x03FF0000 */
+#define DAC_SHHR_THOLD2             DAC_SHHR_THOLD2_Msk                        /*!<DAC channel2 hold time */
+
+/******************  Bit definition for DAC_SHRR register  ******************/
+#define DAC_SHRR_TREFRESH1_Pos      (0U)
+#define DAC_SHRR_TREFRESH1_Msk      (0xFFUL << DAC_SHRR_TREFRESH1_Pos)         /*!< 0x000000FF */
+#define DAC_SHRR_TREFRESH1          DAC_SHRR_TREFRESH1_Msk                     /*!<DAC channel1 refresh time */
+#define DAC_SHRR_TREFRESH2_Pos      (16U)
+#define DAC_SHRR_TREFRESH2_Msk      (0xFFUL << DAC_SHRR_TREFRESH2_Pos)         /*!< 0x00FF0000 */
+#define DAC_SHRR_TREFRESH2          DAC_SHRR_TREFRESH2_Msk                     /*!<DAC channel2 refresh time */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 Debug MCU                                  */
+/*                                                                            */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define DMA_ISR_GIF1_Pos       (0U)
+#define DMA_ISR_GIF1_Msk       (0x1UL << DMA_ISR_GIF1_Pos)                     /*!< 0x00000001 */
+#define DMA_ISR_GIF1           DMA_ISR_GIF1_Msk                                /*!< Channel 1 Global interrupt flag */
+#define DMA_ISR_TCIF1_Pos      (1U)
+#define DMA_ISR_TCIF1_Msk      (0x1UL << DMA_ISR_TCIF1_Pos)                    /*!< 0x00000002 */
+#define DMA_ISR_TCIF1          DMA_ISR_TCIF1_Msk                               /*!< Channel 1 Transfer Complete flag */
+#define DMA_ISR_HTIF1_Pos      (2U)
+#define DMA_ISR_HTIF1_Msk      (0x1UL << DMA_ISR_HTIF1_Pos)                    /*!< 0x00000004 */
+#define DMA_ISR_HTIF1          DMA_ISR_HTIF1_Msk                               /*!< Channel 1 Half Transfer flag */
+#define DMA_ISR_TEIF1_Pos      (3U)
+#define DMA_ISR_TEIF1_Msk      (0x1UL << DMA_ISR_TEIF1_Pos)                    /*!< 0x00000008 */
+#define DMA_ISR_TEIF1          DMA_ISR_TEIF1_Msk                               /*!< Channel 1 Transfer Error flag */
+#define DMA_ISR_GIF2_Pos       (4U)
+#define DMA_ISR_GIF2_Msk       (0x1UL << DMA_ISR_GIF2_Pos)                     /*!< 0x00000010 */
+#define DMA_ISR_GIF2           DMA_ISR_GIF2_Msk                                /*!< Channel 2 Global interrupt flag */
+#define DMA_ISR_TCIF2_Pos      (5U)
+#define DMA_ISR_TCIF2_Msk      (0x1UL << DMA_ISR_TCIF2_Pos)                    /*!< 0x00000020 */
+#define DMA_ISR_TCIF2          DMA_ISR_TCIF2_Msk                               /*!< Channel 2 Transfer Complete flag */
+#define DMA_ISR_HTIF2_Pos      (6U)
+#define DMA_ISR_HTIF2_Msk      (0x1UL << DMA_ISR_HTIF2_Pos)                    /*!< 0x00000040 */
+#define DMA_ISR_HTIF2          DMA_ISR_HTIF2_Msk                               /*!< Channel 2 Half Transfer flag */
+#define DMA_ISR_TEIF2_Pos      (7U)
+#define DMA_ISR_TEIF2_Msk      (0x1UL << DMA_ISR_TEIF2_Pos)                    /*!< 0x00000080 */
+#define DMA_ISR_TEIF2          DMA_ISR_TEIF2_Msk                               /*!< Channel 2 Transfer Error flag */
+#define DMA_ISR_GIF3_Pos       (8U)
+#define DMA_ISR_GIF3_Msk       (0x1UL << DMA_ISR_GIF3_Pos)                     /*!< 0x00000100 */
+#define DMA_ISR_GIF3           DMA_ISR_GIF3_Msk                                /*!< Channel 3 Global interrupt flag */
+#define DMA_ISR_TCIF3_Pos      (9U)
+#define DMA_ISR_TCIF3_Msk      (0x1UL << DMA_ISR_TCIF3_Pos)                    /*!< 0x00000200 */
+#define DMA_ISR_TCIF3          DMA_ISR_TCIF3_Msk                               /*!< Channel 3 Transfer Complete flag */
+#define DMA_ISR_HTIF3_Pos      (10U)
+#define DMA_ISR_HTIF3_Msk      (0x1UL << DMA_ISR_HTIF3_Pos)                    /*!< 0x00000400 */
+#define DMA_ISR_HTIF3          DMA_ISR_HTIF3_Msk                               /*!< Channel 3 Half Transfer flag */
+#define DMA_ISR_TEIF3_Pos      (11U)
+#define DMA_ISR_TEIF3_Msk      (0x1UL << DMA_ISR_TEIF3_Pos)                    /*!< 0x00000800 */
+#define DMA_ISR_TEIF3          DMA_ISR_TEIF3_Msk                               /*!< Channel 3 Transfer Error flag */
+#define DMA_ISR_GIF4_Pos       (12U)
+#define DMA_ISR_GIF4_Msk       (0x1UL << DMA_ISR_GIF4_Pos)                     /*!< 0x00001000 */
+#define DMA_ISR_GIF4           DMA_ISR_GIF4_Msk                                /*!< Channel 4 Global interrupt flag */
+#define DMA_ISR_TCIF4_Pos      (13U)
+#define DMA_ISR_TCIF4_Msk      (0x1UL << DMA_ISR_TCIF4_Pos)                    /*!< 0x00002000 */
+#define DMA_ISR_TCIF4          DMA_ISR_TCIF4_Msk                               /*!< Channel 4 Transfer Complete flag */
+#define DMA_ISR_HTIF4_Pos      (14U)
+#define DMA_ISR_HTIF4_Msk      (0x1UL << DMA_ISR_HTIF4_Pos)                    /*!< 0x00004000 */
+#define DMA_ISR_HTIF4          DMA_ISR_HTIF4_Msk                               /*!< Channel 4 Half Transfer flag */
+#define DMA_ISR_TEIF4_Pos      (15U)
+#define DMA_ISR_TEIF4_Msk      (0x1UL << DMA_ISR_TEIF4_Pos)                    /*!< 0x00008000 */
+#define DMA_ISR_TEIF4          DMA_ISR_TEIF4_Msk                               /*!< Channel 4 Transfer Error flag */
+#define DMA_ISR_GIF5_Pos       (16U)
+#define DMA_ISR_GIF5_Msk       (0x1UL << DMA_ISR_GIF5_Pos)                     /*!< 0x00010000 */
+#define DMA_ISR_GIF5           DMA_ISR_GIF5_Msk                                /*!< Channel 5 Global interrupt flag */
+#define DMA_ISR_TCIF5_Pos      (17U)
+#define DMA_ISR_TCIF5_Msk      (0x1UL << DMA_ISR_TCIF5_Pos)                    /*!< 0x00020000 */
+#define DMA_ISR_TCIF5          DMA_ISR_TCIF5_Msk                               /*!< Channel 5 Transfer Complete flag */
+#define DMA_ISR_HTIF5_Pos      (18U)
+#define DMA_ISR_HTIF5_Msk      (0x1UL << DMA_ISR_HTIF5_Pos)                    /*!< 0x00040000 */
+#define DMA_ISR_HTIF5          DMA_ISR_HTIF5_Msk                               /*!< Channel 5 Half Transfer flag */
+#define DMA_ISR_TEIF5_Pos      (19U)
+#define DMA_ISR_TEIF5_Msk      (0x1UL << DMA_ISR_TEIF5_Pos)                    /*!< 0x00080000 */
+#define DMA_ISR_TEIF5          DMA_ISR_TEIF5_Msk                               /*!< Channel 5 Transfer Error flag */
+#define DMA_ISR_GIF6_Pos       (20U)
+#define DMA_ISR_GIF6_Msk       (0x1UL << DMA_ISR_GIF6_Pos)                     /*!< 0x00100000 */
+#define DMA_ISR_GIF6           DMA_ISR_GIF6_Msk                                /*!< Channel 6 Global interrupt flag */
+#define DMA_ISR_TCIF6_Pos      (21U)
+#define DMA_ISR_TCIF6_Msk      (0x1UL << DMA_ISR_TCIF6_Pos)                    /*!< 0x00200000 */
+#define DMA_ISR_TCIF6          DMA_ISR_TCIF6_Msk                               /*!< Channel 6 Transfer Complete flag */
+#define DMA_ISR_HTIF6_Pos      (22U)
+#define DMA_ISR_HTIF6_Msk      (0x1UL << DMA_ISR_HTIF6_Pos)                    /*!< 0x00400000 */
+#define DMA_ISR_HTIF6          DMA_ISR_HTIF6_Msk                               /*!< Channel 6 Half Transfer flag */
+#define DMA_ISR_TEIF6_Pos      (23U)
+#define DMA_ISR_TEIF6_Msk      (0x1UL << DMA_ISR_TEIF6_Pos)                    /*!< 0x00800000 */
+#define DMA_ISR_TEIF6          DMA_ISR_TEIF6_Msk                               /*!< Channel 6 Transfer Error flag */
+#define DMA_ISR_GIF7_Pos       (24U)
+#define DMA_ISR_GIF7_Msk       (0x1UL << DMA_ISR_GIF7_Pos)                     /*!< 0x01000000 */
+#define DMA_ISR_GIF7           DMA_ISR_GIF7_Msk                                /*!< Channel 7 Global interrupt flag */
+#define DMA_ISR_TCIF7_Pos      (25U)
+#define DMA_ISR_TCIF7_Msk      (0x1UL << DMA_ISR_TCIF7_Pos)                    /*!< 0x02000000 */
+#define DMA_ISR_TCIF7          DMA_ISR_TCIF7_Msk                               /*!< Channel 7 Transfer Complete flag */
+#define DMA_ISR_HTIF7_Pos      (26U)
+#define DMA_ISR_HTIF7_Msk      (0x1UL << DMA_ISR_HTIF7_Pos)                    /*!< 0x04000000 */
+#define DMA_ISR_HTIF7          DMA_ISR_HTIF7_Msk                               /*!< Channel 7 Half Transfer flag */
+#define DMA_ISR_TEIF7_Pos      (27U)
+#define DMA_ISR_TEIF7_Msk      (0x1UL << DMA_ISR_TEIF7_Pos)                    /*!< 0x08000000 */
+#define DMA_ISR_TEIF7          DMA_ISR_TEIF7_Msk                               /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define DMA_IFCR_CGIF1_Pos     (0U)
+#define DMA_IFCR_CGIF1_Msk     (0x1UL << DMA_IFCR_CGIF1_Pos)                   /*!< 0x00000001 */
+#define DMA_IFCR_CGIF1         DMA_IFCR_CGIF1_Msk                              /*!< Channel 1 Global interrupt clearr */
+#define DMA_IFCR_CTCIF1_Pos    (1U)
+#define DMA_IFCR_CTCIF1_Msk    (0x1UL << DMA_IFCR_CTCIF1_Pos)                  /*!< 0x00000002 */
+#define DMA_IFCR_CTCIF1        DMA_IFCR_CTCIF1_Msk                             /*!< Channel 1 Transfer Complete clear */
+#define DMA_IFCR_CHTIF1_Pos    (2U)
+#define DMA_IFCR_CHTIF1_Msk    (0x1UL << DMA_IFCR_CHTIF1_Pos)                  /*!< 0x00000004 */
+#define DMA_IFCR_CHTIF1        DMA_IFCR_CHTIF1_Msk                             /*!< Channel 1 Half Transfer clear */
+#define DMA_IFCR_CTEIF1_Pos    (3U)
+#define DMA_IFCR_CTEIF1_Msk    (0x1UL << DMA_IFCR_CTEIF1_Pos)                  /*!< 0x00000008 */
+#define DMA_IFCR_CTEIF1        DMA_IFCR_CTEIF1_Msk                             /*!< Channel 1 Transfer Error clear */
+#define DMA_IFCR_CGIF2_Pos     (4U)
+#define DMA_IFCR_CGIF2_Msk     (0x1UL << DMA_IFCR_CGIF2_Pos)                   /*!< 0x00000010 */
+#define DMA_IFCR_CGIF2         DMA_IFCR_CGIF2_Msk                              /*!< Channel 2 Global interrupt clear */
+#define DMA_IFCR_CTCIF2_Pos    (5U)
+#define DMA_IFCR_CTCIF2_Msk    (0x1UL << DMA_IFCR_CTCIF2_Pos)                  /*!< 0x00000020 */
+#define DMA_IFCR_CTCIF2        DMA_IFCR_CTCIF2_Msk                             /*!< Channel 2 Transfer Complete clear */
+#define DMA_IFCR_CHTIF2_Pos    (6U)
+#define DMA_IFCR_CHTIF2_Msk    (0x1UL << DMA_IFCR_CHTIF2_Pos)                  /*!< 0x00000040 */
+#define DMA_IFCR_CHTIF2        DMA_IFCR_CHTIF2_Msk                             /*!< Channel 2 Half Transfer clear */
+#define DMA_IFCR_CTEIF2_Pos    (7U)
+#define DMA_IFCR_CTEIF2_Msk    (0x1UL << DMA_IFCR_CTEIF2_Pos)                  /*!< 0x00000080 */
+#define DMA_IFCR_CTEIF2        DMA_IFCR_CTEIF2_Msk                             /*!< Channel 2 Transfer Error clear */
+#define DMA_IFCR_CGIF3_Pos     (8U)
+#define DMA_IFCR_CGIF3_Msk     (0x1UL << DMA_IFCR_CGIF3_Pos)                   /*!< 0x00000100 */
+#define DMA_IFCR_CGIF3         DMA_IFCR_CGIF3_Msk                              /*!< Channel 3 Global interrupt clear */
+#define DMA_IFCR_CTCIF3_Pos    (9U)
+#define DMA_IFCR_CTCIF3_Msk    (0x1UL << DMA_IFCR_CTCIF3_Pos)                  /*!< 0x00000200 */
+#define DMA_IFCR_CTCIF3        DMA_IFCR_CTCIF3_Msk                             /*!< Channel 3 Transfer Complete clear */
+#define DMA_IFCR_CHTIF3_Pos    (10U)
+#define DMA_IFCR_CHTIF3_Msk    (0x1UL << DMA_IFCR_CHTIF3_Pos)                  /*!< 0x00000400 */
+#define DMA_IFCR_CHTIF3        DMA_IFCR_CHTIF3_Msk                             /*!< Channel 3 Half Transfer clear */
+#define DMA_IFCR_CTEIF3_Pos    (11U)
+#define DMA_IFCR_CTEIF3_Msk    (0x1UL << DMA_IFCR_CTEIF3_Pos)                  /*!< 0x00000800 */
+#define DMA_IFCR_CTEIF3        DMA_IFCR_CTEIF3_Msk                             /*!< Channel 3 Transfer Error clear */
+#define DMA_IFCR_CGIF4_Pos     (12U)
+#define DMA_IFCR_CGIF4_Msk     (0x1UL << DMA_IFCR_CGIF4_Pos)                   /*!< 0x00001000 */
+#define DMA_IFCR_CGIF4         DMA_IFCR_CGIF4_Msk                              /*!< Channel 4 Global interrupt clear */
+#define DMA_IFCR_CTCIF4_Pos    (13U)
+#define DMA_IFCR_CTCIF4_Msk    (0x1UL << DMA_IFCR_CTCIF4_Pos)                  /*!< 0x00002000 */
+#define DMA_IFCR_CTCIF4        DMA_IFCR_CTCIF4_Msk                             /*!< Channel 4 Transfer Complete clear */
+#define DMA_IFCR_CHTIF4_Pos    (14U)
+#define DMA_IFCR_CHTIF4_Msk    (0x1UL << DMA_IFCR_CHTIF4_Pos)                  /*!< 0x00004000 */
+#define DMA_IFCR_CHTIF4        DMA_IFCR_CHTIF4_Msk                             /*!< Channel 4 Half Transfer clear */
+#define DMA_IFCR_CTEIF4_Pos    (15U)
+#define DMA_IFCR_CTEIF4_Msk    (0x1UL << DMA_IFCR_CTEIF4_Pos)                  /*!< 0x00008000 */
+#define DMA_IFCR_CTEIF4        DMA_IFCR_CTEIF4_Msk                             /*!< Channel 4 Transfer Error clear */
+#define DMA_IFCR_CGIF5_Pos     (16U)
+#define DMA_IFCR_CGIF5_Msk     (0x1UL << DMA_IFCR_CGIF5_Pos)                   /*!< 0x00010000 */
+#define DMA_IFCR_CGIF5         DMA_IFCR_CGIF5_Msk                              /*!< Channel 5 Global interrupt clear */
+#define DMA_IFCR_CTCIF5_Pos    (17U)
+#define DMA_IFCR_CTCIF5_Msk    (0x1UL << DMA_IFCR_CTCIF5_Pos)                  /*!< 0x00020000 */
+#define DMA_IFCR_CTCIF5        DMA_IFCR_CTCIF5_Msk                             /*!< Channel 5 Transfer Complete clear */
+#define DMA_IFCR_CHTIF5_Pos    (18U)
+#define DMA_IFCR_CHTIF5_Msk    (0x1UL << DMA_IFCR_CHTIF5_Pos)                  /*!< 0x00040000 */
+#define DMA_IFCR_CHTIF5        DMA_IFCR_CHTIF5_Msk                             /*!< Channel 5 Half Transfer clear */
+#define DMA_IFCR_CTEIF5_Pos    (19U)
+#define DMA_IFCR_CTEIF5_Msk    (0x1UL << DMA_IFCR_CTEIF5_Pos)                  /*!< 0x00080000 */
+#define DMA_IFCR_CTEIF5        DMA_IFCR_CTEIF5_Msk                             /*!< Channel 5 Transfer Error clear */
+#define DMA_IFCR_CGIF6_Pos     (20U)
+#define DMA_IFCR_CGIF6_Msk     (0x1UL << DMA_IFCR_CGIF6_Pos)                   /*!< 0x00100000 */
+#define DMA_IFCR_CGIF6         DMA_IFCR_CGIF6_Msk                              /*!< Channel 6 Global interrupt clear */
+#define DMA_IFCR_CTCIF6_Pos    (21U)
+#define DMA_IFCR_CTCIF6_Msk    (0x1UL << DMA_IFCR_CTCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_IFCR_CTCIF6        DMA_IFCR_CTCIF6_Msk                             /*!< Channel 6 Transfer Complete clear */
+#define DMA_IFCR_CHTIF6_Pos    (22U)
+#define DMA_IFCR_CHTIF6_Msk    (0x1UL << DMA_IFCR_CHTIF6_Pos)                  /*!< 0x00400000 */
+#define DMA_IFCR_CHTIF6        DMA_IFCR_CHTIF6_Msk                             /*!< Channel 6 Half Transfer clear */
+#define DMA_IFCR_CTEIF6_Pos    (23U)
+#define DMA_IFCR_CTEIF6_Msk    (0x1UL << DMA_IFCR_CTEIF6_Pos)                  /*!< 0x00800000 */
+#define DMA_IFCR_CTEIF6        DMA_IFCR_CTEIF6_Msk                             /*!< Channel 6 Transfer Error clear */
+#define DMA_IFCR_CGIF7_Pos     (24U)
+#define DMA_IFCR_CGIF7_Msk     (0x1UL << DMA_IFCR_CGIF7_Pos)                   /*!< 0x01000000 */
+#define DMA_IFCR_CGIF7         DMA_IFCR_CGIF7_Msk                              /*!< Channel 7 Global interrupt clear */
+#define DMA_IFCR_CTCIF7_Pos    (25U)
+#define DMA_IFCR_CTCIF7_Msk    (0x1UL << DMA_IFCR_CTCIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_IFCR_CTCIF7        DMA_IFCR_CTCIF7_Msk                             /*!< Channel 7 Transfer Complete clear */
+#define DMA_IFCR_CHTIF7_Pos    (26U)
+#define DMA_IFCR_CHTIF7_Msk    (0x1UL << DMA_IFCR_CHTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_IFCR_CHTIF7        DMA_IFCR_CHTIF7_Msk                             /*!< Channel 7 Half Transfer clear */
+#define DMA_IFCR_CTEIF7_Pos    (27U)
+#define DMA_IFCR_CTEIF7_Msk    (0x1UL << DMA_IFCR_CTEIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_IFCR_CTEIF7        DMA_IFCR_CTEIF7_Msk                             /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define DMA_CCR_EN_Pos         (0U)
+#define DMA_CCR_EN_Msk         (0x1UL << DMA_CCR_EN_Pos)                       /*!< 0x00000001 */
+#define DMA_CCR_EN             DMA_CCR_EN_Msk                                  /*!< Channel enable                      */
+#define DMA_CCR_TCIE_Pos       (1U)
+#define DMA_CCR_TCIE_Msk       (0x1UL << DMA_CCR_TCIE_Pos)                     /*!< 0x00000002 */
+#define DMA_CCR_TCIE           DMA_CCR_TCIE_Msk                                /*!< Transfer complete interrupt enable  */
+#define DMA_CCR_HTIE_Pos       (2U)
+#define DMA_CCR_HTIE_Msk       (0x1UL << DMA_CCR_HTIE_Pos)                     /*!< 0x00000004 */
+#define DMA_CCR_HTIE           DMA_CCR_HTIE_Msk                                /*!< Half Transfer interrupt enable      */
+#define DMA_CCR_TEIE_Pos       (3U)
+#define DMA_CCR_TEIE_Msk       (0x1UL << DMA_CCR_TEIE_Pos)                     /*!< 0x00000008 */
+#define DMA_CCR_TEIE           DMA_CCR_TEIE_Msk                                /*!< Transfer error interrupt enable     */
+#define DMA_CCR_DIR_Pos        (4U)
+#define DMA_CCR_DIR_Msk        (0x1UL << DMA_CCR_DIR_Pos)                      /*!< 0x00000010 */
+#define DMA_CCR_DIR            DMA_CCR_DIR_Msk                                 /*!< Data transfer direction             */
+#define DMA_CCR_CIRC_Pos       (5U)
+#define DMA_CCR_CIRC_Msk       (0x1UL << DMA_CCR_CIRC_Pos)                     /*!< 0x00000020 */
+#define DMA_CCR_CIRC           DMA_CCR_CIRC_Msk                                /*!< Circular mode                       */
+#define DMA_CCR_PINC_Pos       (6U)
+#define DMA_CCR_PINC_Msk       (0x1UL << DMA_CCR_PINC_Pos)                     /*!< 0x00000040 */
+#define DMA_CCR_PINC           DMA_CCR_PINC_Msk                                /*!< Peripheral increment mode           */
+#define DMA_CCR_MINC_Pos       (7U)
+#define DMA_CCR_MINC_Msk       (0x1UL << DMA_CCR_MINC_Pos)                     /*!< 0x00000080 */
+#define DMA_CCR_MINC           DMA_CCR_MINC_Msk                                /*!< Memory increment mode               */
+
+#define DMA_CCR_PSIZE_Pos      (8U)
+#define DMA_CCR_PSIZE_Msk      (0x3UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000300 */
+#define DMA_CCR_PSIZE          DMA_CCR_PSIZE_Msk                               /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define DMA_CCR_PSIZE_0        (0x1UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000100 */
+#define DMA_CCR_PSIZE_1        (0x2UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000200 */
+
+#define DMA_CCR_MSIZE_Pos      (10U)
+#define DMA_CCR_MSIZE_Msk      (0x3UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000C00 */
+#define DMA_CCR_MSIZE          DMA_CCR_MSIZE_Msk                               /*!< MSIZE[1:0] bits (Memory size)       */
+#define DMA_CCR_MSIZE_0        (0x1UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000400 */
+#define DMA_CCR_MSIZE_1        (0x2UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000800 */
+
+#define DMA_CCR_PL_Pos         (12U)
+#define DMA_CCR_PL_Msk         (0x3UL << DMA_CCR_PL_Pos)                       /*!< 0x00003000 */
+#define DMA_CCR_PL             DMA_CCR_PL_Msk                                  /*!< PL[1:0] bits(Channel Priority level)*/
+#define DMA_CCR_PL_0           (0x1UL << DMA_CCR_PL_Pos)                       /*!< 0x00001000 */
+#define DMA_CCR_PL_1           (0x2UL << DMA_CCR_PL_Pos)                        /*!< 0x00002000 */
+
+#define DMA_CCR_MEM2MEM_Pos    (14U)
+#define DMA_CCR_MEM2MEM_Msk    (0x1UL << DMA_CCR_MEM2MEM_Pos)                  /*!< 0x00004000 */
+#define DMA_CCR_MEM2MEM        DMA_CCR_MEM2MEM_Msk                             /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define DMA_CNDTR_NDT_Pos      (0U)
+#define DMA_CNDTR_NDT_Msk      (0xFFFFUL << DMA_CNDTR_NDT_Pos)                 /*!< 0x0000FFFF */
+#define DMA_CNDTR_NDT          DMA_CNDTR_NDT_Msk                               /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define DMA_CPAR_PA_Pos        (0U)
+#define DMA_CPAR_PA_Msk        (0xFFFFFFFFUL << DMA_CPAR_PA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CPAR_PA            DMA_CPAR_PA_Msk                                 /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define DMA_CMAR_MA_Pos        (0U)
+#define DMA_CMAR_MA_Msk        (0xFFFFFFFFUL << DMA_CMAR_MA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CMAR_MA            DMA_CMAR_MA_Msk                                 /*!< Memory Address                      */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMAMUX Controller                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMAMUX_CxCR register  **************/
+#define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
+#define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
+#define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_CxCR_DMAREQ_ID_2                (0x04UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_CxCR_DMAREQ_ID_3                (0x08UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_CxCR_DMAREQ_ID_4                (0x10UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_CxCR_DMAREQ_ID_5                (0x20UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
+#define DMAMUX_CxCR_DMAREQ_ID_6                (0x40UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000040 */
+#define DMAMUX_CxCR_DMAREQ_ID_7                (0x80UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000080 */
+#define DMAMUX_CxCR_SOIE_Pos                   (8U)
+#define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk             /*!< Synchro overrun interrupt enable     */
+#define DMAMUX_CxCR_EGE_Pos                    (9U)
+#define DMAMUX_CxCR_EGE_Msk                    (0x1UL << DMAMUX_CxCR_EGE_Pos)   /*!< 0x00000200 */
+#define DMAMUX_CxCR_EGE                        DMAMUX_CxCR_EGE_Msk              /*!< Event generation interrupt enable    */
+#define DMAMUX_CxCR_SE_Pos                     (16U)
+#define DMAMUX_CxCR_SE_Msk                     (0x1UL << DMAMUX_CxCR_SE_Pos)    /*!< 0x00010000 */
+#define DMAMUX_CxCR_SE                         DMAMUX_CxCR_SE_Msk               /*!< Synchronization enable               */
+#define DMAMUX_CxCR_SPOL_Pos                   (17U)
+#define DMAMUX_CxCR_SPOL_Msk                   (0x3UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00060000 */
+#define DMAMUX_CxCR_SPOL                       DMAMUX_CxCR_SPOL_Msk             /*!< Synchronization polarity             */
+#define DMAMUX_CxCR_SPOL_0                     (0x1UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00020000 */
+#define DMAMUX_CxCR_SPOL_1                     (0x2UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00040000 */
+#define DMAMUX_CxCR_NBREQ_Pos                  (19U)
+#define DMAMUX_CxCR_NBREQ_Msk                  (0x1FUL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_CxCR_NBREQ                      DMAMUX_CxCR_NBREQ_Msk             /*!< Number of request                    */
+#define DMAMUX_CxCR_NBREQ_0                    (0x01UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_CxCR_NBREQ_1                    (0x02UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_CxCR_NBREQ_2                    (0x04UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_CxCR_NBREQ_3                    (0x08UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_CxCR_NBREQ_4                    (0x10UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00800000 */
+#define DMAMUX_CxCR_SYNC_ID_Pos                (24U)
+#define DMAMUX_CxCR_SYNC_ID_Msk                (0x1FUL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x1F000000 */
+#define DMAMUX_CxCR_SYNC_ID                    DMAMUX_CxCR_SYNC_ID_Msk             /*!< Synchronization ID                   */
+#define DMAMUX_CxCR_SYNC_ID_0                  (0x01UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x01000000 */
+#define DMAMUX_CxCR_SYNC_ID_1                  (0x02UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x02000000 */
+#define DMAMUX_CxCR_SYNC_ID_2                  (0x04UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x04000000 */
+#define DMAMUX_CxCR_SYNC_ID_3                  (0x08UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x08000000 */
+#define DMAMUX_CxCR_SYNC_ID_4                  (0x10UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x10000000 */
+
+/*******************  Bits definition for DMAMUX_CSR register  **************/
+#define DMAMUX_CSR_SOF0_Pos                    (0U)
+#define DMAMUX_CSR_SOF0_Msk                    (0x1UL << DMAMUX_CSR_SOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CSR_SOF0                        DMAMUX_CSR_SOF0_Msk             /*!< Synchronization Overrun Flag 0       */
+#define DMAMUX_CSR_SOF1_Pos                    (1U)
+#define DMAMUX_CSR_SOF1_Msk                    (0x1UL << DMAMUX_CSR_SOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CSR_SOF1                        DMAMUX_CSR_SOF1_Msk             /*!< Synchronization Overrun Flag 1       */
+#define DMAMUX_CSR_SOF2_Pos                    (2U)
+#define DMAMUX_CSR_SOF2_Msk                    (0x1UL << DMAMUX_CSR_SOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CSR_SOF2                        DMAMUX_CSR_SOF2_Msk             /*!< Synchronization Overrun Flag 2       */
+#define DMAMUX_CSR_SOF3_Pos                    (3U)
+#define DMAMUX_CSR_SOF3_Msk                    (0x1UL << DMAMUX_CSR_SOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CSR_SOF3                        DMAMUX_CSR_SOF3_Msk             /*!< Synchronization Overrun Flag 3       */
+#define DMAMUX_CSR_SOF4_Pos                    (4U)
+#define DMAMUX_CSR_SOF4_Msk                    (0x1UL << DMAMUX_CSR_SOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CSR_SOF4                        DMAMUX_CSR_SOF4_Msk             /*!< Synchronization Overrun Flag 4       */
+#define DMAMUX_CSR_SOF5_Pos                    (5U)
+#define DMAMUX_CSR_SOF5_Msk                    (0x1UL << DMAMUX_CSR_SOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CSR_SOF5                        DMAMUX_CSR_SOF5_Msk             /*!< Synchronization Overrun Flag 5       */
+#define DMAMUX_CSR_SOF6_Pos                    (6U)
+#define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+
+/********************  Bits definition for DMAMUX_CFR register  **************/
+#define DMAMUX_CFR_CSOF0_Pos                   (0U)
+#define DMAMUX_CFR_CSOF0_Msk                   (0x1UL << DMAMUX_CFR_CSOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CFR_CSOF0                       DMAMUX_CFR_CSOF0_Msk             /*!< Clear Overrun Flag 0                 */
+#define DMAMUX_CFR_CSOF1_Pos                   (1U)
+#define DMAMUX_CFR_CSOF1_Msk                   (0x1UL << DMAMUX_CFR_CSOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CFR_CSOF1                       DMAMUX_CFR_CSOF1_Msk             /*!< Clear Overrun Flag 1                 */
+#define DMAMUX_CFR_CSOF2_Pos                   (2U)
+#define DMAMUX_CFR_CSOF2_Msk                   (0x1UL << DMAMUX_CFR_CSOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CFR_CSOF2                       DMAMUX_CFR_CSOF2_Msk             /*!< Clear Overrun Flag 2                 */
+#define DMAMUX_CFR_CSOF3_Pos                   (3U)
+#define DMAMUX_CFR_CSOF3_Msk                   (0x1UL << DMAMUX_CFR_CSOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CFR_CSOF3                       DMAMUX_CFR_CSOF3_Msk             /*!< Clear Overrun Flag 3                 */
+#define DMAMUX_CFR_CSOF4_Pos                   (4U)
+#define DMAMUX_CFR_CSOF4_Msk                   (0x1UL << DMAMUX_CFR_CSOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CFR_CSOF4                       DMAMUX_CFR_CSOF4_Msk             /*!< Clear Overrun Flag 4                 */
+#define DMAMUX_CFR_CSOF5_Pos                   (5U)
+#define DMAMUX_CFR_CSOF5_Msk                   (0x1UL << DMAMUX_CFR_CSOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CFR_CSOF5                       DMAMUX_CFR_CSOF5_Msk             /*!< Clear Overrun Flag 5                 */
+#define DMAMUX_CFR_CSOF6_Pos                   (6U)
+#define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk             /*!< Clear Overrun Flag 6                 */
+
+/********************  Bits definition for DMAMUX_RGxCR register  ************/
+#define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
+#define DMAMUX_RGxCR_SIG_ID_Msk                (0x1FUL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x0000001F */
+#define DMAMUX_RGxCR_SIG_ID                    DMAMUX_RGxCR_SIG_ID_Msk             /*!< Signal ID                         */
+#define DMAMUX_RGxCR_SIG_ID_0                  (0x01UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGxCR_SIG_ID_1                  (0x02UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGxCR_SIG_ID_2                  (0x04UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGxCR_SIG_ID_3                  (0x08UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGxCR_SIG_ID_4                  (0x10UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_RGxCR_OIE_Pos                   (8U)
+#define DMAMUX_RGxCR_OIE_Msk                   (0x1UL << DMAMUX_RGxCR_OIE_Pos)  /*!< 0x00000100 */
+#define DMAMUX_RGxCR_OIE                       DMAMUX_RGxCR_OIE_Msk             /*!< Overrun interrupt enable             */
+#define DMAMUX_RGxCR_GE_Pos                    (16U)
+#define DMAMUX_RGxCR_GE_Msk                    (0x1UL << DMAMUX_RGxCR_GE_Pos)   /*!< 0x00010000 */
+#define DMAMUX_RGxCR_GE                        DMAMUX_RGxCR_GE_Msk              /*!< Generation enable                    */
+#define DMAMUX_RGxCR_GPOL_Pos                  (17U)
+#define DMAMUX_RGxCR_GPOL_Msk                  (0x3UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_RGxCR_GPOL                      DMAMUX_RGxCR_GPOL_Msk            /*!< Generation polarity                  */
+#define DMAMUX_RGxCR_GPOL_0                    (0x1UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00020000 */
+#define DMAMUX_RGxCR_GPOL_1                    (0x2UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00040000 */
+#define DMAMUX_RGxCR_GNBREQ_Pos                (19U)
+#define DMAMUX_RGxCR_GNBREQ_Msk                (0x1FUL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_RGxCR_GNBREQ                    DMAMUX_RGxCR_GNBREQ_Msk             /*!< Number of request                 */
+#define DMAMUX_RGxCR_GNBREQ_0                  (0x01UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_RGxCR_GNBREQ_1                  (0x02UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_RGxCR_GNBREQ_2                  (0x04UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_RGxCR_GNBREQ_3                  (0x08UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_RGxCR_GNBREQ_4                  (0x10UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00800000 */
+
+/********************  Bits definition for DMAMUX_RGSR register  **************/
+#define DMAMUX_RGSR_OF0_Pos                    (0U)
+#define DMAMUX_RGSR_OF0_Msk                    (0x1UL << DMAMUX_RGSR_OF0_Pos)   /*!< 0x00000001 */
+#define DMAMUX_RGSR_OF0                        DMAMUX_RGSR_OF0_Msk              /*!< Overrun flag 0                       */
+#define DMAMUX_RGSR_OF1_Pos                    (1U)
+#define DMAMUX_RGSR_OF1_Msk                    (0x1UL << DMAMUX_RGSR_OF1_Pos)   /*!< 0x00000002 */
+#define DMAMUX_RGSR_OF1                        DMAMUX_RGSR_OF1_Msk              /*!< Overrun flag 1                       */
+#define DMAMUX_RGSR_OF2_Pos                    (2U)
+#define DMAMUX_RGSR_OF2_Msk                    (0x1UL << DMAMUX_RGSR_OF2_Pos)   /*!< 0x00000004 */
+#define DMAMUX_RGSR_OF2                        DMAMUX_RGSR_OF2_Msk              /*!< Overrun flag 2                       */
+#define DMAMUX_RGSR_OF3_Pos                    (3U)
+#define DMAMUX_RGSR_OF3_Msk                    (0x1UL << DMAMUX_RGSR_OF3_Pos)   /*!< 0x00000008 */
+#define DMAMUX_RGSR_OF3                        DMAMUX_RGSR_OF3_Msk              /*!< Overrun flag 3                       */
+
+/********************  Bits definition for DMAMUX_RGCFR register  **************/
+#define DMAMUX_RGCFR_COF0_Pos                  (0U)
+#define DMAMUX_RGCFR_COF0_Msk                  (0x1UL << DMAMUX_RGCFR_COF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGCFR_COF0                      DMAMUX_RGCFR_COF0_Msk            /*!< Clear Overrun flag 0                 */
+#define DMAMUX_RGCFR_COF1_Pos                  (1U)
+#define DMAMUX_RGCFR_COF1_Msk                  (0x1UL << DMAMUX_RGCFR_COF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGCFR_COF1                      DMAMUX_RGCFR_COF1_Msk            /*!< Clear Overrun flag 1                 */
+#define DMAMUX_RGCFR_COF2_Pos                  (2U)
+#define DMAMUX_RGCFR_COF2_Msk                  (0x1UL << DMAMUX_RGCFR_COF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGCFR_COF2                      DMAMUX_RGCFR_COF2_Msk            /*!< Clear Overrun flag 2                 */
+#define DMAMUX_RGCFR_COF3_Pos                  (3U)
+#define DMAMUX_RGCFR_COF3_Msk                  (0x1UL << DMAMUX_RGCFR_COF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGCFR_COF3                      DMAMUX_RGCFR_COF3_Msk            /*!< Clear Overrun flag 3                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for EXTI_RTSR1 register  ******************/
+#define EXTI_RTSR1_RT0_Pos           (0U)
+#define EXTI_RTSR1_RT0_Msk           (0x1UL << EXTI_RTSR1_RT0_Pos)             /*!< 0x00000001 */
+#define EXTI_RTSR1_RT0               EXTI_RTSR1_RT0_Msk                        /*!< Rising trigger configuration for input line 0 */
+#define EXTI_RTSR1_RT1_Pos           (1U)
+#define EXTI_RTSR1_RT1_Msk           (0x1UL << EXTI_RTSR1_RT1_Pos)             /*!< 0x00000002 */
+#define EXTI_RTSR1_RT1               EXTI_RTSR1_RT1_Msk                        /*!< Rising trigger configuration for input line 1 */
+#define EXTI_RTSR1_RT2_Pos           (2U)
+#define EXTI_RTSR1_RT2_Msk           (0x1UL << EXTI_RTSR1_RT2_Pos)             /*!< 0x00000004 */
+#define EXTI_RTSR1_RT2               EXTI_RTSR1_RT2_Msk                        /*!< Rising trigger configuration for input line 2 */
+#define EXTI_RTSR1_RT3_Pos           (3U)
+#define EXTI_RTSR1_RT3_Msk           (0x1UL << EXTI_RTSR1_RT3_Pos)             /*!< 0x00000008 */
+#define EXTI_RTSR1_RT3               EXTI_RTSR1_RT3_Msk                        /*!< Rising trigger configuration for input line 3 */
+#define EXTI_RTSR1_RT4_Pos           (4U)
+#define EXTI_RTSR1_RT4_Msk           (0x1UL << EXTI_RTSR1_RT4_Pos)             /*!< 0x00000010 */
+#define EXTI_RTSR1_RT4               EXTI_RTSR1_RT4_Msk                        /*!< Rising trigger configuration for input line 4 */
+#define EXTI_RTSR1_RT5_Pos           (5U)
+#define EXTI_RTSR1_RT5_Msk           (0x1UL << EXTI_RTSR1_RT5_Pos)             /*!< 0x00000020 */
+#define EXTI_RTSR1_RT5               EXTI_RTSR1_RT5_Msk                        /*!< Rising trigger configuration for input line 5 */
+#define EXTI_RTSR1_RT6_Pos           (6U)
+#define EXTI_RTSR1_RT6_Msk           (0x1UL << EXTI_RTSR1_RT6_Pos)             /*!< 0x00000040 */
+#define EXTI_RTSR1_RT6               EXTI_RTSR1_RT6_Msk                        /*!< Rising trigger configuration for input line 6 */
+#define EXTI_RTSR1_RT7_Pos           (7U)
+#define EXTI_RTSR1_RT7_Msk           (0x1UL << EXTI_RTSR1_RT7_Pos)             /*!< 0x00000080 */
+#define EXTI_RTSR1_RT7               EXTI_RTSR1_RT7_Msk                        /*!< Rising trigger configuration for input line 7 */
+#define EXTI_RTSR1_RT8_Pos           (8U)
+#define EXTI_RTSR1_RT8_Msk           (0x1UL << EXTI_RTSR1_RT8_Pos)             /*!< 0x00000100 */
+#define EXTI_RTSR1_RT8               EXTI_RTSR1_RT8_Msk                        /*!< Rising trigger configuration for input line 8 */
+#define EXTI_RTSR1_RT9_Pos           (9U)
+#define EXTI_RTSR1_RT9_Msk           (0x1UL << EXTI_RTSR1_RT9_Pos)             /*!< 0x00000200 */
+#define EXTI_RTSR1_RT9               EXTI_RTSR1_RT9_Msk                        /*!< Rising trigger configuration for input line 9 */
+#define EXTI_RTSR1_RT10_Pos          (10U)
+#define EXTI_RTSR1_RT10_Msk          (0x1UL << EXTI_RTSR1_RT10_Pos)            /*!< 0x00000400 */
+#define EXTI_RTSR1_RT10              EXTI_RTSR1_RT10_Msk                       /*!< Rising trigger configuration for input line 10 */
+#define EXTI_RTSR1_RT11_Pos          (11U)
+#define EXTI_RTSR1_RT11_Msk          (0x1UL << EXTI_RTSR1_RT11_Pos)            /*!< 0x00000800 */
+#define EXTI_RTSR1_RT11              EXTI_RTSR1_RT11_Msk                       /*!< Rising trigger configuration for input line 11 */
+#define EXTI_RTSR1_RT12_Pos          (12U)
+#define EXTI_RTSR1_RT12_Msk          (0x1UL << EXTI_RTSR1_RT12_Pos)            /*!< 0x00001000 */
+#define EXTI_RTSR1_RT12              EXTI_RTSR1_RT12_Msk                       /*!< Rising trigger configuration for input line 12 */
+#define EXTI_RTSR1_RT13_Pos          (13U)
+#define EXTI_RTSR1_RT13_Msk          (0x1UL << EXTI_RTSR1_RT13_Pos)            /*!< 0x00002000 */
+#define EXTI_RTSR1_RT13              EXTI_RTSR1_RT13_Msk                       /*!< Rising trigger configuration for input line 13 */
+#define EXTI_RTSR1_RT14_Pos          (14U)
+#define EXTI_RTSR1_RT14_Msk          (0x1UL << EXTI_RTSR1_RT14_Pos)            /*!< 0x00004000 */
+#define EXTI_RTSR1_RT14              EXTI_RTSR1_RT14_Msk                       /*!< Rising trigger configuration for input line 14 */
+#define EXTI_RTSR1_RT15_Pos          (15U)
+#define EXTI_RTSR1_RT15_Msk          (0x1UL << EXTI_RTSR1_RT15_Pos)            /*!< 0x00008000 */
+#define EXTI_RTSR1_RT15              EXTI_RTSR1_RT15_Msk                       /*!< Rising trigger configuration for input line 15 */
+#define EXTI_RTSR1_RT16_Pos          (16U)
+#define EXTI_RTSR1_RT16_Msk          (0x1UL << EXTI_RTSR1_RT16_Pos)            /*!< 0x00010000 */
+#define EXTI_RTSR1_RT16              EXTI_RTSR1_RT16_Msk                       /*!< Rising trigger configuration for input line 16 */
+#define EXTI_RTSR1_RT17_Pos          (17U)
+#define EXTI_RTSR1_RT17_Msk          (0x1UL << EXTI_RTSR1_RT17_Pos)            /*!< 0x00020000 */
+#define EXTI_RTSR1_RT17              EXTI_RTSR1_RT17_Msk                       /*!< Rising trigger configuration for input line 17 */
+#define EXTI_RTSR1_RT18_Pos          (18U)
+#define EXTI_RTSR1_RT18_Msk          (0x1UL << EXTI_RTSR1_RT18_Pos)            /*!< 0x00040000 */
+#define EXTI_RTSR1_RT18              EXTI_RTSR1_RT18_Msk                       /*!< Rising trigger configuration for input line 18 */
+
+/******************  Bit definition for EXTI_FTSR1 register  ******************/
+#define EXTI_FTSR1_FT0_Pos           (0U)
+#define EXTI_FTSR1_FT0_Msk           (0x1UL << EXTI_FTSR1_FT0_Pos)             /*!< 0x00000001 */
+#define EXTI_FTSR1_FT0               EXTI_FTSR1_FT0_Msk                        /*!< Falling trigger configuration for input line 0 */
+#define EXTI_FTSR1_FT1_Pos           (1U)
+#define EXTI_FTSR1_FT1_Msk           (0x1UL << EXTI_FTSR1_FT1_Pos)             /*!< 0x00000002 */
+#define EXTI_FTSR1_FT1               EXTI_FTSR1_FT1_Msk                        /*!< Falling trigger configuration for input line 1 */
+#define EXTI_FTSR1_FT2_Pos           (2U)
+#define EXTI_FTSR1_FT2_Msk           (0x1UL << EXTI_FTSR1_FT2_Pos)             /*!< 0x00000004 */
+#define EXTI_FTSR1_FT2               EXTI_FTSR1_FT2_Msk                        /*!< Falling trigger configuration for input line 2 */
+#define EXTI_FTSR1_FT3_Pos           (3U)
+#define EXTI_FTSR1_FT3_Msk           (0x1UL << EXTI_FTSR1_FT3_Pos)             /*!< 0x00000008 */
+#define EXTI_FTSR1_FT3               EXTI_FTSR1_FT3_Msk                        /*!< Falling trigger configuration for input line 3 */
+#define EXTI_FTSR1_FT4_Pos           (4U)
+#define EXTI_FTSR1_FT4_Msk           (0x1UL << EXTI_FTSR1_FT4_Pos)             /*!< 0x00000010 */
+#define EXTI_FTSR1_FT4               EXTI_FTSR1_FT4_Msk                        /*!< Falling trigger configuration for input line 4 */
+#define EXTI_FTSR1_FT5_Pos           (5U)
+#define EXTI_FTSR1_FT5_Msk           (0x1UL << EXTI_FTSR1_FT5_Pos)             /*!< 0x00000020 */
+#define EXTI_FTSR1_FT5               EXTI_FTSR1_FT5_Msk                        /*!< Falling trigger configuration for input line 5 */
+#define EXTI_FTSR1_FT6_Pos           (6U)
+#define EXTI_FTSR1_FT6_Msk           (0x1UL << EXTI_FTSR1_FT6_Pos)             /*!< 0x00000040 */
+#define EXTI_FTSR1_FT6               EXTI_FTSR1_FT6_Msk                        /*!< Falling trigger configuration for input line 6 */
+#define EXTI_FTSR1_FT7_Pos           (7U)
+#define EXTI_FTSR1_FT7_Msk           (0x1UL << EXTI_FTSR1_FT7_Pos)             /*!< 0x00000080 */
+#define EXTI_FTSR1_FT7               EXTI_FTSR1_FT7_Msk                        /*!< Falling trigger configuration for input line 7 */
+#define EXTI_FTSR1_FT8_Pos           (8U)
+#define EXTI_FTSR1_FT8_Msk           (0x1UL << EXTI_FTSR1_FT8_Pos)             /*!< 0x00000100 */
+#define EXTI_FTSR1_FT8               EXTI_FTSR1_FT8_Msk                        /*!< Falling trigger configuration for input line 8 */
+#define EXTI_FTSR1_FT9_Pos           (9U)
+#define EXTI_FTSR1_FT9_Msk           (0x1UL << EXTI_FTSR1_FT9_Pos)             /*!< 0x00000200 */
+#define EXTI_FTSR1_FT9               EXTI_FTSR1_FT9_Msk                        /*!< Falling trigger configuration for input line 9 */
+#define EXTI_FTSR1_FT10_Pos          (10U)
+#define EXTI_FTSR1_FT10_Msk          (0x1UL << EXTI_FTSR1_FT10_Pos)            /*!< 0x00000400 */
+#define EXTI_FTSR1_FT10              EXTI_FTSR1_FT10_Msk                       /*!< Falling trigger configuration for input line 10 */
+#define EXTI_FTSR1_FT11_Pos          (11U)
+#define EXTI_FTSR1_FT11_Msk          (0x1UL << EXTI_FTSR1_FT11_Pos)            /*!< 0x00000800 */
+#define EXTI_FTSR1_FT11              EXTI_FTSR1_FT11_Msk                       /*!< Falling trigger configuration for input line 11 */
+#define EXTI_FTSR1_FT12_Pos          (12U)
+#define EXTI_FTSR1_FT12_Msk          (0x1UL << EXTI_FTSR1_FT12_Pos)            /*!< 0x00001000 */
+#define EXTI_FTSR1_FT12              EXTI_FTSR1_FT12_Msk                       /*!< Falling trigger configuration for input line 12 */
+#define EXTI_FTSR1_FT13_Pos          (13U)
+#define EXTI_FTSR1_FT13_Msk          (0x1UL << EXTI_FTSR1_FT13_Pos)            /*!< 0x00002000 */
+#define EXTI_FTSR1_FT13              EXTI_FTSR1_FT13_Msk                       /*!< Falling trigger configuration for input line 13 */
+#define EXTI_FTSR1_FT14_Pos          (14U)
+#define EXTI_FTSR1_FT14_Msk          (0x1UL << EXTI_FTSR1_FT14_Pos)            /*!< 0x00004000 */
+#define EXTI_FTSR1_FT14              EXTI_FTSR1_FT14_Msk                       /*!< Falling trigger configuration for input line 14 */
+#define EXTI_FTSR1_FT15_Pos          (15U)
+#define EXTI_FTSR1_FT15_Msk          (0x1UL << EXTI_FTSR1_FT15_Pos)            /*!< 0x00008000 */
+#define EXTI_FTSR1_FT15              EXTI_FTSR1_FT15_Msk                       /*!< Falling trigger configuration for input line 15 */
+#define EXTI_FTSR1_FT16_Pos          (16U)
+#define EXTI_FTSR1_FT16_Msk          (0x1UL << EXTI_FTSR1_FT16_Pos)            /*!< 0x00010000 */
+#define EXTI_FTSR1_FT16              EXTI_FTSR1_FT16_Msk                       /*!< Falling trigger configuration for input line 16 */
+#define EXTI_FTSR1_FT17_Pos          (17U)
+#define EXTI_FTSR1_FT17_Msk          (0x1UL << EXTI_FTSR1_FT17_Pos)            /*!< 0x00020000 */
+#define EXTI_FTSR1_FT17              EXTI_FTSR1_FT17_Msk                       /*!< Falling trigger configuration for input line 17 */
+#define EXTI_FTSR1_FT18_Pos          (18U)
+#define EXTI_FTSR1_FT18_Msk          (0x1UL << EXTI_FTSR1_FT18_Pos)            /*!< 0x00040000 */
+#define EXTI_FTSR1_FT18              EXTI_FTSR1_FT18_Msk                       /*!< Falling trigger configuration for input line 18 */
+
+/******************  Bit definition for EXTI_SWIER1 register  *****************/
+#define EXTI_SWIER1_SWI0_Pos         (0U)
+#define EXTI_SWIER1_SWI0_Msk         (0x1UL << EXTI_SWIER1_SWI0_Pos)           /*!< 0x00000001 */
+#define EXTI_SWIER1_SWI0             EXTI_SWIER1_SWI0_Msk                      /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER1_SWI1_Pos         (1U)
+#define EXTI_SWIER1_SWI1_Msk         (0x1UL << EXTI_SWIER1_SWI1_Pos)           /*!< 0x00000002 */
+#define EXTI_SWIER1_SWI1             EXTI_SWIER1_SWI1_Msk                      /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER1_SWI2_Pos         (2U)
+#define EXTI_SWIER1_SWI2_Msk         (0x1UL << EXTI_SWIER1_SWI2_Pos)           /*!< 0x00000004 */
+#define EXTI_SWIER1_SWI2             EXTI_SWIER1_SWI2_Msk                      /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER1_SWI3_Pos         (3U)
+#define EXTI_SWIER1_SWI3_Msk         (0x1UL << EXTI_SWIER1_SWI3_Pos)           /*!< 0x00000008 */
+#define EXTI_SWIER1_SWI3             EXTI_SWIER1_SWI3_Msk                      /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER1_SWI4_Pos         (4U)
+#define EXTI_SWIER1_SWI4_Msk         (0x1UL << EXTI_SWIER1_SWI4_Pos)           /*!< 0x00000010 */
+#define EXTI_SWIER1_SWI4             EXTI_SWIER1_SWI4_Msk                      /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER1_SWI5_Pos         (5U)
+#define EXTI_SWIER1_SWI5_Msk         (0x1UL << EXTI_SWIER1_SWI5_Pos)           /*!< 0x00000020 */
+#define EXTI_SWIER1_SWI5             EXTI_SWIER1_SWI5_Msk                      /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER1_SWI6_Pos         (6U)
+#define EXTI_SWIER1_SWI6_Msk         (0x1UL << EXTI_SWIER1_SWI6_Pos)           /*!< 0x00000040 */
+#define EXTI_SWIER1_SWI6             EXTI_SWIER1_SWI6_Msk                      /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER1_SWI7_Pos         (7U)
+#define EXTI_SWIER1_SWI7_Msk         (0x1UL << EXTI_SWIER1_SWI7_Pos)           /*!< 0x00000080 */
+#define EXTI_SWIER1_SWI7             EXTI_SWIER1_SWI7_Msk                      /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER1_SWI8_Pos         (8U)
+#define EXTI_SWIER1_SWI8_Msk         (0x1UL << EXTI_SWIER1_SWI8_Pos)           /*!< 0x00000100 */
+#define EXTI_SWIER1_SWI8             EXTI_SWIER1_SWI8_Msk                      /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER1_SWI9_Pos         (9U)
+#define EXTI_SWIER1_SWI9_Msk         (0x1UL << EXTI_SWIER1_SWI9_Pos)           /*!< 0x00000200 */
+#define EXTI_SWIER1_SWI9             EXTI_SWIER1_SWI9_Msk                      /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER1_SWI10_Pos        (10U)
+#define EXTI_SWIER1_SWI10_Msk        (0x1UL << EXTI_SWIER1_SWI10_Pos)          /*!< 0x00000400 */
+#define EXTI_SWIER1_SWI10            EXTI_SWIER1_SWI10_Msk                     /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER1_SWI11_Pos        (11U)
+#define EXTI_SWIER1_SWI11_Msk        (0x1UL << EXTI_SWIER1_SWI11_Pos)          /*!< 0x00000800 */
+#define EXTI_SWIER1_SWI11            EXTI_SWIER1_SWI11_Msk                     /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER1_SWI12_Pos        (12U)
+#define EXTI_SWIER1_SWI12_Msk        (0x1UL << EXTI_SWIER1_SWI12_Pos)          /*!< 0x00001000 */
+#define EXTI_SWIER1_SWI12            EXTI_SWIER1_SWI12_Msk                     /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER1_SWI13_Pos        (13U)
+#define EXTI_SWIER1_SWI13_Msk        (0x1UL << EXTI_SWIER1_SWI13_Pos)          /*!< 0x00002000 */
+#define EXTI_SWIER1_SWI13            EXTI_SWIER1_SWI13_Msk                     /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER1_SWI14_Pos        (14U)
+#define EXTI_SWIER1_SWI14_Msk        (0x1UL << EXTI_SWIER1_SWI14_Pos)          /*!< 0x00004000 */
+#define EXTI_SWIER1_SWI14            EXTI_SWIER1_SWI14_Msk                     /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER1_SWI15_Pos        (15U)
+#define EXTI_SWIER1_SWI15_Msk        (0x1UL << EXTI_SWIER1_SWI15_Pos)          /*!< 0x00008000 */
+#define EXTI_SWIER1_SWI15            EXTI_SWIER1_SWI15_Msk                     /*!< Software Interrupt on line 15 */
+#define EXTI_SWIER1_SWI16_Pos        (16U)
+#define EXTI_SWIER1_SWI16_Msk        (0x1UL << EXTI_SWIER1_SWI16_Pos)          /*!< 0x00010000 */
+#define EXTI_SWIER1_SWI16            EXTI_SWIER1_SWI16_Msk                     /*!< Software Interrupt on line 16 */
+#define EXTI_SWIER1_SWI17_Pos        (17U)
+#define EXTI_SWIER1_SWI17_Msk        (0x1UL << EXTI_SWIER1_SWI17_Pos)          /*!< 0x00020000 */
+#define EXTI_SWIER1_SWI17            EXTI_SWIER1_SWI17_Msk                     /*!< Software Interrupt on line 17 */
+#define EXTI_SWIER1_SWI18_Pos        (18U)
+#define EXTI_SWIER1_SWI18_Msk        (0x1UL << EXTI_SWIER1_SWI18_Pos)          /*!< 0x00040000 */
+#define EXTI_SWIER1_SWI18            EXTI_SWIER1_SWI18_Msk                     /*!< Software Interrupt on line 18 */
+
+/*******************  Bit definition for EXTI_RPR1 register  ******************/
+#define EXTI_RPR1_RPIF0_Pos          (0U)
+#define EXTI_RPR1_RPIF0_Msk          (0x1UL << EXTI_RPR1_RPIF0_Pos)            /*!< 0x00000001 */
+#define EXTI_RPR1_RPIF0              EXTI_RPR1_RPIF0_Msk                       /*!< Rising Pending Interrupt Flag on line 0 */
+#define EXTI_RPR1_RPIF1_Pos          (1U)
+#define EXTI_RPR1_RPIF1_Msk          (0x1UL << EXTI_RPR1_RPIF1_Pos)            /*!< 0x00000002 */
+#define EXTI_RPR1_RPIF1              EXTI_RPR1_RPIF1_Msk                       /*!< Rising Pending Interrupt Flag on line 1 */
+#define EXTI_RPR1_RPIF2_Pos          (2U)
+#define EXTI_RPR1_RPIF2_Msk          (0x1UL << EXTI_RPR1_RPIF2_Pos)            /*!< 0x00000004 */
+#define EXTI_RPR1_RPIF2              EXTI_RPR1_RPIF2_Msk                       /*!< Rising Pending Interrupt Flag on line 2 */
+#define EXTI_RPR1_RPIF3_Pos          (3U)
+#define EXTI_RPR1_RPIF3_Msk          (0x1UL << EXTI_RPR1_RPIF3_Pos)            /*!< 0x00000008 */
+#define EXTI_RPR1_RPIF3              EXTI_RPR1_RPIF3_Msk                       /*!< Rising Pending Interrupt Flag on line 3 */
+#define EXTI_RPR1_RPIF4_Pos          (4U)
+#define EXTI_RPR1_RPIF4_Msk          (0x1UL << EXTI_RPR1_RPIF4_Pos)            /*!< 0x00000010 */
+#define EXTI_RPR1_RPIF4              EXTI_RPR1_RPIF4_Msk                       /*!< Rising Pending Interrupt Flag on line 4 */
+#define EXTI_RPR1_RPIF5_Pos          (5U)
+#define EXTI_RPR1_RPIF5_Msk          (0x1UL << EXTI_RPR1_RPIF5_Pos)            /*!< 0x00000020 */
+#define EXTI_RPR1_RPIF5              EXTI_RPR1_RPIF5_Msk                       /*!< Rising Pending Interrupt Flag on line 5 */
+#define EXTI_RPR1_RPIF6_Pos          (6U)
+#define EXTI_RPR1_RPIF6_Msk          (0x1UL << EXTI_RPR1_RPIF6_Pos)            /*!< 0x00000040 */
+#define EXTI_RPR1_RPIF6              EXTI_RPR1_RPIF6_Msk                       /*!< Rising Pending Interrupt Flag on line 6 */
+#define EXTI_RPR1_RPIF7_Pos          (7U)
+#define EXTI_RPR1_RPIF7_Msk          (0x1UL << EXTI_RPR1_RPIF7_Pos)            /*!< 0x00000080 */
+#define EXTI_RPR1_RPIF7              EXTI_RPR1_RPIF7_Msk                       /*!< Rising Pending Interrupt Flag on line 7 */
+#define EXTI_RPR1_RPIF8_Pos          (8U)
+#define EXTI_RPR1_RPIF8_Msk          (0x1UL << EXTI_RPR1_RPIF8_Pos)            /*!< 0x00000100 */
+#define EXTI_RPR1_RPIF8              EXTI_RPR1_RPIF8_Msk                       /*!< Rising Pending Interrupt Flag on line 8 */
+#define EXTI_RPR1_RPIF9_Pos          (9U)
+#define EXTI_RPR1_RPIF9_Msk          (0x1UL << EXTI_RPR1_RPIF9_Pos)            /*!< 0x00000200 */
+#define EXTI_RPR1_RPIF9              EXTI_RPR1_RPIF9_Msk                       /*!< Rising Pending Interrupt Flag on line 9 */
+#define EXTI_RPR1_RPIF10_Pos         (10U)
+#define EXTI_RPR1_RPIF10_Msk         (0x1UL << EXTI_RPR1_RPIF10_Pos)           /*!< 0x00000400 */
+#define EXTI_RPR1_RPIF10             EXTI_RPR1_RPIF10_Msk                      /*!< Rising Pending Interrupt Flag on line 10 */
+#define EXTI_RPR1_RPIF11_Pos         (11U)
+#define EXTI_RPR1_RPIF11_Msk         (0x1UL << EXTI_RPR1_RPIF11_Pos)           /*!< 0x00000800 */
+#define EXTI_RPR1_RPIF11             EXTI_RPR1_RPIF11_Msk                      /*!< Rising Pending Interrupt Flag on line 11 */
+#define EXTI_RPR1_RPIF12_Pos         (12U)
+#define EXTI_RPR1_RPIF12_Msk         (0x1UL << EXTI_RPR1_RPIF12_Pos)           /*!< 0x00001000 */
+#define EXTI_RPR1_RPIF12             EXTI_RPR1_RPIF12_Msk                      /*!< Rising Pending Interrupt Flag on line 12 */
+#define EXTI_RPR1_RPIF13_Pos         (13U)
+#define EXTI_RPR1_RPIF13_Msk         (0x1UL << EXTI_RPR1_RPIF13_Pos)           /*!< 0x00002000 */
+#define EXTI_RPR1_RPIF13             EXTI_RPR1_RPIF13_Msk                      /*!< Rising Pending Interrupt Flag on line 13 */
+#define EXTI_RPR1_RPIF14_Pos         (14U)
+#define EXTI_RPR1_RPIF14_Msk         (0x1UL << EXTI_RPR1_RPIF14_Pos)           /*!< 0x00004000 */
+#define EXTI_RPR1_RPIF14             EXTI_RPR1_RPIF14_Msk                      /*!< Rising Pending Interrupt Flag on line 14 */
+#define EXTI_RPR1_RPIF15_Pos         (15U)
+#define EXTI_RPR1_RPIF15_Msk         (0x1UL << EXTI_RPR1_RPIF15_Pos)           /*!< 0x00008000 */
+#define EXTI_RPR1_RPIF15             EXTI_RPR1_RPIF15_Msk                      /*!< Rising Pending Interrupt Flag on line 15 */
+#define EXTI_RPR1_RPIF16_Pos         (16U)
+#define EXTI_RPR1_RPIF16_Msk         (0x1UL << EXTI_RPR1_RPIF16_Pos)           /*!< 0x00010000 */
+#define EXTI_RPR1_RPIF16             EXTI_RPR1_RPIF16_Msk                      /*!< Rising Pending Interrupt Flag on line 16 */
+#define EXTI_RPR1_RPIF17_Pos         (17U)
+#define EXTI_RPR1_RPIF17_Msk         (0x1UL << EXTI_RPR1_RPIF17_Pos)           /*!< 0x00020000 */
+#define EXTI_RPR1_RPIF17             EXTI_RPR1_RPIF17_Msk                      /*!< Rising Pending Interrupt Flag on line 17 */
+#define EXTI_RPR1_RPIF18_Pos         (18U)
+#define EXTI_RPR1_RPIF18_Msk         (0x1UL << EXTI_RPR1_RPIF18_Pos)           /*!< 0x00040000 */
+#define EXTI_RPR1_RPIF18             EXTI_RPR1_RPIF18_Msk                      /*!< Rising Pending Interrupt Flag on line 18 */
+
+/*******************  Bit definition for EXTI_FPR1 register  ******************/
+#define EXTI_FPR1_FPIF0_Pos          (0U)
+#define EXTI_FPR1_FPIF0_Msk          (0x1UL << EXTI_FPR1_FPIF0_Pos)            /*!< 0x00000001 */
+#define EXTI_FPR1_FPIF0              EXTI_FPR1_FPIF0_Msk                       /*!< Falling Pending Interrupt Flag on line 0 */
+#define EXTI_FPR1_FPIF1_Pos          (1U)
+#define EXTI_FPR1_FPIF1_Msk          (0x1UL << EXTI_FPR1_FPIF1_Pos)            /*!< 0x00000002 */
+#define EXTI_FPR1_FPIF1              EXTI_FPR1_FPIF1_Msk                       /*!< Falling Pending Interrupt Flag on line 1 */
+#define EXTI_FPR1_FPIF2_Pos          (2U)
+#define EXTI_FPR1_FPIF2_Msk          (0x1UL << EXTI_FPR1_FPIF2_Pos)            /*!< 0x00000004 */
+#define EXTI_FPR1_FPIF2              EXTI_FPR1_FPIF2_Msk                       /*!< Falling Pending Interrupt Flag on line 2 */
+#define EXTI_FPR1_FPIF3_Pos          (3U)
+#define EXTI_FPR1_FPIF3_Msk          (0x1UL << EXTI_FPR1_FPIF3_Pos)            /*!< 0x00000008 */
+#define EXTI_FPR1_FPIF3              EXTI_FPR1_FPIF3_Msk                       /*!< Falling Pending Interrupt Flag on line 3 */
+#define EXTI_FPR1_FPIF4_Pos          (4U)
+#define EXTI_FPR1_FPIF4_Msk          (0x1UL << EXTI_FPR1_FPIF4_Pos)            /*!< 0x00000010 */
+#define EXTI_FPR1_FPIF4              EXTI_FPR1_FPIF4_Msk                       /*!< Falling Pending Interrupt Flag on line 4 */
+#define EXTI_FPR1_FPIF5_Pos          (5U)
+#define EXTI_FPR1_FPIF5_Msk          (0x1UL << EXTI_FPR1_FPIF5_Pos)            /*!< 0x00000020 */
+#define EXTI_FPR1_FPIF5              EXTI_FPR1_FPIF5_Msk                       /*!< Falling Pending Interrupt Flag on line 5 */
+#define EXTI_FPR1_FPIF6_Pos          (6U)
+#define EXTI_FPR1_FPIF6_Msk          (0x1UL << EXTI_FPR1_FPIF6_Pos)            /*!< 0x00000040 */
+#define EXTI_FPR1_FPIF6              EXTI_FPR1_FPIF6_Msk                       /*!< Falling Pending Interrupt Flag on line 6 */
+#define EXTI_FPR1_FPIF7_Pos          (7U)
+#define EXTI_FPR1_FPIF7_Msk          (0x1UL << EXTI_FPR1_FPIF7_Pos)            /*!< 0x00000080 */
+#define EXTI_FPR1_FPIF7              EXTI_FPR1_FPIF7_Msk                       /*!< Falling Pending Interrupt Flag on line 7 */
+#define EXTI_FPR1_FPIF8_Pos          (8U)
+#define EXTI_FPR1_FPIF8_Msk          (0x1UL << EXTI_FPR1_FPIF8_Pos)            /*!< 0x00000100 */
+#define EXTI_FPR1_FPIF8              EXTI_FPR1_FPIF8_Msk                       /*!< Falling Pending Interrupt Flag on line 8 */
+#define EXTI_FPR1_FPIF9_Pos          (9U)
+#define EXTI_FPR1_FPIF9_Msk          (0x1UL << EXTI_FPR1_FPIF9_Pos)            /*!< 0x00000200 */
+#define EXTI_FPR1_FPIF9              EXTI_FPR1_FPIF9_Msk                       /*!< Falling Pending Interrupt Flag on line 9 */
+#define EXTI_FPR1_FPIF10_Pos         (10U)
+#define EXTI_FPR1_FPIF10_Msk         (0x1UL << EXTI_FPR1_FPIF10_Pos)           /*!< 0x00000400 */
+#define EXTI_FPR1_FPIF10             EXTI_FPR1_FPIF10_Msk                      /*!< Falling Pending Interrupt Flag on line 10 */
+#define EXTI_FPR1_FPIF11_Pos         (11U)
+#define EXTI_FPR1_FPIF11_Msk         (0x1UL << EXTI_FPR1_FPIF11_Pos)           /*!< 0x00000800 */
+#define EXTI_FPR1_FPIF11             EXTI_FPR1_FPIF11_Msk                      /*!< Falling Pending Interrupt Flag on line 11 */
+#define EXTI_FPR1_FPIF12_Pos         (12U)
+#define EXTI_FPR1_FPIF12_Msk         (0x1UL << EXTI_FPR1_FPIF12_Pos)           /*!< 0x00001000 */
+#define EXTI_FPR1_FPIF12             EXTI_FPR1_FPIF12_Msk                      /*!< Falling Pending Interrupt Flag on line 12 */
+#define EXTI_FPR1_FPIF13_Pos         (13U)
+#define EXTI_FPR1_FPIF13_Msk         (0x1UL << EXTI_FPR1_FPIF13_Pos)           /*!< 0x00002000 */
+#define EXTI_FPR1_FPIF13             EXTI_FPR1_FPIF13_Msk                      /*!< Falling Pending Interrupt Flag on line 13 */
+#define EXTI_FPR1_FPIF14_Pos         (14U)
+#define EXTI_FPR1_FPIF14_Msk         (0x1UL << EXTI_FPR1_FPIF14_Pos)           /*!< 0x00004000 */
+#define EXTI_FPR1_FPIF14             EXTI_FPR1_FPIF14_Msk                      /*!< Falling Pending Interrupt Flag on line 14 */
+#define EXTI_FPR1_FPIF15_Pos         (15U)
+#define EXTI_FPR1_FPIF15_Msk         (0x1UL << EXTI_FPR1_FPIF15_Pos)           /*!< 0x00008000 */
+#define EXTI_FPR1_FPIF15             EXTI_FPR1_FPIF15_Msk                      /*!< Falling Pending Interrupt Flag on line 15 */
+#define EXTI_FPR1_FPIF16_Pos         (16U)
+#define EXTI_FPR1_FPIF16_Msk         (0x1UL << EXTI_FPR1_FPIF16_Pos)           /*!< 0x00010000 */
+#define EXTI_FPR1_FPIF16             EXTI_FPR1_FPIF16_Msk                      /*!< Falling Pending Interrupt Flag on line 16 */
+#define EXTI_FPR1_FPIF17_Pos         (17U)
+#define EXTI_FPR1_FPIF17_Msk         (0x1UL << EXTI_FPR1_FPIF17_Pos)           /*!< 0x00020000 */
+#define EXTI_FPR1_FPIF17             EXTI_FPR1_FPIF17_Msk                      /*!< Falling Pending Interrupt Flag on line 17 */
+#define EXTI_FPR1_FPIF18_Pos         (18U)
+#define EXTI_FPR1_FPIF18_Msk         (0x1UL << EXTI_FPR1_FPIF18_Pos)           /*!< 0x00040000 */
+#define EXTI_FPR1_FPIF18             EXTI_FPR1_FPIF18_Msk                      /*!< Falling Pending Interrupt Flag on line 18 */
+
+/*****************  Bit definition for EXTI_EXTICR1 register  **************/
+#define EXTI_EXTICR1_EXTI0_Pos       (0U)
+#define EXTI_EXTICR1_EXTI0_Msk       (0x7UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR1_EXTI0           EXTI_EXTICR1_EXTI0_Msk                    /*!< EXTI 0 configuration */
+#define EXTI_EXTICR1_EXTI0_0         (0x1UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR1_EXTI0_1         (0x2UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR1_EXTI0_2         (0x4UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR1_EXTI1_Pos       (8U)
+#define EXTI_EXTICR1_EXTI1_Msk       (0x7UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR1_EXTI1           EXTI_EXTICR1_EXTI1_Msk                    /*!< EXTI 1 configuration */
+#define EXTI_EXTICR1_EXTI1_0         (0x1UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR1_EXTI1_1         (0x2UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR1_EXTI1_2         (0x4UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR1_EXTI2_Pos       (16U)
+#define EXTI_EXTICR1_EXTI2_Msk       (0x7UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00070000 */
+#define EXTI_EXTICR1_EXTI2           EXTI_EXTICR1_EXTI2_Msk                    /*!< EXTI 2 configuration */
+#define EXTI_EXTICR1_EXTI2_0         (0x1UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00010000 */
+#define EXTI_EXTICR1_EXTI2_1         (0x2UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00020000 */
+#define EXTI_EXTICR1_EXTI2_2         (0x4UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00040000 */
+#define EXTI_EXTICR1_EXTI3_Pos       (24U)
+#define EXTI_EXTICR1_EXTI3_Msk       (0x7UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x07000000 */
+#define EXTI_EXTICR1_EXTI3           EXTI_EXTICR1_EXTI3_Msk                    /*!< EXTI 3 configuration */
+#define EXTI_EXTICR1_EXTI3_0         (0x1UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x01000000 */
+#define EXTI_EXTICR1_EXTI3_1         (0x2UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x02000000 */
+#define EXTI_EXTICR1_EXTI3_2         (0x4UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR2 register  **************/
+#define EXTI_EXTICR2_EXTI4_Pos       (0U)
+#define EXTI_EXTICR2_EXTI4_Msk       (0x7UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR2_EXTI4           EXTI_EXTICR2_EXTI4_Msk                    /*!< EXTI 4 configuration */
+#define EXTI_EXTICR2_EXTI4_0         (0x1UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR2_EXTI4_1         (0x2UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR2_EXTI4_2         (0x4UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR2_EXTI5_Pos       (8U)
+#define EXTI_EXTICR2_EXTI5_Msk       (0x7UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR2_EXTI5           EXTI_EXTICR2_EXTI5_Msk                    /*!< EXTI 5 configuration */
+#define EXTI_EXTICR2_EXTI5_0         (0x1UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR2_EXTI5_1         (0x2UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR2_EXTI5_2         (0x4UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR2_EXTI6_Pos       (16U)
+#define EXTI_EXTICR2_EXTI6_Msk       (0x7UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00070000 */
+#define EXTI_EXTICR2_EXTI6           EXTI_EXTICR2_EXTI6_Msk                    /*!< EXTI 6 configuration */
+#define EXTI_EXTICR2_EXTI6_0         (0x1UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00010000 */
+#define EXTI_EXTICR2_EXTI6_1         (0x2UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00020000 */
+#define EXTI_EXTICR2_EXTI6_2         (0x4UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00040000 */
+#define EXTI_EXTICR2_EXTI7_Pos       (24U)
+#define EXTI_EXTICR2_EXTI7_Msk       (0x7UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x07000000 */
+#define EXTI_EXTICR2_EXTI7           EXTI_EXTICR2_EXTI7_Msk                    /*!< EXTI 7 configuration */
+#define EXTI_EXTICR2_EXTI7_0         (0x1UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x01000000 */
+#define EXTI_EXTICR2_EXTI7_1         (0x2UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x02000000 */
+#define EXTI_EXTICR2_EXTI7_2         (0x4UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR3 register  **************/
+#define EXTI_EXTICR3_EXTI8_Pos       (0U)
+#define EXTI_EXTICR3_EXTI8_Msk       (0x7UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR3_EXTI8           EXTI_EXTICR3_EXTI8_Msk                    /*!< EXTI 8 configuration */
+#define EXTI_EXTICR3_EXTI8_0         (0x1UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR3_EXTI8_1         (0x2UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR3_EXTI8_2         (0x4UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR3_EXTI9_Pos       (8U)
+#define EXTI_EXTICR3_EXTI9_Msk       (0x7UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR3_EXTI9           EXTI_EXTICR3_EXTI9_Msk                    /*!< EXTI 9 configuration */
+#define EXTI_EXTICR3_EXTI9_0         (0x1UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR3_EXTI9_1         (0x2UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR3_EXTI9_2         (0x4UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR3_EXTI10_Pos      (16U)
+#define EXTI_EXTICR3_EXTI10_Msk      (0x7UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00070000 */
+#define EXTI_EXTICR3_EXTI10          EXTI_EXTICR3_EXTI10_Msk                   /*!< EXTI 10 configuration */
+#define EXTI_EXTICR3_EXTI10_0        (0x1UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00010000 */
+#define EXTI_EXTICR3_EXTI10_1        (0x2UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00020000 */
+#define EXTI_EXTICR3_EXTI10_2        (0x4UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00040000 */
+#define EXTI_EXTICR3_EXTI11_Pos      (24U)
+#define EXTI_EXTICR3_EXTI11_Msk      (0x7UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x07000000 */
+#define EXTI_EXTICR3_EXTI11          EXTI_EXTICR3_EXTI11_Msk                   /*!< EXTI 11 configuration */
+#define EXTI_EXTICR3_EXTI11_0        (0x1UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x01000000 */
+#define EXTI_EXTICR3_EXTI11_1        (0x2UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x02000000 */
+#define EXTI_EXTICR3_EXTI11_2        (0x4UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR4 register  **************/
+#define EXTI_EXTICR4_EXTI12_Pos      (0U)
+#define EXTI_EXTICR4_EXTI12_Msk      (0x7UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000007 */
+#define EXTI_EXTICR4_EXTI12          EXTI_EXTICR4_EXTI12_Msk                   /*!< EXTI 12 configuration */
+#define EXTI_EXTICR4_EXTI12_0        (0x1UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000001 */
+#define EXTI_EXTICR4_EXTI12_1        (0x2UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000002 */
+#define EXTI_EXTICR4_EXTI12_2        (0x4UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000004 */
+#define EXTI_EXTICR4_EXTI13_Pos      (8U)
+#define EXTI_EXTICR4_EXTI13_Msk      (0x7UL << EXTI_EXTICR4_EXTI13_Pos)        /*!< 0x00000700 */
+#define EXTI_EXTICR4_EXTI13          EXTI_EXTICR4_EXTI13_Msk                   /*!< EXTI 13 configuration */
+#define EXTI_EXTICR4_EXTI13_0        (0x1UL << EXTI_EXTICR4_EXTI13_Pos)        /*!< 0x00000100 */
+#define EXTI_EXTICR4_EXTI13_1        (0x2UL << EXTI_EXTICR4_EXTI13_Pos)       /*!< 0x00000200 */
+#define EXTI_EXTICR4_EXTI13_2        (0x4UL << EXTI_EXTICR4_EXTI13_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR4_EXTI14_Pos      (16U)
+#define EXTI_EXTICR4_EXTI14_Msk      (0x7UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00070000 */
+#define EXTI_EXTICR4_EXTI14          EXTI_EXTICR4_EXTI14_Msk                   /*!< EXTI 14 configuration */
+#define EXTI_EXTICR4_EXTI14_0        (0x1UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00010000 */
+#define EXTI_EXTICR4_EXTI14_1        (0x2UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00020000 */
+#define EXTI_EXTICR4_EXTI14_2        (0x4UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00040000 */
+#define EXTI_EXTICR4_EXTI15_Pos      (24U)
+#define EXTI_EXTICR4_EXTI15_Msk      (0x7UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x07000000 */
+#define EXTI_EXTICR4_EXTI15          EXTI_EXTICR4_EXTI15_Msk                   /*!< EXTI 15 configuration */
+#define EXTI_EXTICR4_EXTI15_0        (0x1UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x01000000 */
+#define EXTI_EXTICR4_EXTI15_1        (0x2UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x02000000 */
+#define EXTI_EXTICR4_EXTI15_2        (0x4UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x04000000 */
+
+/*******************  Bit definition for EXTI_IMR1 register  ******************/
+#define EXTI_IMR1_IM0_Pos            (0U)
+#define EXTI_IMR1_IM0_Msk            (0x1UL << EXTI_IMR1_IM0_Pos)              /*!< 0x00000001 */
+#define EXTI_IMR1_IM0                EXTI_IMR1_IM0_Msk                         /*!< Interrupt Mask on line 0 */
+#define EXTI_IMR1_IM1_Pos            (1U)
+#define EXTI_IMR1_IM1_Msk            (0x1UL << EXTI_IMR1_IM1_Pos)              /*!< 0x00000002 */
+#define EXTI_IMR1_IM1                EXTI_IMR1_IM1_Msk                         /*!< Interrupt Mask on line 1 */
+#define EXTI_IMR1_IM2_Pos            (2U)
+#define EXTI_IMR1_IM2_Msk            (0x1UL << EXTI_IMR1_IM2_Pos)              /*!< 0x00000004 */
+#define EXTI_IMR1_IM2                EXTI_IMR1_IM2_Msk                         /*!< Interrupt Mask on line 2 */
+#define EXTI_IMR1_IM3_Pos            (3U)
+#define EXTI_IMR1_IM3_Msk            (0x1UL << EXTI_IMR1_IM3_Pos)              /*!< 0x00000008 */
+#define EXTI_IMR1_IM3                EXTI_IMR1_IM3_Msk                         /*!< Interrupt Mask on line 3 */
+#define EXTI_IMR1_IM4_Pos            (4U)
+#define EXTI_IMR1_IM4_Msk            (0x1UL << EXTI_IMR1_IM4_Pos)              /*!< 0x00000010 */
+#define EXTI_IMR1_IM4                EXTI_IMR1_IM4_Msk                         /*!< Interrupt Mask on line 4 */
+#define EXTI_IMR1_IM5_Pos            (5U)
+#define EXTI_IMR1_IM5_Msk            (0x1UL << EXTI_IMR1_IM5_Pos)              /*!< 0x00000020 */
+#define EXTI_IMR1_IM5                EXTI_IMR1_IM5_Msk                         /*!< Interrupt Mask on line 5 */
+#define EXTI_IMR1_IM6_Pos            (6U)
+#define EXTI_IMR1_IM6_Msk            (0x1UL << EXTI_IMR1_IM6_Pos)              /*!< 0x00000040 */
+#define EXTI_IMR1_IM6                EXTI_IMR1_IM6_Msk                         /*!< Interrupt Mask on line 6 */
+#define EXTI_IMR1_IM7_Pos            (7U)
+#define EXTI_IMR1_IM7_Msk            (0x1UL << EXTI_IMR1_IM7_Pos)              /*!< 0x00000080 */
+#define EXTI_IMR1_IM7                EXTI_IMR1_IM7_Msk                         /*!< Interrupt Mask on line 7 */
+#define EXTI_IMR1_IM8_Pos            (8U)
+#define EXTI_IMR1_IM8_Msk            (0x1UL << EXTI_IMR1_IM8_Pos)              /*!< 0x00000100 */
+#define EXTI_IMR1_IM8                EXTI_IMR1_IM8_Msk                         /*!< Interrupt Mask on line 8 */
+#define EXTI_IMR1_IM9_Pos            (9U)
+#define EXTI_IMR1_IM9_Msk            (0x1UL << EXTI_IMR1_IM9_Pos)              /*!< 0x00000200 */
+#define EXTI_IMR1_IM9                EXTI_IMR1_IM9_Msk                         /*!< Interrupt Mask on line 9 */
+#define EXTI_IMR1_IM10_Pos           (10U)
+#define EXTI_IMR1_IM10_Msk           (0x1UL << EXTI_IMR1_IM10_Pos)             /*!< 0x00000400 */
+#define EXTI_IMR1_IM10               EXTI_IMR1_IM10_Msk                        /*!< Interrupt Mask on line 10 */
+#define EXTI_IMR1_IM11_Pos           (11U)
+#define EXTI_IMR1_IM11_Msk           (0x1UL << EXTI_IMR1_IM11_Pos)             /*!< 0x00000800 */
+#define EXTI_IMR1_IM11               EXTI_IMR1_IM11_Msk                        /*!< Interrupt Mask on line 11 */
+#define EXTI_IMR1_IM12_Pos           (12U)
+#define EXTI_IMR1_IM12_Msk           (0x1UL << EXTI_IMR1_IM12_Pos)             /*!< 0x00001000 */
+#define EXTI_IMR1_IM12               EXTI_IMR1_IM12_Msk                        /*!< Interrupt Mask on line 12 */
+#define EXTI_IMR1_IM13_Pos           (13U)
+#define EXTI_IMR1_IM13_Msk           (0x1UL << EXTI_IMR1_IM13_Pos)             /*!< 0x00002000 */
+#define EXTI_IMR1_IM13               EXTI_IMR1_IM13_Msk                        /*!< Interrupt Mask on line 13 */
+#define EXTI_IMR1_IM14_Pos           (14U)
+#define EXTI_IMR1_IM14_Msk           (0x1UL << EXTI_IMR1_IM14_Pos)             /*!< 0x00004000 */
+#define EXTI_IMR1_IM14               EXTI_IMR1_IM14_Msk                        /*!< Interrupt Mask on line 14 */
+#define EXTI_IMR1_IM15_Pos           (15U)
+#define EXTI_IMR1_IM15_Msk           (0x1UL << EXTI_IMR1_IM15_Pos)             /*!< 0x00008000 */
+#define EXTI_IMR1_IM15               EXTI_IMR1_IM15_Msk                        /*!< Interrupt Mask on line 15 */
+#define EXTI_IMR1_IM16_Pos           (16U)
+#define EXTI_IMR1_IM16_Msk           (0x1UL << EXTI_IMR1_IM16_Pos)             /*!< 0x00010000 */
+#define EXTI_IMR1_IM16               EXTI_IMR1_IM16_Msk                        /*!< Interrupt Mask on line 16 */
+#define EXTI_IMR1_IM17_Pos           (17U)
+#define EXTI_IMR1_IM17_Msk           (0x1UL << EXTI_IMR1_IM17_Pos)             /*!< 0x00020000 */
+#define EXTI_IMR1_IM17               EXTI_IMR1_IM17_Msk                        /*!< Interrupt Mask on line 17 */
+#define EXTI_IMR1_IM18_Pos           (18U)
+#define EXTI_IMR1_IM18_Msk           (0x1UL << EXTI_IMR1_IM18_Pos)             /*!< 0x00040000 */
+#define EXTI_IMR1_IM18               EXTI_IMR1_IM18_Msk                        /*!< Interrupt Mask on line 18 */
+#define EXTI_IMR1_IM19_Pos           (19U)
+#define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
+#define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
+#define EXTI_IMR1_IM21_Pos           (21U)
+#define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
+#define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
+#define EXTI_IMR1_IM23_Pos           (23U)
+#define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
+#define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
+#define EXTI_IMR1_IM25_Pos           (25U)
+#define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
+#define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
+#define EXTI_IMR1_IM28_Pos           (28U)
+#define EXTI_IMR1_IM28_Msk           (0x1UL << EXTI_IMR1_IM28_Pos)             /*!< 0x10000000 */
+#define EXTI_IMR1_IM28               EXTI_IMR1_IM28_Msk                        /*!< Interrupt Mask on line 28 */
+#define EXTI_IMR1_IM29_Pos           (29U)
+#define EXTI_IMR1_IM29_Msk           (0x1UL << EXTI_IMR1_IM29_Pos)             /*!< 0x20000000 */
+#define EXTI_IMR1_IM29               EXTI_IMR1_IM29_Msk                        /*!< Interrupt Mask on line 29 */
+#define EXTI_IMR1_IM30_Pos           (30U)
+#define EXTI_IMR1_IM30_Msk           (0x1UL << EXTI_IMR1_IM30_Pos)             /*!< 0x40000000 */
+#define EXTI_IMR1_IM30               EXTI_IMR1_IM30_Msk                        /*!< Interrupt Mask on line 30 */
+#define EXTI_IMR1_IM31_Pos           (31U)
+#define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
+#define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
+#define EXTI_IMR1_IM_Pos             (0U)
+#define EXTI_IMR1_IM_Msk             (0xF2AFFFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xF6AFFFFF */
+#define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
+
+
+/*******************  Bit definition for EXTI_EMR1 register  ******************/
+#define EXTI_EMR1_EM0_Pos            (0U)
+#define EXTI_EMR1_EM0_Msk            (0x1UL << EXTI_EMR1_EM0_Pos)              /*!< 0x00000001 */
+#define EXTI_EMR1_EM0                EXTI_EMR1_EM0_Msk                         /*!< Event Mask on line 0 */
+#define EXTI_EMR1_EM1_Pos            (1U)
+#define EXTI_EMR1_EM1_Msk            (0x1UL << EXTI_EMR1_EM1_Pos)              /*!< 0x00000002 */
+#define EXTI_EMR1_EM1                EXTI_EMR1_EM1_Msk                         /*!< Event Mask on line 1 */
+#define EXTI_EMR1_EM2_Pos            (2U)
+#define EXTI_EMR1_EM2_Msk            (0x1UL << EXTI_EMR1_EM2_Pos)              /*!< 0x00000004 */
+#define EXTI_EMR1_EM2                EXTI_EMR1_EM2_Msk                         /*!< Event Mask on line 2 */
+#define EXTI_EMR1_EM3_Pos            (3U)
+#define EXTI_EMR1_EM3_Msk            (0x1UL << EXTI_EMR1_EM3_Pos)              /*!< 0x00000008 */
+#define EXTI_EMR1_EM3                EXTI_EMR1_EM3_Msk                         /*!< Event Mask on line 3 */
+#define EXTI_EMR1_EM4_Pos            (4U)
+#define EXTI_EMR1_EM4_Msk            (0x1UL << EXTI_EMR1_EM4_Pos)              /*!< 0x00000010 */
+#define EXTI_EMR1_EM4                EXTI_EMR1_EM4_Msk                         /*!< Event Mask on line 4 */
+#define EXTI_EMR1_EM5_Pos            (5U)
+#define EXTI_EMR1_EM5_Msk            (0x1UL << EXTI_EMR1_EM5_Pos)              /*!< 0x00000020 */
+#define EXTI_EMR1_EM5                EXTI_EMR1_EM5_Msk                         /*!< Event Mask on line 5 */
+#define EXTI_EMR1_EM6_Pos            (6U)
+#define EXTI_EMR1_EM6_Msk            (0x1UL << EXTI_EMR1_EM6_Pos)              /*!< 0x00000040 */
+#define EXTI_EMR1_EM6                EXTI_EMR1_EM6_Msk                         /*!< Event Mask on line 6 */
+#define EXTI_EMR1_EM7_Pos            (7U)
+#define EXTI_EMR1_EM7_Msk            (0x1UL << EXTI_EMR1_EM7_Pos)              /*!< 0x00000080 */
+#define EXTI_EMR1_EM7                EXTI_EMR1_EM7_Msk                         /*!< Event Mask on line 7 */
+#define EXTI_EMR1_EM8_Pos            (8U)
+#define EXTI_EMR1_EM8_Msk            (0x1UL << EXTI_EMR1_EM8_Pos)              /*!< 0x00000100 */
+#define EXTI_EMR1_EM8                EXTI_EMR1_EM8_Msk                         /*!< Event Mask on line 8 */
+#define EXTI_EMR1_EM9_Pos            (9U)
+#define EXTI_EMR1_EM9_Msk            (0x1UL << EXTI_EMR1_EM9_Pos)              /*!< 0x00000200 */
+#define EXTI_EMR1_EM9                EXTI_EMR1_EM9_Msk                         /*!< Event Mask on line 9 */
+#define EXTI_EMR1_EM10_Pos           (10U)
+#define EXTI_EMR1_EM10_Msk           (0x1UL << EXTI_EMR1_EM10_Pos)             /*!< 0x00000400 */
+#define EXTI_EMR1_EM10               EXTI_EMR1_EM10_Msk                        /*!< Event Mask on line 10 */
+#define EXTI_EMR1_EM11_Pos           (11U)
+#define EXTI_EMR1_EM11_Msk           (0x1UL << EXTI_EMR1_EM11_Pos)             /*!< 0x00000800 */
+#define EXTI_EMR1_EM11               EXTI_EMR1_EM11_Msk                        /*!< Event Mask on line 11 */
+#define EXTI_EMR1_EM12_Pos           (12U)
+#define EXTI_EMR1_EM12_Msk           (0x1UL << EXTI_EMR1_EM12_Pos)             /*!< 0x00001000 */
+#define EXTI_EMR1_EM12               EXTI_EMR1_EM12_Msk                        /*!< Event Mask on line 12 */
+#define EXTI_EMR1_EM13_Pos           (13U)
+#define EXTI_EMR1_EM13_Msk           (0x1UL << EXTI_EMR1_EM13_Pos)             /*!< 0x00002000 */
+#define EXTI_EMR1_EM13               EXTI_EMR1_EM13_Msk                        /*!< Event Mask on line 13 */
+#define EXTI_EMR1_EM14_Pos           (14U)
+#define EXTI_EMR1_EM14_Msk           (0x1UL << EXTI_EMR1_EM14_Pos)             /*!< 0x00004000 */
+#define EXTI_EMR1_EM14               EXTI_EMR1_EM14_Msk                        /*!< Event Mask on line 14 */
+#define EXTI_EMR1_EM15_Pos           (15U)
+#define EXTI_EMR1_EM15_Msk           (0x1UL << EXTI_EMR1_EM15_Pos)             /*!< 0x00008000 */
+#define EXTI_EMR1_EM15               EXTI_EMR1_EM15_Msk                        /*!< Event Mask on line 15 */
+#define EXTI_EMR1_EM16_Pos           (16U)
+#define EXTI_EMR1_EM16_Msk           (0x1UL << EXTI_EMR1_EM16_Pos)             /*!< 0x00010000 */
+#define EXTI_EMR1_EM16               EXTI_EMR1_EM16_Msk                        /*!< Event Mask on line 16 */
+#define EXTI_EMR1_EM17_Pos           (17U)
+#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
+#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
+#define EXTI_EMR1_EM18_Pos           (18U)
+#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
+#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
+#define EXTI_EMR1_EM19_Pos           (19U)
+#define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
+#define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
+#define EXTI_EMR1_EM21_Pos           (21U)
+#define EXTI_EMR1_EM21_Msk           (0x1UL << EXTI_EMR1_EM21_Pos)             /*!< 0x00200000 */
+#define EXTI_EMR1_EM21               EXTI_EMR1_EM21_Msk                        /*!< Event Mask on line 21 */
+#define EXTI_EMR1_EM23_Pos           (23U)
+#define EXTI_EMR1_EM23_Msk           (0x1UL << EXTI_EMR1_EM23_Pos)             /*!< 0x00800000 */
+#define EXTI_EMR1_EM23               EXTI_EMR1_EM23_Msk                        /*!< Event Mask on line 23 */
+#define EXTI_EMR1_EM25_Pos           (25U)
+#define EXTI_EMR1_EM25_Msk           (0x1UL << EXTI_EMR1_EM25_Pos)             /*!< 0x02000000 */
+#define EXTI_EMR1_EM25               EXTI_EMR1_EM25_Msk                        /*!< Event Mask on line 25 */
+#define EXTI_EMR1_EM28_Pos           (28U)
+#define EXTI_EMR1_EM28_Msk           (0x1UL << EXTI_EMR1_EM28_Pos)             /*!< 0x10000000 */
+#define EXTI_EMR1_EM28               EXTI_EMR1_EM28_Msk                        /*!< Event Mask on line 28 */
+#define EXTI_EMR1_EM29_Pos           (29U)
+#define EXTI_EMR1_EM29_Msk           (0x1UL << EXTI_EMR1_EM29_Pos)             /*!< 0x20000000 */
+#define EXTI_EMR1_EM29               EXTI_EMR1_EM29_Msk                        /*!< Event Mask on line 29 */
+#define EXTI_EMR1_EM30_Pos           (30U)
+#define EXTI_EMR1_EM30_Msk           (0x1UL << EXTI_EMR1_EM30_Pos)             /*!< 0x40000000 */
+#define EXTI_EMR1_EM30               EXTI_EMR1_EM30_Msk                        /*!< Event Mask on line 30 */
+#define EXTI_EMR1_EM31_Pos           (31U)
+#define EXTI_EMR1_EM31_Msk           (0x1UL << EXTI_EMR1_EM31_Pos)             /*!< 0x80000000 */
+#define EXTI_EMR1_EM31               EXTI_EMR1_EM31_Msk                        /*!< Event Mask on line 31 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+#define GPIO_NRST_CONFIG_SUPPORT         /*!< GPIO feature available only on specific devices: Configure NRST pin */
+#define FLASH_SECURABLE_MEMORY_SUPPORT   /*!< Flash feature available only on specific devices: allow to secure memory */
+#define FLASH_PCROP_SUPPORT              /*!< Flash feature available only on specific devices: proprietary code read protection areas selected by option */
+
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos                  (0U)
+#define FLASH_ACR_LATENCY_Msk                  (0x7UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY                      FLASH_ACR_LATENCY_Msk
+#define FLASH_ACR_LATENCY_0                    (0x1UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000001 */
+#define FLASH_ACR_LATENCY_1                    (0x2UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000002 */
+#define FLASH_ACR_LATENCY_2                    (0x4UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000004 */
+#define FLASH_ACR_PRFTEN_Pos                   (8U)
+#define FLASH_ACR_PRFTEN_Msk                   (0x1UL << FLASH_ACR_PRFTEN_Pos)  /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN                       FLASH_ACR_PRFTEN_Msk
+#define FLASH_ACR_ICEN_Pos                     (9U)
+#define FLASH_ACR_ICEN_Msk                     (0x1UL << FLASH_ACR_ICEN_Pos)    /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                         FLASH_ACR_ICEN_Msk
+#define FLASH_ACR_ICRST_Pos                    (11U)
+#define FLASH_ACR_ICRST_Msk                    (0x1UL << FLASH_ACR_ICRST_Pos)   /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                        FLASH_ACR_ICRST_Msk
+#define FLASH_ACR_PROGEMPTY_Pos                (16U)
+#define FLASH_ACR_PROGEMPTY_Msk                (0x1UL << FLASH_ACR_PROGEMPTY_Pos) /*!< 0x00010000 */
+#define FLASH_ACR_PROGEMPTY                    FLASH_ACR_PROGEMPTY_Msk
+#define FLASH_ACR_DBG_SWEN_Pos                 (18U)
+#define FLASH_ACR_DBG_SWEN_Msk                 (0x1UL << FLASH_ACR_DBG_SWEN_Pos) /*!< 0x00040000 */
+#define FLASH_ACR_DBG_SWEN                     FLASH_ACR_DBG_SWEN_Msk
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos                       (0U)
+#define FLASH_SR_EOP_Msk                       (0x1UL << FLASH_SR_EOP_Pos)      /*!< 0x00000001 */
+#define FLASH_SR_EOP                           FLASH_SR_EOP_Msk
+#define FLASH_SR_OPERR_Pos                     (1U)
+#define FLASH_SR_OPERR_Msk                     (0x1UL << FLASH_SR_OPERR_Pos)    /*!< 0x00000002 */
+#define FLASH_SR_OPERR                         FLASH_SR_OPERR_Msk
+#define FLASH_SR_PROGERR_Pos                   (3U)
+#define FLASH_SR_PROGERR_Msk                   (0x1UL << FLASH_SR_PROGERR_Pos)  /*!< 0x00000008 */
+#define FLASH_SR_PROGERR                       FLASH_SR_PROGERR_Msk
+#define FLASH_SR_WRPERR_Pos                    (4U)
+#define FLASH_SR_WRPERR_Msk                    (0x1UL << FLASH_SR_WRPERR_Pos)   /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                        FLASH_SR_WRPERR_Msk
+#define FLASH_SR_PGAERR_Pos                    (5U)
+#define FLASH_SR_PGAERR_Msk                    (0x1UL << FLASH_SR_PGAERR_Pos)   /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                        FLASH_SR_PGAERR_Msk
+#define FLASH_SR_SIZERR_Pos                    (6U)
+#define FLASH_SR_SIZERR_Msk                    (0x1UL << FLASH_SR_SIZERR_Pos)   /*!< 0x00000040 */
+#define FLASH_SR_SIZERR                        FLASH_SR_SIZERR_Msk
+#define FLASH_SR_PGSERR_Pos                    (7U)
+#define FLASH_SR_PGSERR_Msk                    (0x1UL << FLASH_SR_PGSERR_Pos)   /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                        FLASH_SR_PGSERR_Msk
+#define FLASH_SR_MISERR_Pos                    (8U)
+#define FLASH_SR_MISERR_Msk                    (0x1UL << FLASH_SR_MISERR_Pos)   /*!< 0x00000100 */
+#define FLASH_SR_MISERR                        FLASH_SR_MISERR_Msk
+#define FLASH_SR_FASTERR_Pos                   (9U)
+#define FLASH_SR_FASTERR_Msk                   (0x1UL << FLASH_SR_FASTERR_Pos)  /*!< 0x00000200 */
+#define FLASH_SR_FASTERR                       FLASH_SR_FASTERR_Msk
+#define FLASH_SR_RDERR_Pos                     (14U)
+#define FLASH_SR_RDERR_Msk                     (0x1UL << FLASH_SR_RDERR_Pos)    /*!< 0x00004000 */
+#define FLASH_SR_RDERR                         FLASH_SR_RDERR_Msk
+#define FLASH_SR_OPTVERR_Pos                   (15U)
+#define FLASH_SR_OPTVERR_Msk                   (0x1UL << FLASH_SR_OPTVERR_Pos)  /*!< 0x00008000 */
+#define FLASH_SR_OPTVERR                       FLASH_SR_OPTVERR_Msk
+#define FLASH_SR_BSY1_Pos                      (16U)
+#define FLASH_SR_BSY1_Msk                      (0x1UL << FLASH_SR_BSY1_Pos)     /*!< 0x00010000 */
+#define FLASH_SR_BSY1                          FLASH_SR_BSY1_Msk
+#define FLASH_SR_CFGBSY_Pos                    (18U)
+#define FLASH_SR_CFGBSY_Msk                    (0x1UL << FLASH_SR_CFGBSY_Pos)   /*!< 0x00040000 */
+#define FLASH_SR_CFGBSY                        FLASH_SR_CFGBSY_Msk
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                        (0U)
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
+#define FLASH_CR_PG                            FLASH_CR_PG_Msk
+#define FLASH_CR_PER_Pos                       (1U)
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
+#define FLASH_CR_PER                           FLASH_CR_PER_Msk
+#define FLASH_CR_MER1_Pos                      (2U)
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
+#define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
+#define FLASH_CR_PNB_Pos                       (3U)
+#define FLASH_CR_PNB_Msk                       (0x1FUL << FLASH_CR_PNB_Pos)       /*!< 0x000000F8 */
+#define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
+#define FLASH_CR_STRT_Pos                      (16U)
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
+#define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
+#define FLASH_CR_OPTSTRT_Pos                   (17U)
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
+#define FLASH_CR_FSTPG_Pos                     (18U)
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
+#define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
+#define FLASH_CR_EOPIE_Pos                     (24U)
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
+#define FLASH_CR_ERRIE_Pos                     (25U)
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
+#define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
+#define FLASH_CR_RDERRIE_Pos                   (26U)
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
+#define FLASH_CR_OBL_LAUNCH_Pos                (27U)
+#define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
+#define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
+#define FLASH_CR_SEC_PROT_Pos                  (28U)
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
+#define FLASH_CR_OPTLOCK_Pos                   (30U)
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
+#define FLASH_CR_LOCK_Pos                      (31U)
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
+#define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
+
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos                (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
+#define FLASH_ECCR_SYSF_ECC_Pos                (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
+#define FLASH_ECCR_ECCCIE_Pos                  (24U)
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
+#define FLASH_ECCR_ECCC_Pos                    (30U)
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
+#define FLASH_ECCR_ECCD_Pos                    (31U)
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
+
+/*******************  Bits definition for FLASH_OPTR register  ****************/
+#define FLASH_OPTR_RDP_Pos                     (0U)
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
+#define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
+#define FLASH_OPTR_BOR_EN_Pos                  (8U)
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
+#define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
+#define FLASH_OPTR_nRST_STOP_Pos               (13U)
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
+#define FLASH_OPTR_nRST_STDBY_Pos              (14U)
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
+#define FLASH_OPTR_nRST_SHDW_Pos               (15U)
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
+#define FLASH_OPTR_IWDG_SW_Pos                 (16U)
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
+#define FLASH_OPTR_IWDG_STOP_Pos               (17U)
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
+#define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
+#define FLASH_OPTR_WWDG_SW_Pos                 (19U)
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
+#define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
+#define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
+#define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
+#define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
+#define FLASH_OPTR_nBOOT1_Pos                  (25U)
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
+#define FLASH_OPTR_nBOOT0_Pos                  (26U)
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
+#define FLASH_OPTR_NRST_MODE_Pos               (27U)
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
+#define FLASH_OPTR_IRHEN_Pos                   (29U)
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
+
+/******************  Bits definition for FLASH_PCROP1ASR register  ************/
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x7FUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)   /*!< 0x0000007F */
+#define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
+
+/******************  Bits definition for FLASH_PCROP1AER register  ************/
+#define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x7FUL << FLASH_PCROP1AER_PCROP1A_END_Pos)    /*!< 0x0000007F */
+#define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
+#define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
+
+/******************  Bits definition for FLASH_WRP1AR register  ***************/
+#define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
+#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x1FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000001F */
+#define FLASH_WRP1AR_WRP1A_STRT                FLASH_WRP1AR_WRP1A_STRT_Msk
+#define FLASH_WRP1AR_WRP1A_END_Pos             (16U)
+#define FLASH_WRP1AR_WRP1A_END_Msk             (0x1FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x001F0000 */
+#define FLASH_WRP1AR_WRP1A_END                 FLASH_WRP1AR_WRP1A_END_Msk
+
+/******************  Bits definition for FLASH_WRP1BR register  ***************/
+#define FLASH_WRP1BR_WRP1B_STRT_Pos            (0U)
+#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x1FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000001F */
+#define FLASH_WRP1BR_WRP1B_STRT                FLASH_WRP1BR_WRP1B_STRT_Msk
+#define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
+#define FLASH_WRP1BR_WRP1B_END_Msk             (0x1FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x001F0000 */
+#define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
+
+/******************  Bits definition for FLASH_PCROP1BSR register  ************/
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x7FUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)   /*!< 0x0000007F */
+#define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
+
+/******************  Bits definition for FLASH_PCROP1BER register  ************/
+#define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x7FUL << FLASH_PCROP1BER_PCROP1B_END_Pos)    /*!< 0x0000007F */
+#define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
+
+/******************  Bits definition for FLASH_SECR register  *****************/
+#define FLASH_SECR_SEC_SIZE_Pos                (0U)
+#define FLASH_SECR_SEC_SIZE_Msk                (0x3FUL << FLASH_SECR_SEC_SIZE_Pos) /*!< 0x0000003F */
+#define FLASH_SECR_SEC_SIZE                    FLASH_SECR_SEC_SIZE_Msk
+#define FLASH_SECR_BOOT_LOCK_Pos               (16U)
+#define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
+#define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0_Pos           (0U)
+#define GPIO_MODER_MODE0_Msk           (0x3UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000003 */
+#define GPIO_MODER_MODE0               GPIO_MODER_MODE0_Msk
+#define GPIO_MODER_MODE0_0             (0x1UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000001 */
+#define GPIO_MODER_MODE0_1             (0x2UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000002 */
+#define GPIO_MODER_MODE1_Pos           (2U)
+#define GPIO_MODER_MODE1_Msk           (0x3UL << GPIO_MODER_MODE1_Pos)          /*!< 0x0000000C */
+#define GPIO_MODER_MODE1               GPIO_MODER_MODE1_Msk
+#define GPIO_MODER_MODE1_0             (0x1UL << GPIO_MODER_MODE1_Pos)          /*!< 0x00000004 */
+#define GPIO_MODER_MODE1_1             (0x2UL << GPIO_MODER_MODE1_Pos)          /*!< 0x00000008 */
+#define GPIO_MODER_MODE2_Pos           (4U)
+#define GPIO_MODER_MODE2_Msk           (0x3UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000030 */
+#define GPIO_MODER_MODE2               GPIO_MODER_MODE2_Msk
+#define GPIO_MODER_MODE2_0             (0x1UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000010 */
+#define GPIO_MODER_MODE2_1             (0x2UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000020 */
+#define GPIO_MODER_MODE3_Pos           (6U)
+#define GPIO_MODER_MODE3_Msk           (0x3UL << GPIO_MODER_MODE3_Pos)          /*!< 0x000000C0 */
+#define GPIO_MODER_MODE3               GPIO_MODER_MODE3_Msk
+#define GPIO_MODER_MODE3_0             (0x1UL << GPIO_MODER_MODE3_Pos)          /*!< 0x00000040 */
+#define GPIO_MODER_MODE3_1             (0x2UL << GPIO_MODER_MODE3_Pos)          /*!< 0x00000080 */
+#define GPIO_MODER_MODE4_Pos           (8U)
+#define GPIO_MODER_MODE4_Msk           (0x3UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000300 */
+#define GPIO_MODER_MODE4               GPIO_MODER_MODE4_Msk
+#define GPIO_MODER_MODE4_0             (0x1UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000100 */
+#define GPIO_MODER_MODE4_1             (0x2UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000200 */
+#define GPIO_MODER_MODE5_Pos           (10U)
+#define GPIO_MODER_MODE5_Msk           (0x3UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000C00 */
+#define GPIO_MODER_MODE5               GPIO_MODER_MODE5_Msk
+#define GPIO_MODER_MODE5_0             (0x1UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000400 */
+#define GPIO_MODER_MODE5_1             (0x2UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000800 */
+#define GPIO_MODER_MODE6_Pos           (12U)
+#define GPIO_MODER_MODE6_Msk           (0x3UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00003000 */
+#define GPIO_MODER_MODE6               GPIO_MODER_MODE6_Msk
+#define GPIO_MODER_MODE6_0             (0x1UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00001000 */
+#define GPIO_MODER_MODE6_1             (0x2UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00002000 */
+#define GPIO_MODER_MODE7_Pos           (14U)
+#define GPIO_MODER_MODE7_Msk           (0x3UL << GPIO_MODER_MODE7_Pos)          /*!< 0x0000C000 */
+#define GPIO_MODER_MODE7               GPIO_MODER_MODE7_Msk
+#define GPIO_MODER_MODE7_0             (0x1UL << GPIO_MODER_MODE7_Pos)          /*!< 0x00004000 */
+#define GPIO_MODER_MODE7_1             (0x2UL << GPIO_MODER_MODE7_Pos)          /*!< 0x00008000 */
+#define GPIO_MODER_MODE8_Pos           (16U)
+#define GPIO_MODER_MODE8_Msk           (0x3UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00030000 */
+#define GPIO_MODER_MODE8               GPIO_MODER_MODE8_Msk
+#define GPIO_MODER_MODE8_0             (0x1UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00010000 */
+#define GPIO_MODER_MODE8_1             (0x2UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00020000 */
+#define GPIO_MODER_MODE9_Pos           (18U)
+#define GPIO_MODER_MODE9_Msk           (0x3UL << GPIO_MODER_MODE9_Pos)          /*!< 0x000C0000 */
+#define GPIO_MODER_MODE9               GPIO_MODER_MODE9_Msk
+#define GPIO_MODER_MODE9_0             (0x1UL << GPIO_MODER_MODE9_Pos)          /*!< 0x00040000 */
+#define GPIO_MODER_MODE9_1             (0x2UL << GPIO_MODER_MODE9_Pos)          /*!< 0x00080000 */
+#define GPIO_MODER_MODE10_Pos          (20U)
+#define GPIO_MODER_MODE10_Msk          (0x3UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00300000 */
+#define GPIO_MODER_MODE10              GPIO_MODER_MODE10_Msk
+#define GPIO_MODER_MODE10_0            (0x1UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00100000 */
+#define GPIO_MODER_MODE10_1            (0x2UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00200000 */
+#define GPIO_MODER_MODE11_Pos          (22U)
+#define GPIO_MODER_MODE11_Msk          (0x3UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00C00000 */
+#define GPIO_MODER_MODE11              GPIO_MODER_MODE11_Msk
+#define GPIO_MODER_MODE11_0            (0x1UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00400000 */
+#define GPIO_MODER_MODE11_1            (0x2UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00800000 */
+#define GPIO_MODER_MODE12_Pos          (24U)
+#define GPIO_MODER_MODE12_Msk          (0x3UL << GPIO_MODER_MODE12_Pos)         /*!< 0x03000000 */
+#define GPIO_MODER_MODE12              GPIO_MODER_MODE12_Msk
+#define GPIO_MODER_MODE12_0            (0x1UL << GPIO_MODER_MODE12_Pos)         /*!< 0x01000000 */
+#define GPIO_MODER_MODE12_1            (0x2UL << GPIO_MODER_MODE12_Pos)         /*!< 0x02000000 */
+#define GPIO_MODER_MODE13_Pos          (26U)
+#define GPIO_MODER_MODE13_Msk          (0x3UL << GPIO_MODER_MODE13_Pos)         /*!< 0x0C000000 */
+#define GPIO_MODER_MODE13              GPIO_MODER_MODE13_Msk
+#define GPIO_MODER_MODE13_0            (0x1UL << GPIO_MODER_MODE13_Pos)         /*!< 0x04000000 */
+#define GPIO_MODER_MODE13_1            (0x2UL << GPIO_MODER_MODE13_Pos)         /*!< 0x08000000 */
+#define GPIO_MODER_MODE14_Pos          (28U)
+#define GPIO_MODER_MODE14_Msk          (0x3UL << GPIO_MODER_MODE14_Pos)         /*!< 0x30000000 */
+#define GPIO_MODER_MODE14              GPIO_MODER_MODE14_Msk
+#define GPIO_MODER_MODE14_0            (0x1UL << GPIO_MODER_MODE14_Pos)         /*!< 0x10000000 */
+#define GPIO_MODER_MODE14_1            (0x2UL << GPIO_MODER_MODE14_Pos)         /*!< 0x20000000 */
+#define GPIO_MODER_MODE15_Pos          (30U)
+#define GPIO_MODER_MODE15_Msk          (0x3UL << GPIO_MODER_MODE15_Pos)         /*!< 0xC0000000 */
+#define GPIO_MODER_MODE15              GPIO_MODER_MODE15_Msk
+#define GPIO_MODER_MODE15_0            (0x1UL << GPIO_MODER_MODE15_Pos)         /*!< 0x40000000 */
+#define GPIO_MODER_MODE15_1            (0x2UL << GPIO_MODER_MODE15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos            (0U)
+#define GPIO_OTYPER_OT0_Msk            (0x1UL << GPIO_OTYPER_OT0_Pos)           /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                GPIO_OTYPER_OT0_Msk
+#define GPIO_OTYPER_OT1_Pos            (1U)
+#define GPIO_OTYPER_OT1_Msk            (0x1UL << GPIO_OTYPER_OT1_Pos)           /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                GPIO_OTYPER_OT1_Msk
+#define GPIO_OTYPER_OT2_Pos            (2U)
+#define GPIO_OTYPER_OT2_Msk            (0x1UL << GPIO_OTYPER_OT2_Pos)           /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                GPIO_OTYPER_OT2_Msk
+#define GPIO_OTYPER_OT3_Pos            (3U)
+#define GPIO_OTYPER_OT3_Msk            (0x1UL << GPIO_OTYPER_OT3_Pos)           /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                GPIO_OTYPER_OT3_Msk
+#define GPIO_OTYPER_OT4_Pos            (4U)
+#define GPIO_OTYPER_OT4_Msk            (0x1UL << GPIO_OTYPER_OT4_Pos)           /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                GPIO_OTYPER_OT4_Msk
+#define GPIO_OTYPER_OT5_Pos            (5U)
+#define GPIO_OTYPER_OT5_Msk            (0x1UL << GPIO_OTYPER_OT5_Pos)           /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                GPIO_OTYPER_OT5_Msk
+#define GPIO_OTYPER_OT6_Pos            (6U)
+#define GPIO_OTYPER_OT6_Msk            (0x1UL << GPIO_OTYPER_OT6_Pos)           /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                GPIO_OTYPER_OT6_Msk
+#define GPIO_OTYPER_OT7_Pos            (7U)
+#define GPIO_OTYPER_OT7_Msk            (0x1UL << GPIO_OTYPER_OT7_Pos)           /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                GPIO_OTYPER_OT7_Msk
+#define GPIO_OTYPER_OT8_Pos            (8U)
+#define GPIO_OTYPER_OT8_Msk            (0x1UL << GPIO_OTYPER_OT8_Pos)           /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                GPIO_OTYPER_OT8_Msk
+#define GPIO_OTYPER_OT9_Pos            (9U)
+#define GPIO_OTYPER_OT9_Msk            (0x1UL << GPIO_OTYPER_OT9_Pos)           /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                GPIO_OTYPER_OT9_Msk
+#define GPIO_OTYPER_OT10_Pos           (10U)
+#define GPIO_OTYPER_OT10_Msk           (0x1UL << GPIO_OTYPER_OT10_Pos)          /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10               GPIO_OTYPER_OT10_Msk
+#define GPIO_OTYPER_OT11_Pos           (11U)
+#define GPIO_OTYPER_OT11_Msk           (0x1UL << GPIO_OTYPER_OT11_Pos)          /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11               GPIO_OTYPER_OT11_Msk
+#define GPIO_OTYPER_OT12_Pos           (12U)
+#define GPIO_OTYPER_OT12_Msk           (0x1UL << GPIO_OTYPER_OT12_Pos)          /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12               GPIO_OTYPER_OT12_Msk
+#define GPIO_OTYPER_OT13_Pos           (13U)
+#define GPIO_OTYPER_OT13_Msk           (0x1UL << GPIO_OTYPER_OT13_Pos)          /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13               GPIO_OTYPER_OT13_Msk
+#define GPIO_OTYPER_OT14_Pos           (14U)
+#define GPIO_OTYPER_OT14_Msk           (0x1UL << GPIO_OTYPER_OT14_Pos)          /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14               GPIO_OTYPER_OT14_Msk
+#define GPIO_OTYPER_OT15_Pos           (15U)
+#define GPIO_OTYPER_OT15_Msk           (0x1UL << GPIO_OTYPER_OT15_Pos)          /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15               GPIO_OTYPER_OT15_Msk
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos       (0U)
+#define GPIO_OSPEEDR_OSPEED0_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0           GPIO_OSPEEDR_OSPEED0_Msk
+#define GPIO_OSPEEDR_OSPEED0_0         (0x1UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1         (0x2UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos       (2U)
+#define GPIO_OSPEEDR_OSPEED1_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1           GPIO_OSPEEDR_OSPEED1_Msk
+#define GPIO_OSPEEDR_OSPEED1_0         (0x1UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1         (0x2UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos       (4U)
+#define GPIO_OSPEEDR_OSPEED2_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2           GPIO_OSPEEDR_OSPEED2_Msk
+#define GPIO_OSPEEDR_OSPEED2_0         (0x1UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1         (0x2UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos       (6U)
+#define GPIO_OSPEEDR_OSPEED3_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3           GPIO_OSPEEDR_OSPEED3_Msk
+#define GPIO_OSPEEDR_OSPEED3_0         (0x1UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1         (0x2UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos       (8U)
+#define GPIO_OSPEEDR_OSPEED4_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4           GPIO_OSPEEDR_OSPEED4_Msk
+#define GPIO_OSPEEDR_OSPEED4_0         (0x1UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1         (0x2UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos       (10U)
+#define GPIO_OSPEEDR_OSPEED5_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5           GPIO_OSPEEDR_OSPEED5_Msk
+#define GPIO_OSPEEDR_OSPEED5_0         (0x1UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1         (0x2UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos       (12U)
+#define GPIO_OSPEEDR_OSPEED6_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6           GPIO_OSPEEDR_OSPEED6_Msk
+#define GPIO_OSPEEDR_OSPEED6_0         (0x1UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1         (0x2UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos       (14U)
+#define GPIO_OSPEEDR_OSPEED7_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7           GPIO_OSPEEDR_OSPEED7_Msk
+#define GPIO_OSPEEDR_OSPEED7_0         (0x1UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1         (0x2UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos       (16U)
+#define GPIO_OSPEEDR_OSPEED8_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8           GPIO_OSPEEDR_OSPEED8_Msk
+#define GPIO_OSPEEDR_OSPEED8_0         (0x1UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1         (0x2UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos       (18U)
+#define GPIO_OSPEEDR_OSPEED9_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9           GPIO_OSPEEDR_OSPEED9_Msk
+#define GPIO_OSPEEDR_OSPEED9_0         (0x1UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1         (0x2UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos      (20U)
+#define GPIO_OSPEEDR_OSPEED10_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10          GPIO_OSPEEDR_OSPEED10_Msk
+#define GPIO_OSPEEDR_OSPEED10_0        (0x1UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1        (0x2UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos      (22U)
+#define GPIO_OSPEEDR_OSPEED11_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11          GPIO_OSPEEDR_OSPEED11_Msk
+#define GPIO_OSPEEDR_OSPEED11_0        (0x1UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1        (0x2UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos      (24U)
+#define GPIO_OSPEEDR_OSPEED12_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12          GPIO_OSPEEDR_OSPEED12_Msk
+#define GPIO_OSPEEDR_OSPEED12_0        (0x1UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1        (0x2UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos      (26U)
+#define GPIO_OSPEEDR_OSPEED13_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13          GPIO_OSPEEDR_OSPEED13_Msk
+#define GPIO_OSPEEDR_OSPEED13_0        (0x1UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1        (0x2UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos      (28U)
+#define GPIO_OSPEEDR_OSPEED14_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14          GPIO_OSPEEDR_OSPEED14_Msk
+#define GPIO_OSPEEDR_OSPEED14_0        (0x1UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1        (0x2UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos      (30U)
+#define GPIO_OSPEEDR_OSPEED15_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15          GPIO_OSPEEDR_OSPEED15_Msk
+#define GPIO_OSPEEDR_OSPEED15_0        (0x1UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1        (0x2UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos           (0U)
+#define GPIO_PUPDR_PUPD0_Msk           (0x3UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0               GPIO_PUPDR_PUPD0_Msk
+#define GPIO_PUPDR_PUPD0_0             (0x1UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1             (0x2UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos           (2U)
+#define GPIO_PUPDR_PUPD1_Msk           (0x3UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1               GPIO_PUPDR_PUPD1_Msk
+#define GPIO_PUPDR_PUPD1_0             (0x1UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1             (0x2UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos           (4U)
+#define GPIO_PUPDR_PUPD2_Msk           (0x3UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2               GPIO_PUPDR_PUPD2_Msk
+#define GPIO_PUPDR_PUPD2_0             (0x1UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1             (0x2UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos           (6U)
+#define GPIO_PUPDR_PUPD3_Msk           (0x3UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3               GPIO_PUPDR_PUPD3_Msk
+#define GPIO_PUPDR_PUPD3_0             (0x1UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1             (0x2UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos           (8U)
+#define GPIO_PUPDR_PUPD4_Msk           (0x3UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4               GPIO_PUPDR_PUPD4_Msk
+#define GPIO_PUPDR_PUPD4_0             (0x1UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1             (0x2UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos           (10U)
+#define GPIO_PUPDR_PUPD5_Msk           (0x3UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5               GPIO_PUPDR_PUPD5_Msk
+#define GPIO_PUPDR_PUPD5_0             (0x1UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1             (0x2UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos           (12U)
+#define GPIO_PUPDR_PUPD6_Msk           (0x3UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6               GPIO_PUPDR_PUPD6_Msk
+#define GPIO_PUPDR_PUPD6_0             (0x1UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1             (0x2UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos           (14U)
+#define GPIO_PUPDR_PUPD7_Msk           (0x3UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7               GPIO_PUPDR_PUPD7_Msk
+#define GPIO_PUPDR_PUPD7_0             (0x1UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1             (0x2UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos           (16U)
+#define GPIO_PUPDR_PUPD8_Msk           (0x3UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8               GPIO_PUPDR_PUPD8_Msk
+#define GPIO_PUPDR_PUPD8_0             (0x1UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1             (0x2UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos           (18U)
+#define GPIO_PUPDR_PUPD9_Msk           (0x3UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9               GPIO_PUPDR_PUPD9_Msk
+#define GPIO_PUPDR_PUPD9_0             (0x1UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1             (0x2UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos          (20U)
+#define GPIO_PUPDR_PUPD10_Msk          (0x3UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10              GPIO_PUPDR_PUPD10_Msk
+#define GPIO_PUPDR_PUPD10_0            (0x1UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1            (0x2UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos          (22U)
+#define GPIO_PUPDR_PUPD11_Msk          (0x3UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11              GPIO_PUPDR_PUPD11_Msk
+#define GPIO_PUPDR_PUPD11_0            (0x1UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1            (0x2UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos          (24U)
+#define GPIO_PUPDR_PUPD12_Msk          (0x3UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12              GPIO_PUPDR_PUPD12_Msk
+#define GPIO_PUPDR_PUPD12_0            (0x1UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1            (0x2UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos          (26U)
+#define GPIO_PUPDR_PUPD13_Msk          (0x3UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13              GPIO_PUPDR_PUPD13_Msk
+#define GPIO_PUPDR_PUPD13_0            (0x1UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1            (0x2UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos          (28U)
+#define GPIO_PUPDR_PUPD14_Msk          (0x3UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14              GPIO_PUPDR_PUPD14_Msk
+#define GPIO_PUPDR_PUPD14_0            (0x1UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1            (0x2UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos          (30U)
+#define GPIO_PUPDR_PUPD15_Msk          (0x3UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15              GPIO_PUPDR_PUPD15_Msk
+#define GPIO_PUPDR_PUPD15_0            (0x1UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1            (0x2UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos               (0U)
+#define GPIO_IDR_ID0_Msk               (0x1UL << GPIO_IDR_ID0_Pos)              /*!< 0x00000001 */
+#define GPIO_IDR_ID0                   GPIO_IDR_ID0_Msk
+#define GPIO_IDR_ID1_Pos               (1U)
+#define GPIO_IDR_ID1_Msk               (0x1UL << GPIO_IDR_ID1_Pos)              /*!< 0x00000002 */
+#define GPIO_IDR_ID1                   GPIO_IDR_ID1_Msk
+#define GPIO_IDR_ID2_Pos               (2U)
+#define GPIO_IDR_ID2_Msk               (0x1UL << GPIO_IDR_ID2_Pos)              /*!< 0x00000004 */
+#define GPIO_IDR_ID2                   GPIO_IDR_ID2_Msk
+#define GPIO_IDR_ID3_Pos               (3U)
+#define GPIO_IDR_ID3_Msk               (0x1UL << GPIO_IDR_ID3_Pos)              /*!< 0x00000008 */
+#define GPIO_IDR_ID3                   GPIO_IDR_ID3_Msk
+#define GPIO_IDR_ID4_Pos               (4U)
+#define GPIO_IDR_ID4_Msk               (0x1UL << GPIO_IDR_ID4_Pos)              /*!< 0x00000010 */
+#define GPIO_IDR_ID4                   GPIO_IDR_ID4_Msk
+#define GPIO_IDR_ID5_Pos               (5U)
+#define GPIO_IDR_ID5_Msk               (0x1UL << GPIO_IDR_ID5_Pos)              /*!< 0x00000020 */
+#define GPIO_IDR_ID5                   GPIO_IDR_ID5_Msk
+#define GPIO_IDR_ID6_Pos               (6U)
+#define GPIO_IDR_ID6_Msk               (0x1UL << GPIO_IDR_ID6_Pos)              /*!< 0x00000040 */
+#define GPIO_IDR_ID6                   GPIO_IDR_ID6_Msk
+#define GPIO_IDR_ID7_Pos               (7U)
+#define GPIO_IDR_ID7_Msk               (0x1UL << GPIO_IDR_ID7_Pos)              /*!< 0x00000080 */
+#define GPIO_IDR_ID7                   GPIO_IDR_ID7_Msk
+#define GPIO_IDR_ID8_Pos               (8U)
+#define GPIO_IDR_ID8_Msk               (0x1UL << GPIO_IDR_ID8_Pos)              /*!< 0x00000100 */
+#define GPIO_IDR_ID8                   GPIO_IDR_ID8_Msk
+#define GPIO_IDR_ID9_Pos               (9U)
+#define GPIO_IDR_ID9_Msk               (0x1UL << GPIO_IDR_ID9_Pos)              /*!< 0x00000200 */
+#define GPIO_IDR_ID9                   GPIO_IDR_ID9_Msk
+#define GPIO_IDR_ID10_Pos              (10U)
+#define GPIO_IDR_ID10_Msk              (0x1UL << GPIO_IDR_ID10_Pos)             /*!< 0x00000400 */
+#define GPIO_IDR_ID10                  GPIO_IDR_ID10_Msk
+#define GPIO_IDR_ID11_Pos              (11U)
+#define GPIO_IDR_ID11_Msk              (0x1UL << GPIO_IDR_ID11_Pos)             /*!< 0x00000800 */
+#define GPIO_IDR_ID11                  GPIO_IDR_ID11_Msk
+#define GPIO_IDR_ID12_Pos              (12U)
+#define GPIO_IDR_ID12_Msk              (0x1UL << GPIO_IDR_ID12_Pos)             /*!< 0x00001000 */
+#define GPIO_IDR_ID12                  GPIO_IDR_ID12_Msk
+#define GPIO_IDR_ID13_Pos              (13U)
+#define GPIO_IDR_ID13_Msk              (0x1UL << GPIO_IDR_ID13_Pos)             /*!< 0x00002000 */
+#define GPIO_IDR_ID13                  GPIO_IDR_ID13_Msk
+#define GPIO_IDR_ID14_Pos              (14U)
+#define GPIO_IDR_ID14_Msk              (0x1UL << GPIO_IDR_ID14_Pos)             /*!< 0x00004000 */
+#define GPIO_IDR_ID14                  GPIO_IDR_ID14_Msk
+#define GPIO_IDR_ID15_Pos              (15U)
+#define GPIO_IDR_ID15_Msk              (0x1UL << GPIO_IDR_ID15_Pos)             /*!< 0x00008000 */
+#define GPIO_IDR_ID15                  GPIO_IDR_ID15_Msk
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos               (0U)
+#define GPIO_ODR_OD0_Msk               (0x1UL << GPIO_ODR_OD0_Pos)              /*!< 0x00000001 */
+#define GPIO_ODR_OD0                   GPIO_ODR_OD0_Msk
+#define GPIO_ODR_OD1_Pos               (1U)
+#define GPIO_ODR_OD1_Msk               (0x1UL << GPIO_ODR_OD1_Pos)              /*!< 0x00000002 */
+#define GPIO_ODR_OD1                   GPIO_ODR_OD1_Msk
+#define GPIO_ODR_OD2_Pos               (2U)
+#define GPIO_ODR_OD2_Msk               (0x1UL << GPIO_ODR_OD2_Pos)              /*!< 0x00000004 */
+#define GPIO_ODR_OD2                   GPIO_ODR_OD2_Msk
+#define GPIO_ODR_OD3_Pos               (3U)
+#define GPIO_ODR_OD3_Msk               (0x1UL << GPIO_ODR_OD3_Pos)              /*!< 0x00000008 */
+#define GPIO_ODR_OD3                   GPIO_ODR_OD3_Msk
+#define GPIO_ODR_OD4_Pos               (4U)
+#define GPIO_ODR_OD4_Msk               (0x1UL << GPIO_ODR_OD4_Pos)              /*!< 0x00000010 */
+#define GPIO_ODR_OD4                   GPIO_ODR_OD4_Msk
+#define GPIO_ODR_OD5_Pos               (5U)
+#define GPIO_ODR_OD5_Msk               (0x1UL << GPIO_ODR_OD5_Pos)              /*!< 0x00000020 */
+#define GPIO_ODR_OD5                   GPIO_ODR_OD5_Msk
+#define GPIO_ODR_OD6_Pos               (6U)
+#define GPIO_ODR_OD6_Msk               (0x1UL << GPIO_ODR_OD6_Pos)              /*!< 0x00000040 */
+#define GPIO_ODR_OD6                   GPIO_ODR_OD6_Msk
+#define GPIO_ODR_OD7_Pos               (7U)
+#define GPIO_ODR_OD7_Msk               (0x1UL << GPIO_ODR_OD7_Pos)              /*!< 0x00000080 */
+#define GPIO_ODR_OD7                   GPIO_ODR_OD7_Msk
+#define GPIO_ODR_OD8_Pos               (8U)
+#define GPIO_ODR_OD8_Msk               (0x1UL << GPIO_ODR_OD8_Pos)              /*!< 0x00000100 */
+#define GPIO_ODR_OD8                   GPIO_ODR_OD8_Msk
+#define GPIO_ODR_OD9_Pos               (9U)
+#define GPIO_ODR_OD9_Msk               (0x1UL << GPIO_ODR_OD9_Pos)              /*!< 0x00000200 */
+#define GPIO_ODR_OD9                   GPIO_ODR_OD9_Msk
+#define GPIO_ODR_OD10_Pos              (10U)
+#define GPIO_ODR_OD10_Msk              (0x1UL << GPIO_ODR_OD10_Pos)             /*!< 0x00000400 */
+#define GPIO_ODR_OD10                  GPIO_ODR_OD10_Msk
+#define GPIO_ODR_OD11_Pos              (11U)
+#define GPIO_ODR_OD11_Msk              (0x1UL << GPIO_ODR_OD11_Pos)             /*!< 0x00000800 */
+#define GPIO_ODR_OD11                  GPIO_ODR_OD11_Msk
+#define GPIO_ODR_OD12_Pos              (12U)
+#define GPIO_ODR_OD12_Msk              (0x1UL << GPIO_ODR_OD12_Pos)             /*!< 0x00001000 */
+#define GPIO_ODR_OD12                  GPIO_ODR_OD12_Msk
+#define GPIO_ODR_OD13_Pos              (13U)
+#define GPIO_ODR_OD13_Msk              (0x1UL << GPIO_ODR_OD13_Pos)             /*!< 0x00002000 */
+#define GPIO_ODR_OD13                  GPIO_ODR_OD13_Msk
+#define GPIO_ODR_OD14_Pos              (14U)
+#define GPIO_ODR_OD14_Msk              (0x1UL << GPIO_ODR_OD14_Pos)             /*!< 0x00004000 */
+#define GPIO_ODR_OD14                  GPIO_ODR_OD14_Msk
+#define GPIO_ODR_OD15_Pos              (15U)
+#define GPIO_ODR_OD15_Msk              (0x1UL << GPIO_ODR_OD15_Pos)             /*!< 0x00008000 */
+#define GPIO_ODR_OD15                  GPIO_ODR_OD15_Msk
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos              (0U)
+#define GPIO_BSRR_BS0_Msk              (0x1UL << GPIO_BSRR_BS0_Pos)             /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                  GPIO_BSRR_BS0_Msk
+#define GPIO_BSRR_BS1_Pos              (1U)
+#define GPIO_BSRR_BS1_Msk              (0x1UL << GPIO_BSRR_BS1_Pos)             /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                  GPIO_BSRR_BS1_Msk
+#define GPIO_BSRR_BS2_Pos              (2U)
+#define GPIO_BSRR_BS2_Msk              (0x1UL << GPIO_BSRR_BS2_Pos)             /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                  GPIO_BSRR_BS2_Msk
+#define GPIO_BSRR_BS3_Pos              (3U)
+#define GPIO_BSRR_BS3_Msk              (0x1UL << GPIO_BSRR_BS3_Pos)             /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                  GPIO_BSRR_BS3_Msk
+#define GPIO_BSRR_BS4_Pos              (4U)
+#define GPIO_BSRR_BS4_Msk              (0x1UL << GPIO_BSRR_BS4_Pos)             /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                  GPIO_BSRR_BS4_Msk
+#define GPIO_BSRR_BS5_Pos              (5U)
+#define GPIO_BSRR_BS5_Msk              (0x1UL << GPIO_BSRR_BS5_Pos)             /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                  GPIO_BSRR_BS5_Msk
+#define GPIO_BSRR_BS6_Pos              (6U)
+#define GPIO_BSRR_BS6_Msk              (0x1UL << GPIO_BSRR_BS6_Pos)             /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                  GPIO_BSRR_BS6_Msk
+#define GPIO_BSRR_BS7_Pos              (7U)
+#define GPIO_BSRR_BS7_Msk              (0x1UL << GPIO_BSRR_BS7_Pos)             /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                  GPIO_BSRR_BS7_Msk
+#define GPIO_BSRR_BS8_Pos              (8U)
+#define GPIO_BSRR_BS8_Msk              (0x1UL << GPIO_BSRR_BS8_Pos)             /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                  GPIO_BSRR_BS8_Msk
+#define GPIO_BSRR_BS9_Pos              (9U)
+#define GPIO_BSRR_BS9_Msk              (0x1UL << GPIO_BSRR_BS9_Pos)             /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                  GPIO_BSRR_BS9_Msk
+#define GPIO_BSRR_BS10_Pos             (10U)
+#define GPIO_BSRR_BS10_Msk             (0x1UL << GPIO_BSRR_BS10_Pos)            /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                 GPIO_BSRR_BS10_Msk
+#define GPIO_BSRR_BS11_Pos             (11U)
+#define GPIO_BSRR_BS11_Msk             (0x1UL << GPIO_BSRR_BS11_Pos)            /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                 GPIO_BSRR_BS11_Msk
+#define GPIO_BSRR_BS12_Pos             (12U)
+#define GPIO_BSRR_BS12_Msk             (0x1UL << GPIO_BSRR_BS12_Pos)            /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                 GPIO_BSRR_BS12_Msk
+#define GPIO_BSRR_BS13_Pos             (13U)
+#define GPIO_BSRR_BS13_Msk             (0x1UL << GPIO_BSRR_BS13_Pos)            /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                 GPIO_BSRR_BS13_Msk
+#define GPIO_BSRR_BS14_Pos             (14U)
+#define GPIO_BSRR_BS14_Msk             (0x1UL << GPIO_BSRR_BS14_Pos)            /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                 GPIO_BSRR_BS14_Msk
+#define GPIO_BSRR_BS15_Pos             (15U)
+#define GPIO_BSRR_BS15_Msk             (0x1UL << GPIO_BSRR_BS15_Pos)            /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                 GPIO_BSRR_BS15_Msk
+#define GPIO_BSRR_BR0_Pos              (16U)
+#define GPIO_BSRR_BR0_Msk              (0x1UL << GPIO_BSRR_BR0_Pos)             /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                  GPIO_BSRR_BR0_Msk
+#define GPIO_BSRR_BR1_Pos              (17U)
+#define GPIO_BSRR_BR1_Msk              (0x1UL << GPIO_BSRR_BR1_Pos)             /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                  GPIO_BSRR_BR1_Msk
+#define GPIO_BSRR_BR2_Pos              (18U)
+#define GPIO_BSRR_BR2_Msk              (0x1UL << GPIO_BSRR_BR2_Pos)             /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                  GPIO_BSRR_BR2_Msk
+#define GPIO_BSRR_BR3_Pos              (19U)
+#define GPIO_BSRR_BR3_Msk              (0x1UL << GPIO_BSRR_BR3_Pos)             /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                  GPIO_BSRR_BR3_Msk
+#define GPIO_BSRR_BR4_Pos              (20U)
+#define GPIO_BSRR_BR4_Msk              (0x1UL << GPIO_BSRR_BR4_Pos)             /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                  GPIO_BSRR_BR4_Msk
+#define GPIO_BSRR_BR5_Pos              (21U)
+#define GPIO_BSRR_BR5_Msk              (0x1UL << GPIO_BSRR_BR5_Pos)             /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                  GPIO_BSRR_BR5_Msk
+#define GPIO_BSRR_BR6_Pos              (22U)
+#define GPIO_BSRR_BR6_Msk              (0x1UL << GPIO_BSRR_BR6_Pos)             /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                  GPIO_BSRR_BR6_Msk
+#define GPIO_BSRR_BR7_Pos              (23U)
+#define GPIO_BSRR_BR7_Msk              (0x1UL << GPIO_BSRR_BR7_Pos)             /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                  GPIO_BSRR_BR7_Msk
+#define GPIO_BSRR_BR8_Pos              (24U)
+#define GPIO_BSRR_BR8_Msk              (0x1UL << GPIO_BSRR_BR8_Pos)             /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                  GPIO_BSRR_BR8_Msk
+#define GPIO_BSRR_BR9_Pos              (25U)
+#define GPIO_BSRR_BR9_Msk              (0x1UL << GPIO_BSRR_BR9_Pos)             /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                  GPIO_BSRR_BR9_Msk
+#define GPIO_BSRR_BR10_Pos             (26U)
+#define GPIO_BSRR_BR10_Msk             (0x1UL << GPIO_BSRR_BR10_Pos)            /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                 GPIO_BSRR_BR10_Msk
+#define GPIO_BSRR_BR11_Pos             (27U)
+#define GPIO_BSRR_BR11_Msk             (0x1UL << GPIO_BSRR_BR11_Pos)            /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                 GPIO_BSRR_BR11_Msk
+#define GPIO_BSRR_BR12_Pos             (28U)
+#define GPIO_BSRR_BR12_Msk             (0x1UL << GPIO_BSRR_BR12_Pos)            /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                 GPIO_BSRR_BR12_Msk
+#define GPIO_BSRR_BR13_Pos             (29U)
+#define GPIO_BSRR_BR13_Msk             (0x1UL << GPIO_BSRR_BR13_Pos)            /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                 GPIO_BSRR_BR13_Msk
+#define GPIO_BSRR_BR14_Pos             (30U)
+#define GPIO_BSRR_BR14_Msk             (0x1UL << GPIO_BSRR_BR14_Pos)            /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                 GPIO_BSRR_BR14_Msk
+#define GPIO_BSRR_BR15_Pos             (31U)
+#define GPIO_BSRR_BR15_Msk             (0x1UL << GPIO_BSRR_BR15_Pos)            /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                 GPIO_BSRR_BR15_Msk
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos             (0U)
+#define GPIO_LCKR_LCK0_Msk             (0x1UL << GPIO_LCKR_LCK0_Pos)            /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                 GPIO_LCKR_LCK0_Msk
+#define GPIO_LCKR_LCK1_Pos             (1U)
+#define GPIO_LCKR_LCK1_Msk             (0x1UL << GPIO_LCKR_LCK1_Pos)            /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                 GPIO_LCKR_LCK1_Msk
+#define GPIO_LCKR_LCK2_Pos             (2U)
+#define GPIO_LCKR_LCK2_Msk             (0x1UL << GPIO_LCKR_LCK2_Pos)            /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                 GPIO_LCKR_LCK2_Msk
+#define GPIO_LCKR_LCK3_Pos             (3U)
+#define GPIO_LCKR_LCK3_Msk             (0x1UL << GPIO_LCKR_LCK3_Pos)            /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                 GPIO_LCKR_LCK3_Msk
+#define GPIO_LCKR_LCK4_Pos             (4U)
+#define GPIO_LCKR_LCK4_Msk             (0x1UL << GPIO_LCKR_LCK4_Pos)            /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                 GPIO_LCKR_LCK4_Msk
+#define GPIO_LCKR_LCK5_Pos             (5U)
+#define GPIO_LCKR_LCK5_Msk             (0x1UL << GPIO_LCKR_LCK5_Pos)            /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                 GPIO_LCKR_LCK5_Msk
+#define GPIO_LCKR_LCK6_Pos             (6U)
+#define GPIO_LCKR_LCK6_Msk             (0x1UL << GPIO_LCKR_LCK6_Pos)            /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                 GPIO_LCKR_LCK6_Msk
+#define GPIO_LCKR_LCK7_Pos             (7U)
+#define GPIO_LCKR_LCK7_Msk             (0x1UL << GPIO_LCKR_LCK7_Pos)            /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                 GPIO_LCKR_LCK7_Msk
+#define GPIO_LCKR_LCK8_Pos             (8U)
+#define GPIO_LCKR_LCK8_Msk             (0x1UL << GPIO_LCKR_LCK8_Pos)            /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                 GPIO_LCKR_LCK8_Msk
+#define GPIO_LCKR_LCK9_Pos             (9U)
+#define GPIO_LCKR_LCK9_Msk             (0x1UL << GPIO_LCKR_LCK9_Pos)            /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                 GPIO_LCKR_LCK9_Msk
+#define GPIO_LCKR_LCK10_Pos            (10U)
+#define GPIO_LCKR_LCK10_Msk            (0x1UL << GPIO_LCKR_LCK10_Pos)           /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                GPIO_LCKR_LCK10_Msk
+#define GPIO_LCKR_LCK11_Pos            (11U)
+#define GPIO_LCKR_LCK11_Msk            (0x1UL << GPIO_LCKR_LCK11_Pos)           /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                GPIO_LCKR_LCK11_Msk
+#define GPIO_LCKR_LCK12_Pos            (12U)
+#define GPIO_LCKR_LCK12_Msk            (0x1UL << GPIO_LCKR_LCK12_Pos)           /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                GPIO_LCKR_LCK12_Msk
+#define GPIO_LCKR_LCK13_Pos            (13U)
+#define GPIO_LCKR_LCK13_Msk            (0x1UL << GPIO_LCKR_LCK13_Pos)           /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                GPIO_LCKR_LCK13_Msk
+#define GPIO_LCKR_LCK14_Pos            (14U)
+#define GPIO_LCKR_LCK14_Msk            (0x1UL << GPIO_LCKR_LCK14_Pos)           /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                GPIO_LCKR_LCK14_Msk
+#define GPIO_LCKR_LCK15_Pos            (15U)
+#define GPIO_LCKR_LCK15_Msk            (0x1UL << GPIO_LCKR_LCK15_Pos)           /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                GPIO_LCKR_LCK15_Msk
+#define GPIO_LCKR_LCKK_Pos             (16U)
+#define GPIO_LCKR_LCKK_Msk             (0x1UL << GPIO_LCKR_LCKK_Pos)            /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                 GPIO_LCKR_LCKK_Msk
+
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos           (0U)
+#define GPIO_AFRL_AFSEL0_Msk           (0xFUL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0               GPIO_AFRL_AFSEL0_Msk
+#define GPIO_AFRL_AFSEL0_0             (0x1UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1             (0x2UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2             (0x4UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3             (0x8UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos           (4U)
+#define GPIO_AFRL_AFSEL1_Msk           (0xFUL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1               GPIO_AFRL_AFSEL1_Msk
+#define GPIO_AFRL_AFSEL1_0             (0x1UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1             (0x2UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2             (0x4UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3             (0x8UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos           (8U)
+#define GPIO_AFRL_AFSEL2_Msk           (0xFUL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2               GPIO_AFRL_AFSEL2_Msk
+#define GPIO_AFRL_AFSEL2_0             (0x1UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1             (0x2UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2             (0x4UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3             (0x8UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos           (12U)
+#define GPIO_AFRL_AFSEL3_Msk           (0xFUL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3               GPIO_AFRL_AFSEL3_Msk
+#define GPIO_AFRL_AFSEL3_0             (0x1UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1             (0x2UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2             (0x4UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3             (0x8UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos           (16U)
+#define GPIO_AFRL_AFSEL4_Msk           (0xFUL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4               GPIO_AFRL_AFSEL4_Msk
+#define GPIO_AFRL_AFSEL4_0             (0x1UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1             (0x2UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2             (0x4UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3             (0x8UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos           (20U)
+#define GPIO_AFRL_AFSEL5_Msk           (0xFUL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5               GPIO_AFRL_AFSEL5_Msk
+#define GPIO_AFRL_AFSEL5_0             (0x1UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1             (0x2UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2             (0x4UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3             (0x8UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos           (24U)
+#define GPIO_AFRL_AFSEL6_Msk           (0xFUL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6               GPIO_AFRL_AFSEL6_Msk
+#define GPIO_AFRL_AFSEL6_0             (0x1UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1             (0x2UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2             (0x4UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3             (0x8UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos           (28U)
+#define GPIO_AFRL_AFSEL7_Msk           (0xFUL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7               GPIO_AFRL_AFSEL7_Msk
+#define GPIO_AFRL_AFSEL7_0             (0x1UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1             (0x2UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2             (0x4UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3             (0x8UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x80000000 */
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos           (0U)
+#define GPIO_AFRH_AFSEL8_Msk           (0xFUL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8               GPIO_AFRH_AFSEL8_Msk
+#define GPIO_AFRH_AFSEL8_0             (0x1UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1             (0x2UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2             (0x4UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3             (0x8UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos           (4U)
+#define GPIO_AFRH_AFSEL9_Msk           (0xFUL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9               GPIO_AFRH_AFSEL9_Msk
+#define GPIO_AFRH_AFSEL9_0             (0x1UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1             (0x2UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2             (0x4UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3             (0x8UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos          (8U)
+#define GPIO_AFRH_AFSEL10_Msk          (0xFUL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10              GPIO_AFRH_AFSEL10_Msk
+#define GPIO_AFRH_AFSEL10_0            (0x1UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1            (0x2UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2            (0x4UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3            (0x8UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos          (12U)
+#define GPIO_AFRH_AFSEL11_Msk          (0xFUL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11              GPIO_AFRH_AFSEL11_Msk
+#define GPIO_AFRH_AFSEL11_0            (0x1UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1            (0x2UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2            (0x4UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3            (0x8UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos          (16U)
+#define GPIO_AFRH_AFSEL12_Msk          (0xFUL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12              GPIO_AFRH_AFSEL12_Msk
+#define GPIO_AFRH_AFSEL12_0            (0x1UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1            (0x2UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2            (0x4UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3            (0x8UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos          (20U)
+#define GPIO_AFRH_AFSEL13_Msk          (0xFUL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13              GPIO_AFRH_AFSEL13_Msk
+#define GPIO_AFRH_AFSEL13_0            (0x1UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1            (0x2UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2            (0x4UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3            (0x8UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos          (24U)
+#define GPIO_AFRH_AFSEL14_Msk          (0xFUL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14              GPIO_AFRH_AFSEL14_Msk
+#define GPIO_AFRH_AFSEL14_0            (0x1UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1            (0x2UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2            (0x4UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3            (0x8UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos          (28U)
+#define GPIO_AFRH_AFSEL15_Msk          (0xFUL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15              GPIO_AFRH_AFSEL15_Msk
+#define GPIO_AFRH_AFSEL15_0            (0x1UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1            (0x2UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2            (0x4UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3            (0x8UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_BRR register  ******************/
+#define GPIO_BRR_BR0_Pos               (0U)
+#define GPIO_BRR_BR0_Msk               (0x1UL << GPIO_BRR_BR0_Pos)              /*!< 0x00000001 */
+#define GPIO_BRR_BR0                   GPIO_BRR_BR0_Msk
+#define GPIO_BRR_BR1_Pos               (1U)
+#define GPIO_BRR_BR1_Msk               (0x1UL << GPIO_BRR_BR1_Pos)              /*!< 0x00000002 */
+#define GPIO_BRR_BR1                   GPIO_BRR_BR1_Msk
+#define GPIO_BRR_BR2_Pos               (2U)
+#define GPIO_BRR_BR2_Msk               (0x1UL << GPIO_BRR_BR2_Pos)              /*!< 0x00000004 */
+#define GPIO_BRR_BR2                   GPIO_BRR_BR2_Msk
+#define GPIO_BRR_BR3_Pos               (3U)
+#define GPIO_BRR_BR3_Msk               (0x1UL << GPIO_BRR_BR3_Pos)              /*!< 0x00000008 */
+#define GPIO_BRR_BR3                   GPIO_BRR_BR3_Msk
+#define GPIO_BRR_BR4_Pos               (4U)
+#define GPIO_BRR_BR4_Msk               (0x1UL << GPIO_BRR_BR4_Pos)              /*!< 0x00000010 */
+#define GPIO_BRR_BR4                   GPIO_BRR_BR4_Msk
+#define GPIO_BRR_BR5_Pos               (5U)
+#define GPIO_BRR_BR5_Msk               (0x1UL << GPIO_BRR_BR5_Pos)              /*!< 0x00000020 */
+#define GPIO_BRR_BR5                   GPIO_BRR_BR5_Msk
+#define GPIO_BRR_BR6_Pos               (6U)
+#define GPIO_BRR_BR6_Msk               (0x1UL << GPIO_BRR_BR6_Pos)              /*!< 0x00000040 */
+#define GPIO_BRR_BR6                   GPIO_BRR_BR6_Msk
+#define GPIO_BRR_BR7_Pos               (7U)
+#define GPIO_BRR_BR7_Msk               (0x1UL << GPIO_BRR_BR7_Pos)              /*!< 0x00000080 */
+#define GPIO_BRR_BR7                   GPIO_BRR_BR7_Msk
+#define GPIO_BRR_BR8_Pos               (8U)
+#define GPIO_BRR_BR8_Msk               (0x1UL << GPIO_BRR_BR8_Pos)              /*!< 0x00000100 */
+#define GPIO_BRR_BR8                   GPIO_BRR_BR8_Msk
+#define GPIO_BRR_BR9_Pos               (9U)
+#define GPIO_BRR_BR9_Msk               (0x1UL << GPIO_BRR_BR9_Pos)              /*!< 0x00000200 */
+#define GPIO_BRR_BR9                   GPIO_BRR_BR9_Msk
+#define GPIO_BRR_BR10_Pos              (10U)
+#define GPIO_BRR_BR10_Msk              (0x1UL << GPIO_BRR_BR10_Pos)             /*!< 0x00000400 */
+#define GPIO_BRR_BR10                  GPIO_BRR_BR10_Msk
+#define GPIO_BRR_BR11_Pos              (11U)
+#define GPIO_BRR_BR11_Msk              (0x1UL << GPIO_BRR_BR11_Pos)             /*!< 0x00000800 */
+#define GPIO_BRR_BR11                  GPIO_BRR_BR11_Msk
+#define GPIO_BRR_BR12_Pos              (12U)
+#define GPIO_BRR_BR12_Msk              (0x1UL << GPIO_BRR_BR12_Pos)             /*!< 0x00001000 */
+#define GPIO_BRR_BR12                  GPIO_BRR_BR12_Msk
+#define GPIO_BRR_BR13_Pos              (13U)
+#define GPIO_BRR_BR13_Msk              (0x1UL << GPIO_BRR_BR13_Pos)             /*!< 0x00002000 */
+#define GPIO_BRR_BR13                  GPIO_BRR_BR13_Msk
+#define GPIO_BRR_BR14_Pos              (14U)
+#define GPIO_BRR_BR14_Msk              (0x1UL << GPIO_BRR_BR14_Pos)             /*!< 0x00004000 */
+#define GPIO_BRR_BR14                  GPIO_BRR_BR14_Msk
+#define GPIO_BRR_BR15_Pos              (15U)
+#define GPIO_BRR_BR15_Msk              (0x1UL << GPIO_BRR_BR15_Pos)             /*!< 0x00008000 */
+#define GPIO_BRR_BR15                  GPIO_BRR_BR15_Msk
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define I2C_CR1_PE_Pos               (0U)
+#define I2C_CR1_PE_Msk               (0x1UL << I2C_CR1_PE_Pos)                 /*!< 0x00000001 */
+#define I2C_CR1_PE                   I2C_CR1_PE_Msk                            /*!< Peripheral enable */
+#define I2C_CR1_TXIE_Pos             (1U)
+#define I2C_CR1_TXIE_Msk             (0x1UL << I2C_CR1_TXIE_Pos)               /*!< 0x00000002 */
+#define I2C_CR1_TXIE                 I2C_CR1_TXIE_Msk                          /*!< TX interrupt enable */
+#define I2C_CR1_RXIE_Pos             (2U)
+#define I2C_CR1_RXIE_Msk             (0x1UL << I2C_CR1_RXIE_Pos)               /*!< 0x00000004 */
+#define I2C_CR1_RXIE                 I2C_CR1_RXIE_Msk                          /*!< RX interrupt enable */
+#define I2C_CR1_ADDRIE_Pos           (3U)
+#define I2C_CR1_ADDRIE_Msk           (0x1UL << I2C_CR1_ADDRIE_Pos)             /*!< 0x00000008 */
+#define I2C_CR1_ADDRIE               I2C_CR1_ADDRIE_Msk                        /*!< Address match interrupt enable */
+#define I2C_CR1_NACKIE_Pos           (4U)
+#define I2C_CR1_NACKIE_Msk           (0x1UL << I2C_CR1_NACKIE_Pos)             /*!< 0x00000010 */
+#define I2C_CR1_NACKIE               I2C_CR1_NACKIE_Msk                        /*!< NACK received interrupt enable */
+#define I2C_CR1_STOPIE_Pos           (5U)
+#define I2C_CR1_STOPIE_Msk           (0x1UL << I2C_CR1_STOPIE_Pos)             /*!< 0x00000020 */
+#define I2C_CR1_STOPIE               I2C_CR1_STOPIE_Msk                        /*!< STOP detection interrupt enable */
+#define I2C_CR1_TCIE_Pos             (6U)
+#define I2C_CR1_TCIE_Msk             (0x1UL << I2C_CR1_TCIE_Pos)               /*!< 0x00000040 */
+#define I2C_CR1_TCIE                 I2C_CR1_TCIE_Msk                          /*!< Transfer complete interrupt enable */
+#define I2C_CR1_ERRIE_Pos            (7U)
+#define I2C_CR1_ERRIE_Msk            (0x1UL << I2C_CR1_ERRIE_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_ERRIE                I2C_CR1_ERRIE_Msk                         /*!< Errors interrupt enable */
+#define I2C_CR1_DNF_Pos              (8U)
+#define I2C_CR1_DNF_Msk              (0xFUL << I2C_CR1_DNF_Pos)                /*!< 0x00000F00 */
+#define I2C_CR1_DNF                  I2C_CR1_DNF_Msk                           /*!< Digital noise filter */
+#define I2C_CR1_ANFOFF_Pos           (12U)
+#define I2C_CR1_ANFOFF_Msk           (0x1UL << I2C_CR1_ANFOFF_Pos)             /*!< 0x00001000 */
+#define I2C_CR1_ANFOFF               I2C_CR1_ANFOFF_Msk                        /*!< Analog noise filter OFF */
+#define I2C_CR1_SWRST_Pos            (13U)
+#define I2C_CR1_SWRST_Msk            (0x1UL << I2C_CR1_SWRST_Pos)              /*!< 0x00002000 */
+#define I2C_CR1_SWRST                I2C_CR1_SWRST_Msk                         /*!< Software reset */
+#define I2C_CR1_TXDMAEN_Pos          (14U)
+#define I2C_CR1_TXDMAEN_Msk          (0x1UL << I2C_CR1_TXDMAEN_Pos)            /*!< 0x00004000 */
+#define I2C_CR1_TXDMAEN              I2C_CR1_TXDMAEN_Msk                       /*!< DMA transmission requests enable */
+#define I2C_CR1_RXDMAEN_Pos          (15U)
+#define I2C_CR1_RXDMAEN_Msk          (0x1UL << I2C_CR1_RXDMAEN_Pos)            /*!< 0x00008000 */
+#define I2C_CR1_RXDMAEN              I2C_CR1_RXDMAEN_Msk                       /*!< DMA reception requests enable */
+#define I2C_CR1_SBC_Pos              (16U)
+#define I2C_CR1_SBC_Msk              (0x1UL << I2C_CR1_SBC_Pos)                /*!< 0x00010000 */
+#define I2C_CR1_SBC                  I2C_CR1_SBC_Msk                           /*!< Slave byte control */
+#define I2C_CR1_NOSTRETCH_Pos        (17U)
+#define I2C_CR1_NOSTRETCH_Msk        (0x1UL << I2C_CR1_NOSTRETCH_Pos)          /*!< 0x00020000 */
+#define I2C_CR1_NOSTRETCH            I2C_CR1_NOSTRETCH_Msk                     /*!< Clock stretching disable */
+#define I2C_CR1_WUPEN_Pos            (18U)
+#define I2C_CR1_WUPEN_Msk            (0x1UL << I2C_CR1_WUPEN_Pos)              /*!< 0x00040000 */
+#define I2C_CR1_WUPEN                I2C_CR1_WUPEN_Msk                         /*!< Wakeup from STOP enable */
+#define I2C_CR1_GCEN_Pos             (19U)
+#define I2C_CR1_GCEN_Msk             (0x1UL << I2C_CR1_GCEN_Pos)               /*!< 0x00080000 */
+#define I2C_CR1_GCEN                 I2C_CR1_GCEN_Msk                          /*!< General call enable */
+#define I2C_CR1_SMBHEN_Pos           (20U)
+#define I2C_CR1_SMBHEN_Msk           (0x1UL << I2C_CR1_SMBHEN_Pos)             /*!< 0x00100000 */
+#define I2C_CR1_SMBHEN               I2C_CR1_SMBHEN_Msk                        /*!< SMBus host address enable */
+#define I2C_CR1_SMBDEN_Pos           (21U)
+#define I2C_CR1_SMBDEN_Msk           (0x1UL << I2C_CR1_SMBDEN_Pos)             /*!< 0x00200000 */
+#define I2C_CR1_SMBDEN               I2C_CR1_SMBDEN_Msk                        /*!< SMBus device default address enable */
+#define I2C_CR1_ALERTEN_Pos          (22U)
+#define I2C_CR1_ALERTEN_Msk          (0x1UL << I2C_CR1_ALERTEN_Pos)            /*!< 0x00400000 */
+#define I2C_CR1_ALERTEN              I2C_CR1_ALERTEN_Msk                       /*!< SMBus alert enable */
+#define I2C_CR1_PECEN_Pos            (23U)
+#define I2C_CR1_PECEN_Msk            (0x1UL << I2C_CR1_PECEN_Pos)              /*!< 0x00800000 */
+#define I2C_CR1_PECEN                I2C_CR1_PECEN_Msk                         /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_SADD_Pos             (0U)
+#define I2C_CR2_SADD_Msk             (0x3FFUL << I2C_CR2_SADD_Pos)             /*!< 0x000003FF */
+#define I2C_CR2_SADD                 I2C_CR2_SADD_Msk                          /*!< Slave address (master mode) */
+#define I2C_CR2_RD_WRN_Pos           (10U)
+#define I2C_CR2_RD_WRN_Msk           (0x1UL << I2C_CR2_RD_WRN_Pos)             /*!< 0x00000400 */
+#define I2C_CR2_RD_WRN               I2C_CR2_RD_WRN_Msk                        /*!< Transfer direction (master mode) */
+#define I2C_CR2_ADD10_Pos            (11U)
+#define I2C_CR2_ADD10_Msk            (0x1UL << I2C_CR2_ADD10_Pos)              /*!< 0x00000800 */
+#define I2C_CR2_ADD10                I2C_CR2_ADD10_Msk                         /*!< 10-bit addressing mode (master mode) */
+#define I2C_CR2_HEAD10R_Pos          (12U)
+#define I2C_CR2_HEAD10R_Msk          (0x1UL << I2C_CR2_HEAD10R_Pos)            /*!< 0x00001000 */
+#define I2C_CR2_HEAD10R              I2C_CR2_HEAD10R_Msk                       /*!< 10-bit address header only read direction (master mode) */
+#define I2C_CR2_START_Pos            (13U)
+#define I2C_CR2_START_Msk            (0x1UL << I2C_CR2_START_Pos)              /*!< 0x00002000 */
+#define I2C_CR2_START                I2C_CR2_START_Msk                         /*!< START generation */
+#define I2C_CR2_STOP_Pos             (14U)
+#define I2C_CR2_STOP_Msk             (0x1UL << I2C_CR2_STOP_Pos)               /*!< 0x00004000 */
+#define I2C_CR2_STOP                 I2C_CR2_STOP_Msk                          /*!< STOP generation (master mode) */
+#define I2C_CR2_NACK_Pos             (15U)
+#define I2C_CR2_NACK_Msk             (0x1UL << I2C_CR2_NACK_Pos)               /*!< 0x00008000 */
+#define I2C_CR2_NACK                 I2C_CR2_NACK_Msk                          /*!< NACK generation (slave mode) */
+#define I2C_CR2_NBYTES_Pos           (16U)
+#define I2C_CR2_NBYTES_Msk           (0xFFUL << I2C_CR2_NBYTES_Pos)            /*!< 0x00FF0000 */
+#define I2C_CR2_NBYTES               I2C_CR2_NBYTES_Msk                        /*!< Number of bytes */
+#define I2C_CR2_RELOAD_Pos           (24U)
+#define I2C_CR2_RELOAD_Msk           (0x1UL << I2C_CR2_RELOAD_Pos)             /*!< 0x01000000 */
+#define I2C_CR2_RELOAD               I2C_CR2_RELOAD_Msk                        /*!< NBYTES reload mode */
+#define I2C_CR2_AUTOEND_Pos          (25U)
+#define I2C_CR2_AUTOEND_Msk          (0x1UL << I2C_CR2_AUTOEND_Pos)            /*!< 0x02000000 */
+#define I2C_CR2_AUTOEND              I2C_CR2_AUTOEND_Msk                       /*!< Automatic end mode (master mode) */
+#define I2C_CR2_PECBYTE_Pos          (26U)
+#define I2C_CR2_PECBYTE_Msk          (0x1UL << I2C_CR2_PECBYTE_Pos)            /*!< 0x04000000 */
+#define I2C_CR2_PECBYTE              I2C_CR2_PECBYTE_Msk                       /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define I2C_OAR1_OA1_Pos             (0U)
+#define I2C_OAR1_OA1_Msk             (0x3FFUL << I2C_OAR1_OA1_Pos)             /*!< 0x000003FF */
+#define I2C_OAR1_OA1                 I2C_OAR1_OA1_Msk                          /*!< Interface own address 1 */
+#define I2C_OAR1_OA1MODE_Pos         (10U)
+#define I2C_OAR1_OA1MODE_Msk         (0x1UL << I2C_OAR1_OA1MODE_Pos)           /*!< 0x00000400 */
+#define I2C_OAR1_OA1MODE             I2C_OAR1_OA1MODE_Msk                      /*!< Own address 1 10-bit mode */
+#define I2C_OAR1_OA1EN_Pos           (15U)
+#define I2C_OAR1_OA1EN_Msk           (0x1UL << I2C_OAR1_OA1EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR1_OA1EN               I2C_OAR1_OA1EN_Msk                        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define I2C_OAR2_OA2_Pos             (1U)
+#define I2C_OAR2_OA2_Msk             (0x7FUL << I2C_OAR2_OA2_Pos)              /*!< 0x000000FE */
+#define I2C_OAR2_OA2                 I2C_OAR2_OA2_Msk                          /*!< Interface own address 2 */
+#define I2C_OAR2_OA2MSK_Pos          (8U)
+#define I2C_OAR2_OA2MSK_Msk          (0x7UL << I2C_OAR2_OA2MSK_Pos)            /*!< 0x00000700 */
+#define I2C_OAR2_OA2MSK              I2C_OAR2_OA2MSK_Msk                       /*!< Own address 2 masks */
+#define I2C_OAR2_OA2NOMASK           (0U)                                      /*!< No mask                                        */
+#define I2C_OAR2_OA2MASK01_Pos       (8U)
+#define I2C_OAR2_OA2MASK01_Msk       (0x1UL << I2C_OAR2_OA2MASK01_Pos)         /*!< 0x00000100 */
+#define I2C_OAR2_OA2MASK01           I2C_OAR2_OA2MASK01_Msk                    /*!< OA2[1] is masked, Only OA2[7:2] are compared   */
+#define I2C_OAR2_OA2MASK02_Pos       (9U)
+#define I2C_OAR2_OA2MASK02_Msk       (0x1UL << I2C_OAR2_OA2MASK02_Pos)         /*!< 0x00000200 */
+#define I2C_OAR2_OA2MASK02           I2C_OAR2_OA2MASK02_Msk                    /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define I2C_OAR2_OA2MASK03_Pos       (8U)
+#define I2C_OAR2_OA2MASK03_Msk       (0x3UL << I2C_OAR2_OA2MASK03_Pos)         /*!< 0x00000300 */
+#define I2C_OAR2_OA2MASK03           I2C_OAR2_OA2MASK03_Msk                    /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define I2C_OAR2_OA2MASK04_Pos       (10U)
+#define I2C_OAR2_OA2MASK04_Msk       (0x1UL << I2C_OAR2_OA2MASK04_Pos)         /*!< 0x00000400 */
+#define I2C_OAR2_OA2MASK04           I2C_OAR2_OA2MASK04_Msk                    /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define I2C_OAR2_OA2MASK05_Pos       (8U)
+#define I2C_OAR2_OA2MASK05_Msk       (0x5UL << I2C_OAR2_OA2MASK05_Pos)         /*!< 0x00000500 */
+#define I2C_OAR2_OA2MASK05           I2C_OAR2_OA2MASK05_Msk                    /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define I2C_OAR2_OA2MASK06_Pos       (9U)
+#define I2C_OAR2_OA2MASK06_Msk       (0x3UL << I2C_OAR2_OA2MASK06_Pos)         /*!< 0x00000600 */
+#define I2C_OAR2_OA2MASK06           I2C_OAR2_OA2MASK06_Msk                    /*!< OA2[6:1] is masked, Only OA2[7] are compared   */
+#define I2C_OAR2_OA2MASK07_Pos       (8U)
+#define I2C_OAR2_OA2MASK07_Msk       (0x7UL << I2C_OAR2_OA2MASK07_Pos)         /*!< 0x00000700 */
+#define I2C_OAR2_OA2MASK07           I2C_OAR2_OA2MASK07_Msk                    /*!< OA2[7:1] is masked, No comparison is done      */
+#define I2C_OAR2_OA2EN_Pos           (15U)
+#define I2C_OAR2_OA2EN_Msk           (0x1UL << I2C_OAR2_OA2EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR2_OA2EN               I2C_OAR2_OA2EN_Msk                        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define I2C_TIMINGR_SCLL_Pos         (0U)
+#define I2C_TIMINGR_SCLL_Msk         (0xFFUL << I2C_TIMINGR_SCLL_Pos)          /*!< 0x000000FF */
+#define I2C_TIMINGR_SCLL             I2C_TIMINGR_SCLL_Msk                      /*!< SCL low period (master mode) */
+#define I2C_TIMINGR_SCLH_Pos         (8U)
+#define I2C_TIMINGR_SCLH_Msk         (0xFFUL << I2C_TIMINGR_SCLH_Pos)          /*!< 0x0000FF00 */
+#define I2C_TIMINGR_SCLH             I2C_TIMINGR_SCLH_Msk                      /*!< SCL high period (master mode) */
+#define I2C_TIMINGR_SDADEL_Pos       (16U)
+#define I2C_TIMINGR_SDADEL_Msk       (0xFUL << I2C_TIMINGR_SDADEL_Pos)         /*!< 0x000F0000 */
+#define I2C_TIMINGR_SDADEL           I2C_TIMINGR_SDADEL_Msk                    /*!< Data hold time */
+#define I2C_TIMINGR_SCLDEL_Pos       (20U)
+#define I2C_TIMINGR_SCLDEL_Msk       (0xFUL << I2C_TIMINGR_SCLDEL_Pos)         /*!< 0x00F00000 */
+#define I2C_TIMINGR_SCLDEL           I2C_TIMINGR_SCLDEL_Msk                    /*!< Data setup time */
+#define I2C_TIMINGR_PRESC_Pos        (28U)
+#define I2C_TIMINGR_PRESC_Msk        (0xFUL << I2C_TIMINGR_PRESC_Pos)          /*!< 0xF0000000 */
+#define I2C_TIMINGR_PRESC            I2C_TIMINGR_PRESC_Msk                     /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define I2C_TIMEOUTR_TIMEOUTA_Pos    (0U)
+#define I2C_TIMEOUTR_TIMEOUTA_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTA_Pos)    /*!< 0x00000FFF */
+#define I2C_TIMEOUTR_TIMEOUTA        I2C_TIMEOUTR_TIMEOUTA_Msk                 /*!< Bus timeout A */
+#define I2C_TIMEOUTR_TIDLE_Pos       (12U)
+#define I2C_TIMEOUTR_TIDLE_Msk       (0x1UL << I2C_TIMEOUTR_TIDLE_Pos)         /*!< 0x00001000 */
+#define I2C_TIMEOUTR_TIDLE           I2C_TIMEOUTR_TIDLE_Msk                    /*!< Idle clock timeout detection */
+#define I2C_TIMEOUTR_TIMOUTEN_Pos    (15U)
+#define I2C_TIMEOUTR_TIMOUTEN_Msk    (0x1UL << I2C_TIMEOUTR_TIMOUTEN_Pos)      /*!< 0x00008000 */
+#define I2C_TIMEOUTR_TIMOUTEN        I2C_TIMEOUTR_TIMOUTEN_Msk                 /*!< Clock timeout enable */
+#define I2C_TIMEOUTR_TIMEOUTB_Pos    (16U)
+#define I2C_TIMEOUTR_TIMEOUTB_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTB_Pos)    /*!< 0x0FFF0000 */
+#define I2C_TIMEOUTR_TIMEOUTB        I2C_TIMEOUTR_TIMEOUTB_Msk                 /*!< Bus timeout B*/
+#define I2C_TIMEOUTR_TEXTEN_Pos      (31U)
+#define I2C_TIMEOUTR_TEXTEN_Msk      (0x1UL << I2C_TIMEOUTR_TEXTEN_Pos)        /*!< 0x80000000 */
+#define I2C_TIMEOUTR_TEXTEN          I2C_TIMEOUTR_TEXTEN_Msk                   /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define I2C_ISR_TXE_Pos              (0U)
+#define I2C_ISR_TXE_Msk              (0x1UL << I2C_ISR_TXE_Pos)                /*!< 0x00000001 */
+#define I2C_ISR_TXE                  I2C_ISR_TXE_Msk                           /*!< Transmit data register empty */
+#define I2C_ISR_TXIS_Pos             (1U)
+#define I2C_ISR_TXIS_Msk             (0x1UL << I2C_ISR_TXIS_Pos)               /*!< 0x00000002 */
+#define I2C_ISR_TXIS                 I2C_ISR_TXIS_Msk                          /*!< Transmit interrupt status */
+#define I2C_ISR_RXNE_Pos             (2U)
+#define I2C_ISR_RXNE_Msk             (0x1UL << I2C_ISR_RXNE_Pos)               /*!< 0x00000004 */
+#define I2C_ISR_RXNE                 I2C_ISR_RXNE_Msk                          /*!< Receive data register not empty */
+#define I2C_ISR_ADDR_Pos             (3U)
+#define I2C_ISR_ADDR_Msk             (0x1UL << I2C_ISR_ADDR_Pos)               /*!< 0x00000008 */
+#define I2C_ISR_ADDR                 I2C_ISR_ADDR_Msk                          /*!< Address matched (slave mode)*/
+#define I2C_ISR_NACKF_Pos            (4U)
+#define I2C_ISR_NACKF_Msk            (0x1UL << I2C_ISR_NACKF_Pos)              /*!< 0x00000010 */
+#define I2C_ISR_NACKF                I2C_ISR_NACKF_Msk                         /*!< NACK received flag */
+#define I2C_ISR_STOPF_Pos            (5U)
+#define I2C_ISR_STOPF_Msk            (0x1UL << I2C_ISR_STOPF_Pos)              /*!< 0x00000020 */
+#define I2C_ISR_STOPF                I2C_ISR_STOPF_Msk                         /*!< STOP detection flag */
+#define I2C_ISR_TC_Pos               (6U)
+#define I2C_ISR_TC_Msk               (0x1UL << I2C_ISR_TC_Pos)                 /*!< 0x00000040 */
+#define I2C_ISR_TC                   I2C_ISR_TC_Msk                            /*!< Transfer complete (master mode) */
+#define I2C_ISR_TCR_Pos              (7U)
+#define I2C_ISR_TCR_Msk              (0x1UL << I2C_ISR_TCR_Pos)                /*!< 0x00000080 */
+#define I2C_ISR_TCR                  I2C_ISR_TCR_Msk                           /*!< Transfer complete reload */
+#define I2C_ISR_BERR_Pos             (8U)
+#define I2C_ISR_BERR_Msk             (0x1UL << I2C_ISR_BERR_Pos)               /*!< 0x00000100 */
+#define I2C_ISR_BERR                 I2C_ISR_BERR_Msk                          /*!< Bus error */
+#define I2C_ISR_ARLO_Pos             (9U)
+#define I2C_ISR_ARLO_Msk             (0x1UL << I2C_ISR_ARLO_Pos)               /*!< 0x00000200 */
+#define I2C_ISR_ARLO                 I2C_ISR_ARLO_Msk                          /*!< Arbitration lost */
+#define I2C_ISR_OVR_Pos              (10U)
+#define I2C_ISR_OVR_Msk              (0x1UL << I2C_ISR_OVR_Pos)                /*!< 0x00000400 */
+#define I2C_ISR_OVR                  I2C_ISR_OVR_Msk                           /*!< Overrun/Underrun */
+#define I2C_ISR_PECERR_Pos           (11U)
+#define I2C_ISR_PECERR_Msk           (0x1UL << I2C_ISR_PECERR_Pos)             /*!< 0x00000800 */
+#define I2C_ISR_PECERR               I2C_ISR_PECERR_Msk                        /*!< PEC error in reception */
+#define I2C_ISR_TIMEOUT_Pos          (12U)
+#define I2C_ISR_TIMEOUT_Msk          (0x1UL << I2C_ISR_TIMEOUT_Pos)            /*!< 0x00001000 */
+#define I2C_ISR_TIMEOUT              I2C_ISR_TIMEOUT_Msk                       /*!< Timeout or Tlow detection flag */
+#define I2C_ISR_ALERT_Pos            (13U)
+#define I2C_ISR_ALERT_Msk            (0x1UL << I2C_ISR_ALERT_Pos)              /*!< 0x00002000 */
+#define I2C_ISR_ALERT                I2C_ISR_ALERT_Msk                         /*!< SMBus alert */
+#define I2C_ISR_BUSY_Pos             (15U)
+#define I2C_ISR_BUSY_Msk             (0x1UL << I2C_ISR_BUSY_Pos)               /*!< 0x00008000 */
+#define I2C_ISR_BUSY                 I2C_ISR_BUSY_Msk                          /*!< Bus busy */
+#define I2C_ISR_DIR_Pos              (16U)
+#define I2C_ISR_DIR_Msk              (0x1UL << I2C_ISR_DIR_Pos)                /*!< 0x00010000 */
+#define I2C_ISR_DIR                  I2C_ISR_DIR_Msk                           /*!< Transfer direction (slave mode) */
+#define I2C_ISR_ADDCODE_Pos          (17U)
+#define I2C_ISR_ADDCODE_Msk          (0x7FUL << I2C_ISR_ADDCODE_Pos)           /*!< 0x00FE0000 */
+#define I2C_ISR_ADDCODE              I2C_ISR_ADDCODE_Msk                       /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define I2C_ICR_ADDRCF_Pos           (3U)
+#define I2C_ICR_ADDRCF_Msk           (0x1UL << I2C_ICR_ADDRCF_Pos)             /*!< 0x00000008 */
+#define I2C_ICR_ADDRCF               I2C_ICR_ADDRCF_Msk                        /*!< Address matched clear flag */
+#define I2C_ICR_NACKCF_Pos           (4U)
+#define I2C_ICR_NACKCF_Msk           (0x1UL << I2C_ICR_NACKCF_Pos)             /*!< 0x00000010 */
+#define I2C_ICR_NACKCF               I2C_ICR_NACKCF_Msk                        /*!< NACK clear flag */
+#define I2C_ICR_STOPCF_Pos           (5U)
+#define I2C_ICR_STOPCF_Msk           (0x1UL << I2C_ICR_STOPCF_Pos)             /*!< 0x00000020 */
+#define I2C_ICR_STOPCF               I2C_ICR_STOPCF_Msk                        /*!< STOP detection clear flag */
+#define I2C_ICR_BERRCF_Pos           (8U)
+#define I2C_ICR_BERRCF_Msk           (0x1UL << I2C_ICR_BERRCF_Pos)             /*!< 0x00000100 */
+#define I2C_ICR_BERRCF               I2C_ICR_BERRCF_Msk                        /*!< Bus error clear flag */
+#define I2C_ICR_ARLOCF_Pos           (9U)
+#define I2C_ICR_ARLOCF_Msk           (0x1UL << I2C_ICR_ARLOCF_Pos)             /*!< 0x00000200 */
+#define I2C_ICR_ARLOCF               I2C_ICR_ARLOCF_Msk                        /*!< Arbitration lost clear flag */
+#define I2C_ICR_OVRCF_Pos            (10U)
+#define I2C_ICR_OVRCF_Msk            (0x1UL << I2C_ICR_OVRCF_Pos)              /*!< 0x00000400 */
+#define I2C_ICR_OVRCF                I2C_ICR_OVRCF_Msk                         /*!< Overrun/Underrun clear flag */
+#define I2C_ICR_PECCF_Pos            (11U)
+#define I2C_ICR_PECCF_Msk            (0x1UL << I2C_ICR_PECCF_Pos)              /*!< 0x00000800 */
+#define I2C_ICR_PECCF                I2C_ICR_PECCF_Msk                         /*!< PAC error clear flag */
+#define I2C_ICR_TIMOUTCF_Pos         (12U)
+#define I2C_ICR_TIMOUTCF_Msk         (0x1UL << I2C_ICR_TIMOUTCF_Pos)           /*!< 0x00001000 */
+#define I2C_ICR_TIMOUTCF             I2C_ICR_TIMOUTCF_Msk                      /*!< Timeout clear flag */
+#define I2C_ICR_ALERTCF_Pos          (13U)
+#define I2C_ICR_ALERTCF_Msk          (0x1UL << I2C_ICR_ALERTCF_Pos)            /*!< 0x00002000 */
+#define I2C_ICR_ALERTCF              I2C_ICR_ALERTCF_Msk                       /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define I2C_PECR_PEC_Pos             (0U)
+#define I2C_PECR_PEC_Msk             (0xFFUL << I2C_PECR_PEC_Pos)              /*!< 0x000000FF */
+#define I2C_PECR_PEC                 I2C_PECR_PEC_Msk                          /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define I2C_RXDR_RXDATA_Pos          (0U)
+#define I2C_RXDR_RXDATA_Msk          (0xFFUL << I2C_RXDR_RXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_RXDR_RXDATA              I2C_RXDR_RXDATA_Msk                       /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define I2C_TXDR_TXDATA_Pos          (0U)
+#define I2C_TXDR_TXDATA_Msk          (0xFFUL << I2C_TXDR_TXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_TXDR_TXDATA              I2C_TXDR_TXDATA_Msk                       /*!< 8-bit transmit data */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos      (0U)
+#define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
+#define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos       (0U)
+#define IWDG_PR_PR_Msk       (0x7UL << IWDG_PR_PR_Pos)                         /*!< 0x00000007 */
+#define IWDG_PR_PR           IWDG_PR_PR_Msk                                    /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0         (0x1UL << IWDG_PR_PR_Pos)                         /*!< 0x00000001 */
+#define IWDG_PR_PR_1         (0x2UL << IWDG_PR_PR_Pos)                         /*!< 0x00000002 */
+#define IWDG_PR_PR_2         (0x4UL << IWDG_PR_PR_Pos)                         /*!< 0x00000004 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos      (0U)
+#define IWDG_RLR_RL_Msk      (0xFFFUL << IWDG_RLR_RL_Pos)                      /*!< 0x00000FFF */
+#define IWDG_RLR_RL          IWDG_RLR_RL_Msk                                   /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos      (0U)
+#define IWDG_SR_PVU_Msk      (0x1UL << IWDG_SR_PVU_Pos)                        /*!< 0x00000001 */
+#define IWDG_SR_PVU          IWDG_SR_PVU_Msk                                   /*!< Watchdog prescaler value update */
+#define IWDG_SR_RVU_Pos      (1U)
+#define IWDG_SR_RVU_Msk      (0x1UL << IWDG_SR_RVU_Pos)                        /*!< 0x00000002 */
+#define IWDG_SR_RVU          IWDG_SR_RVU_Msk                                   /*!< Watchdog counter reload value update */
+#define IWDG_SR_WVU_Pos      (2U)
+#define IWDG_SR_WVU_Msk      (0x1UL << IWDG_SR_WVU_Pos)                        /*!< 0x00000004 */
+#define IWDG_SR_WVU          IWDG_SR_WVU_Msk                                   /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_WINR_WIN_Pos    (0U)
+#define IWDG_WINR_WIN_Msk    (0xFFFUL << IWDG_WINR_WIN_Pos)                    /*!< 0x00000FFF */
+#define IWDG_WINR_WIN        IWDG_WINR_WIN_Msk                                 /*!< Watchdog counter window value */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Power Control                                       */
+/*                                                                            */
+/******************************************************************************/
+#define PWR_PVD_SUPPORT                       /*!< PWR feature available only on specific devices: Power Voltage Detection feature */
+#define PWR_BOR_SUPPORT                       /*!< PWR feature available only on specific devices: Brown-Out Reset feature         */
+#define PWR_SHDW_SUPPORT                      /*!< PWR feature available only on specific devices: Shutdown mode */
+
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define PWR_CR1_LPMS_Pos          (0U)
+#define PWR_CR1_LPMS_Msk          (0x7UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000007 */
+#define PWR_CR1_LPMS              PWR_CR1_LPMS_Msk                             /*!< Low Power Mode Selection */
+#define PWR_CR1_LPMS_0            (0x1UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000001 */
+#define PWR_CR1_LPMS_1            (0x2UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000002 */
+#define PWR_CR1_LPMS_2            (0x4UL << PWR_CR1_LPMS_Pos)                   /*!< 0x00000004 */
+#define PWR_CR1_FPD_STOP_Pos      (3U)
+#define PWR_CR1_FPD_STOP_Msk      (0x1UL << PWR_CR1_FPD_STOP_Pos)              /*!< 0x00000008 */
+#define PWR_CR1_FPD_STOP          PWR_CR1_FPD_STOP_Msk                         /*!< Flash power down mode during stop */
+#define PWR_CR1_FPD_LPRUN_Pos     (4U)
+#define PWR_CR1_FPD_LPRUN_Msk     (0x1UL << PWR_CR1_FPD_LPRUN_Pos)             /*!< 0x00000010 */
+#define PWR_CR1_FPD_LPRUN         PWR_CR1_FPD_LPRUN_Msk                        /*!< Flash power down mode during run */
+#define PWR_CR1_FPD_LPSLP_Pos     (5U)
+#define PWR_CR1_FPD_LPSLP_Msk     (0x1UL << PWR_CR1_FPD_LPSLP_Pos)             /*!< 0x00000020 */
+#define PWR_CR1_FPD_LPSLP         PWR_CR1_FPD_LPSLP_Msk                        /*!< Flash power down mode during sleep */
+#define PWR_CR1_DBP_Pos           (8U)
+#define PWR_CR1_DBP_Msk           (0x1UL << PWR_CR1_DBP_Pos)                   /*!< 0x00000100 */
+#define PWR_CR1_DBP               PWR_CR1_DBP_Msk                              /*!< Disable Backup Domain write protection */
+#define PWR_CR1_VOS_Pos           (9U)
+#define PWR_CR1_VOS_Msk           (0x3UL << PWR_CR1_VOS_Pos)                   /*!< 0x00000600 */
+#define PWR_CR1_VOS               PWR_CR1_VOS_Msk                              /*!< Voltage scaling */
+#define PWR_CR1_VOS_0             (0x1UL << PWR_CR1_VOS_Pos)                   /*!< Voltage scaling bit 0 */
+#define PWR_CR1_VOS_1             (0x2UL << PWR_CR1_VOS_Pos)                   /*!< Voltage scaling bit 1 */
+#define PWR_CR1_LPR_Pos           (14U)
+#define PWR_CR1_LPR_Msk           (0x1UL << PWR_CR1_LPR_Pos)                   /*!< 0x00004000 */
+#define PWR_CR1_LPR               PWR_CR1_LPR_Msk                              /*!< Regulator Low-Power Run mode */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define PWR_CR2_PVDE_Pos          (0U)
+#define PWR_CR2_PVDE_Msk          (0x1UL << PWR_CR2_PVDE_Pos)                  /*!< 0x00000001 */
+#define PWR_CR2_PVDE              PWR_CR2_PVDE_Msk                             /*!< Programmable Voltage Detector Enable */
+#define PWR_CR2_PVDFT_Pos         (1U)
+#define PWR_CR2_PVDFT_Msk         (0x7UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x0000000E */
+#define PWR_CR2_PVDFT             PWR_CR2_PVDFT_Msk                            /*!< PVD Falling Threshold Selection bit field */
+#define PWR_CR2_PVDFT_0           (0x1UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x00000002 */
+#define PWR_CR2_PVDFT_1           (0x2UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x00000004 */
+#define PWR_CR2_PVDFT_2           (0x4UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x00000008 */
+#define PWR_CR2_PVDRT_Pos         (4U)
+#define PWR_CR2_PVDRT_Msk         (0x7UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000070 */
+#define PWR_CR2_PVDRT             PWR_CR2_PVDRT_Msk                            /*!< PVD Rising Threshold Selection bit field */
+#define PWR_CR2_PVDRT_0           (0x1UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000010 */
+#define PWR_CR2_PVDRT_1           (0x2UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000020 */
+#define PWR_CR2_PVDRT_2           (0x4UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000040 */
+
+/********************  Bit definition for PWR_CR3 register  ********************/
+#define PWR_CR3_EWUP_Pos          (0U)
+#define PWR_CR3_EWUP_Msk          (0x2BUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000002B */
+#define PWR_CR3_EWUP              PWR_CR3_EWUP_Msk                             /*!< Enable all Wake-Up Pins  */
+#define PWR_CR3_EWUP1_Pos         (0U)
+#define PWR_CR3_EWUP1_Msk         (0x1UL << PWR_CR3_EWUP1_Pos)                 /*!< 0x00000001 */
+#define PWR_CR3_EWUP1             PWR_CR3_EWUP1_Msk                            /*!< Enable WKUP pin 1 */
+#define PWR_CR3_EWUP2_Pos         (1U)
+#define PWR_CR3_EWUP2_Msk         (0x1UL << PWR_CR3_EWUP2_Pos)                 /*!< 0x00000002 */
+#define PWR_CR3_EWUP2             PWR_CR3_EWUP2_Msk                            /*!< Enable WKUP pin 2 */
+#define PWR_CR3_EWUP4_Pos         (3U)
+#define PWR_CR3_EWUP4_Msk         (0x1UL << PWR_CR3_EWUP4_Pos)                 /*!< 0x00000008 */
+#define PWR_CR3_EWUP4             PWR_CR3_EWUP4_Msk                            /*!< Enable WKUP pin 4 */
+#define PWR_CR3_EWUP6_Pos         (5U)
+#define PWR_CR3_EWUP6_Msk         (0x1UL << PWR_CR3_EWUP6_Pos)                 /*!< 0x00000020 */
+#define PWR_CR3_EWUP6             PWR_CR3_EWUP6_Msk                            /*!< Enable WKUP pin 6 */
+#define PWR_CR3_RRS_Pos           (8U)
+#define PWR_CR3_RRS_Msk           (0x1UL << PWR_CR3_RRS_Pos)                   /*!< 0x00000100 */
+#define PWR_CR3_RRS               PWR_CR3_RRS_Msk                              /*!< RAM retention in Standby mode */
+#define PWR_CR3_ENB_ULP_Pos       (9U)
+#define PWR_CR3_ENB_ULP_Msk       (0x1UL << PWR_CR3_ENB_ULP_Pos)               /*!< 0x00000200 */
+#define PWR_CR3_ENB_ULP           PWR_CR3_ENB_ULP_Msk                          /*!< Enable sampling resistor bridge in the LPMU_RESET block */
+#define PWR_CR3_APC_Pos           (10U)
+#define PWR_CR3_APC_Msk           (0x1UL << PWR_CR3_APC_Pos)                   /*!< 0x00000400 */
+#define PWR_CR3_APC               PWR_CR3_APC_Msk                              /*!< Apply pull-up and pull-down configuration */
+#define PWR_CR3_EIWUL_Pos         (15U)
+#define PWR_CR3_EIWUL_Msk         (0x1UL << PWR_CR3_EIWUL_Pos)                 /*!< 0x00008000 */
+#define PWR_CR3_EIWUL             PWR_CR3_EIWUL_Msk                            /*!< Enable Internal Wake-up line */
+
+/********************  Bit definition for PWR_CR4 register  ********************/
+#define PWR_CR4_WP_Pos            (0U)
+#define PWR_CR4_WP_Msk            (0x2BUL << PWR_CR4_WP_Pos)                   /*!< 0x0000002B */
+#define PWR_CR4_WP                PWR_CR4_WP_Msk                               /*!< all Wake-Up Pin polarity */
+#define PWR_CR4_WP1_Pos           (0U)
+#define PWR_CR4_WP1_Msk           (0x1UL << PWR_CR4_WP1_Pos)                   /*!< 0x00000001 */
+#define PWR_CR4_WP1               PWR_CR4_WP1_Msk                              /*!< Wake-Up Pin 1 polarity */
+#define PWR_CR4_WP2_Pos           (1U)
+#define PWR_CR4_WP2_Msk           (0x1UL << PWR_CR4_WP2_Pos)                   /*!< 0x00000002 */
+#define PWR_CR4_WP2               PWR_CR4_WP2_Msk                              /*!< Wake-Up Pin 2 polarity */
+#define PWR_CR4_WP4_Pos           (3U)
+#define PWR_CR4_WP4_Msk           (0x1UL << PWR_CR4_WP4_Pos)                   /*!< 0x00000008 */
+#define PWR_CR4_WP4               PWR_CR4_WP4_Msk                              /*!< Wake-Up Pin 4 polarity */
+#define PWR_CR4_WP6_Pos           (5U)
+#define PWR_CR4_WP6_Msk           (0x1UL << PWR_CR4_WP6_Pos)                   /*!< 0x00000020 */
+#define PWR_CR4_WP6               PWR_CR4_WP6_Msk                              /*!< Wake-Up Pin 6 polarity */
+#define PWR_CR4_VBE_Pos           (8U)
+#define PWR_CR4_VBE_Msk           (0x1UL << PWR_CR4_VBE_Pos)                   /*!< 0x00000100 */
+#define PWR_CR4_VBE               PWR_CR4_VBE_Msk                              /*!< VBAT Battery charging Enable  */
+#define PWR_CR4_VBRS_Pos          (9U)
+#define PWR_CR4_VBRS_Msk          (0x1UL << PWR_CR4_VBRS_Pos)                  /*!< 0x00000200 */
+#define PWR_CR4_VBRS              PWR_CR4_VBRS_Msk                             /*!< VBAT Battery charging Resistor Selection */
+
+/********************  Bit definition for PWR_SR1 register  ********************/
+#define PWR_SR1_WUF_Pos           (0U)
+#define PWR_SR1_WUF_Msk           (0x2BUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000002B */
+#define PWR_SR1_WUF               PWR_SR1_WUF_Msk                              /*!< Wakeup Flags  */
+#define PWR_SR1_WUF1_Pos          (0U)
+#define PWR_SR1_WUF1_Msk          (0x1UL << PWR_SR1_WUF1_Pos)                  /*!< 0x00000001 */
+#define PWR_SR1_WUF1              PWR_SR1_WUF1_Msk                             /*!< Wakeup Flag 1 */
+#define PWR_SR1_WUF2_Pos          (1U)
+#define PWR_SR1_WUF2_Msk          (0x1UL << PWR_SR1_WUF2_Pos)                  /*!< 0x00000002 */
+#define PWR_SR1_WUF2              PWR_SR1_WUF2_Msk                             /*!< Wakeup Flag 2 */
+#define PWR_SR1_WUF4_Pos          (3U)
+#define PWR_SR1_WUF4_Msk          (0x1UL << PWR_SR1_WUF4_Pos)                  /*!< 0x00000008 */
+#define PWR_SR1_WUF4              PWR_SR1_WUF4_Msk                             /*!< Wakeup Flag 4 */
+#define PWR_SR1_WUF6_Pos          (5U)
+#define PWR_SR1_WUF6_Msk          (0x1UL << PWR_SR1_WUF6_Pos)                  /*!< 0x00000020 */
+#define PWR_SR1_WUF6              PWR_SR1_WUF6_Msk                             /*!< Wakeup Flag 6 */
+#define PWR_SR1_SBF_Pos           (8U)
+#define PWR_SR1_SBF_Msk           (0x1UL << PWR_SR1_SBF_Pos)                   /*!< 0x00000100 */
+#define PWR_SR1_SBF               PWR_SR1_SBF_Msk                              /*!< Standby Flag  */
+#define PWR_SR1_WUFI_Pos          (15U)
+#define PWR_SR1_WUFI_Msk          (0x1UL << PWR_SR1_WUFI_Pos)                  /*!< 0x00008000 */
+#define PWR_SR1_WUFI              PWR_SR1_WUFI_Msk                             /*!< Wakeup Flag Internal */
+
+/********************  Bit definition for PWR_SR2 register  ********************/
+#define PWR_SR2_FLASH_RDY_Pos     (7U)
+#define PWR_SR2_FLASH_RDY_Msk     (0x1UL << PWR_SR2_FLASH_RDY_Pos)             /*!< 0x00000080 */
+#define PWR_SR2_FLASH_RDY         PWR_SR2_FLASH_RDY_Msk                        /*!< Flash Ready */
+#define PWR_SR2_REGLPS_Pos        (8U)
+#define PWR_SR2_REGLPS_Msk        (0x1UL << PWR_SR2_REGLPS_Pos)                /*!< 0x00000100 */
+#define PWR_SR2_REGLPS            PWR_SR2_REGLPS_Msk                           /*!< Regulator Low Power started */
+#define PWR_SR2_REGLPF_Pos        (9U)
+#define PWR_SR2_REGLPF_Msk        (0x1UL << PWR_SR2_REGLPF_Pos)                /*!< 0x00000200 */
+#define PWR_SR2_REGLPF            PWR_SR2_REGLPF_Msk                           /*!< Regulator Low Power flag    */
+#define PWR_SR2_VOSF_Pos          (10U)
+#define PWR_SR2_VOSF_Msk          (0x1UL << PWR_SR2_VOSF_Pos)                  /*!< 0x00000400 */
+#define PWR_SR2_VOSF              PWR_SR2_VOSF_Msk                             /*!< Voltage Scaling Flag */
+#define PWR_SR2_PVDO_Pos          (11U)
+#define PWR_SR2_PVDO_Msk          (0x1UL << PWR_SR2_PVDO_Pos)                  /*!< 0x00000800 */
+#define PWR_SR2_PVDO              PWR_SR2_PVDO_Msk                             /*!< Power voltage detector output */
+
+/********************  Bit definition for PWR_SCR register  ********************/
+#define PWR_SCR_CWUF_Pos          (0U)
+#define PWR_SCR_CWUF_Msk          (0x2BUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000002B */
+#define PWR_SCR_CWUF              PWR_SCR_CWUF_Msk                             /*!< Clear Wake-up Flags  */
+#define PWR_SCR_CWUF1_Pos         (0U)
+#define PWR_SCR_CWUF1_Msk         (0x1UL << PWR_SCR_CWUF1_Pos)                 /*!< 0x00000001 */
+#define PWR_SCR_CWUF1             PWR_SCR_CWUF1_Msk                            /*!< Clear Wake-up Flag 1 */
+#define PWR_SCR_CWUF2_Pos         (1U)
+#define PWR_SCR_CWUF2_Msk         (0x1UL << PWR_SCR_CWUF2_Pos)                 /*!< 0x00000002 */
+#define PWR_SCR_CWUF2             PWR_SCR_CWUF2_Msk                            /*!< Clear Wake-up Flag 2 */
+#define PWR_SCR_CWUF4_Pos         (3U)
+#define PWR_SCR_CWUF4_Msk         (0x1UL << PWR_SCR_CWUF4_Pos)                 /*!< 0x00000008 */
+#define PWR_SCR_CWUF4             PWR_SCR_CWUF4_Msk                            /*!< Clear Wake-up Flag 4 */
+#define PWR_SCR_CWUF6_Pos         (5U)
+#define PWR_SCR_CWUF6_Msk         (0x1UL << PWR_SCR_CWUF6_Pos)                 /*!< 0x00000020 */
+#define PWR_SCR_CWUF6             PWR_SCR_CWUF6_Msk                            /*!< Clear Wake-up Flag 6 */
+#define PWR_SCR_CSBF_Pos          (8U)
+#define PWR_SCR_CSBF_Msk          (0x1UL << PWR_SCR_CSBF_Pos)                  /*!< 0x00000100 */
+#define PWR_SCR_CSBF              PWR_SCR_CSBF_Msk                             /*!< Clear Standby Flag  */
+
+/********************  Bit definition for PWR_PUCRA register  *****************/
+#define PWR_PUCRA_PU0_Pos         (0U)
+#define PWR_PUCRA_PU0_Msk         (0x1UL << PWR_PUCRA_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRA_PU0             PWR_PUCRA_PU0_Msk                            /*!< Pin PA0 Pull-Up set */
+#define PWR_PUCRA_PU1_Pos         (1U)
+#define PWR_PUCRA_PU1_Msk         (0x1UL << PWR_PUCRA_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRA_PU1             PWR_PUCRA_PU1_Msk                            /*!< Pin PA1 Pull-Up set */
+#define PWR_PUCRA_PU2_Pos         (2U)
+#define PWR_PUCRA_PU2_Msk         (0x1UL << PWR_PUCRA_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRA_PU2             PWR_PUCRA_PU2_Msk                            /*!< Pin PA2 Pull-Up set */
+#define PWR_PUCRA_PU3_Pos         (3U)
+#define PWR_PUCRA_PU3_Msk         (0x1UL << PWR_PUCRA_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRA_PU3             PWR_PUCRA_PU3_Msk                            /*!< Pin PA3 Pull-Up set */
+#define PWR_PUCRA_PU4_Pos         (4U)
+#define PWR_PUCRA_PU4_Msk         (0x1UL << PWR_PUCRA_PU4_Pos)                 /*!< 0x00000010 */
+#define PWR_PUCRA_PU4             PWR_PUCRA_PU4_Msk                            /*!< Pin PA4 Pull-Up set */
+#define PWR_PUCRA_PU5_Pos         (5U)
+#define PWR_PUCRA_PU5_Msk         (0x1UL << PWR_PUCRA_PU5_Pos)                 /*!< 0x00000020 */
+#define PWR_PUCRA_PU5             PWR_PUCRA_PU5_Msk                            /*!< Pin PA5 Pull-Up set */
+#define PWR_PUCRA_PU6_Pos         (6U)
+#define PWR_PUCRA_PU6_Msk         (0x1UL << PWR_PUCRA_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRA_PU6             PWR_PUCRA_PU6_Msk                            /*!< Pin PA6 Pull-Up set */
+#define PWR_PUCRA_PU7_Pos         (7U)
+#define PWR_PUCRA_PU7_Msk         (0x1UL << PWR_PUCRA_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRA_PU7             PWR_PUCRA_PU7_Msk                            /*!< Pin PA7 Pull-Up set */
+#define PWR_PUCRA_PU8_Pos         (8U)
+#define PWR_PUCRA_PU8_Msk         (0x1UL << PWR_PUCRA_PU8_Pos)                 /*!< 0x00000100 */
+#define PWR_PUCRA_PU8             PWR_PUCRA_PU8_Msk                            /*!< Pin PA8 Pull-Up set */
+#define PWR_PUCRA_PU9_Pos         (9U)
+#define PWR_PUCRA_PU9_Msk         (0x1UL << PWR_PUCRA_PU9_Pos)                 /*!< 0x00000200 */
+#define PWR_PUCRA_PU9             PWR_PUCRA_PU9_Msk                            /*!< Pin PA9 Pull-Up set */
+#define PWR_PUCRA_PU10_Pos        (10U)
+#define PWR_PUCRA_PU10_Msk        (0x1UL << PWR_PUCRA_PU10_Pos)                /*!< 0x00000400 */
+#define PWR_PUCRA_PU10            PWR_PUCRA_PU10_Msk                           /*!< Pin PA10 Pull-Up set */
+#define PWR_PUCRA_PU11_Pos        (11U)
+#define PWR_PUCRA_PU11_Msk        (0x1UL << PWR_PUCRA_PU11_Pos)                /*!< 0x00000800 */
+#define PWR_PUCRA_PU11            PWR_PUCRA_PU11_Msk                           /*!< Pin PA11 Pull-Up set */
+#define PWR_PUCRA_PU12_Pos        (12U)
+#define PWR_PUCRA_PU12_Msk        (0x1UL << PWR_PUCRA_PU12_Pos)                /*!< 0x00001000 */
+#define PWR_PUCRA_PU12            PWR_PUCRA_PU12_Msk                           /*!< Pin PA12 Pull-Up set */
+#define PWR_PUCRA_PU13_Pos        (13U)
+#define PWR_PUCRA_PU13_Msk        (0x1UL << PWR_PUCRA_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRA_PU13            PWR_PUCRA_PU13_Msk                           /*!< Pin PA13 Pull-Up set */
+#define PWR_PUCRA_PU14_Pos        (14U)
+#define PWR_PUCRA_PU14_Msk        (0x1UL << PWR_PUCRA_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRA_PU14            PWR_PUCRA_PU14_Msk                           /*!< Pin PA14 Pull-Up set */
+#define PWR_PUCRA_PU15_Pos        (15U)
+#define PWR_PUCRA_PU15_Msk        (0x1UL << PWR_PUCRA_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRA_PU15            PWR_PUCRA_PU15_Msk                           /*!< Pin PA15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRA register  *****************/
+#define PWR_PDCRA_PD0_Pos         (0U)
+#define PWR_PDCRA_PD0_Msk         (0x1UL << PWR_PDCRA_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRA_PD0             PWR_PDCRA_PD0_Msk                            /*!< Pin PA0 Pull-Down set */
+#define PWR_PDCRA_PD1_Pos         (1U)
+#define PWR_PDCRA_PD1_Msk         (0x1UL << PWR_PDCRA_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRA_PD1             PWR_PDCRA_PD1_Msk                            /*!< Pin PA1 Pull-Down set */
+#define PWR_PDCRA_PD2_Pos         (2U)
+#define PWR_PDCRA_PD2_Msk         (0x1UL << PWR_PDCRA_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRA_PD2             PWR_PDCRA_PD2_Msk                            /*!< Pin PA2 Pull-Down set */
+#define PWR_PDCRA_PD3_Pos         (3U)
+#define PWR_PDCRA_PD3_Msk         (0x1UL << PWR_PDCRA_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRA_PD3             PWR_PDCRA_PD3_Msk                            /*!< Pin PA3 Pull-Down set */
+#define PWR_PDCRA_PD4_Pos         (4U)
+#define PWR_PDCRA_PD4_Msk         (0x1UL << PWR_PDCRA_PD4_Pos)                 /*!< 0x00000010 */
+#define PWR_PDCRA_PD4             PWR_PDCRA_PD4_Msk                            /*!< Pin PA4 Pull-Down set */
+#define PWR_PDCRA_PD5_Pos         (5U)
+#define PWR_PDCRA_PD5_Msk         (0x1UL << PWR_PDCRA_PD5_Pos)                 /*!< 0x00000020 */
+#define PWR_PDCRA_PD5             PWR_PDCRA_PD5_Msk                            /*!< Pin PA5 Pull-Down set */
+#define PWR_PDCRA_PD6_Pos         (6U)
+#define PWR_PDCRA_PD6_Msk         (0x1UL << PWR_PDCRA_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRA_PD6             PWR_PDCRA_PD6_Msk                            /*!< Pin PA6 Pull-Down set */
+#define PWR_PDCRA_PD7_Pos         (7U)
+#define PWR_PDCRA_PD7_Msk         (0x1UL << PWR_PDCRA_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRA_PD7             PWR_PDCRA_PD7_Msk                            /*!< Pin PA7 Pull-Down set */
+#define PWR_PDCRA_PD8_Pos         (8U)
+#define PWR_PDCRA_PD8_Msk         (0x1UL << PWR_PDCRA_PD8_Pos)                 /*!< 0x00000100 */
+#define PWR_PDCRA_PD8             PWR_PDCRA_PD8_Msk                            /*!< Pin PA8 Pull-Down set */
+#define PWR_PDCRA_PD9_Pos         (9U)
+#define PWR_PDCRA_PD9_Msk         (0x1UL << PWR_PDCRA_PD9_Pos)                 /*!< 0x00000200 */
+#define PWR_PDCRA_PD9             PWR_PDCRA_PD9_Msk                            /*!< Pin PA9 Pull-Down set */
+#define PWR_PDCRA_PD10_Pos        (10U)
+#define PWR_PDCRA_PD10_Msk        (0x1UL << PWR_PDCRA_PD10_Pos)                /*!< 0x00000400 */
+#define PWR_PDCRA_PD10            PWR_PDCRA_PD10_Msk                           /*!< Pin PA10 Pull-Down set */
+#define PWR_PDCRA_PD11_Pos        (11U)
+#define PWR_PDCRA_PD11_Msk        (0x1UL << PWR_PDCRA_PD11_Pos)                /*!< 0x00000800 */
+#define PWR_PDCRA_PD11            PWR_PDCRA_PD11_Msk                           /*!< Pin PA11 Pull-Down set */
+#define PWR_PDCRA_PD12_Pos        (12U)
+#define PWR_PDCRA_PD12_Msk        (0x1UL << PWR_PDCRA_PD12_Pos)                /*!< 0x00001000 */
+#define PWR_PDCRA_PD12            PWR_PDCRA_PD12_Msk                           /*!< Pin PA12 Pull-Down set */
+#define PWR_PDCRA_PD13_Pos        (13U)
+#define PWR_PDCRA_PD13_Msk        (0x1UL << PWR_PDCRA_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRA_PD13            PWR_PDCRA_PD13_Msk                           /*!< Pin PA13 Pull-Down set */
+#define PWR_PDCRA_PD14_Pos        (14U)
+#define PWR_PDCRA_PD14_Msk        (0x1UL << PWR_PDCRA_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRA_PD14            PWR_PDCRA_PD14_Msk                           /*!< Pin PA14 Pull-Down set */
+#define PWR_PDCRA_PD15_Pos        (15U)
+#define PWR_PDCRA_PD15_Msk        (0x1UL << PWR_PDCRA_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRA_PD15            PWR_PDCRA_PD15_Msk                           /*!< Pin PA15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRB register  *****************/
+#define PWR_PUCRB_PU0_Pos         (0U)
+#define PWR_PUCRB_PU0_Msk         (0x1UL << PWR_PUCRB_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRB_PU0             PWR_PUCRB_PU0_Msk                            /*!< Pin PB0 Pull-Up set */
+#define PWR_PUCRB_PU1_Pos         (1U)
+#define PWR_PUCRB_PU1_Msk         (0x1UL << PWR_PUCRB_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRB_PU1             PWR_PUCRB_PU1_Msk                            /*!< Pin PB1 Pull-Up set */
+#define PWR_PUCRB_PU2_Pos         (2U)
+#define PWR_PUCRB_PU2_Msk         (0x1UL << PWR_PUCRB_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRB_PU2             PWR_PUCRB_PU2_Msk                            /*!< Pin PB2 Pull-Up set */
+#define PWR_PUCRB_PU3_Pos         (3U)
+#define PWR_PUCRB_PU3_Msk         (0x1UL << PWR_PUCRB_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRB_PU3             PWR_PUCRB_PU3_Msk                            /*!< Pin PB3 Pull-Up set */
+#define PWR_PUCRB_PU4_Pos         (4U)
+#define PWR_PUCRB_PU4_Msk         (0x1UL << PWR_PUCRB_PU4_Pos)                 /*!< 0x00000010 */
+#define PWR_PUCRB_PU4             PWR_PUCRB_PU4_Msk                            /*!< Pin PB4 Pull-Up set */
+#define PWR_PUCRB_PU5_Pos         (5U)
+#define PWR_PUCRB_PU5_Msk         (0x1UL << PWR_PUCRB_PU5_Pos)                 /*!< 0x00000020 */
+#define PWR_PUCRB_PU5             PWR_PUCRB_PU5_Msk                            /*!< Pin PB5 Pull-Up set */
+#define PWR_PUCRB_PU6_Pos         (6U)
+#define PWR_PUCRB_PU6_Msk         (0x1UL << PWR_PUCRB_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRB_PU6             PWR_PUCRB_PU6_Msk                            /*!< Pin PB6 Pull-Up set */
+#define PWR_PUCRB_PU7_Pos         (7U)
+#define PWR_PUCRB_PU7_Msk         (0x1UL << PWR_PUCRB_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRB_PU7             PWR_PUCRB_PU7_Msk                            /*!< Pin PB7 Pull-Up set */
+#define PWR_PUCRB_PU8_Pos         (8U)
+#define PWR_PUCRB_PU8_Msk         (0x1UL << PWR_PUCRB_PU8_Pos)                 /*!< 0x00000100 */
+#define PWR_PUCRB_PU8             PWR_PUCRB_PU8_Msk                            /*!< Pin PB8 Pull-Up set */
+#define PWR_PUCRB_PU9_Pos         (9U)
+#define PWR_PUCRB_PU9_Msk         (0x1UL << PWR_PUCRB_PU9_Pos)                 /*!< 0x00000200 */
+#define PWR_PUCRB_PU9             PWR_PUCRB_PU9_Msk                            /*!< Pin PB9 Pull-Up set */
+#define PWR_PUCRB_PU10_Pos        (10U)
+#define PWR_PUCRB_PU10_Msk        (0x1UL << PWR_PUCRB_PU10_Pos)                /*!< 0x00000400 */
+#define PWR_PUCRB_PU10            PWR_PUCRB_PU10_Msk                           /*!< Pin PB10 Pull-Up set */
+#define PWR_PUCRB_PU11_Pos        (11U)
+#define PWR_PUCRB_PU11_Msk        (0x1UL << PWR_PUCRB_PU11_Pos)                /*!< 0x00000800 */
+#define PWR_PUCRB_PU11            PWR_PUCRB_PU11_Msk                           /*!< Pin PB11 Pull-Up set */
+#define PWR_PUCRB_PU12_Pos        (12U)
+#define PWR_PUCRB_PU12_Msk        (0x1UL << PWR_PUCRB_PU12_Pos)                /*!< 0x00001000 */
+#define PWR_PUCRB_PU12            PWR_PUCRB_PU12_Msk                           /*!< Pin PB12 Pull-Up set */
+#define PWR_PUCRB_PU13_Pos        (13U)
+#define PWR_PUCRB_PU13_Msk        (0x1UL << PWR_PUCRB_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRB_PU13            PWR_PUCRB_PU13_Msk                           /*!< Pin PB13 Pull-Up set */
+#define PWR_PUCRB_PU14_Pos        (14U)
+#define PWR_PUCRB_PU14_Msk        (0x1UL << PWR_PUCRB_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRB_PU14            PWR_PUCRB_PU14_Msk                           /*!< Pin PB14 Pull-Up set */
+#define PWR_PUCRB_PU15_Pos        (15U)
+#define PWR_PUCRB_PU15_Msk        (0x1UL << PWR_PUCRB_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRB_PU15            PWR_PUCRB_PU15_Msk                           /*!< Pin PB15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRB register  *****************/
+#define PWR_PDCRB_PD0_Pos         (0U)
+#define PWR_PDCRB_PD0_Msk         (0x1UL << PWR_PDCRB_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRB_PD0             PWR_PDCRB_PD0_Msk                            /*!< Pin PB0 Pull-Down set */
+#define PWR_PDCRB_PD1_Pos         (1U)
+#define PWR_PDCRB_PD1_Msk         (0x1UL << PWR_PDCRB_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRB_PD1             PWR_PDCRB_PD1_Msk                            /*!< Pin PB1 Pull-Down set */
+#define PWR_PDCRB_PD2_Pos         (2U)
+#define PWR_PDCRB_PD2_Msk         (0x1UL << PWR_PDCRB_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRB_PD2             PWR_PDCRB_PD2_Msk                            /*!< Pin PB2 Pull-Down set */
+#define PWR_PDCRB_PD3_Pos         (3U)
+#define PWR_PDCRB_PD3_Msk         (0x1UL << PWR_PDCRB_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRB_PD3             PWR_PDCRB_PD3_Msk                            /*!< Pin PB3 Pull-Down set */
+#define PWR_PDCRB_PD4_Pos         (4U)
+#define PWR_PDCRB_PD4_Msk         (0x1UL << PWR_PDCRB_PD4_Pos)                 /*!< 0x00000010 */
+#define PWR_PDCRB_PD4             PWR_PDCRB_PD4_Msk                            /*!< Pin PB4 Pull-Down set */
+#define PWR_PDCRB_PD5_Pos         (5U)
+#define PWR_PDCRB_PD5_Msk         (0x1UL << PWR_PDCRB_PD5_Pos)                 /*!< 0x00000020 */
+#define PWR_PDCRB_PD5             PWR_PDCRB_PD5_Msk                            /*!< Pin PB5 Pull-Down set */
+#define PWR_PDCRB_PD6_Pos         (6U)
+#define PWR_PDCRB_PD6_Msk         (0x1UL << PWR_PDCRB_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRB_PD6             PWR_PDCRB_PD6_Msk                            /*!< Pin PB6 Pull-Down set */
+#define PWR_PDCRB_PD7_Pos         (7U)
+#define PWR_PDCRB_PD7_Msk         (0x1UL << PWR_PDCRB_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRB_PD7             PWR_PDCRB_PD7_Msk                            /*!< Pin PB7 Pull-Down set */
+#define PWR_PDCRB_PD8_Pos         (8U)
+#define PWR_PDCRB_PD8_Msk         (0x1UL << PWR_PDCRB_PD8_Pos)                 /*!< 0x00000100 */
+#define PWR_PDCRB_PD8             PWR_PDCRB_PD8_Msk                            /*!< Pin PB8 Pull-Down set */
+#define PWR_PDCRB_PD9_Pos         (9U)
+#define PWR_PDCRB_PD9_Msk         (0x1UL << PWR_PDCRB_PD9_Pos)                 /*!< 0x00000200 */
+#define PWR_PDCRB_PD9             PWR_PDCRB_PD9_Msk                            /*!< Pin PB9 Pull-Down set */
+#define PWR_PDCRB_PD10_Pos        (10U)
+#define PWR_PDCRB_PD10_Msk        (0x1UL << PWR_PDCRB_PD10_Pos)                /*!< 0x00000400 */
+#define PWR_PDCRB_PD10            PWR_PDCRB_PD10_Msk                           /*!< Pin PB10 Pull-Down set */
+#define PWR_PDCRB_PD11_Pos        (11U)
+#define PWR_PDCRB_PD11_Msk        (0x1UL << PWR_PDCRB_PD11_Pos)                /*!< 0x00000800 */
+#define PWR_PDCRB_PD11            PWR_PDCRB_PD11_Msk                           /*!< Pin PB11 Pull-Down set */
+#define PWR_PDCRB_PD12_Pos        (12U)
+#define PWR_PDCRB_PD12_Msk        (0x1UL << PWR_PDCRB_PD12_Pos)                /*!< 0x00001000 */
+#define PWR_PDCRB_PD12            PWR_PDCRB_PD12_Msk                           /*!< Pin PB12 Pull-Down set */
+#define PWR_PDCRB_PD13_Pos        (13U)
+#define PWR_PDCRB_PD13_Msk        (0x1UL << PWR_PDCRB_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRB_PD13            PWR_PDCRB_PD13_Msk                           /*!< Pin PB13 Pull-Down set */
+#define PWR_PDCRB_PD14_Pos        (14U)
+#define PWR_PDCRB_PD14_Msk        (0x1UL << PWR_PDCRB_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRB_PD14            PWR_PDCRB_PD14_Msk                           /*!< Pin PB14 Pull-Down set */
+#define PWR_PDCRB_PD15_Pos        (15U)
+#define PWR_PDCRB_PD15_Msk        (0x1UL << PWR_PDCRB_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRB_PD15            PWR_PDCRB_PD15_Msk                           /*!< Pin PB15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRC register  *****************/
+#define PWR_PUCRC_PU6_Pos         (6U)
+#define PWR_PUCRC_PU6_Msk         (0x1UL << PWR_PUCRC_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRC_PU6             PWR_PUCRC_PU6_Msk                            /*!< Pin PC6 Pull-Up set */
+#define PWR_PUCRC_PU7_Pos         (7U)
+#define PWR_PUCRC_PU7_Msk         (0x1UL << PWR_PUCRC_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRC_PU7             PWR_PUCRC_PU7_Msk                            /*!< Pin PC7 Pull-Up set */
+#define PWR_PUCRC_PU13_Pos        (13U)
+#define PWR_PUCRC_PU13_Msk        (0x1UL << PWR_PUCRC_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRC_PU13            PWR_PUCRC_PU13_Msk                           /*!< Pin PC13 Pull-Up set */
+#define PWR_PUCRC_PU14_Pos        (14U)
+#define PWR_PUCRC_PU14_Msk        (0x1UL << PWR_PUCRC_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRC_PU14            PWR_PUCRC_PU14_Msk                           /*!< Pin PC14 Pull-Up set */
+#define PWR_PUCRC_PU15_Pos        (15U)
+#define PWR_PUCRC_PU15_Msk        (0x1UL << PWR_PUCRC_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRC_PU15            PWR_PUCRC_PU15_Msk                           /*!< Pin PC15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRC register  *****************/
+#define PWR_PDCRC_PD6_Pos         (6U)
+#define PWR_PDCRC_PD6_Msk         (0x1UL << PWR_PDCRC_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRC_PD6             PWR_PDCRC_PD6_Msk                            /*!< Pin PC6 Pull-Down set */
+#define PWR_PDCRC_PD7_Pos         (7U)
+#define PWR_PDCRC_PD7_Msk         (0x1UL << PWR_PDCRC_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRC_PD7             PWR_PDCRC_PD7_Msk                            /*!< Pin PC7 Pull-Down set */
+#define PWR_PDCRC_PD13_Pos        (13U)
+#define PWR_PDCRC_PD13_Msk        (0x1UL << PWR_PDCRC_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRC_PD13            PWR_PDCRC_PD13_Msk                           /*!< Pin PC13 Pull-Down set */
+#define PWR_PDCRC_PD14_Pos        (14U)
+#define PWR_PDCRC_PD14_Msk        (0x1UL << PWR_PDCRC_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRC_PD14            PWR_PDCRC_PD14_Msk                           /*!< Pin PC14 Pull-Down set */
+#define PWR_PDCRC_PD15_Pos        (15U)
+#define PWR_PDCRC_PD15_Msk        (0x1UL << PWR_PDCRC_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRC_PD15            PWR_PDCRC_PD15_Msk                           /*!< Pin PC15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRD register  *****************/
+#define PWR_PUCRD_PU0_Pos         (0U)
+#define PWR_PUCRD_PU0_Msk         (0x1UL << PWR_PUCRD_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRD_PU0             PWR_PUCRD_PU0_Msk                            /*!< Pin PD0 Pull-Up set */
+#define PWR_PUCRD_PU1_Pos         (1U)
+#define PWR_PUCRD_PU1_Msk         (0x1UL << PWR_PUCRD_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRD_PU1             PWR_PUCRD_PU1_Msk                            /*!< Pin PD1 Pull-Up set */
+#define PWR_PUCRD_PU2_Pos         (2U)
+#define PWR_PUCRD_PU2_Msk         (0x1UL << PWR_PUCRD_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRD_PU2             PWR_PUCRD_PU2_Msk                            /*!< Pin PD2 Pull-Up set */
+#define PWR_PUCRD_PU3_Pos         (3U)
+#define PWR_PUCRD_PU3_Msk         (0x1UL << PWR_PUCRD_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRD_PU3             PWR_PUCRD_PU3_Msk                            /*!< Pin PD3 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRD register  *****************/
+#define PWR_PDCRD_PD0_Pos         (0U)
+#define PWR_PDCRD_PD0_Msk         (0x1UL << PWR_PDCRD_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRD_PD0             PWR_PDCRD_PD0_Msk                            /*!< Pin PD0 Pull-Down set */
+#define PWR_PDCRD_PD1_Pos         (1U)
+#define PWR_PDCRD_PD1_Msk         (0x1UL << PWR_PDCRD_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRD_PD1             PWR_PDCRD_PD1_Msk                            /*!< Pin PD1 Pull-Down set */
+#define PWR_PDCRD_PD2_Pos         (2U)
+#define PWR_PDCRD_PD2_Msk         (0x1UL << PWR_PDCRD_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRD_PD2             PWR_PDCRD_PD2_Msk                            /*!< Pin PD2 Pull-Down set */
+#define PWR_PDCRD_PD3_Pos         (3U)
+#define PWR_PDCRD_PD3_Msk         (0x1UL << PWR_PDCRD_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRD_PD3             PWR_PDCRD_PD3_Msk                            /*!< Pin PD3 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRF register  *****************/
+#define PWR_PUCRF_PU0_Pos         (0U)
+#define PWR_PUCRF_PU0_Msk         (0x1UL << PWR_PUCRF_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRF_PU0             PWR_PUCRF_PU0_Msk                            /*!< Pin PF0 Pull-Up set */
+#define PWR_PUCRF_PU1_Pos         (1U)
+#define PWR_PUCRF_PU1_Msk         (0x1UL << PWR_PUCRF_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRF_PU1             PWR_PUCRF_PU1_Msk                            /*!< Pin PF1 Pull-Up set */
+#define PWR_PUCRF_PU2_Pos         (2U)
+#define PWR_PUCRF_PU2_Msk         (0x1UL << PWR_PUCRF_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRF_PU2             PWR_PUCRF_PU2_Msk                            /*!< Pin PF2 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRF register  *****************/
+#define PWR_PDCRF_PD0_Pos         (0U)
+#define PWR_PDCRF_PD0_Msk         (0x1UL << PWR_PDCRF_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRF_PD0             PWR_PDCRF_PD0_Msk                            /*!< Pin PF0 Pull-Down set */
+#define PWR_PDCRF_PD1_Pos         (1U)
+#define PWR_PDCRF_PD1_Msk         (0x1UL << PWR_PDCRF_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRF_PD1             PWR_PDCRF_PD1_Msk                            /*!< Pin PF1 Pull-Down set */
+#define PWR_PDCRF_PD2_Pos         (2U)
+#define PWR_PDCRF_PD2_Msk         (0x1UL << PWR_PDCRF_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRF_PD2             PWR_PDCRF_PD2_Msk                            /*!< Pin PF2 Pull-Down set */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Reset and Clock Control                          */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
+*/
+#define RCC_PLLQ_SUPPORT
+
+/********************  Bit definition for RCC_CR register  *****************/
+#define RCC_CR_HSION_Pos                 (8U)
+#define RCC_CR_HSION_Msk                 (0x1UL << RCC_CR_HSION_Pos)           /*!< 0x00000100 */
+#define RCC_CR_HSION                     RCC_CR_HSION_Msk                      /*!< Internal High Speed clock enable */
+#define RCC_CR_HSIKERON_Pos              (9U)
+#define RCC_CR_HSIKERON_Msk              (0x1UL << RCC_CR_HSIKERON_Pos)        /*!< 0x00000200 */
+#define RCC_CR_HSIKERON                  RCC_CR_HSIKERON_Msk                   /*!< Internal High Speed clock enable for some IPs Kernel */
+#define RCC_CR_HSIRDY_Pos                (10U)
+#define RCC_CR_HSIRDY_Msk                (0x1UL << RCC_CR_HSIRDY_Pos)          /*!< 0x00000400 */
+#define RCC_CR_HSIRDY                    RCC_CR_HSIRDY_Msk                     /*!< Internal High Speed clock ready flag */
+#define RCC_CR_HSIDIV_Pos                (11U)
+#define RCC_CR_HSIDIV_Msk                (0x7UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00003800 */
+#define RCC_CR_HSIDIV                    RCC_CR_HSIDIV_Msk                     /*!< HSIDIV[13:11] Internal High Speed clock division factor */
+#define RCC_CR_HSIDIV_0                  (0x1UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00000800 */
+#define RCC_CR_HSIDIV_1                  (0x2UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00001000 */
+#define RCC_CR_HSIDIV_2                  (0x4UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00002000 */
+#define RCC_CR_HSEON_Pos                 (16U)
+#define RCC_CR_HSEON_Msk                 (0x1UL << RCC_CR_HSEON_Pos)           /*!< 0x00010000 */
+#define RCC_CR_HSEON                     RCC_CR_HSEON_Msk                      /*!< External High Speed clock enable */
+#define RCC_CR_HSERDY_Pos                (17U)
+#define RCC_CR_HSERDY_Msk                (0x1UL << RCC_CR_HSERDY_Pos)          /*!< 0x00020000 */
+#define RCC_CR_HSERDY                    RCC_CR_HSERDY_Msk                     /*!< External High Speed clock ready */
+#define RCC_CR_HSEBYP_Pos                (18U)
+#define RCC_CR_HSEBYP_Msk                (0x1UL << RCC_CR_HSEBYP_Pos)          /*!< 0x00040000 */
+#define RCC_CR_HSEBYP                    RCC_CR_HSEBYP_Msk                     /*!< External High Speed clock Bypass */
+#define RCC_CR_CSSON_Pos                 (19U)
+#define RCC_CR_CSSON_Msk                 (0x1UL << RCC_CR_CSSON_Pos)           /*!< 0x00080000 */
+#define RCC_CR_CSSON                     RCC_CR_CSSON_Msk                      /*!< HSE Clock Security System enable */
+
+#define RCC_CR_PLLON_Pos                 (24U)
+#define RCC_CR_PLLON_Msk                 (0x1UL << RCC_CR_PLLON_Pos)           /*!< 0x01000000 */
+#define RCC_CR_PLLON                     RCC_CR_PLLON_Msk                      /*!< System PLL clock enable */
+#define RCC_CR_PLLRDY_Pos                (25U)
+#define RCC_CR_PLLRDY_Msk                (0x1UL << RCC_CR_PLLRDY_Pos)          /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                    RCC_CR_PLLRDY_Msk                     /*!< System PLL clock ready */
+
+/********************  Bit definition for RCC_ICSCR register  ***************/
+/*!< HSICAL configuration */
+#define RCC_ICSCR_HSICAL_Pos             (0U)
+#define RCC_ICSCR_HSICAL_Msk             (0xFFUL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x000000FF */
+#define RCC_ICSCR_HSICAL                 RCC_ICSCR_HSICAL_Msk                  /*!< HSICAL[7:0] bits */
+#define RCC_ICSCR_HSICAL_0               (0x01UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000001 */
+#define RCC_ICSCR_HSICAL_1               (0x02UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000002 */
+#define RCC_ICSCR_HSICAL_2               (0x04UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000004 */
+#define RCC_ICSCR_HSICAL_3               (0x08UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000008 */
+#define RCC_ICSCR_HSICAL_4               (0x10UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000010 */
+#define RCC_ICSCR_HSICAL_5               (0x20UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000020 */
+#define RCC_ICSCR_HSICAL_6               (0x40UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000040 */
+#define RCC_ICSCR_HSICAL_7               (0x80UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000080 */
+
+/*!< HSITRIM configuration */
+#define RCC_ICSCR_HSITRIM_Pos            (8U)
+#define RCC_ICSCR_HSITRIM_Msk            (0x7FUL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00007F00 */
+#define RCC_ICSCR_HSITRIM                RCC_ICSCR_HSITRIM_Msk                 /*!< HSITRIM[14:8] bits */
+#define RCC_ICSCR_HSITRIM_0              (0x01UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000100 */
+#define RCC_ICSCR_HSITRIM_1              (0x02UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000200 */
+#define RCC_ICSCR_HSITRIM_2              (0x04UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000400 */
+#define RCC_ICSCR_HSITRIM_3              (0x08UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000800 */
+#define RCC_ICSCR_HSITRIM_4              (0x10UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00001000 */
+#define RCC_ICSCR_HSITRIM_5              (0x20UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00002000 */
+#define RCC_ICSCR_HSITRIM_6              (0x40UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00004000 */
+
+/********************  Bit definition for RCC_CFGR register  ***************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                (0U)
+#define RCC_CFGR_SW_Msk                (0x7UL << RCC_CFGR_SW_Pos)              /*!< 0x00000007 */
+#define RCC_CFGR_SW                    RCC_CFGR_SW_Msk                         /*!< SW[2:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                  (0x1UL << RCC_CFGR_SW_Pos)              /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                  (0x2UL << RCC_CFGR_SW_Pos)              /*!< 0x00000002 */
+#define RCC_CFGR_SW_2                  (0x4UL << RCC_CFGR_SW_Pos)              /*!< 0x00000004 */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos               (3U)
+#define RCC_CFGR_SWS_Msk               (0x7UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000038 */
+#define RCC_CFGR_SWS                   RCC_CFGR_SWS_Msk                        /*!< SWS[2:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                 (0x1UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000008 */
+#define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
+#define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos              (8U)
+#define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
+#define RCC_CFGR_HPRE                  RCC_CFGR_HPRE_Msk                       /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                (0x1UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000100 */
+#define RCC_CFGR_HPRE_1                (0x2UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000200 */
+#define RCC_CFGR_HPRE_2                (0x4UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000400 */
+#define RCC_CFGR_HPRE_3                (0x8UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000800 */
+
+/*!< PPRE configuration */
+#define RCC_CFGR_PPRE_Pos              (12U)
+#define RCC_CFGR_PPRE_Msk              (0x7UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00007000 */
+#define RCC_CFGR_PPRE                  RCC_CFGR_PPRE_Msk                       /*!< PRE1[2:0] bits (APB prescaler) */
+#define RCC_CFGR_PPRE_0                (0x1UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00001000 */
+#define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
+#define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
+
+
+/*!< MCOSEL configuration */
+#define RCC_CFGR_MCOSEL_Pos            (24U)
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
+#define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
+#define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
+#define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
+#define RCC_CFGR_MCOSEL_2              (0x4UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x04000000 */
+
+/*!< MCO Prescaler configuration */
+#define RCC_CFGR_MCOPRE_Pos            (28U)
+#define RCC_CFGR_MCOPRE_Msk            (0x7UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE                RCC_CFGR_MCOPRE_Msk                     /*!< MCO prescaler [2:0] */
+#define RCC_CFGR_MCOPRE_0              (0x1UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x10000000 */
+#define RCC_CFGR_MCOPRE_1              (0x2UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x20000000 */
+#define RCC_CFGR_MCOPRE_2              (0x4UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLSRC_Pos           (0U)
+#define RCC_PLLCFGR_PLLSRC_Msk           (0x3UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC               RCC_PLLCFGR_PLLSRC_Msk
+#define RCC_PLLCFGR_PLLSRC_0             (0x1UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLSRC_1             (0x2UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000002 */
+
+#define RCC_PLLCFGR_PLLSRC_NONE          (0x00000000UL)                        /*!< No clock sent to PLL      */
+#define RCC_PLLCFGR_PLLSRC_HSI_Pos       (1U)
+#define RCC_PLLCFGR_PLLSRC_HSI_Msk       (0x1UL << RCC_PLLCFGR_PLLSRC_HSI_Pos) /*!< 0x00000002 */
+#define RCC_PLLCFGR_PLLSRC_HSI           RCC_PLLCFGR_PLLSRC_HSI_Msk            /*!< HSI source clock selected */
+#define RCC_PLLCFGR_PLLSRC_HSE_Pos       (0U)
+#define RCC_PLLCFGR_PLLSRC_HSE_Msk       (0x3UL << RCC_PLLCFGR_PLLSRC_HSE_Pos) /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC_HSE           RCC_PLLCFGR_PLLSRC_HSE_Msk            /*!< HSE source clock selected */
+
+#define RCC_PLLCFGR_PLLM_Pos             (4U)
+#define RCC_PLLCFGR_PLLM_Msk             (0x7UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000070 */
+#define RCC_PLLCFGR_PLLM                 RCC_PLLCFGR_PLLM_Msk
+#define RCC_PLLCFGR_PLLM_0               (0x1UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_1               (0x2UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000020 */
+#define RCC_PLLCFGR_PLLM_2               (0x4UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000040 */
+
+#define RCC_PLLCFGR_PLLN_Pos             (8U)
+#define RCC_PLLCFGR_PLLN_Msk             (0x7FUL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00007F00 */
+#define RCC_PLLCFGR_PLLN                 RCC_PLLCFGR_PLLN_Msk
+#define RCC_PLLCFGR_PLLN_0               (0x01UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_1               (0x02UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_2               (0x04UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_3               (0x08UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_4               (0x10UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_5               (0x20UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_6               (0x40UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLPEN_Pos           (16U)
+#define RCC_PLLCFGR_PLLPEN_Msk           (0x1UL << RCC_PLLCFGR_PLLPEN_Pos)     /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLPEN               RCC_PLLCFGR_PLLPEN_Msk
+
+#define RCC_PLLCFGR_PLLP_Pos              (17U)
+#define RCC_PLLCFGR_PLLP_Msk              (0x1FUL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x003E0000 */
+#define RCC_PLLCFGR_PLLP                  RCC_PLLCFGR_PLLP_Msk
+#define RCC_PLLCFGR_PLLP_0                (0x01UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00020000 */
+#define RCC_PLLCFGR_PLLP_1                (0x02UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00040000 */
+#define RCC_PLLCFGR_PLLP_2                (0x04UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00080000 */
+#define RCC_PLLCFGR_PLLP_3                (0x08UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00100000 */
+#define RCC_PLLCFGR_PLLP_4                (0x10UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00200000 */
+
+#define RCC_PLLCFGR_PLLQEN_Pos           (24U)
+#define RCC_PLLCFGR_PLLQEN_Msk           (0x1UL << RCC_PLLCFGR_PLLQEN_Pos)     /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQEN               RCC_PLLCFGR_PLLQEN_Msk
+
+#define RCC_PLLCFGR_PLLQ_Pos             (25U)
+#define RCC_PLLCFGR_PLLQ_Msk             (0x7UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x0E000000 */
+#define RCC_PLLCFGR_PLLQ                 RCC_PLLCFGR_PLLQ_Msk
+#define RCC_PLLCFGR_PLLQ_0               (0x1UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_1               (0x2UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_2               (0x4UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x08000000 */
+
+#define RCC_PLLCFGR_PLLREN_Pos           (28U)
+#define RCC_PLLCFGR_PLLREN_Msk           (0x1UL << RCC_PLLCFGR_PLLREN_Pos)     /*!< 0x10000000 */
+#define RCC_PLLCFGR_PLLREN               RCC_PLLCFGR_PLLREN_Msk
+
+#define RCC_PLLCFGR_PLLR_Pos             (29U)
+#define RCC_PLLCFGR_PLLR_Msk             (0x7UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0xE0000000 */
+#define RCC_PLLCFGR_PLLR                 RCC_PLLCFGR_PLLR_Msk
+#define RCC_PLLCFGR_PLLR_0               (0x1UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x20000000 */
+#define RCC_PLLCFGR_PLLR_1               (0x2UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x40000000 */
+#define RCC_PLLCFGR_PLLR_2               (0x4UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIER register  ******************/
+#define RCC_CIER_LSIRDYIE_Pos            (0U)
+#define RCC_CIER_LSIRDYIE_Msk            (0x1UL << RCC_CIER_LSIRDYIE_Pos)      /*!< 0x00000001 */
+#define RCC_CIER_LSIRDYIE                RCC_CIER_LSIRDYIE_Msk
+#define RCC_CIER_LSERDYIE_Pos            (1U)
+#define RCC_CIER_LSERDYIE_Msk            (0x1UL << RCC_CIER_LSERDYIE_Pos)      /*!< 0x00000002 */
+#define RCC_CIER_LSERDYIE                RCC_CIER_LSERDYIE_Msk
+#define RCC_CIER_HSIRDYIE_Pos            (3U)
+#define RCC_CIER_HSIRDYIE_Msk            (0x1UL << RCC_CIER_HSIRDYIE_Pos)      /*!< 0x00000008 */
+#define RCC_CIER_HSIRDYIE                RCC_CIER_HSIRDYIE_Msk
+#define RCC_CIER_HSERDYIE_Pos            (4U)
+#define RCC_CIER_HSERDYIE_Msk            (0x1UL << RCC_CIER_HSERDYIE_Pos)      /*!< 0x00000010 */
+#define RCC_CIER_HSERDYIE                RCC_CIER_HSERDYIE_Msk
+#define RCC_CIER_PLLRDYIE_Pos            (5U)
+#define RCC_CIER_PLLRDYIE_Msk            (0x1UL << RCC_CIER_PLLRDYIE_Pos)      /*!< 0x00000020 */
+#define RCC_CIER_PLLRDYIE                RCC_CIER_PLLRDYIE_Msk
+
+/********************  Bit definition for RCC_CIFR register  ******************/
+#define RCC_CIFR_LSIRDYF_Pos             (0U)
+#define RCC_CIFR_LSIRDYF_Msk             (0x1UL << RCC_CIFR_LSIRDYF_Pos)       /*!< 0x00000001 */
+#define RCC_CIFR_LSIRDYF                 RCC_CIFR_LSIRDYF_Msk
+#define RCC_CIFR_LSERDYF_Pos             (1U)
+#define RCC_CIFR_LSERDYF_Msk             (0x1UL << RCC_CIFR_LSERDYF_Pos)       /*!< 0x00000002 */
+#define RCC_CIFR_LSERDYF                 RCC_CIFR_LSERDYF_Msk
+#define RCC_CIFR_HSIRDYF_Pos             (3U)
+#define RCC_CIFR_HSIRDYF_Msk             (0x1UL << RCC_CIFR_HSIRDYF_Pos)       /*!< 0x00000008 */
+#define RCC_CIFR_HSIRDYF                 RCC_CIFR_HSIRDYF_Msk
+#define RCC_CIFR_HSERDYF_Pos             (4U)
+#define RCC_CIFR_HSERDYF_Msk             (0x1UL << RCC_CIFR_HSERDYF_Pos)       /*!< 0x00000010 */
+#define RCC_CIFR_HSERDYF                 RCC_CIFR_HSERDYF_Msk
+#define RCC_CIFR_PLLRDYF_Pos             (5U)
+#define RCC_CIFR_PLLRDYF_Msk             (0x1UL << RCC_CIFR_PLLRDYF_Pos)       /*!< 0x00000020 */
+#define RCC_CIFR_PLLRDYF                 RCC_CIFR_PLLRDYF_Msk
+#define RCC_CIFR_CSSF_Pos                (8U)
+#define RCC_CIFR_CSSF_Msk                (0x1UL << RCC_CIFR_CSSF_Pos)          /*!< 0x00000100 */
+#define RCC_CIFR_CSSF                    RCC_CIFR_CSSF_Msk
+#define RCC_CIFR_LSECSSF_Pos             (9U)
+#define RCC_CIFR_LSECSSF_Msk             (0x1UL << RCC_CIFR_LSECSSF_Pos)       /*!< 0x00000200 */
+#define RCC_CIFR_LSECSSF                 RCC_CIFR_LSECSSF_Msk
+
+/********************  Bit definition for RCC_CICR register  ******************/
+#define RCC_CICR_LSIRDYC_Pos             (0U)
+#define RCC_CICR_LSIRDYC_Msk             (0x1UL << RCC_CICR_LSIRDYC_Pos)       /*!< 0x00000001 */
+#define RCC_CICR_LSIRDYC                 RCC_CICR_LSIRDYC_Msk
+#define RCC_CICR_LSERDYC_Pos             (1U)
+#define RCC_CICR_LSERDYC_Msk             (0x1UL << RCC_CICR_LSERDYC_Pos)       /*!< 0x00000002 */
+#define RCC_CICR_LSERDYC                 RCC_CICR_LSERDYC_Msk
+#define RCC_CICR_HSIRDYC_Pos             (3U)
+#define RCC_CICR_HSIRDYC_Msk             (0x1UL << RCC_CICR_HSIRDYC_Pos)       /*!< 0x00000008 */
+#define RCC_CICR_HSIRDYC                 RCC_CICR_HSIRDYC_Msk
+#define RCC_CICR_HSERDYC_Pos             (4U)
+#define RCC_CICR_HSERDYC_Msk             (0x1UL << RCC_CICR_HSERDYC_Pos)       /*!< 0x00000010 */
+#define RCC_CICR_HSERDYC                 RCC_CICR_HSERDYC_Msk
+#define RCC_CICR_PLLRDYC_Pos             (5U)
+#define RCC_CICR_PLLRDYC_Msk             (0x1UL << RCC_CICR_PLLRDYC_Pos)       /*!< 0x00000020 */
+#define RCC_CICR_PLLRDYC                 RCC_CICR_PLLRDYC_Msk
+#define RCC_CICR_CSSC_Pos                (8U)
+#define RCC_CICR_CSSC_Msk                (0x1UL << RCC_CICR_CSSC_Pos)          /*!< 0x00000100 */
+#define RCC_CICR_CSSC                    RCC_CICR_CSSC_Msk
+#define RCC_CICR_LSECSSC_Pos             (9U)
+#define RCC_CICR_LSECSSC_Msk             (0x1UL << RCC_CICR_LSECSSC_Pos)       /*!< 0x00000200 */
+#define RCC_CICR_LSECSSC                 RCC_CICR_LSECSSC_Msk
+
+/********************  Bit definition for RCC_IOPRSTR register  ****************/
+#define RCC_IOPRSTR_GPIOARST_Pos         (0U)
+#define RCC_IOPRSTR_GPIOARST_Msk         (0x1UL << RCC_IOPRSTR_GPIOARST_Pos)   /*!< 0x00000001 */
+#define RCC_IOPRSTR_GPIOARST             RCC_IOPRSTR_GPIOARST_Msk
+#define RCC_IOPRSTR_GPIOBRST_Pos         (1U)
+#define RCC_IOPRSTR_GPIOBRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOBRST_Pos)   /*!< 0x00000002 */
+#define RCC_IOPRSTR_GPIOBRST             RCC_IOPRSTR_GPIOBRST_Msk
+#define RCC_IOPRSTR_GPIOCRST_Pos         (2U)
+#define RCC_IOPRSTR_GPIOCRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOCRST_Pos)   /*!< 0x00000004 */
+#define RCC_IOPRSTR_GPIOCRST             RCC_IOPRSTR_GPIOCRST_Msk
+#define RCC_IOPRSTR_GPIODRST_Pos         (3U)
+#define RCC_IOPRSTR_GPIODRST_Msk         (0x1UL << RCC_IOPRSTR_GPIODRST_Pos)   /*!< 0x00000008 */
+#define RCC_IOPRSTR_GPIODRST             RCC_IOPRSTR_GPIODRST_Msk
+#define RCC_IOPRSTR_GPIOFRST_Pos         (5U)
+#define RCC_IOPRSTR_GPIOFRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOFRST_Pos)   /*!< 0x00000020 */
+#define RCC_IOPRSTR_GPIOFRST             RCC_IOPRSTR_GPIOFRST_Msk
+
+/********************  Bit definition for RCC_AHBRSTR register  ***************/
+#define RCC_AHBRSTR_DMA1RST_Pos          (0U)
+#define RCC_AHBRSTR_DMA1RST_Msk          (0x1UL << RCC_AHBRSTR_DMA1RST_Pos)    /*!< 0x00000001 */
+#define RCC_AHBRSTR_DMA1RST              RCC_AHBRSTR_DMA1RST_Msk
+#define RCC_AHBRSTR_FLASHRST_Pos         (8U)
+#define RCC_AHBRSTR_FLASHRST_Msk         (0x1UL << RCC_AHBRSTR_FLASHRST_Pos)   /*!< 0x00000100 */
+#define RCC_AHBRSTR_FLASHRST             RCC_AHBRSTR_FLASHRST_Msk
+#define RCC_AHBRSTR_CRCRST_Pos           (12U)
+#define RCC_AHBRSTR_CRCRST_Msk           (0x1UL << RCC_AHBRSTR_CRCRST_Pos)     /*!< 0x00001000 */
+#define RCC_AHBRSTR_CRCRST               RCC_AHBRSTR_CRCRST_Msk
+
+/********************  Bit definition for RCC_APBRSTR1 register  **************/
+#define RCC_APBRSTR1_TIM2RST_Pos         (0U)
+#define RCC_APBRSTR1_TIM2RST_Msk         (0x1UL << RCC_APBRSTR1_TIM2RST_Pos)   /*!< 0x00000001 */
+#define RCC_APBRSTR1_TIM2RST             RCC_APBRSTR1_TIM2RST_Msk
+#define RCC_APBRSTR1_TIM3RST_Pos         (1U)
+#define RCC_APBRSTR1_TIM3RST_Msk         (0x1UL << RCC_APBRSTR1_TIM3RST_Pos)   /*!< 0x00000002 */
+#define RCC_APBRSTR1_TIM3RST             RCC_APBRSTR1_TIM3RST_Msk
+#define RCC_APBRSTR1_TIM6RST_Pos         (4U)
+#define RCC_APBRSTR1_TIM6RST_Msk         (0x1UL << RCC_APBRSTR1_TIM6RST_Pos)   /*!< 0x00000010 */
+#define RCC_APBRSTR1_TIM6RST             RCC_APBRSTR1_TIM6RST_Msk
+#define RCC_APBRSTR1_TIM7RST_Pos         (5U)
+#define RCC_APBRSTR1_TIM7RST_Msk         (0x1UL << RCC_APBRSTR1_TIM7RST_Pos)   /*!< 0x00000020 */
+#define RCC_APBRSTR1_TIM7RST             RCC_APBRSTR1_TIM7RST_Msk
+#define RCC_APBRSTR1_SPI2RST_Pos         (14U)
+#define RCC_APBRSTR1_SPI2RST_Msk         (0x1UL << RCC_APBRSTR1_SPI2RST_Pos)   /*!< 0x00004000 */
+#define RCC_APBRSTR1_SPI2RST             RCC_APBRSTR1_SPI2RST_Msk
+#define RCC_APBRSTR1_USART2RST_Pos       (17U)
+#define RCC_APBRSTR1_USART2RST_Msk       (0x1UL << RCC_APBRSTR1_USART2RST_Pos) /*!< 0x00020000 */
+#define RCC_APBRSTR1_USART2RST           RCC_APBRSTR1_USART2RST_Msk
+#define RCC_APBRSTR1_LPUART1RST_Pos      (20U)
+#define RCC_APBRSTR1_LPUART1RST_Msk      (0x1UL << RCC_APBRSTR1_LPUART1RST_Pos) /*!< 0x00100000 */
+#define RCC_APBRSTR1_LPUART1RST          RCC_APBRSTR1_LPUART1RST_Msk
+#define RCC_APBRSTR1_I2C1RST_Pos         (21U)
+#define RCC_APBRSTR1_I2C1RST_Msk         (0x1UL << RCC_APBRSTR1_I2C1RST_Pos)    /*!< 0x00200000 */
+#define RCC_APBRSTR1_I2C1RST             RCC_APBRSTR1_I2C1RST_Msk
+#define RCC_APBRSTR1_I2C2RST_Pos         (22U)
+#define RCC_APBRSTR1_I2C2RST_Msk         (0x1UL << RCC_APBRSTR1_I2C2RST_Pos)    /*!< 0x00400000 */
+#define RCC_APBRSTR1_I2C2RST             RCC_APBRSTR1_I2C2RST_Msk
+#define RCC_APBRSTR1_DBGRST_Pos          (27U)
+#define RCC_APBRSTR1_DBGRST_Msk          (0x1UL << RCC_APBRSTR1_DBGRST_Pos)     /*!< 0x08000000 */
+#define RCC_APBRSTR1_DBGRST              RCC_APBRSTR1_DBGRST_Msk
+#define RCC_APBRSTR1_PWRRST_Pos          (28U)
+#define RCC_APBRSTR1_PWRRST_Msk          (0x1UL << RCC_APBRSTR1_PWRRST_Pos)     /*!< 0x10000000 */
+#define RCC_APBRSTR1_PWRRST              RCC_APBRSTR1_PWRRST_Msk
+#define RCC_APBRSTR1_DAC1RST_Pos         (29U)
+#define RCC_APBRSTR1_DAC1RST_Msk         (0x1UL << RCC_APBRSTR1_DAC1RST_Pos)    /*!< 0x20000000 */
+#define RCC_APBRSTR1_DAC1RST             RCC_APBRSTR1_DAC1RST_Msk
+#define RCC_APBRSTR1_LPTIM2RST_Pos       (30U)
+#define RCC_APBRSTR1_LPTIM2RST_Msk       (0x1UL << RCC_APBRSTR1_LPTIM2RST_Pos)  /*!< 0x40000000 */
+#define RCC_APBRSTR1_LPTIM2RST           RCC_APBRSTR1_LPTIM2RST_Msk
+#define RCC_APBRSTR1_LPTIM1RST_Pos       (31U)
+#define RCC_APBRSTR1_LPTIM1RST_Msk       (0x1UL << RCC_APBRSTR1_LPTIM1RST_Pos)  /*!< 0x80000000 */
+#define RCC_APBRSTR1_LPTIM1RST           RCC_APBRSTR1_LPTIM1RST_Msk
+
+/********************  Bit definition for RCC_APBRSTR2 register  **************/
+#define RCC_APBRSTR2_SYSCFGRST_Pos       (0U)
+#define RCC_APBRSTR2_SYSCFGRST_Msk       (0x1UL << RCC_APBRSTR2_SYSCFGRST_Pos)  /*!< 0x00000001 */
+#define RCC_APBRSTR2_SYSCFGRST           RCC_APBRSTR2_SYSCFGRST_Msk
+#define RCC_APBRSTR2_TIM1RST_Pos         (11U)
+#define RCC_APBRSTR2_TIM1RST_Msk         (0x1UL << RCC_APBRSTR2_TIM1RST_Pos)    /*!< 0x00000800 */
+#define RCC_APBRSTR2_TIM1RST             RCC_APBRSTR2_TIM1RST_Msk
+#define RCC_APBRSTR2_SPI1RST_Pos         (12U)
+#define RCC_APBRSTR2_SPI1RST_Msk         (0x1UL << RCC_APBRSTR2_SPI1RST_Pos)    /*!< 0x00001000 */
+#define RCC_APBRSTR2_SPI1RST             RCC_APBRSTR2_SPI1RST_Msk
+#define RCC_APBRSTR2_USART1RST_Pos       (14U)
+#define RCC_APBRSTR2_USART1RST_Msk       (0x1UL << RCC_APBRSTR2_USART1RST_Pos)  /*!< 0x00004000 */
+#define RCC_APBRSTR2_USART1RST           RCC_APBRSTR2_USART1RST_Msk
+#define RCC_APBRSTR2_TIM14RST_Pos        (15U)
+#define RCC_APBRSTR2_TIM14RST_Msk        (0x1UL << RCC_APBRSTR2_TIM14RST_Pos)   /*!< 0x00008000 */
+#define RCC_APBRSTR2_TIM14RST            RCC_APBRSTR2_TIM14RST_Msk
+#define RCC_APBRSTR2_TIM15RST_Pos        (16U)
+#define RCC_APBRSTR2_TIM15RST_Msk        (0x1UL << RCC_APBRSTR2_TIM15RST_Pos)   /*!< 0x00010000 */
+#define RCC_APBRSTR2_TIM15RST            RCC_APBRSTR2_TIM15RST_Msk
+#define RCC_APBRSTR2_TIM16RST_Pos        (17U)
+#define RCC_APBRSTR2_TIM16RST_Msk        (0x1UL << RCC_APBRSTR2_TIM16RST_Pos)   /*!< 0x00020000 */
+#define RCC_APBRSTR2_TIM16RST            RCC_APBRSTR2_TIM16RST_Msk
+#define RCC_APBRSTR2_TIM17RST_Pos        (18U)
+#define RCC_APBRSTR2_TIM17RST_Msk        (0x1UL << RCC_APBRSTR2_TIM17RST_Pos)   /*!< 0x00040000 */
+#define RCC_APBRSTR2_TIM17RST            RCC_APBRSTR2_TIM17RST_Msk
+#define RCC_APBRSTR2_ADCRST_Pos          (20U)
+#define RCC_APBRSTR2_ADCRST_Msk          (0x1UL << RCC_APBRSTR2_ADCRST_Pos)     /*!< 0x00100000 */
+#define RCC_APBRSTR2_ADCRST              RCC_APBRSTR2_ADCRST_Msk
+
+/********************  Bit definition for RCC_IOPENR register  ****************/
+#define RCC_IOPENR_GPIOAEN_Pos           (0U)
+#define RCC_IOPENR_GPIOAEN_Msk           (0x1UL << RCC_IOPENR_GPIOAEN_Pos)      /*!< 0x00000001 */
+#define RCC_IOPENR_GPIOAEN               RCC_IOPENR_GPIOAEN_Msk
+#define RCC_IOPENR_GPIOBEN_Pos           (1U)
+#define RCC_IOPENR_GPIOBEN_Msk           (0x1UL << RCC_IOPENR_GPIOBEN_Pos)      /*!< 0x00000002 */
+#define RCC_IOPENR_GPIOBEN               RCC_IOPENR_GPIOBEN_Msk
+#define RCC_IOPENR_GPIOCEN_Pos           (2U)
+#define RCC_IOPENR_GPIOCEN_Msk           (0x1UL << RCC_IOPENR_GPIOCEN_Pos)      /*!< 0x00000004 */
+#define RCC_IOPENR_GPIOCEN               RCC_IOPENR_GPIOCEN_Msk
+#define RCC_IOPENR_GPIODEN_Pos           (3U)
+#define RCC_IOPENR_GPIODEN_Msk           (0x1UL << RCC_IOPENR_GPIODEN_Pos)      /*!< 0x00000008 */
+#define RCC_IOPENR_GPIODEN               RCC_IOPENR_GPIODEN_Msk
+#define RCC_IOPENR_GPIOFEN_Pos           (5U)
+#define RCC_IOPENR_GPIOFEN_Msk           (0x1UL << RCC_IOPENR_GPIOFEN_Pos)      /*!< 0x00000020 */
+#define RCC_IOPENR_GPIOFEN               RCC_IOPENR_GPIOFEN_Msk
+
+/********************  Bit definition for RCC_AHBENR register  ****************/
+#define RCC_AHBENR_DMA1EN_Pos            (0U)
+#define RCC_AHBENR_DMA1EN_Msk            (0x1UL << RCC_AHBENR_DMA1EN_Pos)       /*!< 0x00000001 */
+#define RCC_AHBENR_DMA1EN                RCC_AHBENR_DMA1EN_Msk
+#define RCC_AHBENR_FLASHEN_Pos           (8U)
+#define RCC_AHBENR_FLASHEN_Msk           (0x1UL << RCC_AHBENR_FLASHEN_Pos)      /*!< 0x00000100 */
+#define RCC_AHBENR_FLASHEN               RCC_AHBENR_FLASHEN_Msk
+#define RCC_AHBENR_CRCEN_Pos             (12U)
+#define RCC_AHBENR_CRCEN_Msk             (0x1UL << RCC_AHBENR_CRCEN_Pos)        /*!< 0x00001000 */
+#define RCC_AHBENR_CRCEN                 RCC_AHBENR_CRCEN_Msk
+
+/********************  Bit definition for RCC_APBENR1 register  ***************/
+#define RCC_APBENR1_TIM2EN_Pos           (0U)
+#define RCC_APBENR1_TIM2EN_Msk           (0x1UL << RCC_APBENR1_TIM2EN_Pos)      /*!< 0x00000001 */
+#define RCC_APBENR1_TIM2EN               RCC_APBENR1_TIM2EN_Msk
+#define RCC_APBENR1_TIM3EN_Pos           (1U)
+#define RCC_APBENR1_TIM3EN_Msk           (0x1UL << RCC_APBENR1_TIM3EN_Pos)      /*!< 0x00000002 */
+#define RCC_APBENR1_TIM3EN               RCC_APBENR1_TIM3EN_Msk
+#define RCC_APBENR1_TIM6EN_Pos           (4U)
+#define RCC_APBENR1_TIM6EN_Msk           (0x1UL << RCC_APBENR1_TIM6EN_Pos)      /*!< 0x00000010 */
+#define RCC_APBENR1_TIM6EN               RCC_APBENR1_TIM6EN_Msk
+#define RCC_APBENR1_TIM7EN_Pos           (5U)
+#define RCC_APBENR1_TIM7EN_Msk           (0x1UL << RCC_APBENR1_TIM7EN_Pos)      /*!< 0x00000020 */
+#define RCC_APBENR1_TIM7EN               RCC_APBENR1_TIM7EN_Msk
+#define RCC_APBENR1_RTCAPBEN_Pos         (10U)
+#define RCC_APBENR1_RTCAPBEN_Msk         (0x1UL << RCC_APBENR1_RTCAPBEN_Pos)    /*!< 0x00000400 */
+#define RCC_APBENR1_RTCAPBEN             RCC_APBENR1_RTCAPBEN_Msk
+#define RCC_APBENR1_WWDGEN_Pos           (11U)
+#define RCC_APBENR1_WWDGEN_Msk           (0x1UL << RCC_APBENR1_WWDGEN_Pos)      /*!< 0x00000800 */
+#define RCC_APBENR1_WWDGEN               RCC_APBENR1_WWDGEN_Msk
+#define RCC_APBENR1_SPI2EN_Pos           (14U)
+#define RCC_APBENR1_SPI2EN_Msk           (0x1UL << RCC_APBENR1_SPI2EN_Pos)      /*!< 0x00004000 */
+#define RCC_APBENR1_SPI2EN               RCC_APBENR1_SPI2EN_Msk
+#define RCC_APBENR1_USART2EN_Pos         (17U)
+#define RCC_APBENR1_USART2EN_Msk         (0x1UL << RCC_APBENR1_USART2EN_Pos)    /*!< 0x00020000 */
+#define RCC_APBENR1_USART2EN             RCC_APBENR1_USART2EN_Msk
+#define RCC_APBENR1_LPUART1EN_Pos        (20U)
+#define RCC_APBENR1_LPUART1EN_Msk        (0x1UL << RCC_APBENR1_LPUART1EN_Pos)   /*!< 0x00100000 */
+#define RCC_APBENR1_LPUART1EN            RCC_APBENR1_LPUART1EN_Msk
+#define RCC_APBENR1_I2C1EN_Pos           (21U)
+#define RCC_APBENR1_I2C1EN_Msk           (0x1UL << RCC_APBENR1_I2C1EN_Pos)      /*!< 0x00200000 */
+#define RCC_APBENR1_I2C1EN               RCC_APBENR1_I2C1EN_Msk
+#define RCC_APBENR1_I2C2EN_Pos           (22U)
+#define RCC_APBENR1_I2C2EN_Msk           (0x1UL << RCC_APBENR1_I2C2EN_Pos)      /*!< 0x00400000 */
+#define RCC_APBENR1_I2C2EN               RCC_APBENR1_I2C2EN_Msk
+#define RCC_APBENR1_DBGEN_Pos            (27U)
+#define RCC_APBENR1_DBGEN_Msk            (0x1UL << RCC_APBENR1_DBGEN_Pos)       /*!< 0x08000000 */
+#define RCC_APBENR1_DBGEN                RCC_APBENR1_DBGEN_Msk
+#define RCC_APBENR1_PWREN_Pos            (28U)
+#define RCC_APBENR1_PWREN_Msk            (0x1UL << RCC_APBENR1_PWREN_Pos)       /*!< 0x10000000 */
+#define RCC_APBENR1_PWREN                RCC_APBENR1_PWREN_Msk
+#define RCC_APBENR1_DAC1EN_Pos           (29U)
+#define RCC_APBENR1_DAC1EN_Msk           (0x1UL << RCC_APBENR1_DAC1EN_Pos)      /*!< 0x20000000 */
+#define RCC_APBENR1_DAC1EN               RCC_APBENR1_DAC1EN_Msk
+#define RCC_APBENR1_LPTIM2EN_Pos         (30U)
+#define RCC_APBENR1_LPTIM2EN_Msk         (0x1UL << RCC_APBENR1_LPTIM2EN_Pos)    /*!< 0x40000000 */
+#define RCC_APBENR1_LPTIM2EN             RCC_APBENR1_LPTIM2EN_Msk
+#define RCC_APBENR1_LPTIM1EN_Pos         (31U)
+#define RCC_APBENR1_LPTIM1EN_Msk         (0x1UL << RCC_APBENR1_LPTIM1EN_Pos)    /*!< 0x80000000 */
+#define RCC_APBENR1_LPTIM1EN             RCC_APBENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_APBENR2 register  **************/
+#define RCC_APBENR2_SYSCFGEN_Pos         (0U)
+#define RCC_APBENR2_SYSCFGEN_Msk         (0x1UL << RCC_APBENR2_SYSCFGEN_Pos)    /*!< 0x00000001 */
+#define RCC_APBENR2_SYSCFGEN             RCC_APBENR2_SYSCFGEN_Msk
+#define RCC_APBENR2_TIM1EN_Pos           (11U)
+#define RCC_APBENR2_TIM1EN_Msk           (0x1UL << RCC_APBENR2_TIM1EN_Pos)      /*!< 0x00000800 */
+#define RCC_APBENR2_TIM1EN               RCC_APBENR2_TIM1EN_Msk
+#define RCC_APBENR2_SPI1EN_Pos           (12U)
+#define RCC_APBENR2_SPI1EN_Msk           (0x1UL << RCC_APBENR2_SPI1EN_Pos)      /*!< 0x00001000 */
+#define RCC_APBENR2_SPI1EN               RCC_APBENR2_SPI1EN_Msk
+#define RCC_APBENR2_USART1EN_Pos         (14U)
+#define RCC_APBENR2_USART1EN_Msk         (0x1UL << RCC_APBENR2_USART1EN_Pos)    /*!< 0x00004000 */
+#define RCC_APBENR2_USART1EN             RCC_APBENR2_USART1EN_Msk
+#define RCC_APBENR2_TIM14EN_Pos          (15U)
+#define RCC_APBENR2_TIM14EN_Msk          (0x1UL << RCC_APBENR2_TIM14EN_Pos)     /*!< 0x00008000 */
+#define RCC_APBENR2_TIM14EN              RCC_APBENR2_TIM14EN_Msk
+#define RCC_APBENR2_TIM15EN_Pos          (16U)
+#define RCC_APBENR2_TIM15EN_Msk          (0x1UL << RCC_APBENR2_TIM15EN_Pos)     /*!< 0x00010000 */
+#define RCC_APBENR2_TIM15EN              RCC_APBENR2_TIM15EN_Msk
+#define RCC_APBENR2_TIM16EN_Pos          (17U)
+#define RCC_APBENR2_TIM16EN_Msk          (0x1UL << RCC_APBENR2_TIM16EN_Pos)     /*!< 0x00020000 */
+#define RCC_APBENR2_TIM16EN              RCC_APBENR2_TIM16EN_Msk
+#define RCC_APBENR2_TIM17EN_Pos          (18U)
+#define RCC_APBENR2_TIM17EN_Msk          (0x1UL << RCC_APBENR2_TIM17EN_Pos)     /*!< 0x00040000 */
+#define RCC_APBENR2_TIM17EN              RCC_APBENR2_TIM17EN_Msk
+#define RCC_APBENR2_ADCEN_Pos            (20U)
+#define RCC_APBENR2_ADCEN_Msk            (0x1UL << RCC_APBENR2_ADCEN_Pos)       /*!< 0x00100000 */
+#define RCC_APBENR2_ADCEN                RCC_APBENR2_ADCEN_Msk
+
+/********************  Bit definition for RCC_IOPSMENR register  *************/
+#define RCC_IOPSMENR_GPIOASMEN_Pos       (0U)
+#define RCC_IOPSMENR_GPIOASMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOASMEN_Pos)  /*!< 0x00000001 */
+#define RCC_IOPSMENR_GPIOASMEN           RCC_IOPSMENR_GPIOASMEN_Msk
+#define RCC_IOPSMENR_GPIOBSMEN_Pos       (1U)
+#define RCC_IOPSMENR_GPIOBSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOBSMEN_Pos)  /*!< 0x00000002 */
+#define RCC_IOPSMENR_GPIOBSMEN           RCC_IOPSMENR_GPIOBSMEN_Msk
+#define RCC_IOPSMENR_GPIOCSMEN_Pos       (2U)
+#define RCC_IOPSMENR_GPIOCSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOCSMEN_Pos)  /*!< 0x00000004 */
+#define RCC_IOPSMENR_GPIOCSMEN           RCC_IOPSMENR_GPIOCSMEN_Msk
+#define RCC_IOPSMENR_GPIODSMEN_Pos       (3U)
+#define RCC_IOPSMENR_GPIODSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIODSMEN_Pos)  /*!< 0x00000008 */
+#define RCC_IOPSMENR_GPIODSMEN           RCC_IOPSMENR_GPIODSMEN_Msk
+#define RCC_IOPSMENR_GPIOFSMEN_Pos       (5U)
+#define RCC_IOPSMENR_GPIOFSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOFSMEN_Pos)  /*!< 0x00000020 */
+#define RCC_IOPSMENR_GPIOFSMEN           RCC_IOPSMENR_GPIOFSMEN_Msk
+
+/********************  Bit definition for RCC_AHBSMENR register  *************/
+#define RCC_AHBSMENR_DMA1SMEN_Pos        (0U)
+#define RCC_AHBSMENR_DMA1SMEN_Msk        (0x1UL << RCC_AHBSMENR_DMA1SMEN_Pos)   /*!< 0x00000001 */
+#define RCC_AHBSMENR_DMA1SMEN            RCC_AHBSMENR_DMA1SMEN_Msk
+#define RCC_AHBSMENR_FLASHSMEN_Pos       (8U)
+#define RCC_AHBSMENR_FLASHSMEN_Msk       (0x1UL << RCC_AHBSMENR_FLASHSMEN_Pos)  /*!< 0x00000100 */
+#define RCC_AHBSMENR_FLASHSMEN           RCC_AHBSMENR_FLASHSMEN_Msk
+#define RCC_AHBSMENR_SRAMSMEN_Pos        (9U)
+#define RCC_AHBSMENR_SRAMSMEN_Msk        (0x1UL << RCC_AHBSMENR_SRAMSMEN_Pos)   /*!< 0x00000200 */
+#define RCC_AHBSMENR_SRAMSMEN            RCC_AHBSMENR_SRAMSMEN_Msk
+#define RCC_AHBSMENR_CRCSMEN_Pos         (12U)
+#define RCC_AHBSMENR_CRCSMEN_Msk         (0x1UL << RCC_AHBSMENR_CRCSMEN_Pos)    /*!< 0x00001000 */
+#define RCC_AHBSMENR_CRCSMEN             RCC_AHBSMENR_CRCSMEN_Msk
+
+/********************  Bit definition for RCC_APBSMENR1 register  *************/
+#define RCC_APBSMENR1_TIM2SMEN_Pos       (0U)
+#define RCC_APBSMENR1_TIM2SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM2SMEN_Pos)  /*!< 0x00000001 */
+#define RCC_APBSMENR1_TIM2SMEN           RCC_APBSMENR1_TIM2SMEN_Msk
+#define RCC_APBSMENR1_TIM3SMEN_Pos       (1U)
+#define RCC_APBSMENR1_TIM3SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM3SMEN_Pos)  /*!< 0x00000002 */
+#define RCC_APBSMENR1_TIM3SMEN           RCC_APBSMENR1_TIM3SMEN_Msk
+#define RCC_APBSMENR1_TIM6SMEN_Pos       (4U)
+#define RCC_APBSMENR1_TIM6SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM6SMEN_Pos)  /*!< 0x00000010 */
+#define RCC_APBSMENR1_TIM6SMEN           RCC_APBSMENR1_TIM6SMEN_Msk
+#define RCC_APBSMENR1_TIM7SMEN_Pos       (5U)
+#define RCC_APBSMENR1_TIM7SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM7SMEN_Pos)  /*!< 0x00000020 */
+#define RCC_APBSMENR1_TIM7SMEN           RCC_APBSMENR1_TIM7SMEN_Msk
+#define RCC_APBSMENR1_RTCAPBSMEN_Pos     (10U)
+#define RCC_APBSMENR1_RTCAPBSMEN_Msk     (0x1UL << RCC_APBSMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_APBSMENR1_RTCAPBSMEN         RCC_APBSMENR1_RTCAPBSMEN_Msk
+#define RCC_APBSMENR1_WWDGSMEN_Pos       (11U)
+#define RCC_APBSMENR1_WWDGSMEN_Msk       (0x1UL << RCC_APBSMENR1_WWDGSMEN_Pos)   /*!< 0x00000800 */
+#define RCC_APBSMENR1_WWDGSMEN           RCC_APBSMENR1_WWDGSMEN_Msk
+#define RCC_APBSMENR1_SPI2SMEN_Pos       (14U)
+#define RCC_APBSMENR1_SPI2SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI2SMEN_Pos)   /*!< 0x00004000 */
+#define RCC_APBSMENR1_SPI2SMEN           RCC_APBSMENR1_SPI2SMEN_Msk
+#define RCC_APBSMENR1_USART2SMEN_Pos     (17U)
+#define RCC_APBSMENR1_USART2SMEN_Msk     (0x1UL << RCC_APBSMENR1_USART2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_APBSMENR1_USART2SMEN         RCC_APBSMENR1_USART2SMEN_Msk
+#define RCC_APBSMENR1_LPUART1SMEN_Pos    (20U)
+#define RCC_APBSMENR1_LPUART1SMEN_Msk    (0x1UL << RCC_APBSMENR1_LPUART1SMEN_Pos) /*!< 0x00100000 */
+#define RCC_APBSMENR1_LPUART1SMEN        RCC_APBSMENR1_LPUART1SMEN_Msk
+#define RCC_APBSMENR1_I2C1SMEN_Pos       (21U)
+#define RCC_APBSMENR1_I2C1SMEN_Msk       (0x1UL << RCC_APBSMENR1_I2C1SMEN_Pos)   /*!< 0x00200000 */
+#define RCC_APBSMENR1_I2C1SMEN           RCC_APBSMENR1_I2C1SMEN_Msk
+#define RCC_APBSMENR1_I2C2SMEN_Pos       (22U)
+#define RCC_APBSMENR1_I2C2SMEN_Msk       (0x1UL << RCC_APBSMENR1_I2C2SMEN_Pos)   /*!< 0x00400000 */
+#define RCC_APBSMENR1_I2C2SMEN           RCC_APBSMENR1_I2C2SMEN_Msk
+#define RCC_APBSMENR1_DBGSMEN_Pos        (27U)
+#define RCC_APBSMENR1_DBGSMEN_Msk        (0x1UL << RCC_APBSMENR1_DBGSMEN_Pos)    /*!< 0x08000000 */
+#define RCC_APBSMENR1_DBGSMEN            RCC_APBSMENR1_DBGSMEN_Msk
+#define RCC_APBSMENR1_PWRSMEN_Pos        (28U)
+#define RCC_APBSMENR1_PWRSMEN_Msk        (0x1UL << RCC_APBSMENR1_PWRSMEN_Pos)    /*!< 0x10000000 */
+#define RCC_APBSMENR1_PWRSMEN            RCC_APBSMENR1_PWRSMEN_Msk
+#define RCC_APBSMENR1_DAC1SMEN_Pos       (29U)
+#define RCC_APBSMENR1_DAC1SMEN_Msk       (0x1UL << RCC_APBSMENR1_DAC1SMEN_Pos)   /*!< 0x20000000 */
+#define RCC_APBSMENR1_DAC1SMEN           RCC_APBSMENR1_DAC1SMEN_Msk
+#define RCC_APBSMENR1_LPTIM2SMEN_Pos     (30U)
+#define RCC_APBSMENR1_LPTIM2SMEN_Msk     (0x1UL << RCC_APBSMENR1_LPTIM2SMEN_Pos) /*!< 0x40000000 */
+#define RCC_APBSMENR1_LPTIM2SMEN         RCC_APBSMENR1_LPTIM2SMEN_Msk
+#define RCC_APBSMENR1_LPTIM1SMEN_Pos     (31U)
+#define RCC_APBSMENR1_LPTIM1SMEN_Msk     (0x1UL << RCC_APBSMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_APBSMENR1_LPTIM1SMEN         RCC_APBSMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_APBSMENR2 register  *************/
+#define RCC_APBSMENR2_SYSCFGSMEN_Pos     (0U)
+#define RCC_APBSMENR2_SYSCFGSMEN_Msk     (0x1UL << RCC_APBSMENR2_SYSCFGSMEN_Pos) /*!< 0x00000001 */
+#define RCC_APBSMENR2_SYSCFGSMEN         RCC_APBSMENR2_SYSCFGSMEN_Msk
+#define RCC_APBSMENR2_TIM1SMEN_Pos       (11U)
+#define RCC_APBSMENR2_TIM1SMEN_Msk       (0x1UL << RCC_APBSMENR2_TIM1SMEN_Pos)  /*!< 0x00000800 */
+#define RCC_APBSMENR2_TIM1SMEN           RCC_APBSMENR2_TIM1SMEN_Msk
+#define RCC_APBSMENR2_SPI1SMEN_Pos       (12U)
+#define RCC_APBSMENR2_SPI1SMEN_Msk       (0x1UL << RCC_APBSMENR2_SPI1SMEN_Pos)  /*!< 0x00001000 */
+#define RCC_APBSMENR2_SPI1SMEN           RCC_APBSMENR2_SPI1SMEN_Msk
+#define RCC_APBSMENR2_USART1SMEN_Pos     (14U)
+#define RCC_APBSMENR2_USART1SMEN_Msk     (0x1UL << RCC_APBSMENR2_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_APBSMENR2_USART1SMEN         RCC_APBSMENR2_USART1SMEN_Msk
+#define RCC_APBSMENR2_TIM14SMEN_Pos      (15U)
+#define RCC_APBSMENR2_TIM14SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM14SMEN_Pos) /*!< 0x00008000 */
+#define RCC_APBSMENR2_TIM14SMEN          RCC_APBSMENR2_TIM14SMEN_Msk
+#define RCC_APBSMENR2_TIM15SMEN_Pos      (16U)
+#define RCC_APBSMENR2_TIM15SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM15SMEN_Pos) /*!< 0x00010000 */
+#define RCC_APBSMENR2_TIM15SMEN          RCC_APBSMENR2_TIM15SMEN_Msk
+#define RCC_APBSMENR2_TIM16SMEN_Pos      (17U)
+#define RCC_APBSMENR2_TIM16SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM16SMEN_Pos) /*!< 0x00020000 */
+#define RCC_APBSMENR2_TIM16SMEN          RCC_APBSMENR2_TIM16SMEN_Msk
+#define RCC_APBSMENR2_TIM17SMEN_Pos      (18U)
+#define RCC_APBSMENR2_TIM17SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM17SMEN_Pos) /*!< 0x00040000 */
+#define RCC_APBSMENR2_TIM17SMEN          RCC_APBSMENR2_TIM17SMEN_Msk
+#define RCC_APBSMENR2_ADCSMEN_Pos        (20U)
+#define RCC_APBSMENR2_ADCSMEN_Msk        (0x1UL << RCC_APBSMENR2_ADCSMEN_Pos)   /*!< 0x00100000 */
+#define RCC_APBSMENR2_ADCSMEN            RCC_APBSMENR2_ADCSMEN_Msk
+
+/********************  Bit definition for RCC_CCIPR register  ******************/
+#define RCC_CCIPR_USART1SEL_Pos          (0U)
+#define RCC_CCIPR_USART1SEL_Msk          (0x3UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000003 */
+#define RCC_CCIPR_USART1SEL              RCC_CCIPR_USART1SEL_Msk
+#define RCC_CCIPR_USART1SEL_0            (0x1UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000001 */
+#define RCC_CCIPR_USART1SEL_1            (0x2UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000002 */
+
+
+
+#define RCC_CCIPR_LPUART1SEL_Pos         (10U)
+#define RCC_CCIPR_LPUART1SEL_Msk         (0x3UL << RCC_CCIPR_LPUART1SEL_Pos)    /*!< 0x00000C00 */
+#define RCC_CCIPR_LPUART1SEL             RCC_CCIPR_LPUART1SEL_Msk
+#define RCC_CCIPR_LPUART1SEL_0           (0x1UL << RCC_CCIPR_LPUART1SEL_Pos)    /*!< 0x00000400 */
+#define RCC_CCIPR_LPUART1SEL_1           (0x2UL << RCC_CCIPR_LPUART1SEL_Pos)    /*!< 0x00000800 */
+
+#define RCC_CCIPR_I2C1SEL_Pos            (12U)
+#define RCC_CCIPR_I2C1SEL_Msk            (0x3UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00003000 */
+#define RCC_CCIPR_I2C1SEL                RCC_CCIPR_I2C1SEL_Msk
+#define RCC_CCIPR_I2C1SEL_0              (0x1UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00001000 */
+#define RCC_CCIPR_I2C1SEL_1              (0x2UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00002000 */
+
+#define RCC_CCIPR_I2S1SEL_Pos            (14U)
+#define RCC_CCIPR_I2S1SEL_Msk            (0x3UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x0000C000 */
+#define RCC_CCIPR_I2S1SEL                RCC_CCIPR_I2S1SEL_Msk
+#define RCC_CCIPR_I2S1SEL_0              (0x1UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x00004000 */
+#define RCC_CCIPR_I2S1SEL_1              (0x2UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x00008000 */
+
+#define RCC_CCIPR_LPTIM1SEL_Pos          (18U)
+#define RCC_CCIPR_LPTIM1SEL_Msk          (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x000C0000 */
+#define RCC_CCIPR_LPTIM1SEL              RCC_CCIPR_LPTIM1SEL_Msk
+#define RCC_CCIPR_LPTIM1SEL_0            (0x1UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x00040000 */
+#define RCC_CCIPR_LPTIM1SEL_1            (0x2UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x00080000 */
+
+#define RCC_CCIPR_LPTIM2SEL_Pos          (20U)
+#define RCC_CCIPR_LPTIM2SEL_Msk          (0x3UL << RCC_CCIPR_LPTIM2SEL_Pos)     /*!< 0x00300000 */
+#define RCC_CCIPR_LPTIM2SEL              RCC_CCIPR_LPTIM2SEL_Msk
+#define RCC_CCIPR_LPTIM2SEL_0            (0x1UL << RCC_CCIPR_LPTIM2SEL_Pos)     /*!< 0x00100000 */
+#define RCC_CCIPR_LPTIM2SEL_1            (0x2UL << RCC_CCIPR_LPTIM2SEL_Pos)     /*!< 0x00200000 */
+
+#define RCC_CCIPR_TIM1SEL_Pos            (22U)
+#define RCC_CCIPR_TIM1SEL_Msk            (0x1UL << RCC_CCIPR_TIM1SEL_Pos)       /*!< 0x00400000 */
+#define RCC_CCIPR_TIM1SEL                RCC_CCIPR_TIM1SEL_Msk
+
+#define RCC_CCIPR_TIM15SEL_Pos           (24U)
+#define RCC_CCIPR_TIM15SEL_Msk           (0x1UL << RCC_CCIPR_TIM15SEL_Pos)      /*!< 0x01000000 */
+#define RCC_CCIPR_TIM15SEL               RCC_CCIPR_TIM15SEL_Msk
+
+
+#define RCC_CCIPR_ADCSEL_Pos             (30U)
+#define RCC_CCIPR_ADCSEL_Msk             (0x3UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0xC0000000 */
+#define RCC_CCIPR_ADCSEL                 RCC_CCIPR_ADCSEL_Msk
+#define RCC_CCIPR_ADCSEL_0               (0x1UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0x40000000 */
+#define RCC_CCIPR_ADCSEL_1               (0x2UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos               (0U)
+#define RCC_BDCR_LSEON_Msk               (0x1UL << RCC_BDCR_LSEON_Pos)          /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                   RCC_BDCR_LSEON_Msk
+#define RCC_BDCR_LSERDY_Pos              (1U)
+#define RCC_BDCR_LSERDY_Msk              (0x1UL << RCC_BDCR_LSERDY_Pos)         /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                  RCC_BDCR_LSERDY_Msk
+#define RCC_BDCR_LSEBYP_Pos              (2U)
+#define RCC_BDCR_LSEBYP_Msk              (0x1UL << RCC_BDCR_LSEBYP_Pos)         /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                  RCC_BDCR_LSEBYP_Msk
+
+#define RCC_BDCR_LSEDRV_Pos              (3U)
+#define RCC_BDCR_LSEDRV_Msk              (0x3UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000018 */
+#define RCC_BDCR_LSEDRV                  RCC_BDCR_LSEDRV_Msk
+#define RCC_BDCR_LSEDRV_0                (0x1UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000008 */
+#define RCC_BDCR_LSEDRV_1                (0x2UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000010 */
+
+#define RCC_BDCR_LSECSSON_Pos            (5U)
+#define RCC_BDCR_LSECSSON_Msk            (0x1UL << RCC_BDCR_LSECSSON_Pos)       /*!< 0x00000020 */
+#define RCC_BDCR_LSECSSON                RCC_BDCR_LSECSSON_Msk
+#define RCC_BDCR_LSECSSD_Pos             (6U)
+#define RCC_BDCR_LSECSSD_Msk             (0x1UL << RCC_BDCR_LSECSSD_Pos)        /*!< 0x00000040 */
+#define RCC_BDCR_LSECSSD                 RCC_BDCR_LSECSSD_Msk
+
+#define RCC_BDCR_RTCSEL_Pos              (8U)
+#define RCC_BDCR_RTCSEL_Msk              (0x3UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                  RCC_BDCR_RTCSEL_Msk
+#define RCC_BDCR_RTCSEL_0                (0x1UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                (0x2UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos               (15U)
+#define RCC_BDCR_RTCEN_Msk               (0x1UL << RCC_BDCR_RTCEN_Pos)          /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                   RCC_BDCR_RTCEN_Msk
+#define RCC_BDCR_BDRST_Pos               (16U)
+#define RCC_BDCR_BDRST_Msk               (0x1UL << RCC_BDCR_BDRST_Pos)          /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                   RCC_BDCR_BDRST_Msk
+
+#define RCC_BDCR_LSCOEN_Pos              (24U)
+#define RCC_BDCR_LSCOEN_Msk              (0x1UL << RCC_BDCR_LSCOEN_Pos)         /*!< 0x01000000 */
+#define RCC_BDCR_LSCOEN                  RCC_BDCR_LSCOEN_Msk
+#define RCC_BDCR_LSCOSEL_Pos             (25U)
+#define RCC_BDCR_LSCOSEL_Msk             (0x1UL << RCC_BDCR_LSCOSEL_Pos)        /*!< 0x02000000 */
+#define RCC_BDCR_LSCOSEL                 RCC_BDCR_LSCOSEL_Msk
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSION_Pos                (0U)
+#define RCC_CSR_LSION_Msk                (0x1UL << RCC_CSR_LSION_Pos)           /*!< 0x00000001 */
+#define RCC_CSR_LSION                    RCC_CSR_LSION_Msk
+#define RCC_CSR_LSIRDY_Pos               (1U)
+#define RCC_CSR_LSIRDY_Msk               (0x1UL << RCC_CSR_LSIRDY_Pos)          /*!< 0x00000002 */
+#define RCC_CSR_LSIRDY                   RCC_CSR_LSIRDY_Msk
+
+#define RCC_CSR_RMVF_Pos                 (23U)
+#define RCC_CSR_RMVF_Msk                 (0x1UL << RCC_CSR_RMVF_Pos)            /*!< 0x00800000 */
+#define RCC_CSR_RMVF                     RCC_CSR_RMVF_Msk
+#define RCC_CSR_OBLRSTF_Pos              (25U)
+#define RCC_CSR_OBLRSTF_Msk              (0x1UL << RCC_CSR_OBLRSTF_Pos)         /*!< 0x02000000 */
+#define RCC_CSR_OBLRSTF                  RCC_CSR_OBLRSTF_Msk
+#define RCC_CSR_PINRSTF_Pos              (26U)
+#define RCC_CSR_PINRSTF_Msk              (0x1UL << RCC_CSR_PINRSTF_Pos)         /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                  RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_PWRRSTF_Pos              (27U)
+#define RCC_CSR_PWRRSTF_Msk              (0x1UL << RCC_CSR_PWRRSTF_Pos)         /*!< 0x08000000 */
+#define RCC_CSR_PWRRSTF                  RCC_CSR_PWRRSTF_Msk
+#define RCC_CSR_SFTRSTF_Pos              (28U)
+#define RCC_CSR_SFTRSTF_Msk              (0x1UL << RCC_CSR_SFTRSTF_Pos)         /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                  RCC_CSR_SFTRSTF_Msk
+#define RCC_CSR_IWDGRSTF_Pos             (29U)
+#define RCC_CSR_IWDGRSTF_Msk             (0x1UL << RCC_CSR_IWDGRSTF_Pos)        /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                 RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos             (30U)
+#define RCC_CSR_WWDGRSTF_Msk             (0x1UL << RCC_CSR_WWDGRSTF_Pos)        /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                 RCC_CSR_WWDGRSTF_Msk
+#define RCC_CSR_LPWRRSTF_Pos             (31U)
+#define RCC_CSR_LPWRRSTF_Msk             (0x1UL << RCC_CSR_LPWRRSTF_Pos)        /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                 RCC_CSR_LPWRRSTF_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions
+*/
+#define RTC_WAKEUP_SUPPORT
+#define RTC_BACKUP_SUPPORT
+
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                (22U)
+#define RTC_TR_PM_Msk                (0x1UL << RTC_TR_PM_Pos)                   /*!< 0x00400000 */
+#define RTC_TR_PM                    RTC_TR_PM_Msk
+#define RTC_TR_HT_Pos                (20U)
+#define RTC_TR_HT_Msk                (0x3UL << RTC_TR_HT_Pos)                   /*!< 0x00300000 */
+#define RTC_TR_HT                    RTC_TR_HT_Msk
+#define RTC_TR_HT_0                  (0x1UL << RTC_TR_HT_Pos)                   /*!< 0x00100000 */
+#define RTC_TR_HT_1                  (0x2UL << RTC_TR_HT_Pos)                   /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                (16U)
+#define RTC_TR_HU_Msk                (0xFUL << RTC_TR_HU_Pos)                   /*!< 0x000F0000 */
+#define RTC_TR_HU                    RTC_TR_HU_Msk
+#define RTC_TR_HU_0                  (0x1UL << RTC_TR_HU_Pos)                   /*!< 0x00010000 */
+#define RTC_TR_HU_1                  (0x2UL << RTC_TR_HU_Pos)                   /*!< 0x00020000 */
+#define RTC_TR_HU_2                  (0x4UL << RTC_TR_HU_Pos)                   /*!< 0x00040000 */
+#define RTC_TR_HU_3                  (0x8UL << RTC_TR_HU_Pos)                   /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos               (12U)
+#define RTC_TR_MNT_Msk               (0x7UL << RTC_TR_MNT_Pos)                  /*!< 0x00007000 */
+#define RTC_TR_MNT                   RTC_TR_MNT_Msk
+#define RTC_TR_MNT_0                 (0x1UL << RTC_TR_MNT_Pos)                  /*!< 0x00001000 */
+#define RTC_TR_MNT_1                 (0x2UL << RTC_TR_MNT_Pos)                  /*!< 0x00002000 */
+#define RTC_TR_MNT_2                 (0x4UL << RTC_TR_MNT_Pos)                  /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos               (8U)
+#define RTC_TR_MNU_Msk               (0xFUL << RTC_TR_MNU_Pos)                  /*!< 0x00000F00 */
+#define RTC_TR_MNU                   RTC_TR_MNU_Msk
+#define RTC_TR_MNU_0                 (0x1UL << RTC_TR_MNU_Pos)                  /*!< 0x00000100 */
+#define RTC_TR_MNU_1                 (0x2UL << RTC_TR_MNU_Pos)                  /*!< 0x00000200 */
+#define RTC_TR_MNU_2                 (0x4UL << RTC_TR_MNU_Pos)                  /*!< 0x00000400 */
+#define RTC_TR_MNU_3                 (0x8UL << RTC_TR_MNU_Pos)                  /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                (4U)
+#define RTC_TR_ST_Msk                (0x7UL << RTC_TR_ST_Pos)                   /*!< 0x00000070 */
+#define RTC_TR_ST                    RTC_TR_ST_Msk
+#define RTC_TR_ST_0                  (0x1UL << RTC_TR_ST_Pos)                   /*!< 0x00000010 */
+#define RTC_TR_ST_1                  (0x2UL << RTC_TR_ST_Pos)                   /*!< 0x00000020 */
+#define RTC_TR_ST_2                  (0x4UL << RTC_TR_ST_Pos)                   /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                (0U)
+#define RTC_TR_SU_Msk                (0xFUL << RTC_TR_SU_Pos)                   /*!< 0x0000000F */
+#define RTC_TR_SU                    RTC_TR_SU_Msk
+#define RTC_TR_SU_0                  (0x1UL << RTC_TR_SU_Pos)                   /*!< 0x00000001 */
+#define RTC_TR_SU_1                  (0x2UL << RTC_TR_SU_Pos)                   /*!< 0x00000002 */
+#define RTC_TR_SU_2                  (0x4UL << RTC_TR_SU_Pos)                   /*!< 0x00000004 */
+#define RTC_TR_SU_3                  (0x8UL << RTC_TR_SU_Pos)                   /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                (20U)
+#define RTC_DR_YT_Msk                (0xFUL << RTC_DR_YT_Pos)                   /*!< 0x00F00000 */
+#define RTC_DR_YT                    RTC_DR_YT_Msk
+#define RTC_DR_YT_0                  (0x1UL << RTC_DR_YT_Pos)                   /*!< 0x00100000 */
+#define RTC_DR_YT_1                  (0x2UL << RTC_DR_YT_Pos)                   /*!< 0x00200000 */
+#define RTC_DR_YT_2                  (0x4UL << RTC_DR_YT_Pos)                   /*!< 0x00400000 */
+#define RTC_DR_YT_3                  (0x8UL << RTC_DR_YT_Pos)                   /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                (16U)
+#define RTC_DR_YU_Msk                (0xFUL << RTC_DR_YU_Pos)                   /*!< 0x000F0000 */
+#define RTC_DR_YU                    RTC_DR_YU_Msk
+#define RTC_DR_YU_0                  (0x1UL << RTC_DR_YU_Pos)                   /*!< 0x00010000 */
+#define RTC_DR_YU_1                  (0x2UL << RTC_DR_YU_Pos)                   /*!< 0x00020000 */
+#define RTC_DR_YU_2                  (0x4UL << RTC_DR_YU_Pos)                   /*!< 0x00040000 */
+#define RTC_DR_YU_3                  (0x8UL << RTC_DR_YU_Pos)                   /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos               (13U)
+#define RTC_DR_WDU_Msk               (0x7UL << RTC_DR_WDU_Pos)                  /*!< 0x0000E000 */
+#define RTC_DR_WDU                   RTC_DR_WDU_Msk
+#define RTC_DR_WDU_0                 (0x1UL << RTC_DR_WDU_Pos)                  /*!< 0x00002000 */
+#define RTC_DR_WDU_1                 (0x2UL << RTC_DR_WDU_Pos)                  /*!< 0x00004000 */
+#define RTC_DR_WDU_2                 (0x4UL << RTC_DR_WDU_Pos)                  /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                (12U)
+#define RTC_DR_MT_Msk                (0x1UL << RTC_DR_MT_Pos)                   /*!< 0x00001000 */
+#define RTC_DR_MT                    RTC_DR_MT_Msk
+#define RTC_DR_MU_Pos                (8U)
+#define RTC_DR_MU_Msk                (0xFUL << RTC_DR_MU_Pos)                   /*!< 0x00000F00 */
+#define RTC_DR_MU                    RTC_DR_MU_Msk
+#define RTC_DR_MU_0                  (0x1UL << RTC_DR_MU_Pos)                   /*!< 0x00000100 */
+#define RTC_DR_MU_1                  (0x2UL << RTC_DR_MU_Pos)                   /*!< 0x00000200 */
+#define RTC_DR_MU_2                  (0x4UL << RTC_DR_MU_Pos)                   /*!< 0x00000400 */
+#define RTC_DR_MU_3                  (0x8UL << RTC_DR_MU_Pos)                   /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                (4U)
+#define RTC_DR_DT_Msk                (0x3UL << RTC_DR_DT_Pos)                   /*!< 0x00000030 */
+#define RTC_DR_DT                    RTC_DR_DT_Msk
+#define RTC_DR_DT_0                  (0x1UL << RTC_DR_DT_Pos)                   /*!< 0x00000010 */
+#define RTC_DR_DT_1                  (0x2UL << RTC_DR_DT_Pos)                   /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                (0U)
+#define RTC_DR_DU_Msk                (0xFUL << RTC_DR_DU_Pos)                   /*!< 0x0000000F */
+#define RTC_DR_DU                    RTC_DR_DU_Msk
+#define RTC_DR_DU_0                  (0x1UL << RTC_DR_DU_Pos)                   /*!< 0x00000001 */
+#define RTC_DR_DU_1                  (0x2UL << RTC_DR_DU_Pos)                   /*!< 0x00000002 */
+#define RTC_DR_DU_2                  (0x4UL << RTC_DR_DU_Pos)                   /*!< 0x00000004 */
+#define RTC_DR_DU_3                  (0x8UL << RTC_DR_DU_Pos)                   /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos               (0U)
+#define RTC_SSR_SS_Msk               (0xFFFFUL << RTC_SSR_SS_Pos)               /*!< 0x0000FFFF */
+#define RTC_SSR_SS                   RTC_SSR_SS_Msk
+
+/********************  Bits definition for RTC_ICSR register  ******************/
+#define RTC_ICSR_RECALPF_Pos         (16U)
+#define RTC_ICSR_RECALPF_Msk         (0x1UL << RTC_ICSR_RECALPF_Pos)            /*!< 0x00010000 */
+#define RTC_ICSR_RECALPF             RTC_ICSR_RECALPF_Msk
+#define RTC_ICSR_INIT_Pos            (7U)
+#define RTC_ICSR_INIT_Msk            (0x1UL << RTC_ICSR_INIT_Pos)               /*!< 0x00000080 */
+#define RTC_ICSR_INIT                RTC_ICSR_INIT_Msk
+#define RTC_ICSR_INITF_Pos           (6U)
+#define RTC_ICSR_INITF_Msk           (0x1UL << RTC_ICSR_INITF_Pos)              /*!< 0x00000040 */
+#define RTC_ICSR_INITF               RTC_ICSR_INITF_Msk
+#define RTC_ICSR_RSF_Pos             (5U)
+#define RTC_ICSR_RSF_Msk             (0x1UL << RTC_ICSR_RSF_Pos)                /*!< 0x00000020 */
+#define RTC_ICSR_RSF                 RTC_ICSR_RSF_Msk
+#define RTC_ICSR_INITS_Pos           (4U)
+#define RTC_ICSR_INITS_Msk           (0x1UL << RTC_ICSR_INITS_Pos)              /*!< 0x00000010 */
+#define RTC_ICSR_INITS               RTC_ICSR_INITS_Msk
+#define RTC_ICSR_SHPF_Pos            (3U)
+#define RTC_ICSR_SHPF_Msk            (0x1UL << RTC_ICSR_SHPF_Pos)               /*!< 0x00000008 */
+#define RTC_ICSR_SHPF                RTC_ICSR_SHPF_Msk
+#define RTC_ICSR_WUTWF_Pos           (2U)
+#define RTC_ICSR_WUTWF_Msk           (0x1UL << RTC_ICSR_WUTWF_Pos)              /*!< 0x00000004 */
+#define RTC_ICSR_WUTWF               RTC_ICSR_WUTWF_Msk                         /*!< Wakeup timer write flag > */
+#define RTC_ICSR_ALRBWF_Pos          (1U)
+#define RTC_ICSR_ALRBWF_Msk          (0x1UL << RTC_ICSR_ALRBWF_Pos)             /*!< 0x00000002 */
+#define RTC_ICSR_ALRBWF              RTC_ICSR_ALRBWF_Msk
+#define RTC_ICSR_ALRAWF_Pos          (0U)
+#define RTC_ICSR_ALRAWF_Msk          (0x1UL << RTC_ICSR_ALRAWF_Pos)             /*!< 0x00000001 */
+#define RTC_ICSR_ALRAWF              RTC_ICSR_ALRAWF_Msk
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos        (16U)
+#define RTC_PRER_PREDIV_A_Msk        (0x7FUL << RTC_PRER_PREDIV_A_Pos)          /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A            RTC_PRER_PREDIV_A_Msk
+#define RTC_PRER_PREDIV_S_Pos        (0U)
+#define RTC_PRER_PREDIV_S_Msk        (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)        /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S            RTC_PRER_PREDIV_S_Msk
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos             (0U)
+#define RTC_WUTR_WUT_Msk             (0xFFFFUL << RTC_WUTR_WUT_Pos)            /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                 RTC_WUTR_WUT_Msk                          /*!< Wakeup auto-reload value bits > */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_OUT2EN_Pos            (31U)
+#define RTC_CR_OUT2EN_Msk            (0x1UL << RTC_CR_OUT2EN_Pos)              /*!< 0x80000000 */
+#define RTC_CR_OUT2EN                RTC_CR_OUT2EN_Msk                         /*!< RTC_OUT2 output enable */
+#define RTC_CR_TAMPALRM_TYPE_Pos     (30U)
+#define RTC_CR_TAMPALRM_TYPE_Msk     (0x1UL << RTC_CR_TAMPALRM_TYPE_Pos)       /*!< 0x40000000 */
+#define RTC_CR_TAMPALRM_TYPE         RTC_CR_TAMPALRM_TYPE_Msk                  /*!< TAMPALARM output type  */
+#define RTC_CR_TAMPALRM_PU_Pos       (29U)
+#define RTC_CR_TAMPALRM_PU_Msk       (0x1UL << RTC_CR_TAMPALRM_PU_Pos)         /*!< 0x20000000 */
+#define RTC_CR_TAMPALRM_PU           RTC_CR_TAMPALRM_PU_Msk                    /*!< TAMPALARM output pull-up config */
+#define RTC_CR_TAMPOE_Pos            (26U)
+#define RTC_CR_TAMPOE_Msk            (0x1UL << RTC_CR_TAMPOE_Pos)              /*!< 0x04000000 */
+#define RTC_CR_TAMPOE                RTC_CR_TAMPOE_Msk                         /*!< Tamper detection output enable on TAMPALARM  */
+#define RTC_CR_TAMPTS_Pos            (25U)
+#define RTC_CR_TAMPTS_Msk            (0x1UL << RTC_CR_TAMPTS_Pos)              /*!< 0x02000000 */
+#define RTC_CR_TAMPTS                RTC_CR_TAMPTS_Msk                         /*!< Activate timestamp on tamper detection event  */
+#define RTC_CR_ITSE_Pos              (24U)
+#define RTC_CR_ITSE_Msk              (0x1UL << RTC_CR_ITSE_Pos)                /*!< 0x01000000 */
+#define RTC_CR_ITSE                  RTC_CR_ITSE_Msk                           /*!< Timestamp on internal event enable  */
+#define RTC_CR_COE_Pos               (23U)
+#define RTC_CR_COE_Msk               (0x1UL << RTC_CR_COE_Pos)                 /*!< 0x00800000 */
+#define RTC_CR_COE                   RTC_CR_COE_Msk
+#define RTC_CR_OSEL_Pos              (21U)
+#define RTC_CR_OSEL_Msk              (0x3UL << RTC_CR_OSEL_Pos)                 /*!< 0x00600000 */
+#define RTC_CR_OSEL                  RTC_CR_OSEL_Msk
+#define RTC_CR_OSEL_0                (0x1UL << RTC_CR_OSEL_Pos)                 /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                (0x2UL << RTC_CR_OSEL_Pos)                 /*!< 0x00400000 */
+#define RTC_CR_POL_Pos               (20U)
+#define RTC_CR_POL_Msk               (0x1UL << RTC_CR_POL_Pos)                  /*!< 0x00100000 */
+#define RTC_CR_POL                   RTC_CR_POL_Msk
+#define RTC_CR_COSEL_Pos             (19U)
+#define RTC_CR_COSEL_Msk             (0x1UL << RTC_CR_COSEL_Pos)                /*!< 0x00080000 */
+#define RTC_CR_COSEL                 RTC_CR_COSEL_Msk
+#define RTC_CR_BKP_Pos               (18U)
+#define RTC_CR_BKP_Msk               (0x1UL << RTC_CR_BKP_Pos)                  /*!< 0x00040000 */
+#define RTC_CR_BKP                   RTC_CR_BKP_Msk
+#define RTC_CR_SUB1H_Pos             (17U)
+#define RTC_CR_SUB1H_Msk             (0x1UL << RTC_CR_SUB1H_Pos)                /*!< 0x00020000 */
+#define RTC_CR_SUB1H                 RTC_CR_SUB1H_Msk
+#define RTC_CR_ADD1H_Pos             (16U)
+#define RTC_CR_ADD1H_Msk             (0x1UL << RTC_CR_ADD1H_Pos)                /*!< 0x00010000 */
+#define RTC_CR_ADD1H                 RTC_CR_ADD1H_Msk
+#define RTC_CR_TSIE_Pos              (15U)
+#define RTC_CR_TSIE_Msk              (0x1UL << RTC_CR_TSIE_Pos)                /*!< 0x00008000 */
+#define RTC_CR_TSIE                  RTC_CR_TSIE_Msk                           /*!< Timestamp interrupt enable > */
+#define RTC_CR_WUTIE_Pos             (14U)
+#define RTC_CR_WUTIE_Msk             (0x1UL << RTC_CR_WUTIE_Pos)               /*!< 0x00004000 */
+#define RTC_CR_WUTIE                 RTC_CR_WUTIE_Msk                          /*!< Wakeup timer interrupt enable > */
+#define RTC_CR_ALRBIE_Pos            (13U)
+#define RTC_CR_ALRBIE_Msk            (0x1UL << RTC_CR_ALRBIE_Pos)              /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                RTC_CR_ALRBIE_Msk
+#define RTC_CR_ALRAIE_Pos            (12U)
+#define RTC_CR_ALRAIE_Msk            (0x1UL << RTC_CR_ALRAIE_Pos)              /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                RTC_CR_ALRAIE_Msk
+#define RTC_CR_TSE_Pos               (11U)
+#define RTC_CR_TSE_Msk               (0x1UL << RTC_CR_TSE_Pos)                 /*!< 0x00000800 */
+#define RTC_CR_TSE                   RTC_CR_TSE_Msk                            /*!< timestamp enable > */
+#define RTC_CR_WUTE_Pos              (10U)
+#define RTC_CR_WUTE_Msk              (0x1UL << RTC_CR_WUTE_Pos)                /*!< 0x00000400 */
+#define RTC_CR_WUTE                  RTC_CR_WUTE_Msk                           /*!< Wakeup timer enable > */
+#define RTC_CR_ALRBE_Pos             (9U)
+#define RTC_CR_ALRBE_Msk             (0x1UL << RTC_CR_ALRBE_Pos)               /*!< 0x00000200 */
+#define RTC_CR_ALRBE                 RTC_CR_ALRBE_Msk
+#define RTC_CR_ALRAE_Pos             (8U)
+#define RTC_CR_ALRAE_Msk             (0x1UL << RTC_CR_ALRAE_Pos)                /*!< 0x00000100 */
+#define RTC_CR_ALRAE                 RTC_CR_ALRAE_Msk
+#define RTC_CR_FMT_Pos               (6U)
+#define RTC_CR_FMT_Msk               (0x1UL << RTC_CR_FMT_Pos)                  /*!< 0x00000040 */
+#define RTC_CR_FMT                   RTC_CR_FMT_Msk
+#define RTC_CR_BYPSHAD_Pos           (5U)
+#define RTC_CR_BYPSHAD_Msk           (0x1UL << RTC_CR_BYPSHAD_Pos)              /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD               RTC_CR_BYPSHAD_Msk
+#define RTC_CR_REFCKON_Pos           (4U)
+#define RTC_CR_REFCKON_Msk           (0x1UL << RTC_CR_REFCKON_Pos)              /*!< 0x00000010 */
+#define RTC_CR_REFCKON               RTC_CR_REFCKON_Msk
+#define RTC_CR_TSEDGE_Pos            (3U)
+#define RTC_CR_TSEDGE_Msk            (0x1UL << RTC_CR_TSEDGE_Pos)              /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                RTC_CR_TSEDGE_Msk                         /*!< Timestamp event active edge > */
+#define RTC_CR_WUCKSEL_Pos           (0U)
+#define RTC_CR_WUCKSEL_Msk           (0x7UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL               RTC_CR_WUCKSEL_Msk                        /*!< Wakeup clock selection > */
+#define RTC_CR_WUCKSEL_0             (0x1UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1             (0x2UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2             (0x4UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000004 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos              (0U)
+#define RTC_WPR_KEY_Msk              (0xFFUL << RTC_WPR_KEY_Pos)                /*!< 0x000000FF */
+#define RTC_WPR_KEY                  RTC_WPR_KEY_Msk
+
+/********************  Bits definition for RTC_CALR register  *****************/
+#define RTC_CALR_CALP_Pos            (15U)
+#define RTC_CALR_CALP_Msk            (0x1UL << RTC_CALR_CALP_Pos)               /*!< 0x00008000 */
+#define RTC_CALR_CALP                RTC_CALR_CALP_Msk
+#define RTC_CALR_CALW8_Pos           (14U)
+#define RTC_CALR_CALW8_Msk           (0x1UL << RTC_CALR_CALW8_Pos)              /*!< 0x00004000 */
+#define RTC_CALR_CALW8               RTC_CALR_CALW8_Msk
+#define RTC_CALR_CALW16_Pos          (13U)
+#define RTC_CALR_CALW16_Msk          (0x1UL << RTC_CALR_CALW16_Pos)             /*!< 0x00002000 */
+#define RTC_CALR_CALW16              RTC_CALR_CALW16_Msk
+#define RTC_CALR_CALM_Pos            (0U)
+#define RTC_CALR_CALM_Msk            (0x1FFUL << RTC_CALR_CALM_Pos)             /*!< 0x000001FF */
+#define RTC_CALR_CALM                RTC_CALR_CALM_Msk
+#define RTC_CALR_CALM_0              (0x001UL << RTC_CALR_CALM_Pos)             /*!< 0x00000001 */
+#define RTC_CALR_CALM_1              (0x002UL << RTC_CALR_CALM_Pos)             /*!< 0x00000002 */
+#define RTC_CALR_CALM_2              (0x004UL << RTC_CALR_CALM_Pos)             /*!< 0x00000004 */
+#define RTC_CALR_CALM_3              (0x008UL << RTC_CALR_CALM_Pos)             /*!< 0x00000008 */
+#define RTC_CALR_CALM_4              (0x010UL << RTC_CALR_CALM_Pos)             /*!< 0x00000010 */
+#define RTC_CALR_CALM_5              (0x020UL << RTC_CALR_CALM_Pos)             /*!< 0x00000020 */
+#define RTC_CALR_CALM_6              (0x040UL << RTC_CALR_CALM_Pos)             /*!< 0x00000040 */
+#define RTC_CALR_CALM_7              (0x080UL << RTC_CALR_CALM_Pos)             /*!< 0x00000080 */
+#define RTC_CALR_CALM_8              (0x100UL << RTC_CALR_CALM_Pos)             /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos         (0U)
+#define RTC_SHIFTR_SUBFS_Msk         (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)         /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS             RTC_SHIFTR_SUBFS_Msk
+#define RTC_SHIFTR_ADD1S_Pos         (31U)
+#define RTC_SHIFTR_ADD1S_Msk         (0x1UL << RTC_SHIFTR_ADD1S_Pos)            /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S             RTC_SHIFTR_ADD1S_Msk
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos              (22U)
+#define RTC_TSTR_PM_Msk              (0x1UL << RTC_TSTR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TSTR_PM                  RTC_TSTR_PM_Msk                           /*!< AM-PM notation > */
+#define RTC_TSTR_HT_Pos              (20U)
+#define RTC_TSTR_HT_Msk              (0x3UL << RTC_TSTR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TSTR_HT                  RTC_TSTR_HT_Msk
+#define RTC_TSTR_HT_0                (0x1UL << RTC_TSTR_HT_Pos)                /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                (0x2UL << RTC_TSTR_HT_Pos)                /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos              (16U)
+#define RTC_TSTR_HU_Msk              (0xFUL << RTC_TSTR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TSTR_HU                  RTC_TSTR_HU_Msk
+#define RTC_TSTR_HU_0                (0x1UL << RTC_TSTR_HU_Pos)                /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                (0x2UL << RTC_TSTR_HU_Pos)                /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                (0x4UL << RTC_TSTR_HU_Pos)                /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                (0x8UL << RTC_TSTR_HU_Pos)                /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos             (12U)
+#define RTC_TSTR_MNT_Msk             (0x7UL << RTC_TSTR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TSTR_MNT                 RTC_TSTR_MNT_Msk
+#define RTC_TSTR_MNT_0               (0x1UL << RTC_TSTR_MNT_Pos)               /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1               (0x2UL << RTC_TSTR_MNT_Pos)               /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2               (0x4UL << RTC_TSTR_MNT_Pos)                /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos             (8U)
+#define RTC_TSTR_MNU_Msk             (0xFUL << RTC_TSTR_MNU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                 RTC_TSTR_MNU_Msk
+#define RTC_TSTR_MNU_0               (0x1UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1               (0x2UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2               (0x4UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3               (0x8UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos              (4U)
+#define RTC_TSTR_ST_Msk              (0x7UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000070 */
+#define RTC_TSTR_ST                  RTC_TSTR_ST_Msk
+#define RTC_TSTR_ST_0                (0x1UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                (0x2UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                (0x4UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos              (0U)
+#define RTC_TSTR_SU_Msk              (0xFUL << RTC_TSTR_SU_Pos)                 /*!< 0x0000000F */
+#define RTC_TSTR_SU                  RTC_TSTR_SU_Msk
+#define RTC_TSTR_SU_0                (0x1UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                (0x2UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                (0x4UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                (0x8UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos             (13U)
+#define RTC_TSDR_WDU_Msk             (0x7UL << RTC_TSDR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                 RTC_TSDR_WDU_Msk                          /*!< Week day units > */
+#define RTC_TSDR_WDU_0               (0x1UL << RTC_TSDR_WDU_Pos)               /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1               (0x2UL << RTC_TSDR_WDU_Pos)               /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2               (0x4UL << RTC_TSDR_WDU_Pos)               /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos              (12U)
+#define RTC_TSDR_MT_Msk              (0x1UL << RTC_TSDR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_TSDR_MT                  RTC_TSDR_MT_Msk
+#define RTC_TSDR_MU_Pos              (8U)
+#define RTC_TSDR_MU_Msk              (0xFUL << RTC_TSDR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSDR_MU                  RTC_TSDR_MU_Msk
+#define RTC_TSDR_MU_0                (0x1UL << RTC_TSDR_MU_Pos)                /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                (0x2UL << RTC_TSDR_MU_Pos)                /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                (0x4UL << RTC_TSDR_MU_Pos)                /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                (0x8UL << RTC_TSDR_MU_Pos)                /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos              (4U)
+#define RTC_TSDR_DT_Msk              (0x3UL << RTC_TSDR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_TSDR_DT                  RTC_TSDR_DT_Msk
+#define RTC_TSDR_DT_0                (0x1UL << RTC_TSDR_DT_Pos)                /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                (0x2UL << RTC_TSDR_DT_Pos)                /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos              (0U)
+#define RTC_TSDR_DU_Msk              (0xFUL << RTC_TSDR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_TSDR_DU                  RTC_TSDR_DU_Msk
+#define RTC_TSDR_DU_0                (0x1UL << RTC_TSDR_DU_Pos)                /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                (0x2UL << RTC_TSDR_DU_Pos)                /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                (0x4UL << RTC_TSDR_DU_Pos)                /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                (0x8UL << RTC_TSDR_DU_Pos)                /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos             (0U)
+#define RTC_TSSSR_SS_Msk             (0xFFFFUL << RTC_TSSSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                 RTC_TSSSR_SS_Msk                          /*!< Sub second value > */
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos          (31U)
+#define RTC_ALRMAR_MSK4_Msk          (0x1UL << RTC_ALRMAR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4              RTC_ALRMAR_MSK4_Msk
+#define RTC_ALRMAR_WDSEL_Pos         (30U)
+#define RTC_ALRMAR_WDSEL_Msk         (0x1UL << RTC_ALRMAR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL             RTC_ALRMAR_WDSEL_Msk
+#define RTC_ALRMAR_DT_Pos            (28U)
+#define RTC_ALRMAR_DT_Msk            (0x3UL << RTC_ALRMAR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                RTC_ALRMAR_DT_Msk
+#define RTC_ALRMAR_DT_0              (0x1UL << RTC_ALRMAR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1              (0x2UL << RTC_ALRMAR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos            (24U)
+#define RTC_ALRMAR_DU_Msk            (0xFUL << RTC_ALRMAR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                RTC_ALRMAR_DU_Msk
+#define RTC_ALRMAR_DU_0              (0x1UL << RTC_ALRMAR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1              (0x2UL << RTC_ALRMAR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2              (0x4UL << RTC_ALRMAR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3              (0x8UL << RTC_ALRMAR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos          (23U)
+#define RTC_ALRMAR_MSK3_Msk          (0x1UL << RTC_ALRMAR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3              RTC_ALRMAR_MSK3_Msk
+#define RTC_ALRMAR_PM_Pos            (22U)
+#define RTC_ALRMAR_PM_Msk            (0x1UL << RTC_ALRMAR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                RTC_ALRMAR_PM_Msk
+#define RTC_ALRMAR_HT_Pos            (20U)
+#define RTC_ALRMAR_HT_Msk            (0x3UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                RTC_ALRMAR_HT_Msk
+#define RTC_ALRMAR_HT_0              (0x1UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1              (0x2UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos            (16U)
+#define RTC_ALRMAR_HU_Msk            (0xFUL << RTC_ALRMAR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                RTC_ALRMAR_HU_Msk
+#define RTC_ALRMAR_HU_0              (0x1UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1              (0x2UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2              (0x4UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3              (0x8UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos          (15U)
+#define RTC_ALRMAR_MSK2_Msk          (0x1UL << RTC_ALRMAR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2              RTC_ALRMAR_MSK2_Msk
+#define RTC_ALRMAR_MNT_Pos           (12U)
+#define RTC_ALRMAR_MNT_Msk           (0x7UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT               RTC_ALRMAR_MNT_Msk
+#define RTC_ALRMAR_MNT_0             (0x1UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1             (0x2UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2             (0x4UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos           (8U)
+#define RTC_ALRMAR_MNU_Msk           (0xFUL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU               RTC_ALRMAR_MNU_Msk
+#define RTC_ALRMAR_MNU_0             (0x1UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1             (0x2UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2             (0x4UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3             (0x8UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos          (7U)
+#define RTC_ALRMAR_MSK1_Msk          (0x1UL << RTC_ALRMAR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1              RTC_ALRMAR_MSK1_Msk
+#define RTC_ALRMAR_ST_Pos            (4U)
+#define RTC_ALRMAR_ST_Msk            (0x7UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                RTC_ALRMAR_ST_Msk
+#define RTC_ALRMAR_ST_0              (0x1UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1              (0x2UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2              (0x4UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos            (0U)
+#define RTC_ALRMAR_SU_Msk            (0xFUL << RTC_ALRMAR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                RTC_ALRMAR_SU_Msk
+#define RTC_ALRMAR_SU_0              (0x1UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1              (0x2UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2              (0x4UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3              (0x8UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos      (24U)
+#define RTC_ALRMASSR_MASKSS_Msk      (0xFUL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS          RTC_ALRMASSR_MASKSS_Msk
+#define RTC_ALRMASSR_MASKSS_0        (0x1UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1        (0x2UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2        (0x4UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3        (0x8UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos          (0U)
+#define RTC_ALRMASSR_SS_Msk          (0x7FFFUL << RTC_ALRMASSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS              RTC_ALRMASSR_SS_Msk
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos          (31U)
+#define RTC_ALRMBR_MSK4_Msk          (0x1UL << RTC_ALRMBR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4              RTC_ALRMBR_MSK4_Msk
+#define RTC_ALRMBR_WDSEL_Pos         (30U)
+#define RTC_ALRMBR_WDSEL_Msk         (0x1UL << RTC_ALRMBR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL             RTC_ALRMBR_WDSEL_Msk
+#define RTC_ALRMBR_DT_Pos            (28U)
+#define RTC_ALRMBR_DT_Msk            (0x3UL << RTC_ALRMBR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                RTC_ALRMBR_DT_Msk
+#define RTC_ALRMBR_DT_0              (0x1UL << RTC_ALRMBR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1              (0x2UL << RTC_ALRMBR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos            (24U)
+#define RTC_ALRMBR_DU_Msk            (0xFUL << RTC_ALRMBR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                RTC_ALRMBR_DU_Msk
+#define RTC_ALRMBR_DU_0              (0x1UL << RTC_ALRMBR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1              (0x2UL << RTC_ALRMBR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2              (0x4UL << RTC_ALRMBR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3              (0x8UL << RTC_ALRMBR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos          (23U)
+#define RTC_ALRMBR_MSK3_Msk          (0x1UL << RTC_ALRMBR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3              RTC_ALRMBR_MSK3_Msk
+#define RTC_ALRMBR_PM_Pos            (22U)
+#define RTC_ALRMBR_PM_Msk            (0x1UL << RTC_ALRMBR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                RTC_ALRMBR_PM_Msk
+#define RTC_ALRMBR_HT_Pos            (20U)
+#define RTC_ALRMBR_HT_Msk            (0x3UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                RTC_ALRMBR_HT_Msk
+#define RTC_ALRMBR_HT_0              (0x1UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1              (0x2UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos            (16U)
+#define RTC_ALRMBR_HU_Msk            (0xFUL << RTC_ALRMBR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                RTC_ALRMBR_HU_Msk
+#define RTC_ALRMBR_HU_0              (0x1UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1              (0x2UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2              (0x4UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3              (0x8UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos          (15U)
+#define RTC_ALRMBR_MSK2_Msk          (0x1UL << RTC_ALRMBR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2              RTC_ALRMBR_MSK2_Msk
+#define RTC_ALRMBR_MNT_Pos           (12U)
+#define RTC_ALRMBR_MNT_Msk           (0x7UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT               RTC_ALRMBR_MNT_Msk
+#define RTC_ALRMBR_MNT_0             (0x1UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1             (0x2UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2             (0x4UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos           (8U)
+#define RTC_ALRMBR_MNU_Msk           (0xFUL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU               RTC_ALRMBR_MNU_Msk
+#define RTC_ALRMBR_MNU_0             (0x1UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1             (0x2UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2             (0x4UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3             (0x8UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos          (7U)
+#define RTC_ALRMBR_MSK1_Msk          (0x1UL << RTC_ALRMBR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1              RTC_ALRMBR_MSK1_Msk
+#define RTC_ALRMBR_ST_Pos            (4U)
+#define RTC_ALRMBR_ST_Msk            (0x7UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                RTC_ALRMBR_ST_Msk
+#define RTC_ALRMBR_ST_0              (0x1UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1              (0x2UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2              (0x4UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos            (0U)
+#define RTC_ALRMBR_SU_Msk            (0xFUL << RTC_ALRMBR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                RTC_ALRMBR_SU_Msk
+#define RTC_ALRMBR_SU_0              (0x1UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1              (0x2UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2              (0x4UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3              (0x8UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos      (24U)
+#define RTC_ALRMBSSR_MASKSS_Msk      (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS          RTC_ALRMBSSR_MASKSS_Msk
+#define RTC_ALRMBSSR_MASKSS_0        (0x1UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1        (0x2UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2        (0x4UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3        (0x8UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos          (0U)
+#define RTC_ALRMBSSR_SS_Msk          (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS              RTC_ALRMBSSR_SS_Msk
+
+/********************  Bits definition for RTC_SR register  *******************/
+#define RTC_SR_ITSF_Pos              (5U)
+#define RTC_SR_ITSF_Msk              (0x1UL << RTC_SR_ITSF_Pos)                /*!< 0x00000020 */
+#define RTC_SR_ITSF                  RTC_SR_ITSF_Msk
+#define RTC_SR_TSOVF_Pos             (4U)
+#define RTC_SR_TSOVF_Msk             (0x1UL << RTC_SR_TSOVF_Pos)               /*!< 0x00000010 */
+#define RTC_SR_TSOVF                 RTC_SR_TSOVF_Msk                          /*!< Timestamp overflow flag > */
+#define RTC_SR_TSF_Pos               (3U)
+#define RTC_SR_TSF_Msk               (0x1UL << RTC_SR_TSF_Pos)                 /*!< 0x00000008 */
+#define RTC_SR_TSF                   RTC_SR_TSF_Msk                            /*!< Timestamp flag > */
+#define RTC_SR_WUTF_Pos              (2U)
+#define RTC_SR_WUTF_Msk              (0x1UL << RTC_SR_WUTF_Pos)                /*!< 0x00000004 */
+#define RTC_SR_WUTF                  RTC_SR_WUTF_Msk                           /*!< Wakeup timer flag > */
+#define RTC_SR_ALRBF_Pos             (1U)
+#define RTC_SR_ALRBF_Msk             (0x1UL << RTC_SR_ALRBF_Pos)               /*!< 0x00000002 */
+#define RTC_SR_ALRBF                 RTC_SR_ALRBF_Msk
+#define RTC_SR_ALRAF_Pos             (0U)
+#define RTC_SR_ALRAF_Msk             (0x1UL << RTC_SR_ALRAF_Pos)               /*!< 0x00000001 */
+#define RTC_SR_ALRAF                 RTC_SR_ALRAF_Msk
+
+/********************  Bits definition for RTC_MISR register  *****************/
+#define RTC_MISR_ITSMF_Pos           (5U)
+#define RTC_MISR_ITSMF_Msk           (0x1UL << RTC_MISR_ITSMF_Pos)             /*!< 0x00000020 */
+#define RTC_MISR_ITSMF               RTC_MISR_ITSMF_Msk
+#define RTC_MISR_TSOVMF_Pos          (4U)
+#define RTC_MISR_TSOVMF_Msk          (0x1UL << RTC_MISR_TSOVMF_Pos)            /*!< 0x00000010 */
+#define RTC_MISR_TSOVMF              RTC_MISR_TSOVMF_Msk                       /*!< Timestamp overflow masked flag > */
+#define RTC_MISR_TSMF_Pos            (3U)
+#define RTC_MISR_TSMF_Msk            (0x1UL << RTC_MISR_TSMF_Pos)              /*!< 0x00000008 */
+#define RTC_MISR_TSMF                RTC_MISR_TSMF_Msk                         /*!< Timestamp masked flag > */
+#define RTC_MISR_WUTMF_Pos           (2U)
+#define RTC_MISR_WUTMF_Msk           (0x1UL << RTC_MISR_WUTMF_Pos)             /*!< 0x00000004 */
+#define RTC_MISR_WUTMF               RTC_MISR_WUTMF_Msk                        /*!< Wakeup timer masked flag > */
+#define RTC_MISR_ALRBMF_Pos          (1U)
+#define RTC_MISR_ALRBMF_Msk          (0x1UL << RTC_MISR_ALRBMF_Pos)            /*!< 0x00000002 */
+#define RTC_MISR_ALRBMF              RTC_MISR_ALRBMF_Msk
+#define RTC_MISR_ALRAMF_Pos          (0U)
+#define RTC_MISR_ALRAMF_Msk          (0x1UL << RTC_MISR_ALRAMF_Pos)            /*!< 0x00000001 */
+#define RTC_MISR_ALRAMF              RTC_MISR_ALRAMF_Msk
+
+/********************  Bits definition for RTC_SCR register  ******************/
+#define RTC_SCR_CITSF_Pos            (5U)
+#define RTC_SCR_CITSF_Msk            (0x1UL << RTC_SCR_CITSF_Pos)              /*!< 0x00000020 */
+#define RTC_SCR_CITSF                RTC_SCR_CITSF_Msk
+#define RTC_SCR_CTSOVF_Pos           (4U)
+#define RTC_SCR_CTSOVF_Msk           (0x1UL << RTC_SCR_CTSOVF_Pos)             /*!< 0x00000010 */
+#define RTC_SCR_CTSOVF               RTC_SCR_CTSOVF_Msk                        /*!< Clear timestamp overflow flag > */
+#define RTC_SCR_CTSF_Pos             (3U)
+#define RTC_SCR_CTSF_Msk             (0x1UL << RTC_SCR_CTSF_Pos)               /*!< 0x00000008 */
+#define RTC_SCR_CTSF                 RTC_SCR_CTSF_Msk                          /*!< Clear timestamp flag > */
+#define RTC_SCR_CWUTF_Pos            (2U)
+#define RTC_SCR_CWUTF_Msk            (0x1UL << RTC_SCR_CWUTF_Pos)              /*!< 0x00000004 */
+#define RTC_SCR_CWUTF                RTC_SCR_CWUTF_Msk                         /*!< Clear wakeup timer flag > */
+#define RTC_SCR_CALRBF_Pos           (1U)
+#define RTC_SCR_CALRBF_Msk           (0x1UL << RTC_SCR_CALRBF_Pos)             /*!< 0x00000002 */
+#define RTC_SCR_CALRBF               RTC_SCR_CALRBF_Msk
+#define RTC_SCR_CALRAF_Pos           (0U)
+#define RTC_SCR_CALRAF_Msk           (0x1UL << RTC_SCR_CALRAF_Pos)             /*!< 0x00000001 */
+#define RTC_SCR_CALRAF               RTC_SCR_CALRAF_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                     Tamper and backup register (TAMP)                      */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for TAMP_CR1 register  *****************/
+#define TAMP_CR1_TAMP1E_Pos          (0U)
+#define TAMP_CR1_TAMP1E_Msk          (0x1UL << TAMP_CR1_TAMP1E_Pos)             /*!< 0x00000001 */
+#define TAMP_CR1_TAMP1E              TAMP_CR1_TAMP1E_Msk
+#define TAMP_CR1_TAMP2E_Pos          (1U)
+#define TAMP_CR1_TAMP2E_Msk          (0x1UL << TAMP_CR1_TAMP2E_Pos)             /*!< 0x00000002 */
+#define TAMP_CR1_TAMP2E              TAMP_CR1_TAMP2E_Msk
+#define TAMP_CR1_ITAMP3E_Pos         (18U)
+#define TAMP_CR1_ITAMP3E_Msk         (0x1UL << TAMP_CR1_ITAMP3E_Pos)            /*!< 0x00040000 */
+#define TAMP_CR1_ITAMP3E             TAMP_CR1_ITAMP3E_Msk
+#define TAMP_CR1_ITAMP4E_Pos         (19U)
+#define TAMP_CR1_ITAMP4E_Msk         (0x1UL << TAMP_CR1_ITAMP4E_Pos)            /*!< 0x00080000 */
+#define TAMP_CR1_ITAMP4E             TAMP_CR1_ITAMP4E_Msk
+#define TAMP_CR1_ITAMP5E_Pos         (20U)
+#define TAMP_CR1_ITAMP5E_Msk         (0x1UL << TAMP_CR1_ITAMP5E_Pos)            /*!< 0x00100000 */
+#define TAMP_CR1_ITAMP5E             TAMP_CR1_ITAMP5E_Msk
+#define TAMP_CR1_ITAMP6E_Pos         (21U)
+#define TAMP_CR1_ITAMP6E_Msk         (0x1UL << TAMP_CR1_ITAMP6E_Pos)            /*!< 0x00200000 */
+#define TAMP_CR1_ITAMP6E             TAMP_CR1_ITAMP6E_Msk
+
+/********************  Bits definition for TAMP_CR2 register  *****************/
+#define TAMP_CR2_TAMP1NOERASE_Pos    (0U)
+#define TAMP_CR2_TAMP1NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP1NOERASE_Pos)       /*!< 0x00000001 */
+#define TAMP_CR2_TAMP1NOERASE        TAMP_CR2_TAMP1NOERASE_Msk
+#define TAMP_CR2_TAMP2NOERASE_Pos    (1U)
+#define TAMP_CR2_TAMP2NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP2NOERASE_Pos)       /*!< 0x00000002 */
+#define TAMP_CR2_TAMP2NOERASE        TAMP_CR2_TAMP2NOERASE_Msk
+#define TAMP_CR2_TAMP1MSK_Pos        (16U)
+#define TAMP_CR2_TAMP1MSK_Msk        (0x1UL << TAMP_CR2_TAMP1MSK_Pos)           /*!< 0x00010000 */
+#define TAMP_CR2_TAMP1MSK            TAMP_CR2_TAMP1MSK_Msk
+#define TAMP_CR2_TAMP2MSK_Pos        (17U)
+#define TAMP_CR2_TAMP2MSK_Msk        (0x1UL << TAMP_CR2_TAMP2MSK_Pos)           /*!< 0x00020000 */
+#define TAMP_CR2_TAMP2MSK            TAMP_CR2_TAMP2MSK_Msk
+#define TAMP_CR2_TAMP1TRG_Pos        (24U)
+#define TAMP_CR2_TAMP1TRG_Msk        (0x1UL << TAMP_CR2_TAMP1TRG_Pos)           /*!< 0x01000000 */
+#define TAMP_CR2_TAMP1TRG            TAMP_CR2_TAMP1TRG_Msk
+#define TAMP_CR2_TAMP2TRG_Pos        (25U)
+#define TAMP_CR2_TAMP2TRG_Msk        (0x1UL << TAMP_CR2_TAMP2TRG_Pos)           /*!< 0x02000000 */
+#define TAMP_CR2_TAMP2TRG            TAMP_CR2_TAMP2TRG_Msk
+
+/********************  Bits definition for TAMP_FLTCR register  ***************/
+#define TAMP_FLTCR_TAMPFREQ_0        0x00000001U
+#define TAMP_FLTCR_TAMPFREQ_1        0x00000002U
+#define TAMP_FLTCR_TAMPFREQ_2        0x00000004U
+#define TAMP_FLTCR_TAMPFREQ_Pos      (0U)
+#define TAMP_FLTCR_TAMPFREQ_Msk      (0x7UL << TAMP_FLTCR_TAMPFREQ_Pos)         /*!< 0x00000007 */
+#define TAMP_FLTCR_TAMPFREQ          TAMP_FLTCR_TAMPFREQ_Msk
+#define TAMP_FLTCR_TAMPFLT_0         0x00000008U
+#define TAMP_FLTCR_TAMPFLT_1         0x00000010U
+#define TAMP_FLTCR_TAMPFLT_Pos       (3U)
+#define TAMP_FLTCR_TAMPFLT_Msk       (0x3UL << TAMP_FLTCR_TAMPFLT_Pos)          /*!< 0x00000018 */
+#define TAMP_FLTCR_TAMPFLT           TAMP_FLTCR_TAMPFLT_Msk
+#define TAMP_FLTCR_TAMPPRCH_0        0x00000020U
+#define TAMP_FLTCR_TAMPPRCH_1        0x00000040U
+#define TAMP_FLTCR_TAMPPRCH_Pos      (5U)
+#define TAMP_FLTCR_TAMPPRCH_Msk      (0x3UL << TAMP_FLTCR_TAMPPRCH_Pos)         /*!< 0x00000060 */
+#define TAMP_FLTCR_TAMPPRCH          TAMP_FLTCR_TAMPPRCH_Msk
+#define TAMP_FLTCR_TAMPPUDIS_Pos     (7U)
+#define TAMP_FLTCR_TAMPPUDIS_Msk     (0x1UL << TAMP_FLTCR_TAMPPUDIS_Pos)        /*!< 0x00000080 */
+#define TAMP_FLTCR_TAMPPUDIS         TAMP_FLTCR_TAMPPUDIS_Msk
+
+/********************  Bits definition for TAMP_IER register  *****************/
+#define TAMP_IER_TAMP1IE_Pos         (0U)
+#define TAMP_IER_TAMP1IE_Msk         (0x1UL << TAMP_IER_TAMP1IE_Pos)            /*!< 0x00000001 */
+#define TAMP_IER_TAMP1IE             TAMP_IER_TAMP1IE_Msk
+#define TAMP_IER_TAMP2IE_Pos         (1U)
+#define TAMP_IER_TAMP2IE_Msk         (0x1UL << TAMP_IER_TAMP2IE_Pos)            /*!< 0x00000002 */
+#define TAMP_IER_TAMP2IE             TAMP_IER_TAMP2IE_Msk
+#define TAMP_IER_ITAMP3IE_Pos        (18U)
+#define TAMP_IER_ITAMP3IE_Msk        (0x1UL << TAMP_IER_ITAMP3IE_Pos)           /*!< 0x00040000 */
+#define TAMP_IER_ITAMP3IE            TAMP_IER_ITAMP3IE_Msk
+#define TAMP_IER_ITAMP4IE_Pos        (19U)
+#define TAMP_IER_ITAMP4IE_Msk        (0x1UL << TAMP_IER_ITAMP4IE_Pos)           /*!< 0x00080000 */
+#define TAMP_IER_ITAMP4IE            TAMP_IER_ITAMP4IE_Msk
+#define TAMP_IER_ITAMP5IE_Pos        (20U)
+#define TAMP_IER_ITAMP5IE_Msk        (0x1UL << TAMP_IER_ITAMP5IE_Pos)           /*!< 0x00100000 */
+#define TAMP_IER_ITAMP5IE            TAMP_IER_ITAMP5IE_Msk
+#define TAMP_IER_ITAMP6IE_Pos        (21U)
+#define TAMP_IER_ITAMP6IE_Msk        (0x1UL << TAMP_IER_ITAMP6IE_Pos)           /*!< 0x00200000 */
+#define TAMP_IER_ITAMP6IE            TAMP_IER_ITAMP6IE_Msk
+
+/********************  Bits definition for TAMP_SR register  ******************/
+#define TAMP_SR_TAMP1F_Pos           (0U)
+#define TAMP_SR_TAMP1F_Msk           (0x1UL << TAMP_SR_TAMP1F_Pos)              /*!< 0x00000001 */
+#define TAMP_SR_TAMP1F               TAMP_SR_TAMP1F_Msk
+#define TAMP_SR_TAMP2F_Pos           (1U)
+#define TAMP_SR_TAMP2F_Msk           (0x1UL << TAMP_SR_TAMP2F_Pos)              /*!< 0x00000002 */
+#define TAMP_SR_TAMP2F               TAMP_SR_TAMP2F_Msk
+#define TAMP_SR_ITAMP3F_Pos          (18U)
+#define TAMP_SR_ITAMP3F_Msk          (0x1UL << TAMP_SR_ITAMP3F_Pos)             /*!< 0x00040000 */
+#define TAMP_SR_ITAMP3F              TAMP_SR_ITAMP3F_Msk
+#define TAMP_SR_ITAMP4F_Pos          (19U)
+#define TAMP_SR_ITAMP4F_Msk          (0x1UL << TAMP_SR_ITAMP4F_Pos)             /*!< 0x00080000 */
+#define TAMP_SR_ITAMP4F              TAMP_SR_ITAMP4F_Msk
+#define TAMP_SR_ITAMP5F_Pos          (20U)
+#define TAMP_SR_ITAMP5F_Msk          (0x1UL << TAMP_SR_ITAMP5F_Pos)             /*!< 0x00100000 */
+#define TAMP_SR_ITAMP5F              TAMP_SR_ITAMP5F_Msk
+#define TAMP_SR_ITAMP6F_Pos          (21U)
+#define TAMP_SR_ITAMP6F_Msk          (0x1UL << TAMP_SR_ITAMP6F_Pos)             /*!< 0x00200000 */
+#define TAMP_SR_ITAMP6F              TAMP_SR_ITAMP6F_Msk
+
+/********************  Bits definition for TAMP_MISR register  ****************/
+#define TAMP_MISR_TAMP1MF_Pos        (0U)
+#define TAMP_MISR_TAMP1MF_Msk        (0x1UL << TAMP_MISR_TAMP1MF_Pos)           /*!< 0x00000001 */
+#define TAMP_MISR_TAMP1MF            TAMP_MISR_TAMP1MF_Msk
+#define TAMP_MISR_TAMP2MF_Pos        (1U)
+#define TAMP_MISR_TAMP2MF_Msk        (0x1UL << TAMP_MISR_TAMP2MF_Pos)           /*!< 0x00000002 */
+#define TAMP_MISR_TAMP2MF            TAMP_MISR_TAMP2MF_Msk
+#define TAMP_MISR_ITAMP3MF_Pos       (18U)
+#define TAMP_MISR_ITAMP3MF_Msk       (0x1UL << TAMP_MISR_ITAMP3MF_Pos)          /*!< 0x00040000 */
+#define TAMP_MISR_ITAMP3MF           TAMP_MISR_ITAMP3MF_Msk
+#define TAMP_MISR_ITAMP4MF_Pos       (19U)
+#define TAMP_MISR_ITAMP4MF_Msk       (0x1UL << TAMP_MISR_ITAMP4MF_Pos)          /*!< 0x00080000 */
+#define TAMP_MISR_ITAMP4MF           TAMP_MISR_ITAMP4MF_Msk
+#define TAMP_MISR_ITAMP5MF_Pos       (20U)
+#define TAMP_MISR_ITAMP5MF_Msk       (0x1UL << TAMP_MISR_ITAMP5MF_Pos)          /*!< 0x00100000 */
+#define TAMP_MISR_ITAMP5MF           TAMP_MISR_ITAMP5MF_Msk
+#define TAMP_MISR_ITAMP6MF_Pos       (21U)
+#define TAMP_MISR_ITAMP6MF_Msk       (0x1UL << TAMP_MISR_ITAMP6MF_Pos)          /*!< 0x00200000 */
+#define TAMP_MISR_ITAMP6MF           TAMP_MISR_ITAMP6MF_Msk
+
+/********************  Bits definition for TAMP_SCR register  *****************/
+#define TAMP_SCR_CTAMP1F_Pos         (0U)
+#define TAMP_SCR_CTAMP1F_Msk         (0x1UL << TAMP_SCR_CTAMP1F_Pos)            /*!< 0x00000001 */
+#define TAMP_SCR_CTAMP1F             TAMP_SCR_CTAMP1F_Msk
+#define TAMP_SCR_CTAMP2F_Pos         (1U)
+#define TAMP_SCR_CTAMP2F_Msk         (0x1UL << TAMP_SCR_CTAMP2F_Pos)            /*!< 0x00000002 */
+#define TAMP_SCR_CTAMP2F             TAMP_SCR_CTAMP2F_Msk
+#define TAMP_SCR_CITAMP3F_Pos        (18U)
+#define TAMP_SCR_CITAMP3F_Msk        (0x1UL << TAMP_SCR_CITAMP3F_Pos)           /*!< 0x00040000 */
+#define TAMP_SCR_CITAMP3F            TAMP_SCR_CITAMP3F_Msk
+#define TAMP_SCR_CITAMP4F_Pos        (19U)
+#define TAMP_SCR_CITAMP4F_Msk        (0x1UL << TAMP_SCR_CITAMP4F_Pos)           /*!< 0x00080000 */
+#define TAMP_SCR_CITAMP4F            TAMP_SCR_CITAMP4F_Msk
+#define TAMP_SCR_CITAMP5F_Pos        (20U)
+#define TAMP_SCR_CITAMP5F_Msk        (0x1UL << TAMP_SCR_CITAMP5F_Pos)           /*!< 0x00100000 */
+#define TAMP_SCR_CITAMP5F            TAMP_SCR_CITAMP5F_Msk
+#define TAMP_SCR_CITAMP6F_Pos        (21U)
+#define TAMP_SCR_CITAMP6F_Msk        (0x1UL << TAMP_SCR_CITAMP6F_Pos)           /*!< 0x00200000 */
+#define TAMP_SCR_CITAMP6F            TAMP_SCR_CITAMP6F_Msk
+
+/********************  Bits definition for TAMP_BKP0R register  ***************/
+#define TAMP_BKP0R_Pos               (0U)
+#define TAMP_BKP0R_Msk               (0xFFFFFFFFUL << TAMP_BKP0R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP0R                   TAMP_BKP0R_Msk
+
+/********************  Bits definition for TAMP_BKP1R register  ***************/
+#define TAMP_BKP1R_Pos               (0U)
+#define TAMP_BKP1R_Msk               (0xFFFFFFFFUL << TAMP_BKP1R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP1R                   TAMP_BKP1R_Msk
+
+/********************  Bits definition for TAMP_BKP2R register  ***************/
+#define TAMP_BKP2R_Pos               (0U)
+#define TAMP_BKP2R_Msk               (0xFFFFFFFFUL << TAMP_BKP2R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP2R                   TAMP_BKP2R_Msk
+
+/********************  Bits definition for TAMP_BKP3R register  ***************/
+#define TAMP_BKP3R_Pos               (0U)
+#define TAMP_BKP3R_Msk               (0xFFFFFFFFUL << TAMP_BKP3R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP3R                   TAMP_BKP3R_Msk
+
+/********************  Bits definition for TAMP_BKP4R register  ***************/
+#define TAMP_BKP4R_Pos               (0U)
+#define TAMP_BKP4R_Msk               (0xFFFFFFFFUL << TAMP_BKP4R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP4R                   TAMP_BKP4R_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
+ */
+#define SPI_I2S_SUPPORT                       /*!< I2S support */
+
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                  /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                  /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                  /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                  /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                 /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)            /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                 /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                 /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)              /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_CRCL_Pos            (11U)
+#define SPI_CR1_CRCL_Msk            (0x1UL << SPI_CR1_CRCL_Pos)                /*!< 0x00000800 */
+#define SPI_CR1_CRCL                SPI_CR1_CRCL_Msk                           /*!< CRC Length */
+#define SPI_CR1_CRCNEXT_Pos         (12U)
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)             /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)               /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)              /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)            /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)             /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!< Rx Buffer DMA Enable */
+#define SPI_CR2_TXDMAEN_Pos         (1U)
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)             /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!< Tx Buffer DMA Enable */
+#define SPI_CR2_SSOE_Pos            (2U)
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!< SS Output Enable */
+#define SPI_CR2_NSSP_Pos            (3U)
+#define SPI_CR2_NSSP_Msk            (0x1UL << SPI_CR2_NSSP_Pos)                /*!< 0x00000008 */
+#define SPI_CR2_NSSP                SPI_CR2_NSSP_Msk                           /*!< NSS pulse management Enable */
+#define SPI_CR2_FRF_Pos             (4U)
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                 /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!< Frame Format Enable */
+#define SPI_CR2_ERRIE_Pos           (5U)
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)               /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!< Error Interrupt Enable */
+#define SPI_CR2_RXNEIE_Pos          (6U)
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)              /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!< RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)               /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!< Tx buffer Empty Interrupt Enable */
+#define SPI_CR2_DS_Pos              (8U)
+#define SPI_CR2_DS_Msk              (0xFUL << SPI_CR2_DS_Pos)                  /*!< 0x00000F00 */
+#define SPI_CR2_DS                  SPI_CR2_DS_Msk                             /*!< DS[3:0] Data Size */
+#define SPI_CR2_DS_0                (0x1UL << SPI_CR2_DS_Pos)                  /*!< 0x00000100 */
+#define SPI_CR2_DS_1                (0x2UL << SPI_CR2_DS_Pos)                  /*!< 0x00000200 */
+#define SPI_CR2_DS_2                (0x4UL << SPI_CR2_DS_Pos)                  /*!< 0x00000400 */
+#define SPI_CR2_DS_3                (0x8UL << SPI_CR2_DS_Pos)                  /*!< 0x00000800 */
+#define SPI_CR2_FRXTH_Pos           (12U)
+#define SPI_CR2_FRXTH_Msk           (0x1UL << SPI_CR2_FRXTH_Pos)               /*!< 0x00001000 */
+#define SPI_CR2_FRXTH               SPI_CR2_FRXTH_Msk                          /*!< FIFO reception Threshold */
+#define SPI_CR2_LDMARX_Pos          (13U)
+#define SPI_CR2_LDMARX_Msk          (0x1UL << SPI_CR2_LDMARX_Pos)              /*!< 0x00002000 */
+#define SPI_CR2_LDMARX              SPI_CR2_LDMARX_Msk                         /*!< Last DMA transfer for reception */
+#define SPI_CR2_LDMATX_Pos          (14U)
+#define SPI_CR2_LDMATX_Msk          (0x1UL << SPI_CR2_LDMATX_Pos)              /*!< 0x00004000 */
+#define SPI_CR2_LDMATX              SPI_CR2_LDMATX_Msk                         /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                 /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!< Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                  /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!< Transmit buffer Empty */
+#define SPI_SR_CHSIDE_Pos           (2U)
+#define SPI_SR_CHSIDE_Msk           (0x1UL << SPI_SR_CHSIDE_Pos)               /*!< 0x00000004 */
+#define SPI_SR_CHSIDE               SPI_SR_CHSIDE_Msk                          /*!< Channel side */
+#define SPI_SR_UDR_Pos              (3U)
+#define SPI_SR_UDR_Msk              (0x1UL << SPI_SR_UDR_Pos)                  /*!< 0x00000008 */
+#define SPI_SR_UDR                  SPI_SR_UDR_Msk                             /*!< Underrun flag */
+#define SPI_SR_CRCERR_Pos           (4U)
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)               /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!< CRC Error flag */
+#define SPI_SR_MODF_Pos             (5U)
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                 /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!< Mode fault */
+#define SPI_SR_OVR_Pos              (6U)
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                  /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!< Overrun flag */
+#define SPI_SR_BSY_Pos              (7U)
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                  /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!< Busy flag */
+#define SPI_SR_FRE_Pos              (8U)
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                  /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!< TI frame format error */
+#define SPI_SR_FRLVL_Pos            (9U)
+#define SPI_SR_FRLVL_Msk            (0x3UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000600 */
+#define SPI_SR_FRLVL                SPI_SR_FRLVL_Msk                           /*!< FIFO Reception Level */
+#define SPI_SR_FRLVL_0              (0x1UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000200 */
+#define SPI_SR_FRLVL_1              (0x2UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000400 */
+#define SPI_SR_FTLVL_Pos            (11U)
+#define SPI_SR_FTLVL_Msk            (0x3UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001800 */
+#define SPI_SR_FTLVL                SPI_SR_FTLVL_Msk                           /*!< FIFO Transmission Level */
+#define SPI_SR_FTLVL_0              (0x1UL << SPI_SR_FTLVL_Pos)                /*!< 0x00000800 */
+#define SPI_SR_FTLVL_1              (0x2UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001000 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)        /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN_Pos       (0U)
+#define SPI_I2SCFGR_CHLEN_Msk       (0x1UL << SPI_I2SCFGR_CHLEN_Pos)           /*!< 0x00000001 */
+#define SPI_I2SCFGR_CHLEN           SPI_I2SCFGR_CHLEN_Msk                      /*!<Channel length (number of bits per audio channel) */
+#define SPI_I2SCFGR_DATLEN_Pos      (1U)
+#define SPI_I2SCFGR_DATLEN_Msk      (0x3UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000006 */
+#define SPI_I2SCFGR_DATLEN          SPI_I2SCFGR_DATLEN_Msk                     /*!<DATLEN[1:0] bits (Data length to be transferred) */
+#define SPI_I2SCFGR_DATLEN_0        (0x1UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000002 */
+#define SPI_I2SCFGR_DATLEN_1        (0x2UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000004 */
+#define SPI_I2SCFGR_CKPOL_Pos       (3U)
+#define SPI_I2SCFGR_CKPOL_Msk       (0x1UL << SPI_I2SCFGR_CKPOL_Pos)           /*!< 0x00000008 */
+#define SPI_I2SCFGR_CKPOL           SPI_I2SCFGR_CKPOL_Msk                      /*!<steady state clock polarity */
+#define SPI_I2SCFGR_I2SSTD_Pos      (4U)
+#define SPI_I2SCFGR_I2SSTD_Msk      (0x3UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000030 */
+#define SPI_I2SCFGR_I2SSTD          SPI_I2SCFGR_I2SSTD_Msk                     /*!<I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0        (0x1UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000010 */
+#define SPI_I2SCFGR_I2SSTD_1        (0x2UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000020 */
+#define SPI_I2SCFGR_PCMSYNC_Pos     (7U)
+#define SPI_I2SCFGR_PCMSYNC_Msk     (0x1UL << SPI_I2SCFGR_PCMSYNC_Pos)         /*!< 0x00000080 */
+#define SPI_I2SCFGR_PCMSYNC         SPI_I2SCFGR_PCMSYNC_Msk                    /*!<PCM frame synchronization */
+#define SPI_I2SCFGR_I2SCFG_Pos      (8U)
+#define SPI_I2SCFGR_I2SCFG_Msk      (0x3UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000300 */
+#define SPI_I2SCFGR_I2SCFG          SPI_I2SCFGR_I2SCFG_Msk                     /*!<I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0        (0x1UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000100 */
+#define SPI_I2SCFGR_I2SCFG_1        (0x2UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000200 */
+#define SPI_I2SCFGR_I2SE_Pos        (10U)
+#define SPI_I2SCFGR_I2SE_Msk        (0x1UL << SPI_I2SCFGR_I2SE_Pos)            /*!< 0x00000400 */
+#define SPI_I2SCFGR_I2SE            SPI_I2SCFGR_I2SE_Msk                       /*!<I2S Enable */
+#define SPI_I2SCFGR_I2SMOD_Pos      (11U)
+#define SPI_I2SCFGR_I2SMOD_Msk      (0x1UL << SPI_I2SCFGR_I2SMOD_Pos)          /*!< 0x00000800 */
+#define SPI_I2SCFGR_I2SMOD          SPI_I2SCFGR_I2SMOD_Msk                     /*!<I2S mode selection */
+#define SPI_I2SCFGR_ASTRTEN_Pos     (12U)
+#define SPI_I2SCFGR_ASTRTEN_Msk     (0x1UL << SPI_I2SCFGR_ASTRTEN_Pos)         /*!< 0x00001000 */
+#define SPI_I2SCFGR_ASTRTEN         SPI_I2SCFGR_ASTRTEN_Msk                    /*!<Asynchronous start enable */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV_Pos        (0U)
+#define SPI_I2SPR_I2SDIV_Msk        (0xFFUL << SPI_I2SPR_I2SDIV_Pos)           /*!< 0x000000FF */
+#define SPI_I2SPR_I2SDIV            SPI_I2SPR_I2SDIV_Msk                       /*!<I2S Linear prescaler */
+#define SPI_I2SPR_ODD_Pos           (8U)
+#define SPI_I2SPR_ODD_Msk           (0x1UL << SPI_I2SPR_ODD_Pos)               /*!< 0x00000100 */
+#define SPI_I2SPR_ODD               SPI_I2SPR_ODD_Msk                          /*!<Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE_Pos         (9U)
+#define SPI_I2SPR_MCKOE_Msk         (0x1UL << SPI_I2SPR_MCKOE_Pos)             /*!< 0x00000200 */
+#define SPI_I2SPR_MCKOE             SPI_I2SPR_MCKOE_Msk                        /*!<Master Clock Output Enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
+/*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
+#define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
+#define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
+#define SYSCFG_CFGR1_MEM_MODE                 SYSCFG_CFGR1_MEM_MODE_Msk            /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_CFGR1_MEM_MODE_0               (0x1UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000001 */
+#define SYSCFG_CFGR1_MEM_MODE_1               (0x2UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000002 */
+#define SYSCFG_CFGR1_PA11_RMP_Pos             (3U)
+#define SYSCFG_CFGR1_PA11_RMP_Msk             (0x1UL << SYSCFG_CFGR1_PA11_RMP_Pos) /*!< 0x00000008 */
+#define SYSCFG_CFGR1_PA11_RMP                 SYSCFG_CFGR1_PA11_RMP_Msk            /*!< PA11 Remap */
+#define SYSCFG_CFGR1_PA12_RMP_Pos             (4U)
+#define SYSCFG_CFGR1_PA12_RMP_Msk             (0x1UL << SYSCFG_CFGR1_PA12_RMP_Pos) /*!< 0x00000010 */
+#define SYSCFG_CFGR1_PA12_RMP                 SYSCFG_CFGR1_PA12_RMP_Msk            /*!< PA12 Remap */
+#define SYSCFG_CFGR1_IR_POL_Pos               (5U)
+#define SYSCFG_CFGR1_IR_POL_Msk               (0x1UL << SYSCFG_CFGR1_IR_POL_Pos) /*!< 0x00000020 */
+#define SYSCFG_CFGR1_IR_POL                   SYSCFG_CFGR1_IR_POL_Msk            /*!< IROut Polarity Selection */
+#define SYSCFG_CFGR1_IR_MOD_Pos               (6U)
+#define SYSCFG_CFGR1_IR_MOD_Msk               (0x3UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x000000C0 */
+#define SYSCFG_CFGR1_IR_MOD                   SYSCFG_CFGR1_IR_MOD_Msk            /*!< IRDA Modulation Envelope signal source selection */
+#define SYSCFG_CFGR1_IR_MOD_0                 (0x1UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x00000040 */
+#define SYSCFG_CFGR1_IR_MOD_1                 (0x2UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x00000080 */
+#define SYSCFG_CFGR1_BOOSTEN_Pos              (8U)
+#define SYSCFG_CFGR1_BOOSTEN_Msk              (0x1UL << SYSCFG_CFGR1_BOOSTEN_Pos) /*!< 0x00000100 */
+#define SYSCFG_CFGR1_BOOSTEN                  SYSCFG_CFGR1_BOOSTEN_Msk            /*!< I/O analog switch voltage booster enable */
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Pos          (16U)
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB6_FMP_Pos)  /*!< 0x00010000 */
+#define SYSCFG_CFGR1_I2C_PB6_FMP              SYSCFG_CFGR1_I2C_PB6_FMP_Msk             /*!< I2C PB6 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Pos          (17U)
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB7_FMP_Pos)  /*!< 0x00020000 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP              SYSCFG_CFGR1_I2C_PB7_FMP_Msk             /*!< I2C PB7 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Pos          (18U)
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB8_FMP_Pos)  /*!< 0x00040000 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP              SYSCFG_CFGR1_I2C_PB8_FMP_Msk             /*!< I2C PB8 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Pos          (19U)
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB9_FMP_Pos)  /*!< 0x00080000 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP              SYSCFG_CFGR1_I2C_PB9_FMP_Msk             /*!< I2C PB9 Fast mode plus */
+#define SYSCFG_CFGR1_I2C1_FMP_Pos             (20U)
+#define SYSCFG_CFGR1_I2C1_FMP_Msk             (0x1UL << SYSCFG_CFGR1_I2C1_FMP_Pos)     /*!< 0x00100000 */
+#define SYSCFG_CFGR1_I2C1_FMP                 SYSCFG_CFGR1_I2C1_FMP_Msk                /*!< Enable Fast Mode Plus on PB10, PB11, PF6 and PF7  */
+#define SYSCFG_CFGR1_I2C2_FMP_Pos             (21U)
+#define SYSCFG_CFGR1_I2C2_FMP_Msk             (0x1UL << SYSCFG_CFGR1_I2C2_FMP_Pos)     /*!< 0x00200000 */
+#define SYSCFG_CFGR1_I2C2_FMP                 SYSCFG_CFGR1_I2C2_FMP_Msk                /*!< Enable I2C2 Fast mode plus  */
+#define SYSCFG_CFGR1_I2C_PA9_FMP_Pos          (22U)
+#define SYSCFG_CFGR1_I2C_PA9_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PA9_FMP_Pos)  /*!< 0x00400000 */
+#define SYSCFG_CFGR1_I2C_PA9_FMP              SYSCFG_CFGR1_I2C_PA9_FMP_Msk             /*!< Enable Fast Mode Plus on PA9  */
+#define SYSCFG_CFGR1_I2C_PA10_FMP_Pos         (23U)
+#define SYSCFG_CFGR1_I2C_PA10_FMP_Msk         (0x1UL << SYSCFG_CFGR1_I2C_PA10_FMP_Pos) /*!< 0x00800000 */
+#define SYSCFG_CFGR1_I2C_PA10_FMP             SYSCFG_CFGR1_I2C_PA10_FMP_Msk            /*!< Enable Fast Mode Plus on PA10 */
+
+/******************  Bit definition for SYSCFG_CFGR2 register  ****************/
+#define SYSCFG_CFGR2_CLL_Pos                  (0U)
+#define SYSCFG_CFGR2_CLL_Msk                  (0x1UL << SYSCFG_CFGR2_CLL_Pos)   /*!< 0x00000001 */
+#define SYSCFG_CFGR2_CLL                      SYSCFG_CFGR2_CLL_Msk              /*!< Enables and locks the LOCKUP (Hardfault) output of CortexM0 with Break Input of TIMER1 */
+#define SYSCFG_CFGR2_SPL_Pos                  (1U)
+#define SYSCFG_CFGR2_SPL_Msk                  (0x1UL << SYSCFG_CFGR2_SPL_Pos)   /*!< 0x00000002 */
+#define SYSCFG_CFGR2_SPL                      SYSCFG_CFGR2_SPL_Msk              /*!< Enables and locks the SRAM_PARITY error signal with Break Input of TIMER1 */
+#define SYSCFG_CFGR2_PVDL_Pos                 (2U)
+#define SYSCFG_CFGR2_PVDL_Msk                 (0x1UL << SYSCFG_CFGR2_PVDL_Pos)  /*!< 0x00000004 */
+#define SYSCFG_CFGR2_PVDL                     SYSCFG_CFGR2_PVDL_Msk             /*!< Enables and locks the PVD connection with Timer1 Break Input and also the PVD_EN and PVDSEL[2:0] bits of the Power Control Interface */
+#define SYSCFG_CFGR2_ECCL_Pos                 (3U)
+#define SYSCFG_CFGR2_ECCL_Msk                 (0x1UL << SYSCFG_CFGR2_ECCL_Pos)  /*!< 0x00000008 */
+#define SYSCFG_CFGR2_ECCL                     SYSCFG_CFGR2_ECCL_Msk             /*!< ECCL */
+#define SYSCFG_CFGR2_SPF_Pos                  (8U)
+#define SYSCFG_CFGR2_SPF_Msk                  (0x1UL << SYSCFG_CFGR2_SPF_Pos)   /*!< 0x00000100 */
+#define SYSCFG_CFGR2_SPF                      SYSCFG_CFGR2_SPF_Msk              /*!< SRAM Parity error flag */
+#define SYSCFG_CFGR2_SRAM_PE                  SYSCFG_CFGR2_SPF                  /*!< SRAM Parity error flag (define maintained for legacy purpose) */
+
+#define SYSCFG_CFGR2_PA1_CDEN_Pos             (16U)
+#define SYSCFG_CFGR2_PA1_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA1_CDEN_Pos)   /* 0x00010000 */
+#define SYSCFG_CFGR2_PA1_CDEN                 SYSCFG_CFGR2_PA1_CDEN_Msk              /*!< PA[1] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA3_CDEN_Pos             (17U)
+#define SYSCFG_CFGR2_PA3_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA3_CDEN_Pos)   /* 0x00020000 */
+#define SYSCFG_CFGR2_PA3_CDEN                 SYSCFG_CFGR2_PA3_CDEN_Msk              /*!< PA[3] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA5_CDEN_Pos             (18U)
+#define SYSCFG_CFGR2_PA5_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA5_CDEN_Pos)   /* 0x00040000 */
+#define SYSCFG_CFGR2_PA5_CDEN                 SYSCFG_CFGR2_PA5_CDEN_Msk              /*!< PA[5] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA6_CDEN_Pos             (19U)
+#define SYSCFG_CFGR2_PA6_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA6_CDEN_Pos)   /* 0x00080000 */
+#define SYSCFG_CFGR2_PA6_CDEN                 SYSCFG_CFGR2_PA6_CDEN_Msk              /*!< PA[6] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA13_CDEN_Pos            (20U)
+#define SYSCFG_CFGR2_PA13_CDEN_Msk            (0x1UL << SYSCFG_CFGR2_PA13_CDEN_Pos)  /* 0x00100000 */
+#define SYSCFG_CFGR2_PA13_CDEN                 SYSCFG_CFGR2_PA13_CDEN_Msk            /*!< PA[13] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB0_CDEN_Pos             (21U)
+#define SYSCFG_CFGR2_PB0_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB0_CDEN_Pos)   /* 0x00200000 */
+#define SYSCFG_CFGR2_PB0_CDEN                 SYSCFG_CFGR2_PB0_CDEN_Msk              /*!< PB[0] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB1_CDEN_Pos             (22U)
+#define SYSCFG_CFGR2_PB1_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB1_CDEN_Pos)   /* 0x00400000 */
+#define SYSCFG_CFGR2_PB1_CDEN                 SYSCFG_CFGR2_PB1_CDEN_Msk              /*!< PB[1] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB2_CDEN_Pos             (23U)
+#define SYSCFG_CFGR2_PB2_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB2_CDEN_Pos)   /* 0x00800000 */
+#define SYSCFG_CFGR2_PB2_CDEN                 SYSCFG_CFGR2_PB2_CDEN_Msk              /*!< PB[2] Clamping Diode Enable */
+/*****************  Bit definition for SYSCFG_ITLINEx ISR Wrapper register  ****************/
+#define SYSCFG_ITLINE0_SR_EWDG_Pos            (0U)
+#define SYSCFG_ITLINE0_SR_EWDG_Msk            (0x1UL << SYSCFG_ITLINE0_SR_EWDG_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE0_SR_EWDG                SYSCFG_ITLINE0_SR_EWDG_Msk       /*!< EWDG interrupt */
+#define SYSCFG_ITLINE1_SR_PVDOUT_Pos          (0U)
+#define SYSCFG_ITLINE1_SR_PVDOUT_Msk          (0x1UL << SYSCFG_ITLINE1_SR_PVDOUT_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE1_SR_PVDOUT              SYSCFG_ITLINE1_SR_PVDOUT_Msk     /*!< Power voltage detection -> exti[16] Interrupt */
+#define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
+#define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
+#define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
+#define SYSCFG_ITLINE3_SR_FLASH_ITF_Pos       (1U)
+#define SYSCFG_ITLINE3_SR_FLASH_ITF_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ITF_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE3_SR_FLASH_ITF           SYSCFG_ITLINE3_SR_FLASH_ITF_Msk  /*!< FLASH ITF interrupt */
+#define SYSCFG_ITLINE4_SR_CLK_CTRL_Pos        (0U)
+#define SYSCFG_ITLINE4_SR_CLK_CTRL_Msk        (0x1UL << SYSCFG_ITLINE4_SR_CLK_CTRL_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE4_SR_CLK_CTRL            SYSCFG_ITLINE4_SR_CLK_CTRL_Msk   /*!< RCC interrupt */
+#define SYSCFG_ITLINE5_SR_EXTI0_Pos           (0U)
+#define SYSCFG_ITLINE5_SR_EXTI0_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI0_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE5_SR_EXTI0               SYSCFG_ITLINE5_SR_EXTI0_Msk      /*!< External Interrupt 0 */
+#define SYSCFG_ITLINE5_SR_EXTI1_Pos           (1U)
+#define SYSCFG_ITLINE5_SR_EXTI1_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE5_SR_EXTI1               SYSCFG_ITLINE5_SR_EXTI1_Msk      /*!< External Interrupt 1 */
+#define SYSCFG_ITLINE6_SR_EXTI2_Pos           (0U)
+#define SYSCFG_ITLINE6_SR_EXTI2_Msk           (0x1UL << SYSCFG_ITLINE6_SR_EXTI2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE6_SR_EXTI2               SYSCFG_ITLINE6_SR_EXTI2_Msk      /*!< External Interrupt 2 */
+#define SYSCFG_ITLINE6_SR_EXTI3_Pos           (1U)
+#define SYSCFG_ITLINE6_SR_EXTI3_Msk           (0x1UL << SYSCFG_ITLINE6_SR_EXTI3_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE6_SR_EXTI3               SYSCFG_ITLINE6_SR_EXTI3_Msk      /*!< External Interrupt 3 */
+#define SYSCFG_ITLINE7_SR_EXTI4_Pos           (0U)
+#define SYSCFG_ITLINE7_SR_EXTI4_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI4_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE7_SR_EXTI4               SYSCFG_ITLINE7_SR_EXTI4_Msk      /*!< External Interrupt 4 */
+#define SYSCFG_ITLINE7_SR_EXTI5_Pos           (1U)
+#define SYSCFG_ITLINE7_SR_EXTI5_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI5_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE7_SR_EXTI5               SYSCFG_ITLINE7_SR_EXTI5_Msk      /*!< External Interrupt 5 */
+#define SYSCFG_ITLINE7_SR_EXTI6_Pos           (2U)
+#define SYSCFG_ITLINE7_SR_EXTI6_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI6_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE7_SR_EXTI6               SYSCFG_ITLINE7_SR_EXTI6_Msk      /*!< External Interrupt 6 */
+#define SYSCFG_ITLINE7_SR_EXTI7_Pos           (3U)
+#define SYSCFG_ITLINE7_SR_EXTI7_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI7_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE7_SR_EXTI7               SYSCFG_ITLINE7_SR_EXTI7_Msk      /*!< External Interrupt 7 */
+#define SYSCFG_ITLINE7_SR_EXTI8_Pos           (4U)
+#define SYSCFG_ITLINE7_SR_EXTI8_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI8_Pos) /*!< 0x00000010 */
+#define SYSCFG_ITLINE7_SR_EXTI8               SYSCFG_ITLINE7_SR_EXTI8_Msk      /*!< External Interrupt 8 */
+#define SYSCFG_ITLINE7_SR_EXTI9_Pos           (5U)
+#define SYSCFG_ITLINE7_SR_EXTI9_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI9_Pos) /*!< 0x00000020 */
+#define SYSCFG_ITLINE7_SR_EXTI9               SYSCFG_ITLINE7_SR_EXTI9_Msk      /*!< External Interrupt 9 */
+#define SYSCFG_ITLINE7_SR_EXTI10_Pos          (6U)
+#define SYSCFG_ITLINE7_SR_EXTI10_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI10_Pos) /*!< 0x00000040 */
+#define SYSCFG_ITLINE7_SR_EXTI10              SYSCFG_ITLINE7_SR_EXTI10_Msk     /*!< External Interrupt 10 */
+#define SYSCFG_ITLINE7_SR_EXTI11_Pos          (7U)
+#define SYSCFG_ITLINE7_SR_EXTI11_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI11_Pos) /*!< 0x00000080 */
+#define SYSCFG_ITLINE7_SR_EXTI11              SYSCFG_ITLINE7_SR_EXTI11_Msk     /*!< External Interrupt 11 */
+#define SYSCFG_ITLINE7_SR_EXTI12_Pos          (8U)
+#define SYSCFG_ITLINE7_SR_EXTI12_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI12_Pos) /*!< 0x00000100 */
+#define SYSCFG_ITLINE7_SR_EXTI12              SYSCFG_ITLINE7_SR_EXTI12_Msk     /*!< External Interrupt 12 */
+#define SYSCFG_ITLINE7_SR_EXTI13_Pos          (9U)
+#define SYSCFG_ITLINE7_SR_EXTI13_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI13_Pos) /*!< 0x00000200 */
+#define SYSCFG_ITLINE7_SR_EXTI13              SYSCFG_ITLINE7_SR_EXTI13_Msk     /*!< External Interrupt 13 */
+#define SYSCFG_ITLINE7_SR_EXTI14_Pos          (10U)
+#define SYSCFG_ITLINE7_SR_EXTI14_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI14_Pos) /*!< 0x00000400 */
+#define SYSCFG_ITLINE7_SR_EXTI14              SYSCFG_ITLINE7_SR_EXTI14_Msk     /*!< External Interrupt 14 */
+#define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
+#define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
+#define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
+#define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
+#define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
+#define SYSCFG_ITLINE10_SR_DMA1_CH2_Pos       (0U)
+#define SYSCFG_ITLINE10_SR_DMA1_CH2_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE10_SR_DMA1_CH2           SYSCFG_ITLINE10_SR_DMA1_CH2_Msk  /*!< DMA1 Channel 2 Interrupt */
+#define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
+#define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH5_Pos       (2U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH5_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH5_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH5           SYSCFG_ITLINE11_SR_DMA1_CH5_Msk  /*!< DMA1 Channel 5 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH6_Pos       (3U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH6_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH6_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH6           SYSCFG_ITLINE11_SR_DMA1_CH6_Msk  /*!< DMA1 Channel 6 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH7_Pos       (4U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH7_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH7_Pos) /*!< 0x00000010 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH7           SYSCFG_ITLINE11_SR_DMA1_CH7_Msk  /*!< DMA1 Channel 7 Interrupt */
+#define SYSCFG_ITLINE12_SR_ADC_Pos            (0U)
+#define SYSCFG_ITLINE12_SR_ADC_Msk            (0x1UL << SYSCFG_ITLINE12_SR_ADC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE12_SR_ADC                SYSCFG_ITLINE12_SR_ADC_Msk       /*!< ADC Interrupt */
+#define SYSCFG_ITLINE12_SR_COMP1_Pos          (1U)
+#define SYSCFG_ITLINE12_SR_COMP1_Msk          (0x1UL << SYSCFG_ITLINE12_SR_COMP1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE12_SR_COMP1              SYSCFG_ITLINE12_SR_COMP1_Msk     /*!< COMP1 Interrupt -> exti[17] */
+#define SYSCFG_ITLINE12_SR_COMP2_Pos          (2U)
+#define SYSCFG_ITLINE12_SR_COMP2_Msk          (0x1UL << SYSCFG_ITLINE12_SR_COMP2_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE12_SR_COMP2              SYSCFG_ITLINE12_SR_COMP2_Msk     /*!< COMP2 Interrupt -> exti[18] */
+#define SYSCFG_ITLINE13_SR_TIM1_CCU_Pos       (0U)
+#define SYSCFG_ITLINE13_SR_TIM1_CCU_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_CCU_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE13_SR_TIM1_CCU           SYSCFG_ITLINE13_SR_TIM1_CCU_Msk  /*!< TIM1 CCU Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_TRG_Pos       (1U)
+#define SYSCFG_ITLINE13_SR_TIM1_TRG_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_TRG_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE13_SR_TIM1_TRG           SYSCFG_ITLINE13_SR_TIM1_TRG_Msk  /*!< TIM1 TRG Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_UPD_Pos       (2U)
+#define SYSCFG_ITLINE13_SR_TIM1_UPD_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_UPD_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE13_SR_TIM1_UPD           SYSCFG_ITLINE13_SR_TIM1_UPD_Msk  /*!< TIM1 UPD Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_BRK_Pos       (3U)
+#define SYSCFG_ITLINE13_SR_TIM1_BRK_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_BRK_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE13_SR_TIM1_BRK           SYSCFG_ITLINE13_SR_TIM1_BRK_Msk  /*!< TIM1 BRK Interrupt */
+#define SYSCFG_ITLINE14_SR_TIM1_CC_Pos        (0U)
+#define SYSCFG_ITLINE14_SR_TIM1_CC_Msk        (0x1UL << SYSCFG_ITLINE14_SR_TIM1_CC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE14_SR_TIM1_CC            SYSCFG_ITLINE14_SR_TIM1_CC_Msk   /*!< TIM1 CC Interrupt */
+#define SYSCFG_ITLINE15_SR_TIM2_GLB_Pos       (0U)
+#define SYSCFG_ITLINE15_SR_TIM2_GLB_Msk       (0x1UL << SYSCFG_ITLINE15_SR_TIM2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE15_SR_TIM2_GLB           SYSCFG_ITLINE15_SR_TIM2_GLB_Msk  /*!< TIM2 GLB Interrupt */
+#define SYSCFG_ITLINE16_SR_TIM3_GLB_Pos       (0U)
+#define SYSCFG_ITLINE16_SR_TIM3_GLB_Msk       (0x1UL << SYSCFG_ITLINE16_SR_TIM3_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE16_SR_TIM3_GLB           SYSCFG_ITLINE16_SR_TIM3_GLB_Msk  /*!< TIM3 GLB Interrupt */
+#define SYSCFG_ITLINE17_SR_TIM6_GLB_Pos       (0U)
+#define SYSCFG_ITLINE17_SR_TIM6_GLB_Msk       (0x1UL << SYSCFG_ITLINE17_SR_TIM6_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE17_SR_TIM6_GLB           SYSCFG_ITLINE17_SR_TIM6_GLB_Msk  /*!< TIM6 GLB Interrupt */
+#define SYSCFG_ITLINE17_SR_DAC_Pos            (1U)
+#define SYSCFG_ITLINE17_SR_DAC_Msk            (0x1UL << SYSCFG_ITLINE17_SR_DAC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE17_SR_DAC                SYSCFG_ITLINE17_SR_DAC_Msk       /*!< DAC Interrupt */
+#define SYSCFG_ITLINE17_SR_LPTIM1_GLB_Pos     (2U)
+#define SYSCFG_ITLINE17_SR_LPTIM1_GLB_Msk     (0x1UL << SYSCFG_ITLINE17_SR_LPTIM1_GLB_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE17_SR_LPTIM1_GLB         SYSCFG_ITLINE17_SR_LPTIM1_GLB_Msk /*!< LPTIM1 -> exti[29] Interrupt */
+#define SYSCFG_ITLINE18_SR_TIM7_GLB_Pos       (0U)
+#define SYSCFG_ITLINE18_SR_TIM7_GLB_Msk       (0x1UL << SYSCFG_ITLINE18_SR_TIM7_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE18_SR_TIM7_GLB           SYSCFG_ITLINE18_SR_TIM7_GLB_Msk  /*!< TIM7 GLB Interrupt */
+#define SYSCFG_ITLINE18_SR_LPTIM2_GLB_Pos     (1U)
+#define SYSCFG_ITLINE18_SR_LPTIM2_GLB_Msk     (0x1UL << SYSCFG_ITLINE18_SR_LPTIM2_GLB_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE18_SR_LPTIM2_GLB         SYSCFG_ITLINE18_SR_LPTIM2_GLB_Msk /*!< LPTIM2 -> exti[30] Interrupt */
+#define SYSCFG_ITLINE19_SR_TIM14_GLB_Pos      (0U)
+#define SYSCFG_ITLINE19_SR_TIM14_GLB_Msk      (0x1UL << SYSCFG_ITLINE19_SR_TIM14_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE19_SR_TIM14_GLB          SYSCFG_ITLINE19_SR_TIM14_GLB_Msk /*!< TIM14 GLB Interrupt */
+#define SYSCFG_ITLINE20_SR_TIM15_GLB_Pos      (0U)
+#define SYSCFG_ITLINE20_SR_TIM15_GLB_Msk      (0x1UL << SYSCFG_ITLINE20_SR_TIM15_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE20_SR_TIM15_GLB          SYSCFG_ITLINE20_SR_TIM15_GLB_Msk /*!< TIM15 GLB Interrupt */
+#define SYSCFG_ITLINE21_SR_TIM16_GLB_Pos      (0U)
+#define SYSCFG_ITLINE21_SR_TIM16_GLB_Msk      (0x1UL << SYSCFG_ITLINE21_SR_TIM16_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE21_SR_TIM16_GLB          SYSCFG_ITLINE21_SR_TIM16_GLB_Msk /*!< TIM16 GLB Interrupt */
+#define SYSCFG_ITLINE22_SR_TIM17_GLB_Pos      (0U)
+#define SYSCFG_ITLINE22_SR_TIM17_GLB_Msk      (0x1UL << SYSCFG_ITLINE22_SR_TIM17_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE22_SR_TIM17_GLB          SYSCFG_ITLINE22_SR_TIM17_GLB_Msk /*!< TIM17 GLB Interrupt */
+#define SYSCFG_ITLINE23_SR_I2C1_GLB_Pos       (0U)
+#define SYSCFG_ITLINE23_SR_I2C1_GLB_Msk       (0x1UL << SYSCFG_ITLINE23_SR_I2C1_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
+#define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
+#define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
+#define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
+#define SYSCFG_ITLINE26_SR_SPI2_Pos           (0U)
+#define SYSCFG_ITLINE26_SR_SPI2_Msk           (0x1UL << SYSCFG_ITLINE26_SR_SPI2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE26_SR_SPI2               SYSCFG_ITLINE26_SR_SPI2_Msk      /*!< SPI2  Interrupt */
+#define SYSCFG_ITLINE27_SR_USART1_GLB_Pos     (0U)
+#define SYSCFG_ITLINE27_SR_USART1_GLB_Msk     (0x1UL << SYSCFG_ITLINE27_SR_USART1_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE27_SR_USART1_GLB         SYSCFG_ITLINE27_SR_USART1_GLB_Msk /*!< USART1 GLB Interrupt -> exti[25] */
+#define SYSCFG_ITLINE28_SR_USART2_GLB_Pos     (0U)
+#define SYSCFG_ITLINE28_SR_USART2_GLB_Msk     (0x1UL << SYSCFG_ITLINE28_SR_USART2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE28_SR_USART2_GLB         SYSCFG_ITLINE28_SR_USART2_GLB_Msk /*!< USART2 GLB Interrupt -> exti[26] */
+#define SYSCFG_ITLINE29_SR_LPUART1_GLB_Pos    (2U)
+#define SYSCFG_ITLINE29_SR_LPUART1_GLB_Msk    (0x1UL << SYSCFG_ITLINE29_SR_LPUART1_GLB_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE29_SR_LPUART1_GLB        SYSCFG_ITLINE29_SR_LPUART1_GLB_Msk /*!< LPUART1 GLB Interrupt -> exti[28] */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                   /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable */
+#define TIM_CR1_UDIS_Pos          (1U)
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                  /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable */
+#define TIM_CR1_URS_Pos           (2U)
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                   /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode */
+#define TIM_CR1_DIR_Pos           (4U)
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                   /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction */
+
+#define TIM_CR1_CMS_Pos           (5U)
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000020 */
+#define TIM_CR1_CMS_1             (0x2UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                  /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable */
+
+#define TIM_CR1_CKD_Pos           (8U)
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000100 */
+#define TIM_CR1_CKD_1             (0x2UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000200 */
+
+#define TIM_CR1_UIFREMAP_Pos      (11U)
+#define TIM_CR1_UIFREMAP_Msk      (0x1UL << TIM_CR1_UIFREMAP_Pos)              /*!< 0x00000800 */
+#define TIM_CR1_UIFREMAP          TIM_CR1_UIFREMAP_Msk                         /*!<Update interrupt flag remap */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                  /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control */
+#define TIM_CR2_CCUS_Pos          (2U)
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                  /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                  /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection */
+
+#define TIM_CR2_MMS_Pos           (4U)
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000010 */
+#define TIM_CR2_MMS_1             (0x2UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000020 */
+#define TIM_CR2_MMS_2             (0x4UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                  /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                  /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output) */
+#define TIM_CR2_OIS1N_Pos         (9U)
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                 /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                  /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output) */
+#define TIM_CR2_OIS2N_Pos         (11U)
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                 /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                  /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output) */
+#define TIM_CR2_OIS3N_Pos         (13U)
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                 /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                  /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output) */
+#define TIM_CR2_OIS5_Pos          (16U)
+#define TIM_CR2_OIS5_Msk          (0x1UL << TIM_CR2_OIS5_Pos)                  /*!< 0x00010000 */
+#define TIM_CR2_OIS5              TIM_CR2_OIS5_Msk                             /*!<Output Idle state 5 (OC5 output) */
+#define TIM_CR2_OIS6_Pos          (18U)
+#define TIM_CR2_OIS6_Msk          (0x1UL << TIM_CR2_OIS6_Pos)                  /*!< 0x00040000 */
+#define TIM_CR2_OIS6              TIM_CR2_OIS6_Msk                             /*!<Output Idle state 6 (OC6 output) */
+
+#define TIM_CR2_MMS2_Pos          (20U)
+#define TIM_CR2_MMS2_Msk          (0xFUL << TIM_CR2_MMS2_Pos)                  /*!< 0x00F00000 */
+#define TIM_CR2_MMS2              TIM_CR2_MMS2_Msk                             /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS2_0            (0x1UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00100000 */
+#define TIM_CR2_MMS2_1            (0x2UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00200000 */
+#define TIM_CR2_MMS2_2            (0x4UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00400000 */
+#define TIM_CR2_MMS2_3            (0x8UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00800000 */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)
+#define TIM_SMCR_SMS_Msk          (0x10007UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMCR_SMS_0            (0x00001UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000001 */
+#define TIM_SMCR_SMS_1            (0x00002UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000002 */
+#define TIM_SMCR_SMS_2            (0x00004UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000004 */
+#define TIM_SMCR_SMS_3            (0x10000UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010000 */
+
+#define TIM_SMCR_OCCS_Pos         (3U)
+#define TIM_SMCR_OCCS_Msk         (0x1UL << TIM_SMCR_OCCS_Pos)                 /*!< 0x00000008 */
+#define TIM_SMCR_OCCS             TIM_SMCR_OCCS_Msk                            /*!< OCREF clear selection */
+
+#define TIM_SMCR_TS_Pos           (4U)
+#define TIM_SMCR_TS_Msk           (0x30007UL << TIM_SMCR_TS_Pos)               /*!< 0x00300070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection) */
+#define TIM_SMCR_TS_0             (0x00001UL << TIM_SMCR_TS_Pos)               /*!< 0x00000010 */
+#define TIM_SMCR_TS_1             (0x00002UL << TIM_SMCR_TS_Pos)               /*!< 0x00000020 */
+#define TIM_SMCR_TS_2             (0x00004UL << TIM_SMCR_TS_Pos)               /*!< 0x00000040 */
+#define TIM_SMCR_TS_3             (0x10000UL << TIM_SMCR_TS_Pos)               /*!< 0x00100000 */
+#define TIM_SMCR_TS_4             (0x20000UL << TIM_SMCR_TS_Pos)               /*!< 0x00200000 */
+
+#define TIM_SMCR_MSM_Pos          (7U)
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                  /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode */
+
+#define TIM_SMCR_ETF_Pos          (8U)
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000100 */
+#define TIM_SMCR_ETF_1            (0x2UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000200 */
+#define TIM_SMCR_ETF_2            (0x4UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000400 */
+#define TIM_SMCR_ETF_3            (0x8UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00001000 */
+#define TIM_SMCR_ETPS_1           (0x2UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00002000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                  /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable */
+#define TIM_SMCR_ETP_Pos          (15U)
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                  /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                  /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable */
+#define TIM_DIER_CC2IE_Pos        (2U)
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable */
+#define TIM_DIER_CC3IE_Pos        (3U)
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable */
+#define TIM_DIER_CC4IE_Pos        (4U)
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable */
+#define TIM_DIER_COMIE_Pos        (5U)
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable */
+#define TIM_DIER_TIE_Pos          (6U)
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                  /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable */
+#define TIM_DIER_BIE_Pos          (7U)
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                  /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable */
+#define TIM_DIER_UDE_Pos          (8U)
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                  /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable */
+#define TIM_DIER_CC1DE_Pos        (9U)
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable */
+#define TIM_DIER_TDE_Pos          (14U)
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                  /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                    /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag */
+#define TIM_SR_CC1IF_Pos          (1U)
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                  /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag */
+#define TIM_SR_CC2IF_Pos          (2U)
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                  /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag */
+#define TIM_SR_CC3IF_Pos          (3U)
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                  /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag */
+#define TIM_SR_CC4IF_Pos          (4U)
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                  /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag */
+#define TIM_SR_COMIF_Pos          (5U)
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                  /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag */
+#define TIM_SR_TIF_Pos            (6U)
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                    /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag */
+#define TIM_SR_BIF_Pos            (7U)
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                    /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag */
+#define TIM_SR_B2IF_Pos           (8U)
+#define TIM_SR_B2IF_Msk           (0x1UL << TIM_SR_B2IF_Pos)                   /*!< 0x00000100 */
+#define TIM_SR_B2IF               TIM_SR_B2IF_Msk                              /*!<Break 2 interrupt Flag */
+#define TIM_SR_CC1OF_Pos          (9U)
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                  /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                  /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                  /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                  /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+#define TIM_SR_SBIF_Pos           (13U)
+#define TIM_SR_SBIF_Msk           (0x1UL << TIM_SR_SBIF_Pos)                   /*!< 0x00002000 */
+#define TIM_SR_SBIF               TIM_SR_SBIF_Msk                              /*!<System Break interrupt Flag */
+#define TIM_SR_CC5IF_Pos          (16U)
+#define TIM_SR_CC5IF_Msk          (0x1UL << TIM_SR_CC5IF_Pos)                  /*!< 0x00010000 */
+#define TIM_SR_CC5IF              TIM_SR_CC5IF_Msk                             /*!<Capture/Compare 5 interrupt Flag */
+#define TIM_SR_CC6IF_Pos          (17U)
+#define TIM_SR_CC6IF_Msk          (0x1UL << TIM_SR_CC6IF_Pos)                  /*!< 0x00020000 */
+#define TIM_SR_CC6IF              TIM_SR_CC6IF_Msk                             /*!<Capture/Compare 6 interrupt Flag */
+
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                    /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation */
+#define TIM_EGR_CC1G_Pos          (1U)
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                  /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation */
+#define TIM_EGR_CC2G_Pos          (2U)
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                  /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation */
+#define TIM_EGR_CC3G_Pos          (3U)
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                  /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation */
+#define TIM_EGR_CC4G_Pos          (4U)
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                  /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation */
+#define TIM_EGR_COMG_Pos          (5U)
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                  /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                    /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation */
+#define TIM_EGR_BG_Pos            (7U)
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                    /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation */
+#define TIM_EGR_B2G_Pos           (8U)
+#define TIM_EGR_B2G_Msk           (0x1UL << TIM_EGR_B2G_Pos)                   /*!< 0x00000100 */
+#define TIM_EGR_B2G               TIM_EGR_B2G_Msk                              /*!<Break 2 Generation */
+
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000001 */
+#define TIM_CCMR1_CC1S_1          (0x2UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable */
+#define TIM_CCMR1_OC1PE_Pos       (3U)
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)
+#define TIM_CCMR1_OC1M_Msk        (0x1007UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_CCMR1_OC1M_0          (0x0001UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR1_OC1M_1          (0x0002UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR1_OC1M_2          (0x0004UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR1_OC1M_3          (0x1000UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1 Clear Enable */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000100 */
+#define TIM_CCMR1_CC2S_1          (0x2UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable */
+#define TIM_CCMR1_OC2PE_Pos       (11U)
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)
+#define TIM_CCMR1_OC2M_Msk        (0x1007UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_CCMR1_OC2M_0          (0x0001UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR1_OC2M_1          (0x0002UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR1_OC2M_2          (0x0004UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR1_OC2M_3          (0x1000UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR1_IC1PSC_Pos      (2U)
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x00000004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x00000008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_CCMR1_IC1F_0          (0x1UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000010 */
+#define TIM_CCMR1_IC1F_1          (0x2UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000020 */
+#define TIM_CCMR1_IC1F_2          (0x4UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000040 */
+#define TIM_CCMR1_IC1F_3          (0x8UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_CCMR1_IC2PSC_0        (0x1UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_CCMR1_IC2F_0          (0x1UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00001000 */
+#define TIM_CCMR1_IC2F_1          (0x2UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00002000 */
+#define TIM_CCMR1_IC2F_2          (0x4UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00004000 */
+#define TIM_CCMR1_IC2F_3          (0x8UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CCMR2_CC3S_0          (0x1UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000001 */
+#define TIM_CCMR2_CC3S_1          (0x2UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable */
+#define TIM_CCMR2_OC3PE_Pos       (3U)
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)
+#define TIM_CCMR2_OC3M_Msk        (0x1007UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x0001UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR2_OC3M_1          (0x0002UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR2_OC3M_2          (0x0004UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR2_OC3M_3          (0x1000UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000100 */
+#define TIM_CCMR2_CC4S_1          (0x2UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable */
+#define TIM_CCMR2_OC4PE_Pos       (11U)
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)
+#define TIM_CCMR2_OC4M_Msk        (0x1007UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x0001UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR2_OC4M_1          (0x0002UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR2_OC4M_2          (0x0004UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR2_OC4M_3          (0x1000UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR2_IC3PSC_Pos      (2U)
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x00000004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x00000008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000010 */
+#define TIM_CCMR2_IC3F_1          (0x2UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000020 */
+#define TIM_CCMR2_IC3F_2          (0x4UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000040 */
+#define TIM_CCMR2_IC3F_3          (0x8UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00001000 */
+#define TIM_CCMR2_IC4F_1          (0x2UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00002000 */
+#define TIM_CCMR2_IC4F_2          (0x4UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00004000 */
+#define TIM_CCMR2_IC4F_3          (0x8UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define TIM_CCMR3_OC5FE_Pos       (2U)
+#define TIM_CCMR3_OC5FE_Msk       (0x1UL << TIM_CCMR3_OC5FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR3_OC5FE           TIM_CCMR3_OC5FE_Msk                          /*!<Output Compare 5 Fast enable */
+#define TIM_CCMR3_OC5PE_Pos       (3U)
+#define TIM_CCMR3_OC5PE_Msk       (0x1UL << TIM_CCMR3_OC5PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR3_OC5PE           TIM_CCMR3_OC5PE_Msk                          /*!<Output Compare 5 Preload enable */
+
+#define TIM_CCMR3_OC5M_Pos        (4U)
+#define TIM_CCMR3_OC5M_Msk        (0x1007UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR3_OC5M            TIM_CCMR3_OC5M_Msk                           /*!<OC5M[3:0] bits (Output Compare 5 Mode) */
+#define TIM_CCMR3_OC5M_0          (0x0001UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR3_OC5M_1          (0x0002UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR3_OC5M_2          (0x0004UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR3_OC5M_3          (0x1000UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR3_OC5CE_Pos       (7U)
+#define TIM_CCMR3_OC5CE_Msk       (0x1UL << TIM_CCMR3_OC5CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR3_OC5CE           TIM_CCMR3_OC5CE_Msk                          /*!<Output Compare 5 Clear Enable */
+
+#define TIM_CCMR3_OC6FE_Pos       (10U)
+#define TIM_CCMR3_OC6FE_Msk       (0x1UL << TIM_CCMR3_OC6FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR3_OC6FE           TIM_CCMR3_OC6FE_Msk                          /*!<Output Compare 6 Fast enable */
+#define TIM_CCMR3_OC6PE_Pos       (11U)
+#define TIM_CCMR3_OC6PE_Msk       (0x1UL << TIM_CCMR3_OC6PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR3_OC6PE           TIM_CCMR3_OC6PE_Msk                          /*!<Output Compare 6 Preload enable */
+
+#define TIM_CCMR3_OC6M_Pos        (12U)
+#define TIM_CCMR3_OC6M_Msk        (0x1007UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR3_OC6M            TIM_CCMR3_OC6M_Msk                           /*!<OC6M[3:0] bits (Output Compare 6 Mode) */
+#define TIM_CCMR3_OC6M_0          (0x0001UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR3_OC6M_1          (0x0002UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR3_OC6M_2          (0x0004UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR3_OC6M_3          (0x1000UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR3_OC6CE_Pos       (15U)
+#define TIM_CCMR3_OC6CE_Msk       (0x1UL << TIM_CCMR3_OC6CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR3_OC6CE           TIM_CCMR3_OC6CE_Msk                          /*!<Output Compare 6 Clear Enable */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                 /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable */
+#define TIM_CCER_CC1P_Pos         (1U)
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                 /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity */
+#define TIM_CCER_CC1NE_Pos        (2U)
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable */
+#define TIM_CCER_CC1NP_Pos        (3U)
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                 /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable */
+#define TIM_CCER_CC2P_Pos         (5U)
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                 /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity */
+#define TIM_CCER_CC2NE_Pos        (6U)
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable */
+#define TIM_CCER_CC2NP_Pos        (7U)
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                 /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable */
+#define TIM_CCER_CC3P_Pos         (9U)
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                 /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity */
+#define TIM_CCER_CC3NE_Pos        (10U)
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable */
+#define TIM_CCER_CC3NP_Pos        (11U)
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                 /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable */
+#define TIM_CCER_CC4P_Pos         (13U)
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                 /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity */
+#define TIM_CCER_CC4NP_Pos        (15U)
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+#define TIM_CCER_CC5E_Pos         (16U)
+#define TIM_CCER_CC5E_Msk         (0x1UL << TIM_CCER_CC5E_Pos)                 /*!< 0x00010000 */
+#define TIM_CCER_CC5E             TIM_CCER_CC5E_Msk                            /*!<Capture/Compare 5 output enable */
+#define TIM_CCER_CC5P_Pos         (17U)
+#define TIM_CCER_CC5P_Msk         (0x1UL << TIM_CCER_CC5P_Pos)                 /*!< 0x00020000 */
+#define TIM_CCER_CC5P             TIM_CCER_CC5P_Msk                            /*!<Capture/Compare 5 output Polarity */
+#define TIM_CCER_CC6E_Pos         (20U)
+#define TIM_CCER_CC6E_Msk         (0x1UL << TIM_CCER_CC6E_Pos)                 /*!< 0x00100000 */
+#define TIM_CCER_CC6E             TIM_CCER_CC6E_Msk                            /*!<Capture/Compare 6 output enable */
+#define TIM_CCER_CC6P_Pos         (21U)
+#define TIM_CCER_CC6P_Msk         (0x1UL << TIM_CCER_CC6P_Pos)                 /*!< 0x00200000 */
+#define TIM_CCER_CC6P             TIM_CCER_CC6P_Msk                            /*!<Capture/Compare 6 output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                              /*!<Counter Value */
+#define TIM_CNT_UIFCPY_Pos        (31U)
+#define TIM_CNT_UIFCPY_Msk        (0x1UL << TIM_CNT_UIFCPY_Pos)                /*!< 0x80000000 */
+#define TIM_CNT_UIFCPY            TIM_CNT_UIFCPY_Msk                           /*!<Update interrupt flag copy (if UIFREMAP=1) */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<Actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)
+#define TIM_RCR_REP_Msk           (0xFFFFUL << TIM_RCR_REP_Pos)                /*!< 0x0000FFFF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define TIM_CCR5_CCR5_Pos         (0U)
+#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
+#define TIM_CCR5_GC5C1_Pos        (29U)
+#define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
+#define TIM_CCR5_GC5C1            TIM_CCR5_GC5C1_Msk                           /*!<Group Channel 5 and Channel 1 */
+#define TIM_CCR5_GC5C2_Pos        (30U)
+#define TIM_CCR5_GC5C2_Msk        (0x1UL << TIM_CCR5_GC5C2_Pos)                /*!< 0x40000000 */
+#define TIM_CCR5_GC5C2            TIM_CCR5_GC5C2_Msk                           /*!<Group Channel 5 and Channel 2 */
+#define TIM_CCR5_GC5C3_Pos        (31U)
+#define TIM_CCR5_GC5C3_Msk        (0x1UL << TIM_CCR5_GC5C3_Pos)                /*!< 0x80000000 */
+#define TIM_CCR5_GC5C3            TIM_CCR5_GC5C3_Msk                           /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define TIM_CCR6_CCR6_Pos         (0U)
+#define TIM_CCR6_CCR6_Msk         (0xFFFFUL << TIM_CCR6_CCR6_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6             TIM_CCR6_CCR6_Msk                            /*!<Capture/Compare 6 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                 /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000001 */
+#define TIM_BDTR_DTG_1            (0x02UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000002 */
+#define TIM_BDTR_DTG_2            (0x04UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000004 */
+#define TIM_BDTR_DTG_3            (0x08UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000008 */
+#define TIM_BDTR_DTG_4            (0x10UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000010 */
+#define TIM_BDTR_DTG_5            (0x20UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000020 */
+#define TIM_BDTR_DTG_6            (0x40UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000040 */
+#define TIM_BDTR_DTG_7            (0x80UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000100 */
+#define TIM_BDTR_LOCK_1           (0x2UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                 /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                 /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode */
+#define TIM_BDTR_BKE_Pos          (12U)
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                  /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable for Break 1 */
+#define TIM_BDTR_BKP_Pos          (13U)
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                  /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity for Break 1 */
+#define TIM_BDTR_AOE_Pos          (14U)
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                  /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable */
+#define TIM_BDTR_MOE_Pos          (15U)
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                  /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable */
+
+#define TIM_BDTR_BKF_Pos          (16U)
+#define TIM_BDTR_BKF_Msk          (0xFUL << TIM_BDTR_BKF_Pos)                  /*!< 0x000F0000 */
+#define TIM_BDTR_BKF              TIM_BDTR_BKF_Msk                             /*!<Break Filter for Break 1 */
+#define TIM_BDTR_BK2F_Pos         (20U)
+#define TIM_BDTR_BK2F_Msk         (0xFUL << TIM_BDTR_BK2F_Pos)                 /*!< 0x00F00000 */
+#define TIM_BDTR_BK2F             TIM_BDTR_BK2F_Msk                            /*!<Break Filter for Break 2 */
+
+#define TIM_BDTR_BK2E_Pos         (24U)
+#define TIM_BDTR_BK2E_Msk         (0x1UL << TIM_BDTR_BK2E_Pos)                 /*!< 0x01000000 */
+#define TIM_BDTR_BK2E             TIM_BDTR_BK2E_Msk                            /*!<Break enable for Break 2 */
+#define TIM_BDTR_BK2P_Pos         (25U)
+#define TIM_BDTR_BK2P_Msk         (0x1UL << TIM_BDTR_BK2P_Pos)                 /*!< 0x02000000 */
+#define TIM_BDTR_BK2P             TIM_BDTR_BK2P_Msk                            /*!<Break Polarity for Break 2 */
+
+#define TIM_BDTR_BKDSRM_Pos       (26U)
+#define TIM_BDTR_BKDSRM_Msk       (0x1UL << TIM_BDTR_BKDSRM_Pos)               /*!< 0x04000000 */
+#define TIM_BDTR_BKDSRM           TIM_BDTR_BKDSRM_Msk                          /*!<Break disarming/re-arming */
+#define TIM_BDTR_BK2DSRM_Pos      (27U)
+#define TIM_BDTR_BK2DSRM_Msk      (0x1UL << TIM_BDTR_BK2DSRM_Pos)              /*!< 0x08000000 */
+#define TIM_BDTR_BK2DSRM          TIM_BDTR_BK2DSRM_Msk                         /*!<Break2 disarming/re-arming */
+
+#define TIM_BDTR_BKBID_Pos        (28U)
+#define TIM_BDTR_BKBID_Msk        (0x1UL << TIM_BDTR_BKBID_Pos)                /*!< 0x10000000 */
+#define TIM_BDTR_BKBID            TIM_BDTR_BKBID_Msk                           /*!<Break BIDirectional */
+#define TIM_BDTR_BK2BID_Pos       (29U)
+#define TIM_BDTR_BK2BID_Msk       (0x1UL << TIM_BDTR_BK2BID_Pos)               /*!< 0x20000000 */
+#define TIM_BDTR_BK2BID           TIM_BDTR_BK2BID_Msk                          /*!<Break2 BIDirectional */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                  /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000001 */
+#define TIM_DCR_DBA_1             (0x02UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000002 */
+#define TIM_DCR_DBA_2             (0x04UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000004 */
+#define TIM_DCR_DBA_3             (0x08UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000008 */
+#define TIM_DCR_DBA_4             (0x10UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000010 */
+
+#define TIM_DCR_DBL_Pos           (8U)
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                  /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000100 */
+#define TIM_DCR_DBL_1             (0x02UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000200 */
+#define TIM_DCR_DBL_2             (0x04UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000400 */
+#define TIM_DCR_DBL_3             (0x08UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000800 */
+#define TIM_DCR_DBL_4             (0x10UL << TIM_DCR_DBL_Pos)                  /*!< 0x00001000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)              /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM1_OR1 register  *******************/
+#define TIM1_OR1_OCREF_CLR_Pos     (0U)
+#define TIM1_OR1_OCREF_CLR_Msk     (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM1_AF1 register  *******************/
+#define TIM1_AF1_BKINE_Pos        (0U)
+#define TIM1_AF1_BKINE_Msk        (0x1UL << TIM1_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM1_AF1_BKINE            TIM1_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM1_AF1_BKCMP1E_Pos      (1U)
+#define TIM1_AF1_BKCMP1E_Msk      (0x1UL << TIM1_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM1_AF1_BKCMP1E          TIM1_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM1_AF1_BKCMP2E_Pos      (2U)
+#define TIM1_AF1_BKCMP2E_Msk      (0x1UL << TIM1_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM1_AF1_BKCMP2E          TIM1_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM1_AF1_BKINP_Pos        (9U)
+#define TIM1_AF1_BKINP_Msk        (0x1UL << TIM1_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM1_AF1_BKINP            TIM1_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM1_AF1_BKCMP1P_Pos      (10U)
+#define TIM1_AF1_BKCMP1P_Msk      (0x1UL << TIM1_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM1_AF1_BKCMP1P          TIM1_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM1_AF1_BKCMP2P_Pos      (11U)
+#define TIM1_AF1_BKCMP2P_Msk      (0x1UL << TIM1_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM1_AF1_BKCMP2P          TIM1_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+#define TIM1_AF1_ETRSEL_Pos       (14U)
+#define TIM1_AF1_ETRSEL_Msk       (0xFUL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM1_AF1_ETRSEL           TIM1_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM1 ETR source selection) */
+#define TIM1_AF1_ETRSEL_0         (0x1UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM1_AF1_ETRSEL_1         (0x2UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM1_AF1_ETRSEL_2         (0x4UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM1_AF1_ETRSEL_3         (0x8UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM1_AF2 register  *******************/
+#define TIM1_AF2_BK2INE_Pos       (0U)
+#define TIM1_AF2_BK2INE_Msk       (0x1UL << TIM1_AF2_BK2INE_Pos)               /*!< 0x00000001 */
+#define TIM1_AF2_BK2INE           TIM1_AF2_BK2INE_Msk                          /*!<BRK2 BKIN2 input enable */
+#define TIM1_AF2_BK2CMP1E_Pos     (1U)
+#define TIM1_AF2_BK2CMP1E_Msk     (0x1UL << TIM1_AF2_BK2CMP1E_Pos)             /*!< 0x00000002 */
+#define TIM1_AF2_BK2CMP1E         TIM1_AF2_BK2CMP1E_Msk                        /*!<BRK2 COMP1 enable */
+#define TIM1_AF2_BK2CMP2E_Pos     (2U)
+#define TIM1_AF2_BK2CMP2E_Msk     (0x1UL << TIM1_AF2_BK2CMP2E_Pos)             /*!< 0x00000004 */
+#define TIM1_AF2_BK2CMP2E         TIM1_AF2_BK2CMP2E_Msk                        /*!<BRK2 COMP2 enable */
+#define TIM1_AF2_BK2INP_Pos       (9U)
+#define TIM1_AF2_BK2INP_Msk       (0x1UL << TIM1_AF2_BK2INP_Pos)               /*!< 0x00000200 */
+#define TIM1_AF2_BK2INP           TIM1_AF2_BK2INP_Msk                          /*!<BRK2 BKIN2 input polarity */
+#define TIM1_AF2_BK2CMP1P_Pos     (10U)
+#define TIM1_AF2_BK2CMP1P_Msk     (0x1UL << TIM1_AF2_BK2CMP1P_Pos)             /*!< 0x00000400 */
+#define TIM1_AF2_BK2CMP1P         TIM1_AF2_BK2CMP1P_Msk                        /*!<BRK2 COMP1 input polarity */
+#define TIM1_AF2_BK2CMP2P_Pos     (11U)
+#define TIM1_AF2_BK2CMP2P_Msk     (0x1UL << TIM1_AF2_BK2CMP2P_Pos)             /*!< 0x00000800 */
+#define TIM1_AF2_BK2CMP2P         TIM1_AF2_BK2CMP2P_Msk                        /*!<BRK2 COMP2 input polarity */
+
+/*******************  Bit definition for TIM2_OR1 register  *******************/
+#define TIM2_OR1_OCREF_CLR_Pos     (0U)
+#define TIM2_OR1_OCREF_CLR_Msk     (0x1UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM2_OR1_OCREF_CLR         TIM2_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM2_AF1 register  *******************/
+#define TIM2_AF1_ETRSEL_Pos       (14U)
+#define TIM2_AF1_ETRSEL_Msk       (0xFUL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM2_AF1_ETRSEL           TIM2_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM2 ETR source selection) */
+#define TIM2_AF1_ETRSEL_0         (0x1UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM2_AF1_ETRSEL_1         (0x2UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM2_AF1_ETRSEL_2         (0x4UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM2_AF1_ETRSEL_3         (0x8UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM3_OR1 register  *******************/
+#define TIM3_OR1_OCREF_CLR_Pos     (0U)
+#define TIM3_OR1_OCREF_CLR_Msk     (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM3_AF1 register  *******************/
+#define TIM3_AF1_ETRSEL_Pos       (14U)
+#define TIM3_AF1_ETRSEL_Msk       (0xFUL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM3_AF1_ETRSEL           TIM3_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM3_AF1_ETRSEL_0         (0x1UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM3_AF1_ETRSEL_1         (0x2UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM3_AF1_ETRSEL_2         (0x4UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM3_AF1_ETRSEL_3         (0x8UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM14_AF1 register  *******************/
+#define TIM14_AF1_ETRSEL_Pos      (14U)
+#define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
+#define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
+#define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
+#define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
+#define TIM14_AF1_ETRSEL_3        (0x8UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM15_AF1 register  ******************/
+#define TIM15_AF1_BKINE_Pos      (0U)
+#define TIM15_AF1_BKINE_Msk      (0x1UL << TIM15_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM15_AF1_BKINE          TIM15_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM15_AF1_BKCMP1E_Pos    (1U)
+#define TIM15_AF1_BKCMP1E_Msk    (0x1UL << TIM15_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM15_AF1_BKCMP1E        TIM15_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM15_AF1_BKCMP2E_Pos    (2U)
+#define TIM15_AF1_BKCMP2E_Msk    (0x1UL << TIM15_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM15_AF1_BKCMP2E        TIM15_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM15_AF1_BKINP_Pos      (9U)
+#define TIM15_AF1_BKINP_Msk      (0x1UL << TIM15_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM15_AF1_BKINP          TIM15_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM15_AF1_BKCMP1P_Pos    (10U)
+#define TIM15_AF1_BKCMP1P_Msk    (0x1UL << TIM15_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM15_AF1_BKCMP1P        TIM15_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM15_AF1_BKCMP2P_Pos    (11U)
+#define TIM15_AF1_BKCMP2P_Msk    (0x1UL << TIM15_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM15_AF1_BKCMP2P        TIM15_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM16_AF1 register  ******************/
+#define TIM16_AF1_BKINE_Pos      (0U)
+#define TIM16_AF1_BKINE_Msk      (0x1UL << TIM16_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM16_AF1_BKINE          TIM16_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM16_AF1_BKCMP1E_Pos    (1U)
+#define TIM16_AF1_BKCMP1E_Msk    (0x1UL << TIM16_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM16_AF1_BKCMP1E        TIM16_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM16_AF1_BKCMP2E_Pos    (2U)
+#define TIM16_AF1_BKCMP2E_Msk    (0x1UL << TIM16_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM16_AF1_BKCMP2E        TIM16_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM16_AF1_BKINP_Pos      (9U)
+#define TIM16_AF1_BKINP_Msk      (0x1UL << TIM16_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM16_AF1_BKINP          TIM16_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM16_AF1_BKCMP1P_Pos    (10U)
+#define TIM16_AF1_BKCMP1P_Msk    (0x1UL << TIM16_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM16_AF1_BKCMP1P        TIM16_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM16_AF1_BKCMP2P_Pos    (11U)
+#define TIM16_AF1_BKCMP2P_Msk    (0x1UL << TIM16_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM16_AF1_BKCMP2P        TIM16_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM17_AF1 register  ******************/
+#define TIM17_AF1_BKINE_Pos      (0U)
+#define TIM17_AF1_BKINE_Msk      (0x1UL << TIM17_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM17_AF1_BKINE          TIM17_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM17_AF1_BKCMP1E_Pos    (1U)
+#define TIM17_AF1_BKCMP1E_Msk    (0x1UL << TIM17_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM17_AF1_BKCMP1E        TIM17_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM17_AF1_BKCMP2E_Pos    (2U)
+#define TIM17_AF1_BKCMP2E_Msk    (0x1UL << TIM17_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM17_AF1_BKCMP2E        TIM17_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM17_AF1_BKINP_Pos      (9U)
+#define TIM17_AF1_BKINP_Msk      (0x1UL << TIM17_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM17_AF1_BKINP          TIM17_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM17_AF1_BKCMP1P_Pos    (10U)
+#define TIM17_AF1_BKCMP1P_Msk    (0x1UL << TIM17_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM17_AF1_BKCMP1P        TIM17_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM17_AF1_BKCMP2P_Pos    (11U)
+#define TIM17_AF1_BKCMP2P_Msk    (0x1UL << TIM17_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM17_AF1_BKCMP2P        TIM17_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM_TISEL register  *********************/
+#define TIM_TISEL_TI1SEL_Pos      (0U)
+#define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
+#define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
+#define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
+#define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
+#define TIM_TISEL_TI1SEL_3        (0x8UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000008 */
+
+#define TIM_TISEL_TI2SEL_Pos      (8U)
+#define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
+#define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
+#define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
+#define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
+#define TIM_TISEL_TI2SEL_3        (0x8UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000800 */
+
+#define TIM_TISEL_TI3SEL_Pos      (16U)
+#define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
+#define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
+#define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
+#define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
+#define TIM_TISEL_TI3SEL_3        (0x8UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00080000 */
+
+#define TIM_TISEL_TI4SEL_Pos      (24U)
+#define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
+#define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
+#define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
+#define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
+#define TIM_TISEL_TI4SEL_3        (0x8UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x08000000 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define LPTIM_ISR_CMPM_Pos          (0U)
+#define LPTIM_ISR_CMPM_Msk          (0x1UL << LPTIM_ISR_CMPM_Pos)              /*!< 0x00000001 */
+#define LPTIM_ISR_CMPM              LPTIM_ISR_CMPM_Msk                         /*!< Compare match */
+#define LPTIM_ISR_ARRM_Pos          (1U)
+#define LPTIM_ISR_ARRM_Msk          (0x1UL << LPTIM_ISR_ARRM_Pos)              /*!< 0x00000002 */
+#define LPTIM_ISR_ARRM              LPTIM_ISR_ARRM_Msk                         /*!< Autoreload match */
+#define LPTIM_ISR_EXTTRIG_Pos       (2U)
+#define LPTIM_ISR_EXTTRIG_Msk       (0x1UL << LPTIM_ISR_EXTTRIG_Pos)           /*!< 0x00000004 */
+#define LPTIM_ISR_EXTTRIG           LPTIM_ISR_EXTTRIG_Msk                      /*!< External trigger edge event */
+#define LPTIM_ISR_CMPOK_Pos         (3U)
+#define LPTIM_ISR_CMPOK_Msk         (0x1UL << LPTIM_ISR_CMPOK_Pos)             /*!< 0x00000008 */
+#define LPTIM_ISR_CMPOK             LPTIM_ISR_CMPOK_Msk                        /*!< Compare register update OK */
+#define LPTIM_ISR_ARROK_Pos         (4U)
+#define LPTIM_ISR_ARROK_Msk         (0x1UL << LPTIM_ISR_ARROK_Pos)             /*!< 0x00000010 */
+#define LPTIM_ISR_ARROK             LPTIM_ISR_ARROK_Msk                        /*!< Autoreload register update OK */
+#define LPTIM_ISR_UP_Pos            (5U)
+#define LPTIM_ISR_UP_Msk            (0x1UL << LPTIM_ISR_UP_Pos)                /*!< 0x00000020 */
+#define LPTIM_ISR_UP                LPTIM_ISR_UP_Msk                           /*!< Counter direction change down to up */
+#define LPTIM_ISR_DOWN_Pos          (6U)
+#define LPTIM_ISR_DOWN_Msk          (0x1UL << LPTIM_ISR_DOWN_Pos)              /*!< 0x00000040 */
+#define LPTIM_ISR_DOWN              LPTIM_ISR_DOWN_Msk                         /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define LPTIM_ICR_CMPMCF_Pos        (0U)
+#define LPTIM_ICR_CMPMCF_Msk        (0x1UL << LPTIM_ICR_CMPMCF_Pos)            /*!< 0x00000001 */
+#define LPTIM_ICR_CMPMCF            LPTIM_ICR_CMPMCF_Msk                       /*!< Compare match Clear Flag */
+#define LPTIM_ICR_ARRMCF_Pos        (1U)
+#define LPTIM_ICR_ARRMCF_Msk        (0x1UL << LPTIM_ICR_ARRMCF_Pos)            /*!< 0x00000002 */
+#define LPTIM_ICR_ARRMCF            LPTIM_ICR_ARRMCF_Msk                       /*!< Autoreload match Clear Flag */
+#define LPTIM_ICR_EXTTRIGCF_Pos     (2U)
+#define LPTIM_ICR_EXTTRIGCF_Msk     (0x1UL << LPTIM_ICR_EXTTRIGCF_Pos)         /*!< 0x00000004 */
+#define LPTIM_ICR_EXTTRIGCF         LPTIM_ICR_EXTTRIGCF_Msk                    /*!< External trigger edge event Clear Flag */
+#define LPTIM_ICR_CMPOKCF_Pos       (3U)
+#define LPTIM_ICR_CMPOKCF_Msk       (0x1UL << LPTIM_ICR_CMPOKCF_Pos)           /*!< 0x00000008 */
+#define LPTIM_ICR_CMPOKCF           LPTIM_ICR_CMPOKCF_Msk                      /*!< Compare register update OK Clear Flag */
+#define LPTIM_ICR_ARROKCF_Pos       (4U)
+#define LPTIM_ICR_ARROKCF_Msk       (0x1UL << LPTIM_ICR_ARROKCF_Pos)           /*!< 0x00000010 */
+#define LPTIM_ICR_ARROKCF           LPTIM_ICR_ARROKCF_Msk                      /*!< Autoreload register update OK Clear Flag */
+#define LPTIM_ICR_UPCF_Pos          (5U)
+#define LPTIM_ICR_UPCF_Msk          (0x1UL << LPTIM_ICR_UPCF_Pos)              /*!< 0x00000020 */
+#define LPTIM_ICR_UPCF              LPTIM_ICR_UPCF_Msk                         /*!< Counter direction change down to up Clear Flag */
+#define LPTIM_ICR_DOWNCF_Pos        (6U)
+#define LPTIM_ICR_DOWNCF_Msk        (0x1UL << LPTIM_ICR_DOWNCF_Pos)            /*!< 0x00000040 */
+#define LPTIM_ICR_DOWNCF            LPTIM_ICR_DOWNCF_Msk                       /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define LPTIM_IER_CMPMIE_Pos        (0U)
+#define LPTIM_IER_CMPMIE_Msk        (0x1UL << LPTIM_IER_CMPMIE_Pos)            /*!< 0x00000001 */
+#define LPTIM_IER_CMPMIE            LPTIM_IER_CMPMIE_Msk                       /*!< Compare match Interrupt Enable */
+#define LPTIM_IER_ARRMIE_Pos        (1U)
+#define LPTIM_IER_ARRMIE_Msk        (0x1UL << LPTIM_IER_ARRMIE_Pos)            /*!< 0x00000002 */
+#define LPTIM_IER_ARRMIE            LPTIM_IER_ARRMIE_Msk                       /*!< Autoreload match Interrupt Enable */
+#define LPTIM_IER_EXTTRIGIE_Pos     (2U)
+#define LPTIM_IER_EXTTRIGIE_Msk     (0x1UL << LPTIM_IER_EXTTRIGIE_Pos)         /*!< 0x00000004 */
+#define LPTIM_IER_EXTTRIGIE         LPTIM_IER_EXTTRIGIE_Msk                    /*!< External trigger edge event Interrupt Enable */
+#define LPTIM_IER_CMPOKIE_Pos       (3U)
+#define LPTIM_IER_CMPOKIE_Msk       (0x1UL << LPTIM_IER_CMPOKIE_Pos)           /*!< 0x00000008 */
+#define LPTIM_IER_CMPOKIE           LPTIM_IER_CMPOKIE_Msk                      /*!< Compare register update OK Interrupt Enable */
+#define LPTIM_IER_ARROKIE_Pos       (4U)
+#define LPTIM_IER_ARROKIE_Msk       (0x1UL << LPTIM_IER_ARROKIE_Pos)           /*!< 0x00000010 */
+#define LPTIM_IER_ARROKIE           LPTIM_IER_ARROKIE_Msk                      /*!< Autoreload register update OK Interrupt Enable */
+#define LPTIM_IER_UPIE_Pos          (5U)
+#define LPTIM_IER_UPIE_Msk          (0x1UL << LPTIM_IER_UPIE_Pos)              /*!< 0x00000020 */
+#define LPTIM_IER_UPIE              LPTIM_IER_UPIE_Msk                         /*!< Counter direction change down to up Interrupt Enable */
+#define LPTIM_IER_DOWNIE_Pos        (6U)
+#define LPTIM_IER_DOWNIE_Msk        (0x1UL << LPTIM_IER_DOWNIE_Pos)            /*!< 0x00000040 */
+#define LPTIM_IER_DOWNIE            LPTIM_IER_DOWNIE_Msk                       /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define LPTIM_CFGR_CKSEL_Pos        (0U)
+#define LPTIM_CFGR_CKSEL_Msk        (0x1UL << LPTIM_CFGR_CKSEL_Pos)            /*!< 0x00000001 */
+#define LPTIM_CFGR_CKSEL            LPTIM_CFGR_CKSEL_Msk                       /*!< Clock selector */
+
+#define LPTIM_CFGR_CKPOL_Pos        (1U)
+#define LPTIM_CFGR_CKPOL_Msk        (0x3UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000006 */
+#define LPTIM_CFGR_CKPOL            LPTIM_CFGR_CKPOL_Msk                       /*!< CKPOL[1:0] bits (Clock polarity) */
+#define LPTIM_CFGR_CKPOL_0          (0x1UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000002 */
+#define LPTIM_CFGR_CKPOL_1          (0x2UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000004 */
+
+#define LPTIM_CFGR_CKFLT_Pos        (3U)
+#define LPTIM_CFGR_CKFLT_Msk        (0x3UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000018 */
+#define LPTIM_CFGR_CKFLT            LPTIM_CFGR_CKFLT_Msk                       /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define LPTIM_CFGR_CKFLT_0          (0x1UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000008 */
+#define LPTIM_CFGR_CKFLT_1          (0x2UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000010 */
+
+#define LPTIM_CFGR_TRGFLT_Pos       (6U)
+#define LPTIM_CFGR_TRGFLT_Msk       (0x3UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x000000C0 */
+#define LPTIM_CFGR_TRGFLT           LPTIM_CFGR_TRGFLT_Msk                      /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define LPTIM_CFGR_TRGFLT_0         (0x1UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x00000040 */
+#define LPTIM_CFGR_TRGFLT_1         (0x2UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x00000080 */
+
+#define LPTIM_CFGR_PRESC_Pos        (9U)
+#define LPTIM_CFGR_PRESC_Msk        (0x7UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000E00 */
+#define LPTIM_CFGR_PRESC            LPTIM_CFGR_PRESC_Msk                       /*!< PRESC[2:0] bits (Clock prescaler) */
+#define LPTIM_CFGR_PRESC_0          (0x1UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000200 */
+#define LPTIM_CFGR_PRESC_1          (0x2UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000400 */
+#define LPTIM_CFGR_PRESC_2          (0x4UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000800 */
+
+#define LPTIM_CFGR_TRIGSEL_Pos      (13U)
+#define LPTIM_CFGR_TRIGSEL_Msk      (0x7UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x0000E000 */
+#define LPTIM_CFGR_TRIGSEL          LPTIM_CFGR_TRIGSEL_Msk                     /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define LPTIM_CFGR_TRIGSEL_0        (0x1UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x00002000 */
+#define LPTIM_CFGR_TRIGSEL_1        (0x2UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x00004000 */
+#define LPTIM_CFGR_TRIGSEL_2        (0x4UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x00008000 */
+
+#define LPTIM_CFGR_TRIGEN_Pos       (17U)
+#define LPTIM_CFGR_TRIGEN_Msk       (0x3UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00060000 */
+#define LPTIM_CFGR_TRIGEN           LPTIM_CFGR_TRIGEN_Msk                      /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define LPTIM_CFGR_TRIGEN_0         (0x1UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00020000 */
+#define LPTIM_CFGR_TRIGEN_1         (0x2UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00040000 */
+
+#define LPTIM_CFGR_TIMOUT_Pos       (19U)
+#define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
+#define LPTIM_CFGR_WAVE_Pos         (20U)
+#define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
+#define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
+#define LPTIM_CFGR_WAVPOL_Pos       (21U)
+#define LPTIM_CFGR_WAVPOL_Msk       (0x1UL << LPTIM_CFGR_WAVPOL_Pos)           /*!< 0x00200000 */
+#define LPTIM_CFGR_WAVPOL           LPTIM_CFGR_WAVPOL_Msk                      /*!< Waveform shape polarity */
+#define LPTIM_CFGR_PRELOAD_Pos      (22U)
+#define LPTIM_CFGR_PRELOAD_Msk      (0x1UL << LPTIM_CFGR_PRELOAD_Pos)          /*!< 0x00400000 */
+#define LPTIM_CFGR_PRELOAD          LPTIM_CFGR_PRELOAD_Msk                     /*!< Reg update mode */
+#define LPTIM_CFGR_COUNTMODE_Pos    (23U)
+#define LPTIM_CFGR_COUNTMODE_Msk    (0x1UL << LPTIM_CFGR_COUNTMODE_Pos)        /*!< 0x00800000 */
+#define LPTIM_CFGR_COUNTMODE        LPTIM_CFGR_COUNTMODE_Msk                   /*!< Counter mode enable */
+#define LPTIM_CFGR_ENC_Pos          (24U)
+#define LPTIM_CFGR_ENC_Msk          (0x1UL << LPTIM_CFGR_ENC_Pos)              /*!< 0x01000000 */
+#define LPTIM_CFGR_ENC              LPTIM_CFGR_ENC_Msk                         /*!< Encoder mode enable */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define LPTIM_CR_ENABLE_Pos         (0U)
+#define LPTIM_CR_ENABLE_Msk         (0x1UL << LPTIM_CR_ENABLE_Pos)             /*!< 0x00000001 */
+#define LPTIM_CR_ENABLE             LPTIM_CR_ENABLE_Msk                        /*!< LPTIMer enable */
+#define LPTIM_CR_SNGSTRT_Pos        (1U)
+#define LPTIM_CR_SNGSTRT_Msk        (0x1UL << LPTIM_CR_SNGSTRT_Pos)            /*!< 0x00000002 */
+#define LPTIM_CR_SNGSTRT            LPTIM_CR_SNGSTRT_Msk                       /*!< Timer start in single mode */
+#define LPTIM_CR_CNTSTRT_Pos        (2U)
+#define LPTIM_CR_CNTSTRT_Msk        (0x1UL << LPTIM_CR_CNTSTRT_Pos)            /*!< 0x00000004 */
+#define LPTIM_CR_CNTSTRT            LPTIM_CR_CNTSTRT_Msk                       /*!< Timer start in continuous mode */
+#define LPTIM_CR_COUNTRST_Pos       (3U)
+#define LPTIM_CR_COUNTRST_Msk       (0x1UL << LPTIM_CR_COUNTRST_Pos)           /*!< 0x00000008 */
+#define LPTIM_CR_COUNTRST           LPTIM_CR_COUNTRST_Msk                      /*!< Counter reset */
+#define LPTIM_CR_RSTARE_Pos         (4U)
+#define LPTIM_CR_RSTARE_Msk         (0x1UL << LPTIM_CR_RSTARE_Pos)             /*!< 0x00000010 */
+#define LPTIM_CR_RSTARE             LPTIM_CR_RSTARE_Msk                        /*!< Reset after read enable */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define LPTIM_CMP_CMP_Pos           (0U)
+#define LPTIM_CMP_CMP_Msk           (0xFFFFUL << LPTIM_CMP_CMP_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CMP_CMP               LPTIM_CMP_CMP_Msk                          /*!< Compare register */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define LPTIM_ARR_ARR_Pos           (0U)
+#define LPTIM_ARR_ARR_Msk           (0xFFFFUL << LPTIM_ARR_ARR_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_ARR_ARR               LPTIM_ARR_ARR_Msk                          /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define LPTIM_CNT_CNT_Pos           (0U)
+#define LPTIM_CNT_CNT_Msk           (0xFFFFUL << LPTIM_CNT_CNT_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CNT_CNT               LPTIM_CNT_CNT_Msk                          /*!< Counter register */
+
+/******************  Bit definition for LPTIM_CFGR2 register  *******************/
+#define LPTIM_CFGR2_IN1SEL_Pos      (0U)
+#define LPTIM_CFGR2_IN1SEL_Msk      (0xFUL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x0000000F */
+#define LPTIM_CFGR2_IN1SEL          LPTIM_CFGR2_IN1SEL_Msk                     /*!< CFGR2[3:0] bits (INPUT1 selection) */
+#define LPTIM_CFGR2_IN1SEL_0        (0x1UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000001 */
+#define LPTIM_CFGR2_IN1SEL_1        (0x2UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000002 */
+#define LPTIM_CFGR2_IN1SEL_2        (0x4UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000004 */
+#define LPTIM_CFGR2_IN1SEL_3        (0x8UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000008 */
+
+#define LPTIM_CFGR2_IN2SEL_Pos      (4U)
+#define LPTIM_CFGR2_IN2SEL_Msk      (0xFUL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x000000F0 */
+#define LPTIM_CFGR2_IN2SEL          LPTIM_CFGR2_IN2SEL_Msk                     /*!< CFGR2[7:4] bits (INPUT2 selection) */
+#define LPTIM_CFGR2_IN2SEL_0        (0x1UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000010 */
+#define LPTIM_CFGR2_IN2SEL_1        (0x2UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000020 */
+#define LPTIM_CFGR2_IN2SEL_2        (0x4UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000040 */
+#define LPTIM_CFGR2_IN2SEL_3        (0x8UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000080 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog Comparators (COMP)                             */
+/*                                                                            */
+/******************************************************************************/
+/**********************  Bit definition for COMP_CSR register  ****************/
+#define COMP_CSR_EN_Pos            (0U)
+#define COMP_CSR_EN_Msk            (0x1UL << COMP_CSR_EN_Pos)                  /*!< 0x00000001 */
+#define COMP_CSR_EN                COMP_CSR_EN_Msk                             /*!< Comparator enable */
+
+#define COMP_CSR_INMSEL_Pos        (4U)
+#define COMP_CSR_INMSEL_Msk        (0xFUL << COMP_CSR_INMSEL_Pos)              /*!< 0x000000F0 */
+#define COMP_CSR_INMSEL            COMP_CSR_INMSEL_Msk                         /*!< Comparator input minus selection */
+#define COMP_CSR_INMSEL_0          (0x1UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000010 */
+#define COMP_CSR_INMSEL_1          (0x2UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000020 */
+#define COMP_CSR_INMSEL_2          (0x4UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000040 */
+#define COMP_CSR_INMSEL_3          (0x8UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000080 */
+
+#define COMP_CSR_INPSEL_Pos        (8U)
+#define COMP_CSR_INPSEL_Msk        (0x3UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000300 */
+#define COMP_CSR_INPSEL            COMP_CSR_INPSEL_Msk                         /*!< Comparator plus minus selection */
+#define COMP_CSR_INPSEL_0          (0x1UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000100 */
+#define COMP_CSR_INPSEL_1          (0x2UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000200 */
+
+#define COMP_CSR_WINMODE_Pos       (11U)
+#define COMP_CSR_WINMODE_Msk       (0x1UL << COMP_CSR_WINMODE_Pos)             /*!< 0x00000800 */
+#define COMP_CSR_WINMODE           COMP_CSR_WINMODE_Msk                        /*!< Pair of comparators window mode. Bit intended to be used with COMP common instance (COMP_Common_TypeDef) */
+#define COMP_CSR_WINOUT_Pos        (14U)
+#define COMP_CSR_WINOUT_Msk        (0x1UL << COMP_CSR_WINOUT_Pos)              /*!< 0x00004000 */
+#define COMP_CSR_WINOUT            COMP_CSR_WINOUT_Msk                         /*!< Pair of comparators window output level. Bit intended to be used with COMP common instance (COMP_Common_TypeDef) */
+
+#define COMP_CSR_POLARITY_Pos      (15U)
+#define COMP_CSR_POLARITY_Msk      (0x1UL << COMP_CSR_POLARITY_Pos)            /*!< 0x00008000 */
+#define COMP_CSR_POLARITY          COMP_CSR_POLARITY_Msk                       /*!< Comparator output polarity */
+
+#define COMP_CSR_HYST_Pos          (16U)
+#define COMP_CSR_HYST_Msk          (0x3UL << COMP_CSR_HYST_Pos)                /*!< 0x00030000 */
+#define COMP_CSR_HYST              COMP_CSR_HYST_Msk                           /*!< Comparator input hysteresis */
+#define COMP_CSR_HYST_0            (0x1UL << COMP_CSR_HYST_Pos)                /*!< 0x00010000 */
+#define COMP_CSR_HYST_1            (0x2UL << COMP_CSR_HYST_Pos)                /*!< 0x00020000 */
+
+#define COMP_CSR_PWRMODE_Pos       (18U)
+#define COMP_CSR_PWRMODE_Msk       (0x3UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x000C0000 */
+#define COMP_CSR_PWRMODE           COMP_CSR_PWRMODE_Msk                        /*!< Comparator power mode */
+#define COMP_CSR_PWRMODE_0         (0x1UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00040000 */
+#define COMP_CSR_PWRMODE_1         (0x2UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00080000 */
+
+#define COMP_CSR_BLANKING_Pos      (20U)
+#define COMP_CSR_BLANKING_Msk      (0x1FUL << COMP_CSR_BLANKING_Pos)           /*!< 0x01F00000 */
+#define COMP_CSR_BLANKING          COMP_CSR_BLANKING_Msk                       /*!< Comparator blanking source */
+#define COMP_CSR_BLANKING_0        (0x01UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00100000 */
+#define COMP_CSR_BLANKING_1        (0x02UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00200000 */
+#define COMP_CSR_BLANKING_2        (0x04UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00400000 */
+#define COMP_CSR_BLANKING_3        (0x08UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00800000 */
+#define COMP_CSR_BLANKING_4        (0x10UL << COMP_CSR_BLANKING_Pos)           /*!< 0x01000000 */
+
+#define COMP_CSR_VALUE_Pos         (30U)
+#define COMP_CSR_VALUE_Msk         (0x1UL << COMP_CSR_VALUE_Pos)               /*!< 0x40000000 */
+#define COMP_CSR_VALUE             COMP_CSR_VALUE_Msk                          /*!< Comparator output level */
+
+#define COMP_CSR_LOCK_Pos          (31U)
+#define COMP_CSR_LOCK_Msk          (0x1UL << COMP_CSR_LOCK_Pos)                /*!< 0x80000000 */
+#define COMP_CSR_LOCK              COMP_CSR_LOCK_Msk                           /*!< Comparator lock */
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_UE_Pos             (0U)
+#define USART_CR1_UE_Msk             (0x1UL << USART_CR1_UE_Pos)               /*!< 0x00000001 */
+#define USART_CR1_UE                 USART_CR1_UE_Msk                          /*!< USART Enable */
+#define USART_CR1_UESM_Pos           (1U)
+#define USART_CR1_UESM_Msk           (0x1UL << USART_CR1_UESM_Pos)             /*!< 0x00000002 */
+#define USART_CR1_UESM               USART_CR1_UESM_Msk                        /*!< USART Enable in STOP Mode */
+#define USART_CR1_RE_Pos             (2U)
+#define USART_CR1_RE_Msk             (0x1UL << USART_CR1_RE_Pos)               /*!< 0x00000004 */
+#define USART_CR1_RE                 USART_CR1_RE_Msk                          /*!< Receiver Enable */
+#define USART_CR1_TE_Pos             (3U)
+#define USART_CR1_TE_Msk             (0x1UL << USART_CR1_TE_Pos)               /*!< 0x00000008 */
+#define USART_CR1_TE                 USART_CR1_TE_Msk                          /*!< Transmitter Enable */
+#define USART_CR1_IDLEIE_Pos         (4U)
+#define USART_CR1_IDLEIE_Msk         (0x1UL << USART_CR1_IDLEIE_Pos)           /*!< 0x00000010 */
+#define USART_CR1_IDLEIE             USART_CR1_IDLEIE_Msk                      /*!< IDLE Interrupt Enable */
+#define USART_CR1_RXNEIE_RXFNEIE_Pos   (5U)
+#define USART_CR1_RXNEIE_RXFNEIE_Msk   (0x1UL << USART_CR1_RXNEIE_RXFNEIE_Pos) /*!< 0x00000020 */
+#define USART_CR1_RXNEIE_RXFNEIE       USART_CR1_RXNEIE_RXFNEIE_Msk            /*!< RXNE/RXFIFO not empty Interrupt Enable */
+#define USART_CR1_TCIE_Pos           (6U)
+#define USART_CR1_TCIE_Msk           (0x1UL << USART_CR1_TCIE_Pos)             /*!< 0x00000040 */
+#define USART_CR1_TCIE               USART_CR1_TCIE_Msk                        /*!< Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_TXFNFIE_Pos  (7U)
+#define USART_CR1_TXEIE_TXFNFIE_Msk   (0x1UL << USART_CR1_TXEIE_TXFNFIE_Pos)   /*!< 0x00000080 */
+#define USART_CR1_TXEIE_TXFNFIE       USART_CR1_TXEIE_TXFNFIE_Msk              /*!< TXE/TXFIFO not full Interrupt Enable */
+#define USART_CR1_PEIE_Pos           (8U)
+#define USART_CR1_PEIE_Msk           (0x1UL << USART_CR1_PEIE_Pos)             /*!< 0x00000100 */
+#define USART_CR1_PEIE               USART_CR1_PEIE_Msk                        /*!< PE Interrupt Enable */
+#define USART_CR1_PS_Pos             (9U)
+#define USART_CR1_PS_Msk             (0x1UL << USART_CR1_PS_Pos)               /*!< 0x00000200 */
+#define USART_CR1_PS                 USART_CR1_PS_Msk                          /*!< Parity Selection */
+#define USART_CR1_PCE_Pos            (10U)
+#define USART_CR1_PCE_Msk            (0x1UL << USART_CR1_PCE_Pos)              /*!< 0x00000400 */
+#define USART_CR1_PCE                USART_CR1_PCE_Msk                         /*!< Parity Control Enable */
+#define USART_CR1_WAKE_Pos           (11U)
+#define USART_CR1_WAKE_Msk           (0x1UL << USART_CR1_WAKE_Pos)             /*!< 0x00000800 */
+#define USART_CR1_WAKE               USART_CR1_WAKE_Msk                        /*!< Receiver Wakeup method */
+#define USART_CR1_M_Pos              (12U)
+#define USART_CR1_M_Msk              (0x10001UL << USART_CR1_M_Pos)            /*!< 0x10001000 */
+#define USART_CR1_M                  USART_CR1_M_Msk                           /*!< Word length */
+#define USART_CR1_M0_Pos             (12U)
+#define USART_CR1_M0_Msk             (0x1UL << USART_CR1_M0_Pos)               /*!< 0x00001000 */
+#define USART_CR1_M0                 USART_CR1_M0_Msk                          /*!< Word length - Bit 0 */
+#define USART_CR1_MME_Pos            (13U)
+#define USART_CR1_MME_Msk            (0x1UL << USART_CR1_MME_Pos)              /*!< 0x00002000 */
+#define USART_CR1_MME                USART_CR1_MME_Msk                         /*!< Mute Mode Enable */
+#define USART_CR1_CMIE_Pos           (14U)
+#define USART_CR1_CMIE_Msk           (0x1UL << USART_CR1_CMIE_Pos)             /*!< 0x00004000 */
+#define USART_CR1_CMIE               USART_CR1_CMIE_Msk                        /*!< Character match interrupt enable */
+#define USART_CR1_OVER8_Pos          (15U)
+#define USART_CR1_OVER8_Msk          (0x1UL << USART_CR1_OVER8_Pos)            /*!< 0x00008000 */
+#define USART_CR1_OVER8              USART_CR1_OVER8_Msk                       /*!< Oversampling by 8-bit or 16-bit mode */
+#define USART_CR1_DEDT_Pos           (16U)
+#define USART_CR1_DEDT_Msk           (0x1FUL << USART_CR1_DEDT_Pos)            /*!< 0x001F0000 */
+#define USART_CR1_DEDT               USART_CR1_DEDT_Msk                        /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define USART_CR1_DEDT_0             (0x01UL << USART_CR1_DEDT_Pos)            /*!< 0x00010000 */
+#define USART_CR1_DEDT_1             (0x02UL << USART_CR1_DEDT_Pos)            /*!< 0x00020000 */
+#define USART_CR1_DEDT_2             (0x04UL << USART_CR1_DEDT_Pos)            /*!< 0x00040000 */
+#define USART_CR1_DEDT_3             (0x08UL << USART_CR1_DEDT_Pos)            /*!< 0x00080000 */
+#define USART_CR1_DEDT_4             (0x10UL << USART_CR1_DEDT_Pos)            /*!< 0x00100000 */
+#define USART_CR1_DEAT_Pos           (21U)
+#define USART_CR1_DEAT_Msk           (0x1FUL << USART_CR1_DEAT_Pos)            /*!< 0x03E00000 */
+#define USART_CR1_DEAT               USART_CR1_DEAT_Msk                        /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define USART_CR1_DEAT_0             (0x01UL << USART_CR1_DEAT_Pos)            /*!< 0x00200000 */
+#define USART_CR1_DEAT_1             (0x02UL << USART_CR1_DEAT_Pos)            /*!< 0x00400000 */
+#define USART_CR1_DEAT_2             (0x04UL << USART_CR1_DEAT_Pos)            /*!< 0x00800000 */
+#define USART_CR1_DEAT_3             (0x08UL << USART_CR1_DEAT_Pos)            /*!< 0x01000000 */
+#define USART_CR1_DEAT_4             (0x10UL << USART_CR1_DEAT_Pos)            /*!< 0x02000000 */
+#define USART_CR1_RTOIE_Pos          (26U)
+#define USART_CR1_RTOIE_Msk          (0x1UL << USART_CR1_RTOIE_Pos)            /*!< 0x04000000 */
+#define USART_CR1_RTOIE              USART_CR1_RTOIE_Msk                       /*!< Receive Time Out interrupt enable */
+#define USART_CR1_EOBIE_Pos          (27U)
+#define USART_CR1_EOBIE_Msk          (0x1UL << USART_CR1_EOBIE_Pos)            /*!< 0x08000000 */
+#define USART_CR1_EOBIE              USART_CR1_EOBIE_Msk                       /*!< End of Block interrupt enable */
+#define USART_CR1_M1_Pos             (28U)
+#define USART_CR1_M1_Msk             (0x1UL << USART_CR1_M1_Pos)               /*!< 0x10000000 */
+#define USART_CR1_M1                 USART_CR1_M1_Msk                          /*!< Word length - Bit 1 */
+#define USART_CR1_FIFOEN_Pos         (29U)
+#define USART_CR1_FIFOEN_Msk         (0x1UL << USART_CR1_FIFOEN_Pos)           /*!< 0x20000000 */
+#define USART_CR1_FIFOEN             USART_CR1_FIFOEN_Msk                      /*!< FIFO mode enable */
+#define USART_CR1_TXFEIE_Pos         (30U)
+#define USART_CR1_TXFEIE_Msk         (0x1UL << USART_CR1_TXFEIE_Pos)           /*!< 0x40000000 */
+#define USART_CR1_TXFEIE             USART_CR1_TXFEIE_Msk                      /*!< TXFIFO empty interrupt enable */
+#define USART_CR1_RXFFIE_Pos         (31U)
+#define USART_CR1_RXFFIE_Msk         (0x1UL << USART_CR1_RXFFIE_Pos)           /*!< 0x80000000 */
+#define USART_CR1_RXFFIE             USART_CR1_RXFFIE_Msk                      /*!< RXFIFO Full interrupt enable */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_SLVEN_Pos          (0U)
+#define USART_CR2_SLVEN_Msk          (0x1UL << USART_CR2_SLVEN_Pos)            /*!< 0x00000001 */
+#define USART_CR2_SLVEN              USART_CR2_SLVEN_Msk                       /*!< Synchronous Slave mode enable */
+#define USART_CR2_DIS_NSS_Pos        (3U)
+#define USART_CR2_DIS_NSS_Msk        (0x1UL << USART_CR2_DIS_NSS_Pos)          /*!< 0x00000008 */
+#define USART_CR2_DIS_NSS            USART_CR2_DIS_NSS_Msk                     /*!< NSS input pin disable for SPI slave selection */
+#define USART_CR2_ADDM7_Pos          (4U)
+#define USART_CR2_ADDM7_Msk          (0x1UL << USART_CR2_ADDM7_Pos)            /*!< 0x00000010 */
+#define USART_CR2_ADDM7              USART_CR2_ADDM7_Msk                       /*!< 7-bit or 4-bit Address Detection */
+#define USART_CR2_LBDL_Pos           (5U)
+#define USART_CR2_LBDL_Msk           (0x1UL << USART_CR2_LBDL_Pos)             /*!< 0x00000020 */
+#define USART_CR2_LBDL               USART_CR2_LBDL_Msk                        /*!< LIN Break Detection Length */
+#define USART_CR2_LBDIE_Pos          (6U)
+#define USART_CR2_LBDIE_Msk          (0x1UL << USART_CR2_LBDIE_Pos)            /*!< 0x00000040 */
+#define USART_CR2_LBDIE              USART_CR2_LBDIE_Msk                       /*!< LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos           (8U)
+#define USART_CR2_LBCL_Msk           (0x1UL << USART_CR2_LBCL_Pos)             /*!< 0x00000100 */
+#define USART_CR2_LBCL               USART_CR2_LBCL_Msk                        /*!< Last Bit Clock pulse */
+#define USART_CR2_CPHA_Pos           (9U)
+#define USART_CR2_CPHA_Msk           (0x1UL << USART_CR2_CPHA_Pos)             /*!< 0x00000200 */
+#define USART_CR2_CPHA               USART_CR2_CPHA_Msk                        /*!< Clock Phase */
+#define USART_CR2_CPOL_Pos           (10U)
+#define USART_CR2_CPOL_Msk           (0x1UL << USART_CR2_CPOL_Pos)             /*!< 0x00000400 */
+#define USART_CR2_CPOL               USART_CR2_CPOL_Msk                        /*!< Clock Polarity */
+#define USART_CR2_CLKEN_Pos          (11U)
+#define USART_CR2_CLKEN_Msk          (0x1UL << USART_CR2_CLKEN_Pos)            /*!< 0x00000800 */
+#define USART_CR2_CLKEN              USART_CR2_CLKEN_Msk                       /*!< Clock Enable */
+#define USART_CR2_STOP_Pos           (12U)
+#define USART_CR2_STOP_Msk           (0x3UL << USART_CR2_STOP_Pos)             /*!< 0x00003000 */
+#define USART_CR2_STOP               USART_CR2_STOP_Msk                        /*!< STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0             (0x1UL << USART_CR2_STOP_Pos)             /*!< 0x00001000 */
+#define USART_CR2_STOP_1             (0x2UL << USART_CR2_STOP_Pos)             /*!< 0x00002000 */
+#define USART_CR2_LINEN_Pos          (14U)
+#define USART_CR2_LINEN_Msk          (0x1UL << USART_CR2_LINEN_Pos)            /*!< 0x00004000 */
+#define USART_CR2_LINEN              USART_CR2_LINEN_Msk                       /*!< LIN mode enable */
+#define USART_CR2_SWAP_Pos           (15U)
+#define USART_CR2_SWAP_Msk           (0x1UL << USART_CR2_SWAP_Pos)             /*!< 0x00008000 */
+#define USART_CR2_SWAP               USART_CR2_SWAP_Msk                        /*!< SWAP TX/RX pins */
+#define USART_CR2_RXINV_Pos          (16U)
+#define USART_CR2_RXINV_Msk          (0x1UL << USART_CR2_RXINV_Pos)            /*!< 0x00010000 */
+#define USART_CR2_RXINV              USART_CR2_RXINV_Msk                       /*!< RX pin active level inversion */
+#define USART_CR2_TXINV_Pos          (17U)
+#define USART_CR2_TXINV_Msk          (0x1UL << USART_CR2_TXINV_Pos)            /*!< 0x00020000 */
+#define USART_CR2_TXINV              USART_CR2_TXINV_Msk                       /*!< TX pin active level inversion */
+#define USART_CR2_DATAINV_Pos        (18U)
+#define USART_CR2_DATAINV_Msk        (0x1UL << USART_CR2_DATAINV_Pos)          /*!< 0x00040000 */
+#define USART_CR2_DATAINV            USART_CR2_DATAINV_Msk                     /*!< Binary data inversion */
+#define USART_CR2_MSBFIRST_Pos       (19U)
+#define USART_CR2_MSBFIRST_Msk       (0x1UL << USART_CR2_MSBFIRST_Pos)         /*!< 0x00080000 */
+#define USART_CR2_MSBFIRST           USART_CR2_MSBFIRST_Msk                    /*!< Most Significant Bit First */
+#define USART_CR2_ABREN_Pos          (20U)
+#define USART_CR2_ABREN_Msk          (0x1UL << USART_CR2_ABREN_Pos)            /*!< 0x00100000 */
+#define USART_CR2_ABREN              USART_CR2_ABREN_Msk                       /*!< Auto Baud-Rate Enable*/
+#define USART_CR2_ABRMODE_Pos        (21U)
+#define USART_CR2_ABRMODE_Msk        (0x3UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00600000 */
+#define USART_CR2_ABRMODE            USART_CR2_ABRMODE_Msk                     /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define USART_CR2_ABRMODE_0          (0x1UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00200000 */
+#define USART_CR2_ABRMODE_1          (0x2UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00400000 */
+#define USART_CR2_RTOEN_Pos          (23U)
+#define USART_CR2_RTOEN_Msk          (0x1UL << USART_CR2_RTOEN_Pos)            /*!< 0x00800000 */
+#define USART_CR2_RTOEN              USART_CR2_RTOEN_Msk                       /*!< Receiver Time-Out enable */
+#define USART_CR2_ADD_Pos            (24U)
+#define USART_CR2_ADD_Msk            (0xFFUL << USART_CR2_ADD_Pos)             /*!< 0xFF000000 */
+#define USART_CR2_ADD                USART_CR2_ADD_Msk                         /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos            (0U)
+#define USART_CR3_EIE_Msk            (0x1UL << USART_CR3_EIE_Pos)              /*!< 0x00000001 */
+#define USART_CR3_EIE                USART_CR3_EIE_Msk                         /*!< Error Interrupt Enable */
+#define USART_CR3_IREN_Pos           (1U)
+#define USART_CR3_IREN_Msk           (0x1UL << USART_CR3_IREN_Pos)             /*!< 0x00000002 */
+#define USART_CR3_IREN               USART_CR3_IREN_Msk                        /*!< IrDA mode Enable */
+#define USART_CR3_IRLP_Pos           (2U)
+#define USART_CR3_IRLP_Msk           (0x1UL << USART_CR3_IRLP_Pos)             /*!< 0x00000004 */
+#define USART_CR3_IRLP               USART_CR3_IRLP_Msk                        /*!< IrDA Low-Power */
+#define USART_CR3_HDSEL_Pos          (3U)
+#define USART_CR3_HDSEL_Msk          (0x1UL << USART_CR3_HDSEL_Pos)            /*!< 0x00000008 */
+#define USART_CR3_HDSEL              USART_CR3_HDSEL_Msk                       /*!< Half-Duplex Selection */
+#define USART_CR3_NACK_Pos           (4U)
+#define USART_CR3_NACK_Msk           (0x1UL << USART_CR3_NACK_Pos)             /*!< 0x00000010 */
+#define USART_CR3_NACK               USART_CR3_NACK_Msk                        /*!< SmartCard NACK enable */
+#define USART_CR3_SCEN_Pos           (5U)
+#define USART_CR3_SCEN_Msk           (0x1UL << USART_CR3_SCEN_Pos)             /*!< 0x00000020 */
+#define USART_CR3_SCEN               USART_CR3_SCEN_Msk                        /*!< SmartCard mode enable */
+#define USART_CR3_DMAR_Pos           (6U)
+#define USART_CR3_DMAR_Msk           (0x1UL << USART_CR3_DMAR_Pos)             /*!< 0x00000040 */
+#define USART_CR3_DMAR               USART_CR3_DMAR_Msk                        /*!< DMA Enable Receiver */
+#define USART_CR3_DMAT_Pos           (7U)
+#define USART_CR3_DMAT_Msk           (0x1UL << USART_CR3_DMAT_Pos)             /*!< 0x00000080 */
+#define USART_CR3_DMAT               USART_CR3_DMAT_Msk                        /*!< DMA Enable Transmitter */
+#define USART_CR3_RTSE_Pos           (8U)
+#define USART_CR3_RTSE_Msk           (0x1UL << USART_CR3_RTSE_Pos)             /*!< 0x00000100 */
+#define USART_CR3_RTSE               USART_CR3_RTSE_Msk                        /*!< RTS Enable */
+#define USART_CR3_CTSE_Pos           (9U)
+#define USART_CR3_CTSE_Msk           (0x1UL << USART_CR3_CTSE_Pos)             /*!< 0x00000200 */
+#define USART_CR3_CTSE               USART_CR3_CTSE_Msk                        /*!< CTS Enable */
+#define USART_CR3_CTSIE_Pos          (10U)
+#define USART_CR3_CTSIE_Msk          (0x1UL << USART_CR3_CTSIE_Pos)            /*!< 0x00000400 */
+#define USART_CR3_CTSIE              USART_CR3_CTSIE_Msk                       /*!< CTS Interrupt Enable */
+#define USART_CR3_ONEBIT_Pos         (11U)
+#define USART_CR3_ONEBIT_Msk         (0x1UL << USART_CR3_ONEBIT_Pos)           /*!< 0x00000800 */
+#define USART_CR3_ONEBIT             USART_CR3_ONEBIT_Msk                      /*!< One sample bit method enable */
+#define USART_CR3_OVRDIS_Pos         (12U)
+#define USART_CR3_OVRDIS_Msk         (0x1UL << USART_CR3_OVRDIS_Pos)           /*!< 0x00001000 */
+#define USART_CR3_OVRDIS             USART_CR3_OVRDIS_Msk                      /*!< Overrun Disable */
+#define USART_CR3_DDRE_Pos           (13U)
+#define USART_CR3_DDRE_Msk           (0x1UL << USART_CR3_DDRE_Pos)             /*!< 0x00002000 */
+#define USART_CR3_DDRE               USART_CR3_DDRE_Msk                        /*!< DMA Disable on Reception Error */
+#define USART_CR3_DEM_Pos            (14U)
+#define USART_CR3_DEM_Msk            (0x1UL << USART_CR3_DEM_Pos)              /*!< 0x00004000 */
+#define USART_CR3_DEM                USART_CR3_DEM_Msk                         /*!< Driver Enable Mode */
+#define USART_CR3_DEP_Pos            (15U)
+#define USART_CR3_DEP_Msk            (0x1UL << USART_CR3_DEP_Pos)              /*!< 0x00008000 */
+#define USART_CR3_DEP                USART_CR3_DEP_Msk                         /*!< Driver Enable Polarity Selection */
+#define USART_CR3_SCARCNT_Pos        (17U)
+#define USART_CR3_SCARCNT_Msk        (0x7UL << USART_CR3_SCARCNT_Pos)          /*!< 0x000E0000 */
+#define USART_CR3_SCARCNT            USART_CR3_SCARCNT_Msk                     /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define USART_CR3_SCARCNT_0          (0x1UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00020000 */
+#define USART_CR3_SCARCNT_1          (0x2UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00040000 */
+#define USART_CR3_SCARCNT_2          (0x4UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00080000 */
+#define USART_CR3_WUS_Pos            (20U)
+#define USART_CR3_WUS_Msk            (0x3UL << USART_CR3_WUS_Pos)              /*!< 0x00300000 */
+#define USART_CR3_WUS                USART_CR3_WUS_Msk                         /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define USART_CR3_WUS_0              (0x1UL << USART_CR3_WUS_Pos)              /*!< 0x00100000 */
+#define USART_CR3_WUS_1              (0x2UL << USART_CR3_WUS_Pos)              /*!< 0x00200000 */
+#define USART_CR3_WUFIE_Pos          (22U)
+#define USART_CR3_WUFIE_Msk          (0x1UL << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
+#define USART_CR3_WUFIE              USART_CR3_WUFIE_Msk                       /*!< Wake Up Interrupt Enable */
+#define USART_CR3_TXFTIE_Pos         (23U)
+#define USART_CR3_TXFTIE_Msk         (0x1UL << USART_CR3_TXFTIE_Pos)           /*!< 0x00800000 */
+#define USART_CR3_TXFTIE             USART_CR3_TXFTIE_Msk                      /*!< TXFIFO threshold interrupt enable */
+#define USART_CR3_TCBGTIE_Pos        (24U)
+#define USART_CR3_TCBGTIE_Msk        (0x1UL << USART_CR3_TCBGTIE_Pos)          /*!< 0x01000000 */
+#define USART_CR3_TCBGTIE            USART_CR3_TCBGTIE_Msk                     /*!< Transmission Complete Before Guard Time Interrupt Enable */
+#define USART_CR3_RXFTCFG_Pos        (25U)
+#define USART_CR3_RXFTCFG_Msk        (0x7UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x0E000000 */
+#define USART_CR3_RXFTCFG            USART_CR3_RXFTCFG_Msk                     /*!< RXFIFO FIFO threshold configuration */
+#define USART_CR3_RXFTCFG_0          (0x1UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x02000000 */
+#define USART_CR3_RXFTCFG_1          (0x2UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x04000000 */
+#define USART_CR3_RXFTCFG_2          (0x4UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x08000000 */
+#define USART_CR3_RXFTIE_Pos         (28U)
+#define USART_CR3_RXFTIE_Msk         (0x1UL << USART_CR3_RXFTIE_Pos)           /*!< 0x10000000 */
+#define USART_CR3_RXFTIE             USART_CR3_RXFTIE_Msk                      /*!< RXFIFO threshold interrupt enable */
+#define USART_CR3_TXFTCFG_Pos        (29U)
+#define USART_CR3_TXFTCFG_Msk        (0x7UL << USART_CR3_TXFTCFG_Pos)          /*!< 0xE0000000 */
+#define USART_CR3_TXFTCFG            USART_CR3_TXFTCFG_Msk                     /*!< TXFIFO threshold configuration */
+#define USART_CR3_TXFTCFG_0          (0x1UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x20000000 */
+#define USART_CR3_TXFTCFG_1          (0x2UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x40000000 */
+#define USART_CR3_TXFTCFG_2          (0x4UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x80000000 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_LPUART_Pos         (0U)
+#define USART_BRR_LPUART_Msk         (0xFFFFFUL << USART_BRR_LPUART_Pos)       /*!< 0x000FFFFF */
+#define USART_BRR_LPUART             USART_BRR_LPUART_Msk                      /*!< LPUART Baud rate register [19:0] */
+#define USART_BRR_BRR                ((uint16_t)0xFFFF)                        /*!< USART  Baud rate register [15:0] */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos           (0U)
+#define USART_GTPR_PSC_Msk           (0xFFUL << USART_GTPR_PSC_Pos)            /*!< 0x000000FF */
+#define USART_GTPR_PSC               USART_GTPR_PSC_Msk                        /*!< PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_GT_Pos            (8U)
+#define USART_GTPR_GT_Msk            (0xFFUL << USART_GTPR_GT_Pos)             /*!< 0x0000FF00 */
+#define USART_GTPR_GT                USART_GTPR_GT_Msk                         /*!< GT[7:0] bits (Guard time value) */
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define USART_RTOR_RTO_Pos           (0U)
+#define USART_RTOR_RTO_Msk           (0xFFFFFFUL << USART_RTOR_RTO_Pos)        /*!< 0x00FFFFFF */
+#define USART_RTOR_RTO               USART_RTOR_RTO_Msk                        /*!< Receiver Time Out Value */
+#define USART_RTOR_BLEN_Pos          (24U)
+#define USART_RTOR_BLEN_Msk          (0xFFUL << USART_RTOR_BLEN_Pos)           /*!< 0xFF000000 */
+#define USART_RTOR_BLEN              USART_RTOR_BLEN_Msk                       /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define USART_RQR_ABRRQ        ((uint16_t)0x0001)                              /*!< Auto-Baud Rate Request */
+#define USART_RQR_SBKRQ        ((uint16_t)0x0002)                              /*!< Send Break Request */
+#define USART_RQR_MMRQ         ((uint16_t)0x0004)                              /*!< Mute Mode Request */
+#define USART_RQR_RXFRQ        ((uint16_t)0x0008)                              /*!< Receive Data flush Request */
+#define USART_RQR_TXFRQ        ((uint16_t)0x0010)                              /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define USART_ISR_PE_Pos             (0U)
+#define USART_ISR_PE_Msk             (0x1UL << USART_ISR_PE_Pos)               /*!< 0x00000001 */
+#define USART_ISR_PE                 USART_ISR_PE_Msk                          /*!< Parity Error */
+#define USART_ISR_FE_Pos             (1U)
+#define USART_ISR_FE_Msk             (0x1UL << USART_ISR_FE_Pos)               /*!< 0x00000002 */
+#define USART_ISR_FE                 USART_ISR_FE_Msk                          /*!< Framing Error */
+#define USART_ISR_NE_Pos             (2U)
+#define USART_ISR_NE_Msk             (0x1UL << USART_ISR_NE_Pos)               /*!< 0x00000004 */
+#define USART_ISR_NE                 USART_ISR_NE_Msk                          /*!< Noise detected Flag */
+#define USART_ISR_ORE_Pos            (3U)
+#define USART_ISR_ORE_Msk            (0x1UL << USART_ISR_ORE_Pos)              /*!< 0x00000008 */
+#define USART_ISR_ORE                USART_ISR_ORE_Msk                         /*!< OverRun Error */
+#define USART_ISR_IDLE_Pos           (4U)
+#define USART_ISR_IDLE_Msk           (0x1UL << USART_ISR_IDLE_Pos)             /*!< 0x00000010 */
+#define USART_ISR_IDLE               USART_ISR_IDLE_Msk                        /*!< IDLE line detected */
+#define USART_ISR_RXNE_RXFNE_Pos     (5U)
+#define USART_ISR_RXNE_RXFNE_Msk     (0x1UL << USART_ISR_RXNE_RXFNE_Pos)       /*!< 0x00000020 */
+#define USART_ISR_RXNE_RXFNE         USART_ISR_RXNE_RXFNE_Msk                  /*!< Read Data Register Not Empty/RXFIFO Not Empty */
+#define USART_ISR_TC_Pos             (6U)
+#define USART_ISR_TC_Msk             (0x1UL << USART_ISR_TC_Pos)               /*!< 0x00000040 */
+#define USART_ISR_TC                 USART_ISR_TC_Msk                          /*!< Transmission Complete */
+#define USART_ISR_TXE_TXFNF_Pos      (7U)
+#define USART_ISR_TXE_TXFNF_Msk      (0x1UL << USART_ISR_TXE_TXFNF_Pos)        /*!< 0x00000080 */
+#define USART_ISR_TXE_TXFNF          USART_ISR_TXE_TXFNF_Msk                   /*!< Transmit Data Register Empty/TXFIFO Not Full */
+#define USART_ISR_LBDF_Pos           (8U)
+#define USART_ISR_LBDF_Msk           (0x1UL << USART_ISR_LBDF_Pos)             /*!< 0x00000100 */
+#define USART_ISR_LBDF               USART_ISR_LBDF_Msk                        /*!< LIN Break Detection Flag */
+#define USART_ISR_CTSIF_Pos          (9U)
+#define USART_ISR_CTSIF_Msk          (0x1UL << USART_ISR_CTSIF_Pos)            /*!< 0x00000200 */
+#define USART_ISR_CTSIF              USART_ISR_CTSIF_Msk                       /*!< CTS interrupt flag */
+#define USART_ISR_CTS_Pos            (10U)
+#define USART_ISR_CTS_Msk            (0x1UL << USART_ISR_CTS_Pos)              /*!< 0x00000400 */
+#define USART_ISR_CTS                USART_ISR_CTS_Msk                         /*!< CTS flag */
+#define USART_ISR_RTOF_Pos           (11U)
+#define USART_ISR_RTOF_Msk           (0x1UL << USART_ISR_RTOF_Pos)             /*!< 0x00000800 */
+#define USART_ISR_RTOF               USART_ISR_RTOF_Msk                        /*!< Receiver Time Out */
+#define USART_ISR_EOBF_Pos           (12U)
+#define USART_ISR_EOBF_Msk           (0x1UL << USART_ISR_EOBF_Pos)             /*!< 0x00001000 */
+#define USART_ISR_EOBF               USART_ISR_EOBF_Msk                        /*!< End Of Block Flag */
+#define USART_ISR_UDR_Pos            (13U)
+#define USART_ISR_UDR_Msk            (0x1UL << USART_ISR_UDR_Pos)              /*!< 0x00002000 */
+#define USART_ISR_UDR                 USART_ISR_UDR_Msk                        /*!< SPI Slave Underrun Error Flag */
+#define USART_ISR_ABRE_Pos           (14U)
+#define USART_ISR_ABRE_Msk           (0x1UL << USART_ISR_ABRE_Pos)             /*!< 0x00004000 */
+#define USART_ISR_ABRE               USART_ISR_ABRE_Msk                        /*!< Auto-Baud Rate Error */
+#define USART_ISR_ABRF_Pos           (15U)
+#define USART_ISR_ABRF_Msk           (0x1UL << USART_ISR_ABRF_Pos)             /*!< 0x00008000 */
+#define USART_ISR_ABRF               USART_ISR_ABRF_Msk                        /*!< Auto-Baud Rate Flag */
+#define USART_ISR_BUSY_Pos           (16U)
+#define USART_ISR_BUSY_Msk           (0x1UL << USART_ISR_BUSY_Pos)             /*!< 0x00010000 */
+#define USART_ISR_BUSY               USART_ISR_BUSY_Msk                        /*!< Busy Flag */
+#define USART_ISR_CMF_Pos            (17U)
+#define USART_ISR_CMF_Msk            (0x1UL << USART_ISR_CMF_Pos)              /*!< 0x00020000 */
+#define USART_ISR_CMF                USART_ISR_CMF_Msk                         /*!< Character Match Flag */
+#define USART_ISR_SBKF_Pos           (18U)
+#define USART_ISR_SBKF_Msk           (0x1UL << USART_ISR_SBKF_Pos)             /*!< 0x00040000 */
+#define USART_ISR_SBKF               USART_ISR_SBKF_Msk                        /*!< Send Break Flag */
+#define USART_ISR_RWU_Pos            (19U)
+#define USART_ISR_RWU_Msk            (0x1UL << USART_ISR_RWU_Pos)              /*!< 0x00080000 */
+#define USART_ISR_RWU                USART_ISR_RWU_Msk                         /*!< Receive Wake Up from mute mode Flag */
+#define USART_ISR_WUF_Pos            (20U)
+#define USART_ISR_WUF_Msk            (0x1UL << USART_ISR_WUF_Pos)              /*!< 0x00100000 */
+#define USART_ISR_WUF                USART_ISR_WUF_Msk                         /*!< Wake Up from stop mode Flag */
+#define USART_ISR_TEACK_Pos          (21U)
+#define USART_ISR_TEACK_Msk          (0x1UL << USART_ISR_TEACK_Pos)            /*!< 0x00200000 */
+#define USART_ISR_TEACK              USART_ISR_TEACK_Msk                       /*!< Transmit Enable Acknowledge Flag */
+#define USART_ISR_REACK_Pos          (22U)
+#define USART_ISR_REACK_Msk          (0x1UL << USART_ISR_REACK_Pos)            /*!< 0x00400000 */
+#define USART_ISR_REACK              USART_ISR_REACK_Msk                       /*!< Receive Enable Acknowledge Flag */
+#define USART_ISR_TXFE_Pos           (23U)
+#define USART_ISR_TXFE_Msk           (0x1UL << USART_ISR_TXFE_Pos)             /*!< 0x00800000 */
+#define USART_ISR_TXFE               USART_ISR_TXFE_Msk                        /*!< TXFIFO Empty Flag */
+#define USART_ISR_RXFF_Pos           (24U)
+#define USART_ISR_RXFF_Msk           (0x1UL << USART_ISR_RXFF_Pos)             /*!< 0x01000000 */
+#define USART_ISR_RXFF               USART_ISR_RXFF_Msk                        /*!< RXFIFO Full Flag */
+#define USART_ISR_TCBGT_Pos          (25U)
+#define USART_ISR_TCBGT_Msk          (0x1UL << USART_ISR_TCBGT_Pos)            /*!< 0x02000000 */
+#define USART_ISR_TCBGT              USART_ISR_TCBGT_Msk                       /*!< Transmission Complete Before Guard Time Completion Flag */
+#define USART_ISR_RXFT_Pos           (26U)
+#define USART_ISR_RXFT_Msk           (0x1UL << USART_ISR_RXFT_Pos)             /*!< 0x04000000 */
+#define USART_ISR_RXFT               USART_ISR_RXFT_Msk                        /*!< RXFIFO Threshold Flag */
+#define USART_ISR_TXFT_Pos           (27U)
+#define USART_ISR_TXFT_Msk           (0x1UL << USART_ISR_TXFT_Pos)             /*!< 0x08000000 */
+#define USART_ISR_TXFT               USART_ISR_TXFT_Msk                        /*!< TXFIFO Threshold Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define USART_ICR_PECF_Pos           (0U)
+#define USART_ICR_PECF_Msk           (0x1UL << USART_ICR_PECF_Pos)             /*!< 0x00000001 */
+#define USART_ICR_PECF               USART_ICR_PECF_Msk                        /*!< Parity Error Clear Flag */
+#define USART_ICR_FECF_Pos           (1U)
+#define USART_ICR_FECF_Msk           (0x1UL << USART_ICR_FECF_Pos)             /*!< 0x00000002 */
+#define USART_ICR_FECF               USART_ICR_FECF_Msk                        /*!< Framing Error Clear Flag */
+#define USART_ICR_NECF_Pos           (2U)
+#define USART_ICR_NECF_Msk           (0x1UL << USART_ICR_NECF_Pos)             /*!< 0x00000004 */
+#define USART_ICR_NECF               USART_ICR_NECF_Msk                        /*!< Noise Error detected Clear Flag */
+#define USART_ICR_ORECF_Pos          (3U)
+#define USART_ICR_ORECF_Msk          (0x1UL << USART_ICR_ORECF_Pos)            /*!< 0x00000008 */
+#define USART_ICR_ORECF              USART_ICR_ORECF_Msk                       /*!< OverRun Error Clear Flag */
+#define USART_ICR_IDLECF_Pos         (4U)
+#define USART_ICR_IDLECF_Msk         (0x1UL << USART_ICR_IDLECF_Pos)           /*!< 0x00000010 */
+#define USART_ICR_IDLECF             USART_ICR_IDLECF_Msk                      /*!< IDLE line detected Clear Flag */
+#define USART_ICR_TXFECF_Pos         (5U)
+#define USART_ICR_TXFECF_Msk         (0x1UL << USART_ICR_TXFECF_Pos)           /*!< 0x00000020 */
+#define USART_ICR_TXFECF             USART_ICR_TXFECF_Msk                      /*!< TXFIFO Empty Clear Flag */
+#define USART_ICR_TCCF_Pos           (6U)
+#define USART_ICR_TCCF_Msk           (0x1UL << USART_ICR_TCCF_Pos)             /*!< 0x00000040 */
+#define USART_ICR_TCCF               USART_ICR_TCCF_Msk                        /*!< Transmission Complete Clear Flag */
+#define USART_ICR_TCBGTCF_Pos        (7U)
+#define USART_ICR_TCBGTCF_Msk        (0x1UL << USART_ICR_TCBGTCF_Pos)          /*!< 0x00000080 */
+#define USART_ICR_TCBGTCF            USART_ICR_TCBGTCF_Msk                     /*!< Transmission Complete Before Guard Time Clear Flag */
+#define USART_ICR_LBDCF_Pos          (8U)
+#define USART_ICR_LBDCF_Msk          (0x1UL << USART_ICR_LBDCF_Pos)            /*!< 0x00000100 */
+#define USART_ICR_LBDCF              USART_ICR_LBDCF_Msk                       /*!< LIN Break Detection Clear Flag */
+#define USART_ICR_CTSCF_Pos          (9U)
+#define USART_ICR_CTSCF_Msk          (0x1UL << USART_ICR_CTSCF_Pos)            /*!< 0x00000200 */
+#define USART_ICR_CTSCF              USART_ICR_CTSCF_Msk                       /*!< CTS Interrupt Clear Flag */
+#define USART_ICR_RTOCF_Pos          (11U)
+#define USART_ICR_RTOCF_Msk          (0x1UL << USART_ICR_RTOCF_Pos)            /*!< 0x00000800 */
+#define USART_ICR_RTOCF              USART_ICR_RTOCF_Msk                       /*!< Receiver Time Out Clear Flag */
+#define USART_ICR_EOBCF_Pos          (12U)
+#define USART_ICR_EOBCF_Msk          (0x1UL << USART_ICR_EOBCF_Pos)            /*!< 0x00001000 */
+#define USART_ICR_EOBCF              USART_ICR_EOBCF_Msk                       /*!< End Of Block Clear Flag */
+#define USART_ICR_UDRCF_Pos          (13U)
+#define USART_ICR_UDRCF_Msk          (0x1UL << USART_ICR_UDRCF_Pos)            /*!< 0x00002000 */
+#define USART_ICR_UDRCF              USART_ICR_UDRCF_Msk                       /*!< SPI Slave Underrun Clear Flag */
+#define USART_ICR_CMCF_Pos           (17U)
+#define USART_ICR_CMCF_Msk           (0x1UL << USART_ICR_CMCF_Pos)             /*!< 0x00020000 */
+#define USART_ICR_CMCF               USART_ICR_CMCF_Msk                        /*!< Character Match Clear Flag */
+#define USART_ICR_WUCF_Pos           (20U)
+#define USART_ICR_WUCF_Msk           (0x1UL << USART_ICR_WUCF_Pos)             /*!< 0x00100000 */
+#define USART_ICR_WUCF               USART_ICR_WUCF_Msk                        /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define USART_RDR_RDR_Pos             (0U)
+#define USART_RDR_RDR_Msk             (0x1FFUL << USART_RDR_RDR_Pos)           /*!< 0x000001FF */
+#define USART_RDR_RDR                 USART_RDR_RDR_Msk                        /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define USART_TDR_TDR_Pos             (0U)
+#define USART_TDR_TDR_Msk             (0x1FFUL << USART_TDR_TDR_Pos)           /*!< 0x000001FF */
+#define USART_TDR_TDR                 USART_TDR_TDR_Msk                        /*!< TDR[8:0] bits (Transmit Data value) */
+
+/*******************  Bit definition for USART_PRESC register  ****************/
+#define USART_PRESC_PRESCALER_Pos    (0U)
+#define USART_PRESC_PRESCALER_Msk    (0xFUL << USART_PRESC_PRESCALER_Pos)      /*!< 0x0000000F */
+#define USART_PRESC_PRESCALER        USART_PRESC_PRESCALER_Msk                 /*!< PRESCALER[3:0] bits (Clock prescaler) */
+#define USART_PRESC_PRESCALER_0      (0x1UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000001 */
+#define USART_PRESC_PRESCALER_1      (0x2UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000002 */
+#define USART_PRESC_PRESCALER_2      (0x4UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000004 */
+#define USART_PRESC_PRESCALER_3      (0x8UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000008 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 VREFBUF                                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for VREFBUF_CSR register  ****************/
+#define VREFBUF_CSR_ENVR_Pos    (0U)
+#define VREFBUF_CSR_ENVR_Msk    (0x1UL << VREFBUF_CSR_ENVR_Pos)                /*!< 0x00000001 */
+#define VREFBUF_CSR_ENVR        VREFBUF_CSR_ENVR_Msk                           /*!<Voltage reference buffer enable */
+#define VREFBUF_CSR_HIZ_Pos     (1U)
+#define VREFBUF_CSR_HIZ_Msk     (0x1UL << VREFBUF_CSR_HIZ_Pos)                 /*!< 0x00000002 */
+#define VREFBUF_CSR_HIZ         VREFBUF_CSR_HIZ_Msk                            /*!<High impedance mode             */
+#define VREFBUF_CSR_VRS_Pos     (2U)
+#define VREFBUF_CSR_VRS_Msk     (0x1UL << VREFBUF_CSR_VRS_Pos)                 /*!< 0x00000004 */
+#define VREFBUF_CSR_VRS         VREFBUF_CSR_VRS_Msk                            /*!<Voltage reference scale         */
+#define VREFBUF_CSR_VRR_Pos     (3U)
+#define VREFBUF_CSR_VRR_Msk     (0x1UL << VREFBUF_CSR_VRR_Pos)                 /*!< 0x00000008 */
+#define VREFBUF_CSR_VRR         VREFBUF_CSR_VRR_Msk                            /*!<Voltage reference buffer ready  */
+
+/*******************  Bit definition for VREFBUF_CCR register  ******************/
+#define VREFBUF_CCR_TRIM_Pos    (0U)
+#define VREFBUF_CCR_TRIM_Msk    (0x3FUL << VREFBUF_CCR_TRIM_Pos)               /*!< 0x0000003F */
+#define VREFBUF_CCR_TRIM        VREFBUF_CCR_TRIM_Msk                           /*!<TRIM[5:0] bits (Trimming code)  */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                      /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01UL << WWDG_CR_T_Pos)                      /*!< 0x00000001 */
+#define WWDG_CR_T_1             (0x02UL << WWDG_CR_T_Pos)                      /*!< 0x00000002 */
+#define WWDG_CR_T_2             (0x04UL << WWDG_CR_T_Pos)                      /*!< 0x00000004 */
+#define WWDG_CR_T_3             (0x08UL << WWDG_CR_T_Pos)                      /*!< 0x00000008 */
+#define WWDG_CR_T_4             (0x10UL << WWDG_CR_T_Pos)                      /*!< 0x00000010 */
+#define WWDG_CR_T_5             (0x20UL << WWDG_CR_T_Pos)                      /*!< 0x00000020 */
+#define WWDG_CR_T_6             (0x40UL << WWDG_CR_T_Pos)                      /*!< 0x00000040 */
+
+#define WWDG_CR_WDGA_Pos        (7U)
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                    /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                     /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01UL << WWDG_CFR_W_Pos)                     /*!< 0x00000001 */
+#define WWDG_CFR_W_1            (0x02UL << WWDG_CFR_W_Pos)                     /*!< 0x00000002 */
+#define WWDG_CFR_W_2            (0x04UL << WWDG_CFR_W_Pos)                     /*!< 0x00000004 */
+#define WWDG_CFR_W_3            (0x08UL << WWDG_CFR_W_Pos)                     /*!< 0x00000008 */
+#define WWDG_CFR_W_4            (0x10UL << WWDG_CFR_W_Pos)                     /*!< 0x00000010 */
+#define WWDG_CFR_W_5            (0x20UL << WWDG_CFR_W_Pos)                     /*!< 0x00000020 */
+#define WWDG_CFR_W_6            (0x40UL << WWDG_CFR_W_Pos)                     /*!< 0x00000040 */
+
+#define WWDG_CFR_WDGTB_Pos      (11U)
+#define WWDG_CFR_WDGTB_Msk      (0x7UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00003800 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[2:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00000800 */
+#define WWDG_CFR_WDGTB_1        (0x2UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00001000 */
+#define WWDG_CFR_WDGTB_2        (0x4UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00002000 */
+
+#define WWDG_CFR_EWI_Pos        (9U)
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                    /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                    /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                Debug MCU                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBG_IDCODE register  *************/
+#define DBG_IDCODE_DEV_ID_Pos                          (0U)
+#define DBG_IDCODE_DEV_ID_Msk                          (0xFFFUL << DBG_IDCODE_DEV_ID_Pos)  /*!< 0x00000FFF */
+#define DBG_IDCODE_DEV_ID                              DBG_IDCODE_DEV_ID_Msk
+#define DBG_IDCODE_REV_ID_Pos                          (16U)
+#define DBG_IDCODE_REV_ID_Msk                          (0xFFFFUL << DBG_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBG_IDCODE_REV_ID                              DBG_IDCODE_REV_ID_Msk
+
+/********************  Bit definition for DBG_CR register  *****************/
+#define DBG_CR_DBG_STOP_Pos                            (1U)
+#define DBG_CR_DBG_STOP_Msk                            (0x1UL << DBG_CR_DBG_STOP_Pos)      /*!< 0x00000002 */
+#define DBG_CR_DBG_STOP                                DBG_CR_DBG_STOP_Msk
+#define DBG_CR_DBG_STANDBY_Pos                         (2U)
+#define DBG_CR_DBG_STANDBY_Msk                         (0x1UL << DBG_CR_DBG_STANDBY_Pos)   /*!< 0x00000004 */
+#define DBG_CR_DBG_STANDBY                             DBG_CR_DBG_STANDBY_Msk
+
+
+/********************  Bit definition for DBG_APB_FZ1 register  ***********/
+#define DBG_APB_FZ1_DBG_TIM2_STOP_Pos                  (0U)
+#define DBG_APB_FZ1_DBG_TIM2_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM2_STOP_Pos) /*!< 0x00000001 */
+#define DBG_APB_FZ1_DBG_TIM2_STOP                      DBG_APB_FZ1_DBG_TIM2_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM3_STOP_Pos                  (1U)
+#define DBG_APB_FZ1_DBG_TIM3_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
+#define DBG_APB_FZ1_DBG_TIM3_STOP                      DBG_APB_FZ1_DBG_TIM3_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM6_STOP_Pos                  (4U)
+#define DBG_APB_FZ1_DBG_TIM6_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM6_STOP_Pos) /*!< 0x00000010 */
+#define DBG_APB_FZ1_DBG_TIM6_STOP                      DBG_APB_FZ1_DBG_TIM6_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM7_STOP_Pos                  (5U)
+#define DBG_APB_FZ1_DBG_TIM7_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM7_STOP_Pos) /*!< 0x00000020 */
+#define DBG_APB_FZ1_DBG_TIM7_STOP                      DBG_APB_FZ1_DBG_TIM7_STOP_Msk
+#define DBG_APB_FZ1_DBG_RTC_STOP_Pos                   (10U)
+#define DBG_APB_FZ1_DBG_RTC_STOP_Msk                   (0x1UL << DBG_APB_FZ1_DBG_RTC_STOP_Pos)  /*!< 0x00000400 */
+#define DBG_APB_FZ1_DBG_RTC_STOP                       DBG_APB_FZ1_DBG_RTC_STOP_Msk
+#define DBG_APB_FZ1_DBG_WWDG_STOP_Pos                  (11U)
+#define DBG_APB_FZ1_DBG_WWDG_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_WWDG_STOP_Pos) /*!< 0x00000800 */
+#define DBG_APB_FZ1_DBG_WWDG_STOP                      DBG_APB_FZ1_DBG_WWDG_STOP_Msk
+#define DBG_APB_FZ1_DBG_IWDG_STOP_Pos                  (12U)
+#define DBG_APB_FZ1_DBG_IWDG_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_IWDG_STOP_Pos) /*!< 0x00001000 */
+#define DBG_APB_FZ1_DBG_IWDG_STOP                      DBG_APB_FZ1_DBG_IWDG_STOP_Msk
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Pos    (21U)
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00200000 */
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Msk
+#define DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos                (30U)
+#define DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk                (0x1UL << DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos) /*!< 0x40000000 */
+#define DBG_APB_FZ1_DBG_LPTIM2_STOP                    DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk
+#define DBG_APB_FZ1_DBG_LPTIM1_STOP_Pos                (31U)
+#define DBG_APB_FZ1_DBG_LPTIM1_STOP_Msk                (0x1UL << DBG_APB_FZ1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBG_APB_FZ1_DBG_LPTIM1_STOP                    DBG_APB_FZ1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBG_APB_FZ2 register  ************/
+#define DBG_APB_FZ2_DBG_TIM1_STOP_Pos                  (11U)
+#define DBG_APB_FZ2_DBG_TIM1_STOP_Msk                  (0x1UL << DBG_APB_FZ2_DBG_TIM1_STOP_Pos)  /*!< 0x00000800 */
+#define DBG_APB_FZ2_DBG_TIM1_STOP                      DBG_APB_FZ2_DBG_TIM1_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM14_STOP_Pos                 (15U)
+#define DBG_APB_FZ2_DBG_TIM14_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM14_STOP_Pos) /*!< 0x00008000 */
+#define DBG_APB_FZ2_DBG_TIM14_STOP                     DBG_APB_FZ2_DBG_TIM14_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM15_STOP_Pos                 (16U)
+#define DBG_APB_FZ2_DBG_TIM15_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM15_STOP_Pos) /*!< 0x00010000 */
+#define DBG_APB_FZ2_DBG_TIM15_STOP                     DBG_APB_FZ2_DBG_TIM15_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM16_STOP_Pos                 (17U)
+#define DBG_APB_FZ2_DBG_TIM16_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM16_STOP_Pos) /*!< 0x00020000 */
+#define DBG_APB_FZ2_DBG_TIM16_STOP                     DBG_APB_FZ2_DBG_TIM16_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM17_STOP_Pos                 (18U)
+#define DBG_APB_FZ2_DBG_TIM17_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM17_STOP_Pos) /*!< 0x00040000 */
+#define DBG_APB_FZ2_DBG_TIM17_STOP                     DBG_APB_FZ2_DBG_TIM17_STOP_Msk
+
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+
+
+
+/******************************** COMP Instances ******************************/
+#define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                        ((INSTANCE) == COMP2))
+
+#define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) ((COMMON_INSTANCE) == COMP12_COMMON)
+
+/******************** COMP Instances with window mode capability **************/
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                               ((INSTANCE) == COMP2))
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+/******************************* DAC Instances ********************************/
+#define IS_DAC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DAC1)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Channel1) || \
+                                       ((INSTANCE) == DMA1_Channel2) || \
+                                       ((INSTANCE) == DMA1_Channel3) || \
+                                       ((INSTANCE) == DMA1_Channel4) || \
+                                       ((INSTANCE) == DMA1_Channel5) || \
+                                       ((INSTANCE) == DMA1_Channel6) || \
+                                       ((INSTANCE) == DMA1_Channel7))
+
+/******************************** DMAMUX Instances ****************************/
+#define IS_DMAMUX_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DMAMUX1)
+
+#define IS_DMAMUX_REQUEST_GEN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMAMUX1_RequestGenerator0) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator1) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator2) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator3))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOD) || \
+                                        ((INSTANCE) == GPIOF))
+/******************************* GPIO AF Instances ****************************/
+#define IS_GPIO_AF_INSTANCE(INSTANCE)   IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/**************************** GPIO Lock Instances *****************************/
+#define IS_GPIO_LOCK_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                         ((INSTANCE) == GPIOB) || \
+                                         ((INSTANCE) == GPIOC))
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1) || \
+                                       ((INSTANCE) == I2C2))
+
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/****************************** SMBUS Instances *******************************/
+#define IS_SMBUS_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1))
+
+/****************************** WAKEUP_FROMSTOP Instances *******************************/
+#define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) (((INSTANCE) == I2C1))
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
+                                       ((INSTANCE) == SPI2))
+
+/******************************** SPI Instances *******************************/
+#define IS_I2S_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == SPI1)
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
+                                         ((INSTANCE) == LPTIM2))
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) ((INSTANCE) == LPTIM1)
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM6)   || \
+                                         ((INSTANCE) == TIM7)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting 32 bits counter ****************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) ((INSTANCE) == TIM2)
+
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)    || \
+                                            ((INSTANCE) == TIM15)   || \
+                                            ((INSTANCE) == TIM16)   || \
+                                            ((INSTANCE) == TIM17))
+
+/************** TIM Instances : supporting Break source selection *************/
+#define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                               ((INSTANCE) == TIM15)  || \
+                                               ((INSTANCE) == TIM16)  || \
+                                               ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BKIN2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM15))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(INSTANCE)   ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(INSTANCE)   ((INSTANCE) == TIM1)
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.COMDE) *******/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : DMA requests generation (TIMx_DIER.UDE) ***/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM6)   || \
+                                            ((INSTANCE) == TIM7)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM14)  || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+    ((((INSTANCE) == TIM1) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4) ||          \
+      ((CHANNEL) == TIM_CHANNEL_5) ||          \
+      ((CHANNEL) == TIM_CHANNEL_6)))           \
+     ||                                        \
+     (((INSTANCE) == TIM2) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
+     (((INSTANCE) == TIM3) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
+     (((INSTANCE) == TIM14) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+     ||                                        \
+     (((INSTANCE) == TIM15) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2)))           \
+     ||                                        \
+     (((INSTANCE) == TIM16) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+     ||                                        \
+     (((INSTANCE) == TIM17) &&                 \
+      (((CHANNEL) == TIM_CHANNEL_1))))
+
+/****************** TIM Instances : supporting complementary output(s) ********/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+   ((((INSTANCE) == TIM1) &&                    \
+     (((CHANNEL) == TIM_CHANNEL_1) ||           \
+      ((CHANNEL) == TIM_CHANNEL_2) ||           \
+      ((CHANNEL) == TIM_CHANNEL_3)))            \
+    ||                                          \
+    (((INSTANCE) == TIM15) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1))              \
+    ||                                          \
+    (((INSTANCE) == TIM16) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1))              \
+    ||                                          \
+    (((INSTANCE) == TIM17) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1)))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
+                                                    ((INSTANCE) == TIM2)    || \
+                                                    ((INSTANCE) == TIM3)    || \
+                                                    ((INSTANCE) == TIM14)   || \
+                                                    ((INSTANCE) == TIM15)   || \
+                                                    ((INSTANCE) == TIM16)   || \
+                                                    ((INSTANCE) == TIM17))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting commutation event generation ***/
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                     ((INSTANCE) == TIM15)  || \
+                                                     ((INSTANCE) == TIM16)  || \
+                                                     ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                      ((INSTANCE) == TIM2)  || \
+                                                      ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                         ((INSTANCE) == TIM2)   || \
+                                                         ((INSTANCE) == TIM3))
+
+/**************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3))
+
+/************* TIM Instances : supporting ETR source selection ***************/
+#define IS_TIM_ETRSEL_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                             ((INSTANCE) == TIM2)  || \
+                                             ((INSTANCE) == TIM3))
+
+/****** TIM Instances : Master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3)  || \
+                                            ((INSTANCE) == TIM6)  || \
+                                            ((INSTANCE) == TIM7)  || \
+                                            ((INSTANCE) == TIM15))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3)  || \
+                                            ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM2) || \
+                                                       ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM15) || \
+                                                       ((INSTANCE) == TIM16) || \
+                                                       ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM15))
+
+/******************* TIM Instances : Timer input selection ********************/
+#define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/************ TIM Instances : Advanced timers  ********************************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                    ((INSTANCE) == USART2))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                     ((INSTANCE) == USART2))
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == USART2) || \
+                                           ((INSTANCE) == LPUART1))
+
+/********************* USART Instances : Smard card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+/****************** UART Instances : Auto Baud Rate detection ****************/
+#define IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+/******************** UART Instances : Half-Duplex mode **********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                 ((INSTANCE) == USART2) || \
+                                                 ((INSTANCE) == LPUART1))
+
+/******************** UART Instances : LIN mode **********************/
+#define IS_UART_LIN_INSTANCE(INSTANCE)   ((INSTANCE) == USART1)
+/******************** UART Instances : Wake-up from Stop mode **********************/
+#define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == LPUART1))
+
+/****************** UART Instances : Driver Enable *****************/
+#define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE)     (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == USART2) || \
+                                                      ((INSTANCE) == LPUART1))
+
+/****************** UART Instances : SPI Slave selection mode ***************/
+#define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                              ((INSTANCE) == USART2))
+
+/****************** UART Instances : Driver Enable *****************/
+#define IS_UART_FIFO_INSTANCE(INSTANCE)     (((INSTANCE) == USART1) || \
+                                             ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/******************** LPUART Instance *****************************************/
+#define IS_LPUART_INSTANCE(INSTANCE)    ((INSTANCE) == LPUART1)
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+
+/**
+  * @}
+  */
+
+ /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* STM32G051xx_H */
+
+/**
+  * @}
+  */
+
+  /**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/soc/stm32g061xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g061xx.h
@@ -1,0 +1,8713 @@
+/**
+  ******************************************************************************
+  * @file    stm32g061xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for stm32g061xx devices.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral's registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under Apache License, Version 2.0,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/Apache-2.0
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32g061xx
+  * @{
+  */
+
+#ifndef STM32G061xx_H
+#define STM32G061xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+
+/**
+  * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+   */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+ * @brief stm32g061xx Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
+ */
+
+/*!< Interrupt Number Definition */
+typedef enum
+{
+/******  Cortex-M0+ Processor Exceptions Numbers ***************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  HardFault_IRQn              = -13,    /*!< 3 Cortex-M Hard Fault Interrupt                                   */
+  SVC_IRQn                    = -5,     /*!< 11 Cortex-M SV Call Interrupt                                     */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M Pend SV Interrupt                                     */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
+/******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI line 16                                          */
+  RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
+  FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
+  EXTI0_1_IRQn                = 5,      /*!< EXTI 0 and 1 Interrupts                                           */
+  EXTI2_3_IRQn                = 6,      /*!< EXTI Line 2 and 3 Interrupts                                      */
+  EXTI4_15_IRQn               = 7,      /*!< EXTI Line 4 to 15 Interrupts                                      */
+  DMA1_Channel1_IRQn          = 9,      /*!< DMA1 Channel 1 Interrupt                                          */
+  DMA1_Channel2_3_IRQn        = 10,     /*!< DMA1 Channel 2 and Channel 3 Interrupts                           */
+  DMA1_Ch4_7_DMAMUX1_OVR_IRQn = 11,     /*!< DMA1 Channel 4 to Channel 7 and DMAMUX1 Overrun Interrupts        */
+  ADC1_COMP_IRQn              = 12,     /*!< ADC1, COMP1 and COMP2 Interrupts (combined with EXTI 17 & 18)     */
+  TIM1_BRK_UP_TRG_COM_IRQn    = 13,     /*!< TIM1 Break, Update, Trigger and Commutation Interrupts            */
+  TIM1_CC_IRQn                = 14,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 15,     /*!< TIM2 Interrupt                                                    */
+  TIM3_IRQn                   = 16,     /*!< TIM3 global Interrupt                                             */
+  TIM6_DAC_LPTIM1_IRQn        = 17,     /*!< TIM6, DAC and LPTIM1 global Interrupts                            */
+  TIM7_LPTIM2_IRQn            = 18,     /*!< TIM7 and LPTIM2 global Interrupt                                  */
+  TIM14_IRQn                  = 19,     /*!< TIM14 global Interrupt                                            */
+  TIM15_IRQn                  = 20,     /*!< TIM15 global Interrupt                                            */
+  TIM16_IRQn                  = 21,     /*!< TIM16 global Interrupt                                            */
+  TIM17_IRQn                  = 22,     /*!< TIM17 global Interrupt                                            */
+  I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt  (combined with EXTI 23)                           */
+  I2C2_IRQn                   = 24,     /*!< I2C2 Interrupt                                                    */
+  SPI1_IRQn                   = 25,     /*!< SPI1/I2S1 Interrupt                                               */
+  SPI2_IRQn                   = 26,     /*!< SPI2 Interrupt                                                    */
+  USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
+  USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                                  */
+  LPUART1_IRQn                = 29,     /*!< LPUART1 globlal Interrupts (combined with EXTI 28)                 */
+  AES_RNG_IRQn                = 31,     /*!< AES & RNG Interrupt                                                */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+#include "core_cm0plus.h"               /* Cortex-M0+ processor and core peripherals */
+#include "system_stm32g0xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC interrupt and status register,             Address offset: 0x00 */
+  __IO uint32_t IER;          /*!< ADC interrupt enable register,                 Address offset: 0x04 */
+  __IO uint32_t CR;           /*!< ADC control register,                          Address offset: 0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC configuration register 1,                  Address offset: 0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC configuration register 2,                  Address offset: 0x10 */
+  __IO uint32_t SMPR;         /*!< ADC sampling time register,                    Address offset: 0x14 */
+       uint32_t RESERVED1;    /*!< Reserved,                                                      0x18 */
+       uint32_t RESERVED2;    /*!< Reserved,                                                      0x1C */
+  __IO uint32_t TR1;          /*!< ADC analog watchdog 1 threshold register,      Address offset: 0x20 */
+  __IO uint32_t TR2;          /*!< ADC analog watchdog 2 threshold register,      Address offset: 0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC group regular sequencer register,          Address offset: 0x28 */
+  __IO uint32_t TR3;          /*!< ADC analog watchdog 3 threshold register,      Address offset: 0x2C */
+       uint32_t RESERVED3[4]; /*!< Reserved,                                               0x30 - 0x3C */
+  __IO uint32_t DR;           /*!< ADC group regular data register,               Address offset: 0x40 */
+       uint32_t RESERVED4[23];/*!< Reserved,                                               0x44 - 0x9C */
+  __IO uint32_t AWD2CR;       /*!< ADC analog watchdog 2 configuration register,  Address offset: 0xA0 */
+  __IO uint32_t AWD3CR;       /*!< ADC analog watchdog 3 configuration register,  Address offset: 0xA4 */
+       uint32_t RESERVED5[3]; /*!< Reserved,                                               0xA8 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC Calibration factor register,               Address offset: 0xB4 */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CCR;          /*!< ADC common configuration register,             Address offset: ADC1 base address + 0x308 */
+} ADC_Common_TypeDef;
+
+
+
+/**
+  * @brief Comparator
+  */
+typedef struct
+{
+  __IO uint32_t CSR;         /*!< COMP control and status register,                                                 Address offset: 0x00 */
+} COMP_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSR_ODD;    /*!< COMP control and status register located in register of comparator instance odd, used for bits common to several COMP instances, Address offset: 0x00 */
+  __IO uint32_t CSR_EVEN;   /*!< COMP control and status register located in register of comparator instance even, used for bits common to several COMP instances, Address offset: 0x04 */
+} COMP_Common_TypeDef;
+
+/**
+  * @brief CRC calculation unit
+  */
+typedef struct
+{
+  __IO uint32_t DR;             /*!< CRC Data register,                         Address offset: 0x00 */
+  __IO uint32_t IDR;            /*!< CRC Independent data register,             Address offset: 0x04 */
+  __IO uint32_t CR;             /*!< CRC Control register,                      Address offset: 0x08 */
+       uint32_t RESERVED1;      /*!< Reserved,                                                  0x0C */
+  __IO uint32_t INIT;           /*!< Initial CRC value register,                Address offset: 0x10 */
+  __IO uint32_t POL;            /*!< CRC polynomial register,                   Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Digital to Analog Converter
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;     /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;     /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;     /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;      /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  __IO uint32_t DHR12R2;     /*!< DAC channel2 12-bit right aligned data holding register, Address offset: 0x14 */
+  __IO uint32_t DHR12L2;     /*!< DAC channel2 12-bit left aligned data holding register,  Address offset: 0x18 */
+  __IO uint32_t DHR8R2;      /*!< DAC channel2 8-bit right-aligned data holding register,  Address offset: 0x1C */
+  __IO uint32_t DHR12RD;     /*!< Dual DAC 12-bit right-aligned data holding register,     Address offset: 0x20 */
+  __IO uint32_t DHR12LD;     /*!< DUAL DAC 12-bit left aligned data holding register,      Address offset: 0x24 */
+  __IO uint32_t DHR8RD;      /*!< DUAL DAC 8-bit right aligned data holding register,      Address offset: 0x28 */
+  __IO uint32_t DOR1;        /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  __IO uint32_t DOR2;        /*!< DAC channel2 data output register,                       Address offset: 0x30 */
+  __IO uint32_t SR;          /*!< DAC status register,                                     Address offset: 0x34 */
+  __IO uint32_t CCR;         /*!< DAC calibration control register,                        Address offset: 0x38 */
+  __IO uint32_t MCR;         /*!< DAC mode control register,                               Address offset: 0x3C */
+  __IO uint32_t SHSR1;       /*!< DAC Sample and Hold sample time register 1,              Address offset: 0x40 */
+  __IO uint32_t SHSR2;       /*!< DAC Sample and Hold sample time register 2,              Address offset: 0x44 */
+  __IO uint32_t SHHR;        /*!< DAC Sample and Hold hold time register,                  Address offset: 0x48 */
+  __IO uint32_t SHRR;        /*!< DAC Sample and Hold refresh time register,               Address offset: 0x4C */
+} DAC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+typedef struct
+{
+  __IO uint32_t IDCODE;      /*!< MCU device ID code,              Address offset: 0x00 */
+  __IO uint32_t CR;          /*!< Debug configuration register,    Address offset: 0x04 */
+  __IO uint32_t APBFZ1;      /*!< Debug APB freeze register 1,     Address offset: 0x08 */
+  __IO uint32_t APBFZ2;      /*!< Debug APB freeze register 2,     Address offset: 0x0C */
+} DBG_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+typedef struct
+{
+  __IO uint32_t CCR;         /*!< DMA channel x configuration register        */
+  __IO uint32_t CNDTR;       /*!< DMA channel x number of data register       */
+  __IO uint32_t CPAR;        /*!< DMA channel x peripheral address register   */
+  __IO uint32_t CMAR;        /*!< DMA channel x memory address register       */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< DMA interrupt status register,                 Address offset: 0x00 */
+  __IO uint32_t IFCR;        /*!< DMA interrupt flag clear register,             Address offset: 0x04 */
+} DMA_TypeDef;
+
+/**
+  * @brief DMA Multiplexer
+  */
+typedef struct
+{
+  __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
+}DMAMUX_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
+  __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
+}DMAMUX_ChannelStatus_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
+}DMAMUX_RequestGen_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
+  __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
+}DMAMUX_RequestGenStatus_TypeDef;
+
+/**
+  * @brief Asynch Interrupt/Event Controller (EXTI)
+  */
+typedef struct
+{
+  __IO uint32_t RTSR1;          /*!< EXTI Rising Trigger Selection Register 1,        Address offset:   0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI Falling Trigger Selection Register 1,       Address offset:   0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI Software Interrupt event Register 1,        Address offset:   0x08 */
+  __IO uint32_t RPR1;           /*!< EXTI Rising Pending Register 1,                  Address offset:   0x0C */
+  __IO uint32_t FPR1;           /*!< EXTI Falling Pending Register 1,                 Address offset:   0x10 */
+       uint32_t RESERVED1[3];   /*!< Reserved 1,                                                0x14 -- 0x1C */
+       uint32_t RESERVED2[5];   /*!< Reserved 2,                                                0x20 -- 0x30 */
+       uint32_t RESERVED3[11];  /*!< Reserved 3,                                                0x34 -- 0x5C */
+  __IO uint32_t EXTICR[4];      /*!< EXTI External Interrupt Configuration Register,            0x60 -- 0x6C */
+       uint32_t RESERVED4[4];   /*!< Reserved 4,                                                0x70 -- 0x7C */
+  __IO uint32_t IMR1;           /*!< EXTI Interrupt Mask Register 1,                  Address offset:   0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI Event Mask Register 1,                      Address offset:   0x84 */
+} EXTI_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;          /*!< FLASH Access Control register,                     Address offset: 0x00 */
+       uint32_t RESERVED1;    /*!< Reserved1,                                         Address offset: 0x04 */
+  __IO uint32_t KEYR;         /*!< FLASH Key register,                                Address offset: 0x08 */
+  __IO uint32_t OPTKEYR;      /*!< FLASH Option Key register,                         Address offset: 0x0C */
+  __IO uint32_t SR;           /*!< FLASH Status register,                             Address offset: 0x10 */
+  __IO uint32_t CR;           /*!< FLASH Control register,                            Address offset: 0x14 */
+  __IO uint32_t ECCR;         /*!< FLASH ECC register,                                Address offset: 0x18 */
+       uint32_t RESERVED2;    /*!< Reserved2,                                         Address offset: 0x1C */
+  __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
+  __IO uint32_t PCROP1ASR;    /*!< FLASH Bank PCROP area A Start address register,    Address offset: 0x24 */
+  __IO uint32_t PCROP1AER;    /*!< FLASH Bank PCROP area A End address register,      Address offset: 0x28 */
+  __IO uint32_t WRP1AR;       /*!< FLASH Bank WRP area A address register,            Address offset: 0x2C */
+  __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
+  __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
+  __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
+       uint32_t RESERVED8[17];/*!< Reserved8,                                         Address offset: 0x3C--0x7C */
+  __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
+} FLASH_TypeDef;
+
+/**
+  * @brief General Purpose I/O
+  */
+typedef struct
+{
+  __IO uint32_t MODER;       /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;      /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;     /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;       /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;         /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;         /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;        /*!< GPIO port bit set/reset  register,     Address offset: 0x18      */
+  __IO uint32_t LCKR;        /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];      /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;         /*!< GPIO Bit Reset register,               Address offset: 0x28      */
+} GPIO_TypeDef;
+
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;          /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;          /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;         /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;          /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR;        /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+/**
+  * @brief LPTIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;              /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;              /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;              /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;             /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;               /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;              /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;              /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;              /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t RESERVED1;        /*!< Reserved1,                                          Address offset: 0x20 */
+  __IO uint32_t CFGR2;            /*!< LPTIM Option register,                              Address offset: 0x24 */
+} LPTIM_TypeDef;
+
+
+/**
+  * @brief Power Control
+  */
+typedef struct
+{
+  __IO uint32_t CR1;          /*!< PWR Power Control Register 1,                     Address offset: 0x00 */
+  __IO uint32_t CR2;          /*!< PWR Power Control Register 2,                     Address offset: 0x04 */
+  __IO uint32_t CR3;          /*!< PWR Power Control Register 3,                     Address offset: 0x08 */
+  __IO uint32_t CR4;          /*!< PWR Power Control Register 4,                     Address offset: 0x0C */
+  __IO uint32_t SR1;          /*!< PWR Power Status Register 1,                      Address offset: 0x10 */
+  __IO uint32_t SR2;          /*!< PWR Power Status Register 2,                      Address offset: 0x14 */
+  __IO uint32_t SCR;          /*!< PWR Power Status Clear Register,                  Address offset: 0x18 */
+       uint32_t RESERVED1;    /*!< Reserved,                                         Address offset: 0x1C */
+  __IO uint32_t PUCRA;        /*!< PWR Pull-Up Control Register of port A,           Address offset: 0x20 */
+  __IO uint32_t PDCRA;        /*!< PWR Pull-Down Control Register of port A,         Address offset: 0x24 */
+  __IO uint32_t PUCRB;        /*!< PWR Pull-Up Control Register of port B,           Address offset: 0x28 */
+  __IO uint32_t PDCRB;        /*!< PWR Pull-Down Control Register of port B,         Address offset: 0x2C */
+  __IO uint32_t PUCRC;        /*!< PWR Pull-Up Control Register of port C,           Address offset: 0x30 */
+  __IO uint32_t PDCRC;        /*!< PWR Pull-Down Control Register of port C,         Address offset: 0x34 */
+  __IO uint32_t PUCRD;        /*!< PWR Pull-Up Control Register of port D,           Address offset: 0x38 */
+  __IO uint32_t PDCRD;        /*!< PWR Pull-Down Control Register of port D,         Address offset: 0x3C */
+       uint32_t RESERVED2;    /*!< Reserved,                                         Address offset: 0x40 */
+       uint32_t RESERVED3;    /*!< Reserved,                                         Address offset: 0x44 */
+  __IO uint32_t PUCRF;        /*!< PWR Pull-Up Control Register of port F,           Address offset: 0x48 */
+  __IO uint32_t PDCRF;        /*!< PWR Pull-Down Control Register of port F,         Address offset: 0x4C */
+} PWR_TypeDef;
+
+/**
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< RCC Clock Sources Control Register,                                     Address offset: 0x00 */
+  __IO uint32_t ICSCR;       /*!< RCC Internal Clock Sources Calibration Register,                        Address offset: 0x04 */
+  __IO uint32_t CFGR;        /*!< RCC Regulated Domain Clocks Configuration Register,                     Address offset: 0x08 */
+  __IO uint32_t PLLCFGR;     /*!< RCC System PLL configuration Register,                                  Address offset: 0x0C */
+  __IO uint32_t RESERVED0;   /*!< Reserved,                                                               Address offset: 0x10 */
+  __IO uint32_t RESERVED1;   /*!< Reserved,                                                               Address offset: 0x14 */
+  __IO uint32_t CIER;        /*!< RCC Clock Interrupt Enable Register,                                    Address offset: 0x18 */
+  __IO uint32_t CIFR;        /*!< RCC Clock Interrupt Flag Register,                                      Address offset: 0x1C */
+  __IO uint32_t CICR;        /*!< RCC Clock Interrupt Clear Register,                                     Address offset: 0x20 */
+  __IO uint32_t IOPRSTR;     /*!< RCC IO port reset register,                                             Address offset: 0x24 */
+  __IO uint32_t AHBRSTR;     /*!< RCC AHB peripherals reset register,                                     Address offset: 0x28 */
+  __IO uint32_t APBRSTR1;    /*!< RCC APB peripherals reset register 1,                                   Address offset: 0x2C */
+  __IO uint32_t APBRSTR2;    /*!< RCC APB peripherals reset register 2,                                   Address offset: 0x30 */
+  __IO uint32_t IOPENR;      /*!< RCC IO port enable register,                                            Address offset: 0x34 */
+  __IO uint32_t AHBENR;      /*!< RCC AHB peripherals clock enable register,                              Address offset: 0x38 */
+  __IO uint32_t APBENR1;     /*!< RCC APB peripherals clock enable register1,                             Address offset: 0x3C */
+  __IO uint32_t APBENR2;     /*!< RCC APB peripherals clock enable register2,                             Address offset: 0x40 */
+  __IO uint32_t IOPSMENR;    /*!< RCC IO port clocks enable in sleep mode register,                       Address offset: 0x44 */
+  __IO uint32_t AHBSMENR;    /*!< RCC AHB peripheral clocks enable in sleep mode register,                Address offset: 0x48 */
+  __IO uint32_t APBSMENR1;   /*!< RCC APB peripheral clocks enable in sleep mode register1,               Address offset: 0x4C */
+  __IO uint32_t APBSMENR2;   /*!< RCC APB peripheral clocks enable in sleep mode register2,               Address offset: 0x50 */
+  __IO uint32_t CCIPR;       /*!< RCC Peripherals Independent Clocks Configuration Register,              Address offset: 0x54 */
+  __IO uint32_t RESERVED2;   /*!< Reserved,                                                               Address offset: 0x58 */
+  __IO uint32_t BDCR;        /*!< RCC Backup Domain Control Register,                                     Address offset: 0x5C */
+  __IO uint32_t CSR;         /*!< RCC Unregulated Domain Clock Control and Status Register,               Address offset: 0x60 */
+} RCC_TypeDef;
+
+/**
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;          /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;          /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t SSR;         /*!< RTC sub second register,                                   Address offset: 0x08 */
+  __IO uint32_t ICSR;        /*!< RTC initialization control and status register,            Address offset: 0x0C */
+  __IO uint32_t PRER;        /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;        /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+  __IO uint32_t CR;          /*!< RTC control register,                                      Address offset: 0x18 */
+       uint32_t RESERVED0;   /*!< Reserved                                                   Address offset: 0x1C */
+       uint32_t RESERVED1;   /*!< Reserved                                                   Address offset: 0x20 */
+  __IO uint32_t WPR;         /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t CALR;        /*!< RTC calibration register,                                  Address offset: 0x28 */
+  __IO uint32_t SHIFTR;      /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;        /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;        /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;       /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+       uint32_t RESERVED2;   /*!< Reserved                                                   Address offset: 0x1C */
+  __IO uint32_t ALRMAR;      /*!< RTC alarm A register,                                      Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;    /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBR;      /*!< RTC alarm B register,                                      Address offset: 0x48 */
+  __IO uint32_t ALRMBSSR;    /*!< RTC alarm B sub second register,                           Address offset: 0x4C */
+  __IO uint32_t SR;          /*!< RTC Status register,                                       Address offset: 0x50 */
+  __IO uint32_t MISR;        /*!< RTC Masked Interrupt Status register,                      Address offset: 0x54 */
+       uint32_t RESERVED3;   /*!< Reserved                                                   Address offset: 0x58 */
+  __IO uint32_t SCR;         /*!< RTC Status Clear register,                                 Address offset: 0x5C */
+  __IO uint32_t OR;          /*!< RTC option register,                                       Address offset: 0x60 */
+} RTC_TypeDef;
+
+/**
+  * @brief Tamper and backup registers
+  */
+typedef struct
+{
+  __IO uint32_t CR1;            /*!< TAMP configuration register 1,                             Address offset: 0x00 */
+  __IO uint32_t CR2;            /*!< TAMP configuration register 2,                             Address offset: 0x04 */
+       uint32_t RESERVED0;      /*!< Reserved                                                   Address offset: 0x08 */
+  __IO uint32_t FLTCR;          /*!< Reserved                                                   Address offset: 0x0C */
+       uint32_t RESERVED1[7];   /*!< Reserved                                                   Address offset: 0x10 -- 0x28 */
+  __IO uint32_t IER;            /*!< TAMP Interrupt enable register,                            Address offset: 0x2C */
+  __IO uint32_t SR;             /*!< TAMP Status register,                                      Address offset: 0x30 */
+  __IO uint32_t MISR;           /*!< TAMP Masked Interrupt Status register,                     Address offset: 0x34 */
+       uint32_t RESERVED2;      /*!< Reserved                                                   Address offset: 0x38 */
+  __IO uint32_t SCR;            /*!< TAMP Status clear register,                                Address offset: 0x3C */
+       uint32_t RESERVED3[48];  /*!< Reserved                                                   Address offset: 0x54 -- 0xFC */
+  __IO uint32_t BKP0R;          /*!< TAMP backup register 0,                                    Address offset: 0x100 */
+  __IO uint32_t BKP1R;          /*!< TAMP backup register 1,                                    Address offset: 0x104 */
+  __IO uint32_t BKP2R;          /*!< TAMP backup register 2,                                    Address offset: 0x108 */
+  __IO uint32_t BKP3R;          /*!< TAMP backup register 3,                                    Address offset: 0x10C */
+  __IO uint32_t BKP4R;          /*!< TAMP backup register 4,                                    Address offset: 0x110 */
+} TAMP_TypeDef;
+
+  /**
+  * @brief Serial Peripheral Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1 (not used in I2S mode),       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,                              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,                                 Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,                                   Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register (not used in I2S mode),  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register (not used in I2S mode),          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register (not used in I2S mode),          Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;  /*!< SPI_I2S configuration register,                      Address offset: 0x1C */
+  __IO uint32_t I2SPR;    /*!< SPI_I2S prescaler register,                          Address offset: 0x20 */
+} SPI_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+typedef struct
+{
+  __IO uint32_t CFGR1;          /*!< SYSCFG configuration register 1,                   Address offset: 0x00 */
+       uint32_t RESERVED0[5];   /*!< Reserved,                                                   0x04 --0x14 */
+  __IO uint32_t CFGR2;          /*!< SYSCFG configuration register 2,                   Address offset: 0x18 */
+       uint32_t RESERVED1[25];  /*!< Reserved                                                           0x1C */
+  __IO uint32_t IT_LINE_SR[32]; /*!< SYSCFG configuration IT_LINE register,             Address offset: 0x80 */
+} SYSCFG_TypeDef;
+
+/**
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,                   Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,                   Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,          Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,        Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                      Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,            Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1,      Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2,      Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register,      Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                     Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */
+  __IO uint32_t OR1;         /*!< TIM option register,                      Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare register5,            Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare register6,            Address offset: 0x5C */
+  __IO uint32_t AF1;         /*!< TIM alternate function register 1,        Address offset: 0x60 */
+  __IO uint32_t AF2;         /*!< TIM alternate function register 2,        Address offset: 0x64 */
+  __IO uint32_t TISEL;       /*!< TIM Input Selection register,             Address offset: 0x68 */
+} TIM_TypeDef;
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< USART Control register 1,                 Address offset: 0x00  */
+  __IO uint32_t CR2;         /*!< USART Control register 2,                 Address offset: 0x04  */
+  __IO uint32_t CR3;         /*!< USART Control register 3,                 Address offset: 0x08  */
+  __IO uint32_t BRR;         /*!< USART Baud rate register,                 Address offset: 0x0C  */
+  __IO uint32_t GTPR;        /*!< USART Guard time and prescaler register,  Address offset: 0x10  */
+  __IO uint32_t RTOR;        /*!< USART Receiver Time Out register,         Address offset: 0x14  */
+  __IO uint32_t RQR;         /*!< USART Request register,                   Address offset: 0x18  */
+  __IO uint32_t ISR;         /*!< USART Interrupt and status register,      Address offset: 0x1C  */
+  __IO uint32_t ICR;         /*!< USART Interrupt flag Clear register,      Address offset: 0x20  */
+  __IO uint32_t RDR;         /*!< USART Receive Data register,              Address offset: 0x24  */
+  __IO uint32_t TDR;         /*!< USART Transmit Data register,             Address offset: 0x28  */
+  __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C  */
+} USART_TypeDef;
+
+/**
+  * @brief VREFBUF
+  */
+typedef struct
+{
+  __IO uint32_t CSR;         /*!< VREFBUF control and status register,         Address offset: 0x00 */
+  __IO uint32_t CCR;         /*!< VREFBUF calibration and control register,    Address offset: 0x04 */
+} VREFBUF_TypeDef;
+
+/**
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;         /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+/**
+  * @brief AES hardware accelerator
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
+  __IO uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
+  __IO uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
+  __IO uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
+  __IO uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
+  __IO uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
+  __IO uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
+  __IO uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
+  __IO uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
+  __IO uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
+  __IO uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
+  __IO uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
+  __IO uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
+  __IO uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
+  __IO uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
+  __IO uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
+  __IO uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
+  __IO uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
+  __IO uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
+  __IO uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
+  __IO uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
+  __IO uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
+  __IO uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x5C */
+} AES_TypeDef;
+
+/**
+  * @brief RNG
+  */
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+#define FLASH_BASE            (0x08000000UL)  /*!< FLASH base address */
+#define SRAM_BASE             (0x20000000UL)  /*!< SRAM base address */
+#define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
+#define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
+#define SRAM_SIZE_MAX         (0x00004000UL)  /*!< maximum SRAM size (up to 16 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x007FU)) << 10U)
+
+/*!< Peripheral memory map */
+#define APBPERIPH_BASE        (PERIPH_BASE)
+#define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
+
+/*!< APB peripherals */
+
+#define TIM2_BASE             (APBPERIPH_BASE + 0UL)
+#define TIM3_BASE             (APBPERIPH_BASE + 0x00000400UL)
+#define TIM6_BASE             (APBPERIPH_BASE + 0x00001000UL)
+#define TIM7_BASE             (APBPERIPH_BASE + 0x00001400UL)
+#define TIM14_BASE            (APBPERIPH_BASE + 0x00002000UL)
+#define RTC_BASE              (APBPERIPH_BASE + 0x00002800UL)
+#define WWDG_BASE             (APBPERIPH_BASE + 0x00002C00UL)
+#define IWDG_BASE             (APBPERIPH_BASE + 0x00003000UL)
+#define SPI2_BASE             (APBPERIPH_BASE + 0x00003800UL)
+#define USART2_BASE           (APBPERIPH_BASE + 0x00004400UL)
+#define I2C1_BASE             (APBPERIPH_BASE + 0x00005400UL)
+#define I2C2_BASE             (APBPERIPH_BASE + 0x00005800UL)
+#define PWR_BASE              (APBPERIPH_BASE + 0x00007000UL)
+#define DAC1_BASE             (APBPERIPH_BASE + 0x00007400UL)
+#define DAC_BASE              (APBPERIPH_BASE + 0x00007400UL) /* Kept for legacy purpose */
+#define LPTIM1_BASE           (APBPERIPH_BASE + 0x00007C00UL)
+#define LPUART1_BASE          (APBPERIPH_BASE + 0x00008000UL)
+#define LPTIM2_BASE           (APBPERIPH_BASE + 0x00009400UL)
+#define TAMP_BASE             (APBPERIPH_BASE + 0x0000B000UL)
+#define SYSCFG_BASE           (APBPERIPH_BASE + 0x00010000UL)
+#define VREFBUF_BASE          (APBPERIPH_BASE + 0x00010030UL)
+#define COMP1_BASE            (SYSCFG_BASE + 0x0200UL)
+#define COMP2_BASE            (SYSCFG_BASE + 0x0204UL)
+#define ADC1_BASE             (APBPERIPH_BASE + 0x00012400UL)
+#define ADC1_COMMON_BASE      (APBPERIPH_BASE + 0x00012708UL)
+#define ADC_BASE              (ADC1_COMMON_BASE) /* Kept for legacy purpose */
+#define TIM1_BASE             (APBPERIPH_BASE + 0x00012C00UL)
+#define SPI1_BASE             (APBPERIPH_BASE + 0x00013000UL)
+#define USART1_BASE           (APBPERIPH_BASE + 0x00013800UL)
+#define TIM15_BASE            (APBPERIPH_BASE + 0x00014000UL)
+#define TIM16_BASE            (APBPERIPH_BASE + 0x00014400UL)
+#define TIM17_BASE            (APBPERIPH_BASE + 0x00014800UL)
+#define DBG_BASE              (APBPERIPH_BASE + 0x00015800UL)
+
+
+/*!< AHB peripherals */
+#define DMA1_BASE             (AHBPERIPH_BASE)
+#define DMAMUX1_BASE          (AHBPERIPH_BASE + 0x00000800UL)
+#define RCC_BASE              (AHBPERIPH_BASE + 0x00001000UL)
+#define EXTI_BASE             (AHBPERIPH_BASE + 0x00001800UL)
+#define FLASH_R_BASE          (AHBPERIPH_BASE + 0x00002000UL)
+#define CRC_BASE              (AHBPERIPH_BASE + 0x00003000UL)
+
+#define RNG_BASE              (AHBPERIPH_BASE + 0x00005000UL)
+#define AES_BASE              (AHBPERIPH_BASE + 0x00006000UL)
+
+#define DMA1_Channel1_BASE    (DMA1_BASE + 0x00000008UL)
+#define DMA1_Channel2_BASE    (DMA1_BASE + 0x0000001CUL)
+#define DMA1_Channel3_BASE    (DMA1_BASE + 0x00000030UL)
+#define DMA1_Channel4_BASE    (DMA1_BASE + 0x00000044UL)
+#define DMA1_Channel5_BASE    (DMA1_BASE + 0x00000058UL)
+#define DMA1_Channel6_BASE    (DMA1_BASE + 0x0000006CUL)
+#define DMA1_Channel7_BASE    (DMA1_BASE + 0x00000080UL)
+
+#define DMAMUX1_Channel0_BASE    (DMAMUX1_BASE)
+#define DMAMUX1_Channel1_BASE    (DMAMUX1_BASE + 0x00000004UL)
+#define DMAMUX1_Channel2_BASE    (DMAMUX1_BASE + 0x00000008UL)
+#define DMAMUX1_Channel3_BASE    (DMAMUX1_BASE + 0x0000000CUL)
+#define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
+#define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
+#define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+
+#define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
+#define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
+#define DMAMUX1_RequestGenerator2_BASE  (DMAMUX1_BASE + 0x00000108UL)
+#define DMAMUX1_RequestGenerator3_BASE  (DMAMUX1_BASE + 0x0000010CUL)
+
+#define DMAMUX1_ChannelStatus_BASE      (DMAMUX1_BASE + 0x00000080UL)
+#define DMAMUX1_RequestGenStatus_BASE   (DMAMUX1_BASE + 0x00000140UL)
+
+/*!< IOPORT */
+#define GPIOA_BASE            (IOPORT_BASE + 0x00000000UL)
+#define GPIOB_BASE            (IOPORT_BASE + 0x00000400UL)
+#define GPIOC_BASE            (IOPORT_BASE + 0x00000800UL)
+#define GPIOD_BASE            (IOPORT_BASE + 0x00000C00UL)
+#define GPIOF_BASE            (IOPORT_BASE + 0x00001400UL)
+
+/*!< Device Electronic Signature */
+#define PACKAGE_BASE          (0x1FFF7500UL)        /*!< Package data register base address     */
+#define UID_BASE              (0x1FFF7590UL)        /*!< Unique device ID register base address */
+#define FLASHSIZE_BASE        (0x1FFF75E0UL)        /*!< Flash size data register base address  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define TIM3                ((TIM_TypeDef *) TIM3_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define TIM7                ((TIM_TypeDef *) TIM7_BASE)
+#define TIM14               ((TIM_TypeDef *) TIM14_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define TAMP                ((TAMP_TypeDef *) TAMP_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define DAC1                ((DAC_TypeDef *) DAC1_BASE)
+#define DAC                 ((DAC_TypeDef *) DAC_BASE) /* Kept for legacy purpose */
+#define LPUART1             ((USART_TypeDef *) LPUART1_BASE)
+#define LPTIM2              ((LPTIM_TypeDef *) LPTIM2_BASE)
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define VREFBUF             ((VREFBUF_TypeDef *) VREFBUF_BASE)
+#define COMP1               ((COMP_TypeDef *) COMP1_BASE)
+#define COMP2               ((COMP_TypeDef *) COMP2_BASE)
+#define COMP12_COMMON       ((COMP_Common_TypeDef *) COMP1_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define TIM15               ((TIM_TypeDef *) TIM15_BASE)
+#define TIM16               ((TIM_TypeDef *) TIM16_BASE)
+#define TIM17               ((TIM_TypeDef *) TIM17_BASE)
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOF               ((GPIO_TypeDef *) GPIOF_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) ADC1_COMMON_BASE)
+#define ADC                 (ADC1_COMMON) /* Kept for legacy purpose */
+
+#define AES                 ((AES_TypeDef *) AES_BASE)
+#define AES1                ((AES_TypeDef *) AES_BASE)
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+
+
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+#define DMAMUX1                ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
+#define DMAMUX1_Channel0       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
+#define DMAMUX1_Channel1       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel1_BASE)
+#define DMAMUX1_Channel2       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel2_BASE)
+#define DMAMUX1_Channel3       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel3_BASE)
+#define DMAMUX1_Channel4       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
+#define DMAMUX1_Channel5       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
+#define DMAMUX1_Channel6       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+
+#define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
+#define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
+#define DMAMUX1_RequestGenerator2  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator2_BASE)
+#define DMAMUX1_RequestGenerator3  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator3_BASE)
+
+#define DMAMUX1_ChannelStatus      ((DMAMUX_ChannelStatus_TypeDef *) DMAMUX1_ChannelStatus_BASE)
+#define DMAMUX1_RequestGenStatus   ((DMAMUX_RequestGenStatus_TypeDef *) DMAMUX1_RequestGenStatus_BASE)
+
+#define DBG              ((DBG_TypeDef *) DBG_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for ADC_ISR register  *******************/
+#define ADC_ISR_ADRDY_Pos              (0U)
+#define ADC_ISR_ADRDY_Msk              (0x1UL << ADC_ISR_ADRDY_Pos)            /*!< 0x00000001 */
+#define ADC_ISR_ADRDY                  ADC_ISR_ADRDY_Msk                       /*!< ADC ready flag */
+#define ADC_ISR_EOSMP_Pos              (1U)
+#define ADC_ISR_EOSMP_Msk              (0x1UL << ADC_ISR_EOSMP_Pos)            /*!< 0x00000002 */
+#define ADC_ISR_EOSMP                  ADC_ISR_EOSMP_Msk                       /*!< ADC group regular end of sampling flag */
+#define ADC_ISR_EOC_Pos                (2U)
+#define ADC_ISR_EOC_Msk                (0x1UL << ADC_ISR_EOC_Pos)              /*!< 0x00000004 */
+#define ADC_ISR_EOC                    ADC_ISR_EOC_Msk                         /*!< ADC group regular end of unitary conversion flag */
+#define ADC_ISR_EOS_Pos                (3U)
+#define ADC_ISR_EOS_Msk                (0x1UL << ADC_ISR_EOS_Pos)              /*!< 0x00000008 */
+#define ADC_ISR_EOS                    ADC_ISR_EOS_Msk                         /*!< ADC group regular end of sequence conversions flag */
+#define ADC_ISR_OVR_Pos                (4U)
+#define ADC_ISR_OVR_Msk                (0x1UL << ADC_ISR_OVR_Pos)              /*!< 0x00000010 */
+#define ADC_ISR_OVR                    ADC_ISR_OVR_Msk                         /*!< ADC group regular overrun flag */
+#define ADC_ISR_AWD1_Pos               (7U)
+#define ADC_ISR_AWD1_Msk               (0x1UL << ADC_ISR_AWD1_Pos)             /*!< 0x00000080 */
+#define ADC_ISR_AWD1                   ADC_ISR_AWD1_Msk                        /*!< ADC analog watchdog 1 flag */
+#define ADC_ISR_AWD2_Pos               (8U)
+#define ADC_ISR_AWD2_Msk               (0x1UL << ADC_ISR_AWD2_Pos)             /*!< 0x00000100 */
+#define ADC_ISR_AWD2                   ADC_ISR_AWD2_Msk                        /*!< ADC analog watchdog 2 flag */
+#define ADC_ISR_AWD3_Pos               (9U)
+#define ADC_ISR_AWD3_Msk               (0x1UL << ADC_ISR_AWD3_Pos)             /*!< 0x00000200 */
+#define ADC_ISR_AWD3                   ADC_ISR_AWD3_Msk                        /*!< ADC analog watchdog 3 flag */
+#define ADC_ISR_EOCAL_Pos              (11U)
+#define ADC_ISR_EOCAL_Msk              (0x1UL << ADC_ISR_EOCAL_Pos)            /*!< 0x00000800 */
+#define ADC_ISR_EOCAL                  ADC_ISR_EOCAL_Msk                       /*!< ADC end of calibration flag */
+#define ADC_ISR_CCRDY_Pos              (13U)
+#define ADC_ISR_CCRDY_Msk              (0x1UL << ADC_ISR_CCRDY_Pos)            /*!< 0x00002000 */
+#define ADC_ISR_CCRDY                  ADC_ISR_CCRDY_Msk                       /*!< ADC channel configuration ready flag */
+
+/* Legacy defines */
+#define ADC_ISR_EOSEQ           (ADC_ISR_EOS)
+
+/********************  Bit definition for ADC_IER register  *******************/
+#define ADC_IER_ADRDYIE_Pos            (0U)
+#define ADC_IER_ADRDYIE_Msk            (0x1UL << ADC_IER_ADRDYIE_Pos)          /*!< 0x00000001 */
+#define ADC_IER_ADRDYIE                ADC_IER_ADRDYIE_Msk                     /*!< ADC ready interrupt */
+#define ADC_IER_EOSMPIE_Pos            (1U)
+#define ADC_IER_EOSMPIE_Msk            (0x1UL << ADC_IER_EOSMPIE_Pos)          /*!< 0x00000002 */
+#define ADC_IER_EOSMPIE                ADC_IER_EOSMPIE_Msk                     /*!< ADC group regular end of sampling interrupt */
+#define ADC_IER_EOCIE_Pos              (2U)
+#define ADC_IER_EOCIE_Msk              (0x1UL << ADC_IER_EOCIE_Pos)            /*!< 0x00000004 */
+#define ADC_IER_EOCIE                  ADC_IER_EOCIE_Msk                       /*!< ADC group regular end of unitary conversion interrupt */
+#define ADC_IER_EOSIE_Pos              (3U)
+#define ADC_IER_EOSIE_Msk              (0x1UL << ADC_IER_EOSIE_Pos)            /*!< 0x00000008 */
+#define ADC_IER_EOSIE                  ADC_IER_EOSIE_Msk                       /*!< ADC group regular end of sequence conversions interrupt */
+#define ADC_IER_OVRIE_Pos              (4U)
+#define ADC_IER_OVRIE_Msk              (0x1UL << ADC_IER_OVRIE_Pos)            /*!< 0x00000010 */
+#define ADC_IER_OVRIE                  ADC_IER_OVRIE_Msk                       /*!< ADC group regular overrun interrupt */
+#define ADC_IER_AWD1IE_Pos             (7U)
+#define ADC_IER_AWD1IE_Msk             (0x1UL << ADC_IER_AWD1IE_Pos)           /*!< 0x00000080 */
+#define ADC_IER_AWD1IE                 ADC_IER_AWD1IE_Msk                      /*!< ADC analog watchdog 1 interrupt */
+#define ADC_IER_AWD2IE_Pos             (8U)
+#define ADC_IER_AWD2IE_Msk             (0x1UL << ADC_IER_AWD2IE_Pos)           /*!< 0x00000100 */
+#define ADC_IER_AWD2IE                 ADC_IER_AWD2IE_Msk                      /*!< ADC analog watchdog 2 interrupt */
+#define ADC_IER_AWD3IE_Pos             (9U)
+#define ADC_IER_AWD3IE_Msk             (0x1UL << ADC_IER_AWD3IE_Pos)           /*!< 0x00000200 */
+#define ADC_IER_AWD3IE                 ADC_IER_AWD3IE_Msk                      /*!< ADC analog watchdog 3 interrupt */
+#define ADC_IER_EOCALIE_Pos            (11U)
+#define ADC_IER_EOCALIE_Msk            (0x1UL << ADC_IER_EOCALIE_Pos)          /*!< 0x00000800 */
+#define ADC_IER_EOCALIE                ADC_IER_EOCALIE_Msk                     /*!< ADC end of calibration interrupt */
+#define ADC_IER_CCRDYIE_Pos            (13U)
+#define ADC_IER_CCRDYIE_Msk            (0x1UL << ADC_IER_CCRDYIE_Pos)          /*!< 0x00002000 */
+#define ADC_IER_CCRDYIE                ADC_IER_CCRDYIE_Msk                     /*!< ADC channel configuration ready interrupt */
+
+/* Legacy defines */
+#define ADC_IER_EOSEQIE           (ADC_IER_EOSIE)
+
+/********************  Bit definition for ADC_CR register  ********************/
+#define ADC_CR_ADEN_Pos                (0U)
+#define ADC_CR_ADEN_Msk                (0x1UL << ADC_CR_ADEN_Pos)              /*!< 0x00000001 */
+#define ADC_CR_ADEN                    ADC_CR_ADEN_Msk                         /*!< ADC enable */
+#define ADC_CR_ADDIS_Pos               (1U)
+#define ADC_CR_ADDIS_Msk               (0x1UL << ADC_CR_ADDIS_Pos)             /*!< 0x00000002 */
+#define ADC_CR_ADDIS                   ADC_CR_ADDIS_Msk                        /*!< ADC disable */
+#define ADC_CR_ADSTART_Pos             (2U)
+#define ADC_CR_ADSTART_Msk             (0x1UL << ADC_CR_ADSTART_Pos)           /*!< 0x00000004 */
+#define ADC_CR_ADSTART                 ADC_CR_ADSTART_Msk                      /*!< ADC group regular conversion start */
+#define ADC_CR_ADSTP_Pos               (4U)
+#define ADC_CR_ADSTP_Msk               (0x1UL << ADC_CR_ADSTP_Pos)             /*!< 0x00000010 */
+#define ADC_CR_ADSTP                   ADC_CR_ADSTP_Msk                        /*!< ADC group regular conversion stop */
+#define ADC_CR_ADVREGEN_Pos            (28U)
+#define ADC_CR_ADVREGEN_Msk            (0x1UL << ADC_CR_ADVREGEN_Pos)          /*!< 0x10000000 */
+#define ADC_CR_ADVREGEN                ADC_CR_ADVREGEN_Msk                     /*!< ADC voltage regulator enable */
+#define ADC_CR_ADCAL_Pos               (31U)
+#define ADC_CR_ADCAL_Msk               (0x1UL << ADC_CR_ADCAL_Pos)             /*!< 0x80000000 */
+#define ADC_CR_ADCAL                   ADC_CR_ADCAL_Msk                        /*!< ADC calibration */
+
+/********************  Bit definition for ADC_CFGR1 register  *****************/
+#define ADC_CFGR1_DMAEN_Pos            (0U)
+#define ADC_CFGR1_DMAEN_Msk            (0x1UL << ADC_CFGR1_DMAEN_Pos)          /*!< 0x00000001 */
+#define ADC_CFGR1_DMAEN                ADC_CFGR1_DMAEN_Msk                     /*!< ADC DMA transfer enable */
+#define ADC_CFGR1_DMACFG_Pos           (1U)
+#define ADC_CFGR1_DMACFG_Msk           (0x1UL << ADC_CFGR1_DMACFG_Pos)         /*!< 0x00000002 */
+#define ADC_CFGR1_DMACFG               ADC_CFGR1_DMACFG_Msk                    /*!< ADC DMA transfer configuration */
+
+#define ADC_CFGR1_SCANDIR_Pos          (2U)
+#define ADC_CFGR1_SCANDIR_Msk          (0x1UL << ADC_CFGR1_SCANDIR_Pos)        /*!< 0x00000004 */
+#define ADC_CFGR1_SCANDIR              ADC_CFGR1_SCANDIR_Msk                   /*!< ADC group regular sequencer scan direction */
+
+#define ADC_CFGR1_RES_Pos              (3U)
+#define ADC_CFGR1_RES_Msk              (0x3UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000018 */
+#define ADC_CFGR1_RES                  ADC_CFGR1_RES_Msk                       /*!< ADC data resolution */
+#define ADC_CFGR1_RES_0                (0x1U << ADC_CFGR1_RES_Pos)             /*!< 0x00000008 */
+#define ADC_CFGR1_RES_1                (0x2U << ADC_CFGR1_RES_Pos)             /*!< 0x00000010 */
+
+#define ADC_CFGR1_ALIGN_Pos            (5U)
+#define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
+
+#define ADC_CFGR1_EXTSEL_Pos           (6U)
+#define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
+#define ADC_CFGR1_EXTSEL               ADC_CFGR1_EXTSEL_Msk                    /*!< ADC group regular external trigger source */
+#define ADC_CFGR1_EXTSEL_0             (0x1UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000040 */
+#define ADC_CFGR1_EXTSEL_1             (0x2UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000080 */
+#define ADC_CFGR1_EXTSEL_2             (0x4UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000100 */
+
+#define ADC_CFGR1_EXTEN_Pos            (10U)
+#define ADC_CFGR1_EXTEN_Msk            (0x3UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000C00 */
+#define ADC_CFGR1_EXTEN                ADC_CFGR1_EXTEN_Msk                     /*!< ADC group regular external trigger polarity */
+#define ADC_CFGR1_EXTEN_0              (0x1UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000400 */
+#define ADC_CFGR1_EXTEN_1              (0x2UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000800 */
+
+#define ADC_CFGR1_OVRMOD_Pos           (12U)
+#define ADC_CFGR1_OVRMOD_Msk           (0x1UL << ADC_CFGR1_OVRMOD_Pos)         /*!< 0x00001000 */
+#define ADC_CFGR1_OVRMOD               ADC_CFGR1_OVRMOD_Msk                    /*!< ADC group regular overrun configuration */
+#define ADC_CFGR1_CONT_Pos             (13U)
+#define ADC_CFGR1_CONT_Msk             (0x1UL << ADC_CFGR1_CONT_Pos)           /*!< 0x00002000 */
+#define ADC_CFGR1_CONT                 ADC_CFGR1_CONT_Msk                      /*!< ADC group regular continuous conversion mode */
+#define ADC_CFGR1_WAIT_Pos             (14U)
+#define ADC_CFGR1_WAIT_Msk             (0x1UL << ADC_CFGR1_WAIT_Pos)           /*!< 0x00004000 */
+#define ADC_CFGR1_WAIT                 ADC_CFGR1_WAIT_Msk                      /*!< ADC low power auto wait */
+#define ADC_CFGR1_AUTOFF_Pos           (15U)
+#define ADC_CFGR1_AUTOFF_Msk           (0x1UL << ADC_CFGR1_AUTOFF_Pos)         /*!< 0x00008000 */
+#define ADC_CFGR1_AUTOFF               ADC_CFGR1_AUTOFF_Msk                    /*!< ADC low power auto power off */
+#define ADC_CFGR1_DISCEN_Pos           (16U)
+#define ADC_CFGR1_DISCEN_Msk           (0x1UL << ADC_CFGR1_DISCEN_Pos)         /*!< 0x00010000 */
+#define ADC_CFGR1_DISCEN               ADC_CFGR1_DISCEN_Msk                    /*!< ADC group regular sequencer discontinuous mode */
+#define ADC_CFGR1_CHSELRMOD_Pos        (21U)
+#define ADC_CFGR1_CHSELRMOD_Msk        (0x1UL << ADC_CFGR1_CHSELRMOD_Pos)      /*!< 0x00200000 */
+#define ADC_CFGR1_CHSELRMOD            ADC_CFGR1_CHSELRMOD_Msk                 /*!< ADC group regular sequencer mode */
+
+#define ADC_CFGR1_AWD1SGL_Pos          (22U)
+#define ADC_CFGR1_AWD1SGL_Msk          (0x1UL << ADC_CFGR1_AWD1SGL_Pos)        /*!< 0x00400000 */
+#define ADC_CFGR1_AWD1SGL              ADC_CFGR1_AWD1SGL_Msk                   /*!< ADC analog watchdog 1 monitoring a single channel or all channels */
+#define ADC_CFGR1_AWD1EN_Pos           (23U)
+#define ADC_CFGR1_AWD1EN_Msk           (0x1UL << ADC_CFGR1_AWD1EN_Pos)         /*!< 0x00800000 */
+#define ADC_CFGR1_AWD1EN               ADC_CFGR1_AWD1EN_Msk                    /*!< ADC analog watchdog 1 enable on scope ADC group regular */
+
+#define ADC_CFGR1_AWD1CH_Pos           (26U)
+#define ADC_CFGR1_AWD1CH_Msk           (0x1FUL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x7C000000 */
+#define ADC_CFGR1_AWD1CH               ADC_CFGR1_AWD1CH_Msk                    /*!< ADC analog watchdog 1 monitored channel selection */
+#define ADC_CFGR1_AWD1CH_0             (0x01UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x04000000 */
+#define ADC_CFGR1_AWD1CH_1             (0x02UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x08000000 */
+#define ADC_CFGR1_AWD1CH_2             (0x04UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x10000000 */
+#define ADC_CFGR1_AWD1CH_3             (0x08UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x20000000 */
+#define ADC_CFGR1_AWD1CH_4             (0x10UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x40000000 */
+
+/* Legacy defines */
+#define ADC_CFGR1_AUTDLY          (ADC_CFGR1_WAIT)
+
+/********************  Bit definition for ADC_CFGR2 register  *****************/
+#define ADC_CFGR2_OVSE_Pos             (0U)
+#define ADC_CFGR2_OVSE_Msk             (0x1UL << ADC_CFGR2_OVSE_Pos)           /*!< 0x00000001 */
+#define ADC_CFGR2_OVSE                 ADC_CFGR2_OVSE_Msk                      /*!< ADC oversampler enable on scope ADC group regular */
+
+#define ADC_CFGR2_OVSR_Pos             (2U)
+#define ADC_CFGR2_OVSR_Msk             (0x7UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x0000001C */
+#define ADC_CFGR2_OVSR                 ADC_CFGR2_OVSR_Msk                      /*!< ADC oversampling ratio */
+#define ADC_CFGR2_OVSR_0               (0x1UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000004 */
+#define ADC_CFGR2_OVSR_1               (0x2UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000008 */
+#define ADC_CFGR2_OVSR_2               (0x4UL << ADC_CFGR2_OVSR_Pos)           /*!< 0x00000010 */
+
+#define ADC_CFGR2_OVSS_Pos             (5U)
+#define ADC_CFGR2_OVSS_Msk             (0xFUL << ADC_CFGR2_OVSS_Pos)           /*!< 0x000001E0 */
+#define ADC_CFGR2_OVSS                 ADC_CFGR2_OVSS_Msk                      /*!< ADC oversampling shift */
+#define ADC_CFGR2_OVSS_0               (0x1UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000020 */
+#define ADC_CFGR2_OVSS_1               (0x2UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000040 */
+#define ADC_CFGR2_OVSS_2               (0x4UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000080 */
+#define ADC_CFGR2_OVSS_3               (0x8UL << ADC_CFGR2_OVSS_Pos)           /*!< 0x00000100 */
+
+#define ADC_CFGR2_TOVS_Pos             (9U)
+#define ADC_CFGR2_TOVS_Msk             (0x1UL << ADC_CFGR2_TOVS_Pos)           /*!< 0x00000200 */
+#define ADC_CFGR2_TOVS                 ADC_CFGR2_TOVS_Msk                      /*!< ADC oversampling discontinuous mode (triggered mode) for ADC group regular */
+
+#define ADC_CFGR2_LFTRIG_Pos           (29U)
+#define ADC_CFGR2_LFTRIG_Msk           (0x1UL << ADC_CFGR2_LFTRIG_Pos)         /*!< 0x20000000 */
+#define ADC_CFGR2_LFTRIG               ADC_CFGR2_LFTRIG_Msk                    /*!< ADC low frequency trigger mode */
+
+#define ADC_CFGR2_CKMODE_Pos           (30U)
+#define ADC_CFGR2_CKMODE_Msk           (0x3UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0xC0000000 */
+#define ADC_CFGR2_CKMODE               ADC_CFGR2_CKMODE_Msk                    /*!< ADC clock source and prescaler (prescaler only for clock source synchronous) */
+#define ADC_CFGR2_CKMODE_1             (0x2UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x80000000 */
+#define ADC_CFGR2_CKMODE_0             (0x1UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x40000000 */
+
+/********************  Bit definition for ADC_SMPR register  ******************/
+#define ADC_SMPR_SMP1_Pos              (0U)
+#define ADC_SMPR_SMP1_Msk              (0x7UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000007 */
+#define ADC_SMPR_SMP1                  ADC_SMPR_SMP1_Msk                       /*!< ADC group of channels sampling time 1 */
+#define ADC_SMPR_SMP1_0                (0x1UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000001 */
+#define ADC_SMPR_SMP1_1                (0x2UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000002 */
+#define ADC_SMPR_SMP1_2                (0x4UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000004 */
+
+#define ADC_SMPR_SMP2_Pos              (4U)
+#define ADC_SMPR_SMP2_Msk              (0x7UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000070 */
+#define ADC_SMPR_SMP2                  ADC_SMPR_SMP2_Msk                       /*!< ADC group of channels sampling time 2 */
+#define ADC_SMPR_SMP2_0                (0x1UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000010 */
+#define ADC_SMPR_SMP2_1                (0x2UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000020 */
+#define ADC_SMPR_SMP2_2                (0x4UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000040 */
+
+#define ADC_SMPR_SMPSEL_Pos            (8U)
+#define ADC_SMPR_SMPSEL_Msk            (0x7FFFFUL << ADC_SMPR_SMPSEL_Pos)      /*!< 0x07FFFF00 */
+#define ADC_SMPR_SMPSEL                ADC_SMPR_SMPSEL_Msk                     /*!< ADC all channels sampling time selection */
+#define ADC_SMPR_SMPSEL0_Pos           (8U)
+#define ADC_SMPR_SMPSEL0_Msk           (0x1UL << ADC_SMPR_SMPSEL0_Pos)         /*!< 0x00000100 */
+#define ADC_SMPR_SMPSEL0               ADC_SMPR_SMPSEL0_Msk                    /*!< ADC channel 0 sampling time selection */
+#define ADC_SMPR_SMPSEL1_Pos           (9U)
+#define ADC_SMPR_SMPSEL1_Msk           (0x1UL << ADC_SMPR_SMPSEL1_Pos)         /*!< 0x00000200 */
+#define ADC_SMPR_SMPSEL1               ADC_SMPR_SMPSEL1_Msk                    /*!< ADC channel 1 sampling time selection */
+#define ADC_SMPR_SMPSEL2_Pos           (10U)
+#define ADC_SMPR_SMPSEL2_Msk           (0x1UL << ADC_SMPR_SMPSEL2_Pos)         /*!< 0x00000400 */
+#define ADC_SMPR_SMPSEL2               ADC_SMPR_SMPSEL2_Msk                    /*!< ADC channel 2 sampling time selection */
+#define ADC_SMPR_SMPSEL3_Pos           (11U)
+#define ADC_SMPR_SMPSEL3_Msk           (0x1UL << ADC_SMPR_SMPSEL3_Pos)         /*!< 0x00000800 */
+#define ADC_SMPR_SMPSEL3               ADC_SMPR_SMPSEL3_Msk                    /*!< ADC channel 3 sampling time selection */
+#define ADC_SMPR_SMPSEL4_Pos           (12U)
+#define ADC_SMPR_SMPSEL4_Msk           (0x1UL << ADC_SMPR_SMPSEL4_Pos)         /*!< 0x00001000 */
+#define ADC_SMPR_SMPSEL4               ADC_SMPR_SMPSEL4_Msk                    /*!< ADC channel 4 sampling time selection */
+#define ADC_SMPR_SMPSEL5_Pos           (13U)
+#define ADC_SMPR_SMPSEL5_Msk           (0x1UL << ADC_SMPR_SMPSEL5_Pos)         /*!< 0x00002000 */
+#define ADC_SMPR_SMPSEL5               ADC_SMPR_SMPSEL5_Msk                    /*!< ADC channel 5 sampling time selection */
+#define ADC_SMPR_SMPSEL6_Pos           (14U)
+#define ADC_SMPR_SMPSEL6_Msk           (0x1UL << ADC_SMPR_SMPSEL6_Pos)         /*!< 0x00004000 */
+#define ADC_SMPR_SMPSEL6               ADC_SMPR_SMPSEL6_Msk                    /*!< ADC channel 6 sampling time selection */
+#define ADC_SMPR_SMPSEL7_Pos           (15U)
+#define ADC_SMPR_SMPSEL7_Msk           (0x1UL << ADC_SMPR_SMPSEL7_Pos)         /*!< 0x00008000 */
+#define ADC_SMPR_SMPSEL7               ADC_SMPR_SMPSEL7_Msk                    /*!< ADC channel 7 sampling time selection */
+#define ADC_SMPR_SMPSEL8_Pos           (16U)
+#define ADC_SMPR_SMPSEL8_Msk           (0x1UL << ADC_SMPR_SMPSEL8_Pos)         /*!< 0x00010000 */
+#define ADC_SMPR_SMPSEL8               ADC_SMPR_SMPSEL8_Msk                    /*!< ADC channel 8 sampling time selection */
+#define ADC_SMPR_SMPSEL9_Pos           (17U)
+#define ADC_SMPR_SMPSEL9_Msk           (0x1UL << ADC_SMPR_SMPSEL9_Pos)         /*!< 0x00020000 */
+#define ADC_SMPR_SMPSEL9               ADC_SMPR_SMPSEL9_Msk                    /*!< ADC channel 9 sampling time selection */
+#define ADC_SMPR_SMPSEL10_Pos          (18U)
+#define ADC_SMPR_SMPSEL10_Msk          (0x1UL << ADC_SMPR_SMPSEL10_Pos)        /*!< 0x00040000 */
+#define ADC_SMPR_SMPSEL10              ADC_SMPR_SMPSEL10_Msk                   /*!< ADC channel 10 sampling time selection */
+#define ADC_SMPR_SMPSEL11_Pos          (19U)
+#define ADC_SMPR_SMPSEL11_Msk          (0x1UL << ADC_SMPR_SMPSEL11_Pos)        /*!< 0x00080000 */
+#define ADC_SMPR_SMPSEL11              ADC_SMPR_SMPSEL11_Msk                   /*!< ADC channel 11 sampling time selection */
+#define ADC_SMPR_SMPSEL12_Pos          (20U)
+#define ADC_SMPR_SMPSEL12_Msk          (0x1UL << ADC_SMPR_SMPSEL12_Pos)        /*!< 0x00100000 */
+#define ADC_SMPR_SMPSEL12              ADC_SMPR_SMPSEL12_Msk                   /*!< ADC channel 12 sampling time selection */
+#define ADC_SMPR_SMPSEL13_Pos          (21U)
+#define ADC_SMPR_SMPSEL13_Msk          (0x1UL << ADC_SMPR_SMPSEL13_Pos)        /*!< 0x00200000 */
+#define ADC_SMPR_SMPSEL13              ADC_SMPR_SMPSEL13_Msk                   /*!< ADC channel 13 sampling time selection */
+#define ADC_SMPR_SMPSEL14_Pos          (22U)
+#define ADC_SMPR_SMPSEL14_Msk          (0x1UL << ADC_SMPR_SMPSEL14_Pos)        /*!< 0x00400000 */
+#define ADC_SMPR_SMPSEL14              ADC_SMPR_SMPSEL14_Msk                   /*!< ADC channel 14 sampling time selection */
+#define ADC_SMPR_SMPSEL15_Pos          (23U)
+#define ADC_SMPR_SMPSEL15_Msk          (0x1UL << ADC_SMPR_SMPSEL15_Pos)        /*!< 0x00800000 */
+#define ADC_SMPR_SMPSEL15              ADC_SMPR_SMPSEL15_Msk                   /*!< ADC channel 15 sampling time selection */
+#define ADC_SMPR_SMPSEL16_Pos          (24U)
+#define ADC_SMPR_SMPSEL16_Msk          (0x1UL << ADC_SMPR_SMPSEL16_Pos)        /*!< 0x01000000 */
+#define ADC_SMPR_SMPSEL16              ADC_SMPR_SMPSEL16_Msk                   /*!< ADC channel 16 sampling time selection */
+#define ADC_SMPR_SMPSEL17_Pos          (25U)
+#define ADC_SMPR_SMPSEL17_Msk          (0x1UL << ADC_SMPR_SMPSEL17_Pos)        /*!< 0x02000000 */
+#define ADC_SMPR_SMPSEL17              ADC_SMPR_SMPSEL17_Msk                   /*!< ADC channel 17 sampling time selection */
+#define ADC_SMPR_SMPSEL18_Pos          (26U)
+#define ADC_SMPR_SMPSEL18_Msk          (0x1UL << ADC_SMPR_SMPSEL18_Pos)        /*!< 0x04000000 */
+#define ADC_SMPR_SMPSEL18              ADC_SMPR_SMPSEL18_Msk                   /*!< ADC channel 18 sampling time selection */
+
+/********************  Bit definition for ADC_TR1 register  *******************/
+#define ADC_TR1_LT1_Pos                (0U)
+#define ADC_TR1_LT1_Msk                (0xFFFUL << ADC_TR1_LT1_Pos)            /*!< 0x00000FFF */
+#define ADC_TR1_LT1                    ADC_TR1_LT1_Msk                         /*!< ADC analog watchdog 1 threshold low */
+#define ADC_TR1_LT1_0                  (0x001UL << ADC_TR1_LT1_Pos)            /*!< 0x00000001 */
+#define ADC_TR1_LT1_1                  (0x002UL << ADC_TR1_LT1_Pos)            /*!< 0x00000002 */
+#define ADC_TR1_LT1_2                  (0x004UL << ADC_TR1_LT1_Pos)            /*!< 0x00000004 */
+#define ADC_TR1_LT1_3                  (0x008UL << ADC_TR1_LT1_Pos)            /*!< 0x00000008 */
+#define ADC_TR1_LT1_4                  (0x010UL << ADC_TR1_LT1_Pos)            /*!< 0x00000010 */
+#define ADC_TR1_LT1_5                  (0x020UL << ADC_TR1_LT1_Pos)            /*!< 0x00000020 */
+#define ADC_TR1_LT1_6                  (0x040UL << ADC_TR1_LT1_Pos)            /*!< 0x00000040 */
+#define ADC_TR1_LT1_7                  (0x080UL << ADC_TR1_LT1_Pos)            /*!< 0x00000080 */
+#define ADC_TR1_LT1_8                  (0x100UL << ADC_TR1_LT1_Pos)            /*!< 0x00000100 */
+#define ADC_TR1_LT1_9                  (0x200UL << ADC_TR1_LT1_Pos)            /*!< 0x00000200 */
+#define ADC_TR1_LT1_10                 (0x400UL << ADC_TR1_LT1_Pos)            /*!< 0x00000400 */
+#define ADC_TR1_LT1_11                 (0x800UL << ADC_TR1_LT1_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR1_HT1_Pos                (16U)
+#define ADC_TR1_HT1_Msk                (0xFFFUL << ADC_TR1_HT1_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR1_HT1                    ADC_TR1_HT1_Msk                         /*!< ADC Analog watchdog 1 threshold high */
+#define ADC_TR1_HT1_0                  (0x001UL << ADC_TR1_HT1_Pos)            /*!< 0x00010000 */
+#define ADC_TR1_HT1_1                  (0x002UL << ADC_TR1_HT1_Pos)            /*!< 0x00020000 */
+#define ADC_TR1_HT1_2                  (0x004UL << ADC_TR1_HT1_Pos)            /*!< 0x00040000 */
+#define ADC_TR1_HT1_3                  (0x008UL << ADC_TR1_HT1_Pos)            /*!< 0x00080000 */
+#define ADC_TR1_HT1_4                  (0x010UL << ADC_TR1_HT1_Pos)            /*!< 0x00100000 */
+#define ADC_TR1_HT1_5                  (0x020UL << ADC_TR1_HT1_Pos)            /*!< 0x00200000 */
+#define ADC_TR1_HT1_6                  (0x040UL << ADC_TR1_HT1_Pos)            /*!< 0x00400000 */
+#define ADC_TR1_HT1_7                  (0x080UL << ADC_TR1_HT1_Pos)            /*!< 0x00800000 */
+#define ADC_TR1_HT1_8                  (0x100UL << ADC_TR1_HT1_Pos)            /*!< 0x01000000 */
+#define ADC_TR1_HT1_9                  (0x200UL << ADC_TR1_HT1_Pos)            /*!< 0x02000000 */
+#define ADC_TR1_HT1_10                 (0x400UL << ADC_TR1_HT1_Pos)            /*!< 0x04000000 */
+#define ADC_TR1_HT1_11                 (0x800UL << ADC_TR1_HT1_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_TR2 register  *******************/
+#define ADC_TR2_LT2_Pos                (0U)
+#define ADC_TR2_LT2_Msk                (0xFFFUL << ADC_TR2_LT2_Pos)            /*!< 0x00000FFF */
+#define ADC_TR2_LT2                    ADC_TR2_LT2_Msk                         /*!< ADC analog watchdog 2 threshold low */
+#define ADC_TR2_LT2_0                  (0x001UL << ADC_TR2_LT2_Pos)            /*!< 0x00000001 */
+#define ADC_TR2_LT2_1                  (0x002UL << ADC_TR2_LT2_Pos)            /*!< 0x00000002 */
+#define ADC_TR2_LT2_2                  (0x004UL << ADC_TR2_LT2_Pos)            /*!< 0x00000004 */
+#define ADC_TR2_LT2_3                  (0x008UL << ADC_TR2_LT2_Pos)            /*!< 0x00000008 */
+#define ADC_TR2_LT2_4                  (0x010UL << ADC_TR2_LT2_Pos)            /*!< 0x00000010 */
+#define ADC_TR2_LT2_5                  (0x020UL << ADC_TR2_LT2_Pos)            /*!< 0x00000020 */
+#define ADC_TR2_LT2_6                  (0x040UL << ADC_TR2_LT2_Pos)            /*!< 0x00000040 */
+#define ADC_TR2_LT2_7                  (0x080UL << ADC_TR2_LT2_Pos)            /*!< 0x00000080 */
+#define ADC_TR2_LT2_8                  (0x100UL << ADC_TR2_LT2_Pos)            /*!< 0x00000100 */
+#define ADC_TR2_LT2_9                  (0x200UL << ADC_TR2_LT2_Pos)            /*!< 0x00000200 */
+#define ADC_TR2_LT2_10                 (0x400UL << ADC_TR2_LT2_Pos)            /*!< 0x00000400 */
+#define ADC_TR2_LT2_11                 (0x800UL << ADC_TR2_LT2_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR2_HT2_Pos                (16U)
+#define ADC_TR2_HT2_Msk                (0xFFFUL << ADC_TR2_HT2_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR2_HT2                    ADC_TR2_HT2_Msk                         /*!< ADC analog watchdog 2 threshold high */
+#define ADC_TR2_HT2_0                  (0x001UL << ADC_TR2_HT2_Pos)            /*!< 0x00010000 */
+#define ADC_TR2_HT2_1                  (0x002UL << ADC_TR2_HT2_Pos)            /*!< 0x00020000 */
+#define ADC_TR2_HT2_2                  (0x004UL << ADC_TR2_HT2_Pos)            /*!< 0x00040000 */
+#define ADC_TR2_HT2_3                  (0x008UL << ADC_TR2_HT2_Pos)            /*!< 0x00080000 */
+#define ADC_TR2_HT2_4                  (0x010UL << ADC_TR2_HT2_Pos)            /*!< 0x00100000 */
+#define ADC_TR2_HT2_5                  (0x020UL << ADC_TR2_HT2_Pos)            /*!< 0x00200000 */
+#define ADC_TR2_HT2_6                  (0x040UL << ADC_TR2_HT2_Pos)            /*!< 0x00400000 */
+#define ADC_TR2_HT2_7                  (0x080UL << ADC_TR2_HT2_Pos)            /*!< 0x00800000 */
+#define ADC_TR2_HT2_8                  (0x100UL << ADC_TR2_HT2_Pos)            /*!< 0x01000000 */
+#define ADC_TR2_HT2_9                  (0x200UL << ADC_TR2_HT2_Pos)            /*!< 0x02000000 */
+#define ADC_TR2_HT2_10                 (0x400UL << ADC_TR2_HT2_Pos)            /*!< 0x04000000 */
+#define ADC_TR2_HT2_11                 (0x800UL << ADC_TR2_HT2_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_CHSELR register  ****************/
+#define ADC_CHSELR_CHSEL_Pos           (0U)
+#define ADC_CHSELR_CHSEL_Msk           (0x7FFFFUL << ADC_CHSELR_CHSEL_Pos)     /*!< 0x0007FFFF */
+#define ADC_CHSELR_CHSEL               ADC_CHSELR_CHSEL_Msk                    /*!< ADC group regular sequencer channels, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL18_Pos         (18U)
+#define ADC_CHSELR_CHSEL18_Msk         (0x1UL << ADC_CHSELR_CHSEL18_Pos)       /*!< 0x00040000 */
+#define ADC_CHSELR_CHSEL18             ADC_CHSELR_CHSEL18_Msk                  /*!< ADC group regular sequencer channel 18, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL17_Pos         (17U)
+#define ADC_CHSELR_CHSEL17_Msk         (0x1UL << ADC_CHSELR_CHSEL17_Pos)       /*!< 0x00020000 */
+#define ADC_CHSELR_CHSEL17             ADC_CHSELR_CHSEL17_Msk                  /*!< ADC group regular sequencer channel 17, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL16_Pos         (16U)
+#define ADC_CHSELR_CHSEL16_Msk         (0x1UL << ADC_CHSELR_CHSEL16_Pos)       /*!< 0x00010000 */
+#define ADC_CHSELR_CHSEL16             ADC_CHSELR_CHSEL16_Msk                  /*!< ADC group regular sequencer channel 16, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL15_Pos         (15U)
+#define ADC_CHSELR_CHSEL15_Msk         (0x1UL << ADC_CHSELR_CHSEL15_Pos)       /*!< 0x00008000 */
+#define ADC_CHSELR_CHSEL15             ADC_CHSELR_CHSEL15_Msk                  /*!< ADC group regular sequencer channel 15, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL14_Pos         (14U)
+#define ADC_CHSELR_CHSEL14_Msk         (0x1UL << ADC_CHSELR_CHSEL14_Pos)       /*!< 0x00004000 */
+#define ADC_CHSELR_CHSEL14             ADC_CHSELR_CHSEL14_Msk                  /*!< ADC group regular sequencer channel 14, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL13_Pos         (13U)
+#define ADC_CHSELR_CHSEL13_Msk         (0x1UL << ADC_CHSELR_CHSEL13_Pos)       /*!< 0x00002000 */
+#define ADC_CHSELR_CHSEL13             ADC_CHSELR_CHSEL13_Msk                  /*!< ADC group regular sequencer channel 13, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL12_Pos         (12U)
+#define ADC_CHSELR_CHSEL12_Msk         (0x1UL << ADC_CHSELR_CHSEL12_Pos)       /*!< 0x00001000 */
+#define ADC_CHSELR_CHSEL12             ADC_CHSELR_CHSEL12_Msk                  /*!< ADC group regular sequencer channel 12, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL11_Pos         (11U)
+#define ADC_CHSELR_CHSEL11_Msk         (0x1UL << ADC_CHSELR_CHSEL11_Pos)       /*!< 0x00000800 */
+#define ADC_CHSELR_CHSEL11             ADC_CHSELR_CHSEL11_Msk                  /*!< ADC group regular sequencer channel 11, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL10_Pos         (10U)
+#define ADC_CHSELR_CHSEL10_Msk         (0x1UL << ADC_CHSELR_CHSEL10_Pos)       /*!< 0x00000400 */
+#define ADC_CHSELR_CHSEL10             ADC_CHSELR_CHSEL10_Msk                  /*!< ADC group regular sequencer channel 10, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL9_Pos          (9U)
+#define ADC_CHSELR_CHSEL9_Msk          (0x1UL << ADC_CHSELR_CHSEL9_Pos)        /*!< 0x00000200 */
+#define ADC_CHSELR_CHSEL9              ADC_CHSELR_CHSEL9_Msk                   /*!< ADC group regular sequencer channel 9, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL8_Pos          (8U)
+#define ADC_CHSELR_CHSEL8_Msk          (0x1UL << ADC_CHSELR_CHSEL8_Pos)        /*!< 0x00000100 */
+#define ADC_CHSELR_CHSEL8              ADC_CHSELR_CHSEL8_Msk                   /*!< ADC group regular sequencer channel 8, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL7_Pos          (7U)
+#define ADC_CHSELR_CHSEL7_Msk          (0x1UL << ADC_CHSELR_CHSEL7_Pos)        /*!< 0x00000080 */
+#define ADC_CHSELR_CHSEL7              ADC_CHSELR_CHSEL7_Msk                   /*!< ADC group regular sequencer channel 7, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL6_Pos          (6U)
+#define ADC_CHSELR_CHSEL6_Msk          (0x1UL << ADC_CHSELR_CHSEL6_Pos)        /*!< 0x00000040 */
+#define ADC_CHSELR_CHSEL6              ADC_CHSELR_CHSEL6_Msk                   /*!< ADC group regular sequencer channel 6, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL5_Pos          (5U)
+#define ADC_CHSELR_CHSEL5_Msk          (0x1UL << ADC_CHSELR_CHSEL5_Pos)        /*!< 0x00000020 */
+#define ADC_CHSELR_CHSEL5              ADC_CHSELR_CHSEL5_Msk                   /*!< ADC group regular sequencer channel 5, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL4_Pos          (4U)
+#define ADC_CHSELR_CHSEL4_Msk          (0x1UL << ADC_CHSELR_CHSEL4_Pos)        /*!< 0x00000010 */
+#define ADC_CHSELR_CHSEL4              ADC_CHSELR_CHSEL4_Msk                   /*!< ADC group regular sequencer channel 4, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL3_Pos          (3U)
+#define ADC_CHSELR_CHSEL3_Msk          (0x1UL << ADC_CHSELR_CHSEL3_Pos)        /*!< 0x00000008 */
+#define ADC_CHSELR_CHSEL3              ADC_CHSELR_CHSEL3_Msk                   /*!< ADC group regular sequencer channel 3, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL2_Pos          (2U)
+#define ADC_CHSELR_CHSEL2_Msk          (0x1UL << ADC_CHSELR_CHSEL2_Pos)        /*!< 0x00000004 */
+#define ADC_CHSELR_CHSEL2              ADC_CHSELR_CHSEL2_Msk                   /*!< ADC group regular sequencer channel 2, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL1_Pos          (1U)
+#define ADC_CHSELR_CHSEL1_Msk          (0x1UL << ADC_CHSELR_CHSEL1_Pos)        /*!< 0x00000002 */
+#define ADC_CHSELR_CHSEL1              ADC_CHSELR_CHSEL1_Msk                   /*!< ADC group regular sequencer channel 1, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL0_Pos          (0U)
+#define ADC_CHSELR_CHSEL0_Msk          (0x1UL << ADC_CHSELR_CHSEL0_Pos)        /*!< 0x00000001 */
+#define ADC_CHSELR_CHSEL0              ADC_CHSELR_CHSEL0_Msk                   /*!< ADC group regular sequencer channel 0, available when ADC_CFGR1_CHSELRMOD is reset */
+
+#define ADC_CHSELR_SQ_ALL_Pos          (0U)
+#define ADC_CHSELR_SQ_ALL_Msk          (0xFFFFFFFFUL << ADC_CHSELR_SQ_ALL_Pos) /*!< 0xFFFFFFFF */
+#define ADC_CHSELR_SQ_ALL              ADC_CHSELR_SQ_ALL_Msk                   /*!< ADC group regular sequencer all ranks, available when ADC_CFGR1_CHSELRMOD is set */
+
+#define ADC_CHSELR_SQ8_Pos             (28U)
+#define ADC_CHSELR_SQ8_Msk             (0xFUL << ADC_CHSELR_SQ8_Pos)           /*!< 0xF0000000 */
+#define ADC_CHSELR_SQ8                 ADC_CHSELR_SQ8_Msk                      /*!< ADC group regular sequencer rank 8, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ8_0               (0x1UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x10000000 */
+#define ADC_CHSELR_SQ8_1               (0x2UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x20000000 */
+#define ADC_CHSELR_SQ8_2               (0x4UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x40000000 */
+#define ADC_CHSELR_SQ8_3               (0x8UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x80000000 */
+
+#define ADC_CHSELR_SQ7_Pos             (24U)
+#define ADC_CHSELR_SQ7_Msk             (0xFUL << ADC_CHSELR_SQ7_Pos)           /*!< 0x0F000000 */
+#define ADC_CHSELR_SQ7                 ADC_CHSELR_SQ7_Msk                      /*!< ADC group regular sequencer rank 7, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ7_0               (0x1UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x01000000 */
+#define ADC_CHSELR_SQ7_1               (0x2UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x02000000 */
+#define ADC_CHSELR_SQ7_2               (0x4UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x04000000 */
+#define ADC_CHSELR_SQ7_3               (0x8UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x08000000 */
+
+#define ADC_CHSELR_SQ6_Pos             (20U)
+#define ADC_CHSELR_SQ6_Msk             (0xFUL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00F00000 */
+#define ADC_CHSELR_SQ6                 ADC_CHSELR_SQ6_Msk                      /*!< ADC group regular sequencer rank 6, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ6_0               (0x1UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00100000 */
+#define ADC_CHSELR_SQ6_1               (0x2UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00200000 */
+#define ADC_CHSELR_SQ6_2               (0x4UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00400000 */
+#define ADC_CHSELR_SQ6_3               (0x8UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00800000 */
+
+#define ADC_CHSELR_SQ5_Pos             (16U)
+#define ADC_CHSELR_SQ5_Msk             (0xFUL << ADC_CHSELR_SQ5_Pos)           /*!< 0x000F0000 */
+#define ADC_CHSELR_SQ5                 ADC_CHSELR_SQ5_Msk                      /*!< ADC group regular sequencer rank 5, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ5_0               (0x1UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00010000 */
+#define ADC_CHSELR_SQ5_1               (0x2UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00020000 */
+#define ADC_CHSELR_SQ5_2               (0x4UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00040000 */
+#define ADC_CHSELR_SQ5_3               (0x8UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00080000 */
+
+#define ADC_CHSELR_SQ4_Pos             (12U)
+#define ADC_CHSELR_SQ4_Msk             (0xFUL << ADC_CHSELR_SQ4_Pos)           /*!< 0x0000F000 */
+#define ADC_CHSELR_SQ4                 ADC_CHSELR_SQ4_Msk                      /*!< ADC group regular sequencer rank 4, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ4_0               (0x1UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00001000 */
+#define ADC_CHSELR_SQ4_1               (0x2UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00002000 */
+#define ADC_CHSELR_SQ4_2               (0x4UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00004000 */
+#define ADC_CHSELR_SQ4_3               (0x8UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00008000 */
+
+#define ADC_CHSELR_SQ3_Pos             (8U)
+#define ADC_CHSELR_SQ3_Msk             (0xFUL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000F00 */
+#define ADC_CHSELR_SQ3                 ADC_CHSELR_SQ3_Msk                      /*!< ADC group regular sequencer rank 3, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ3_0               (0x1UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000100 */
+#define ADC_CHSELR_SQ3_1               (0x2UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000200 */
+#define ADC_CHSELR_SQ3_2               (0x4UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000400 */
+#define ADC_CHSELR_SQ3_3               (0x8UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000800 */
+
+#define ADC_CHSELR_SQ2_Pos             (4U)
+#define ADC_CHSELR_SQ2_Msk             (0xFUL << ADC_CHSELR_SQ2_Pos)           /*!< 0x000000F0 */
+#define ADC_CHSELR_SQ2                 ADC_CHSELR_SQ2_Msk                      /*!< ADC group regular sequencer rank 2, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ2_0               (0x1UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000010 */
+#define ADC_CHSELR_SQ2_1               (0x2UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000020 */
+#define ADC_CHSELR_SQ2_2               (0x4UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000040 */
+#define ADC_CHSELR_SQ2_3               (0x8UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000080 */
+
+#define ADC_CHSELR_SQ1_Pos             (0U)
+#define ADC_CHSELR_SQ1_Msk             (0xFUL << ADC_CHSELR_SQ1_Pos)           /*!< 0x0000000F */
+#define ADC_CHSELR_SQ1                 ADC_CHSELR_SQ1_Msk                      /*!< ADC group regular sequencer rank 1, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ1_0               (0x1UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000001 */
+#define ADC_CHSELR_SQ1_1               (0x2UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000002 */
+#define ADC_CHSELR_SQ1_2               (0x4UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000004 */
+#define ADC_CHSELR_SQ1_3               (0x8UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000008 */
+
+/********************  Bit definition for ADC_TR3 register  *******************/
+#define ADC_TR3_LT3_Pos                (0U)
+#define ADC_TR3_LT3_Msk                (0xFFFUL << ADC_TR3_LT3_Pos)            /*!< 0x00000FFF */
+#define ADC_TR3_LT3                    ADC_TR3_LT3_Msk                         /*!< ADC analog watchdog 3 threshold low */
+#define ADC_TR3_LT3_0                  (0x001UL << ADC_TR3_LT3_Pos)            /*!< 0x00000001 */
+#define ADC_TR3_LT3_1                  (0x002UL << ADC_TR3_LT3_Pos)            /*!< 0x00000002 */
+#define ADC_TR3_LT3_2                  (0x004UL << ADC_TR3_LT3_Pos)            /*!< 0x00000004 */
+#define ADC_TR3_LT3_3                  (0x008UL << ADC_TR3_LT3_Pos)            /*!< 0x00000008 */
+#define ADC_TR3_LT3_4                  (0x010UL << ADC_TR3_LT3_Pos)            /*!< 0x00000010 */
+#define ADC_TR3_LT3_5                  (0x020UL << ADC_TR3_LT3_Pos)            /*!< 0x00000020 */
+#define ADC_TR3_LT3_6                  (0x040UL << ADC_TR3_LT3_Pos)            /*!< 0x00000040 */
+#define ADC_TR3_LT3_7                  (0x080UL << ADC_TR3_LT3_Pos)            /*!< 0x00000080 */
+#define ADC_TR3_LT3_8                  (0x100UL << ADC_TR3_LT3_Pos)            /*!< 0x00000100 */
+#define ADC_TR3_LT3_9                  (0x200UL << ADC_TR3_LT3_Pos)            /*!< 0x00000200 */
+#define ADC_TR3_LT3_10                 (0x400UL << ADC_TR3_LT3_Pos)            /*!< 0x00000400 */
+#define ADC_TR3_LT3_11                 (0x800UL << ADC_TR3_LT3_Pos)            /*!< 0x00000800 */
+
+#define ADC_TR3_HT3_Pos                (16U)
+#define ADC_TR3_HT3_Msk                (0xFFFUL << ADC_TR3_HT3_Pos)            /*!< 0x0FFF0000 */
+#define ADC_TR3_HT3                    ADC_TR3_HT3_Msk                         /*!< ADC analog watchdog 3 threshold high */
+#define ADC_TR3_HT3_0                  (0x001UL << ADC_TR3_HT3_Pos)            /*!< 0x00010000 */
+#define ADC_TR3_HT3_1                  (0x002UL << ADC_TR3_HT3_Pos)            /*!< 0x00020000 */
+#define ADC_TR3_HT3_2                  (0x004UL << ADC_TR3_HT3_Pos)            /*!< 0x00040000 */
+#define ADC_TR3_HT3_3                  (0x008UL << ADC_TR3_HT3_Pos)            /*!< 0x00080000 */
+#define ADC_TR3_HT3_4                  (0x010UL << ADC_TR3_HT3_Pos)            /*!< 0x00100000 */
+#define ADC_TR3_HT3_5                  (0x020UL << ADC_TR3_HT3_Pos)            /*!< 0x00200000 */
+#define ADC_TR3_HT3_6                  (0x040UL << ADC_TR3_HT3_Pos)            /*!< 0x00400000 */
+#define ADC_TR3_HT3_7                  (0x080UL << ADC_TR3_HT3_Pos)            /*!< 0x00800000 */
+#define ADC_TR3_HT3_8                  (0x100UL << ADC_TR3_HT3_Pos)            /*!< 0x01000000 */
+#define ADC_TR3_HT3_9                  (0x200UL << ADC_TR3_HT3_Pos)            /*!< 0x02000000 */
+#define ADC_TR3_HT3_10                 (0x400UL << ADC_TR3_HT3_Pos)            /*!< 0x04000000 */
+#define ADC_TR3_HT3_11                 (0x800UL << ADC_TR3_HT3_Pos)            /*!< 0x08000000 */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos                (0U)
+#define ADC_DR_DATA_Msk                (0xFFFFUL << ADC_DR_DATA_Pos)           /*!< 0x0000FFFF */
+#define ADC_DR_DATA                    ADC_DR_DATA_Msk                         /*!< ADC group regular conversion data */
+#define ADC_DR_DATA_0                  (0x0001UL << ADC_DR_DATA_Pos)           /*!< 0x00000001 */
+#define ADC_DR_DATA_1                  (0x0002UL << ADC_DR_DATA_Pos)           /*!< 0x00000002 */
+#define ADC_DR_DATA_2                  (0x0004UL << ADC_DR_DATA_Pos)           /*!< 0x00000004 */
+#define ADC_DR_DATA_3                  (0x0008UL << ADC_DR_DATA_Pos)           /*!< 0x00000008 */
+#define ADC_DR_DATA_4                  (0x0010UL << ADC_DR_DATA_Pos)           /*!< 0x00000010 */
+#define ADC_DR_DATA_5                  (0x0020UL << ADC_DR_DATA_Pos)           /*!< 0x00000020 */
+#define ADC_DR_DATA_6                  (0x0040UL << ADC_DR_DATA_Pos)           /*!< 0x00000040 */
+#define ADC_DR_DATA_7                  (0x0080UL << ADC_DR_DATA_Pos)           /*!< 0x00000080 */
+#define ADC_DR_DATA_8                  (0x0100UL << ADC_DR_DATA_Pos)           /*!< 0x00000100 */
+#define ADC_DR_DATA_9                  (0x0200UL << ADC_DR_DATA_Pos)           /*!< 0x00000200 */
+#define ADC_DR_DATA_10                 (0x0400UL << ADC_DR_DATA_Pos)           /*!< 0x00000400 */
+#define ADC_DR_DATA_11                 (0x0800UL << ADC_DR_DATA_Pos)           /*!< 0x00000800 */
+#define ADC_DR_DATA_12                 (0x1000UL << ADC_DR_DATA_Pos)           /*!< 0x00001000 */
+#define ADC_DR_DATA_13                 (0x2000UL << ADC_DR_DATA_Pos)           /*!< 0x00002000 */
+#define ADC_DR_DATA_14                 (0x4000UL << ADC_DR_DATA_Pos)           /*!< 0x00004000 */
+#define ADC_DR_DATA_15                 (0x8000UL << ADC_DR_DATA_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for ADC_AWD2CR register  ****************/
+#define ADC_AWD2CR_AWD2CH_Pos          (0U)
+#define ADC_AWD2CR_AWD2CH_Msk          (0x7FFFFUL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x0007FFFF */
+#define ADC_AWD2CR_AWD2CH              ADC_AWD2CR_AWD2CH_Msk                   /*!< ADC analog watchdog 2 monitored channel selection */
+#define ADC_AWD2CR_AWD2CH_0            (0x00001UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000001 */
+#define ADC_AWD2CR_AWD2CH_1            (0x00002UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000002 */
+#define ADC_AWD2CR_AWD2CH_2            (0x00004UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000004 */
+#define ADC_AWD2CR_AWD2CH_3            (0x00008UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000008 */
+#define ADC_AWD2CR_AWD2CH_4            (0x00010UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000010 */
+#define ADC_AWD2CR_AWD2CH_5            (0x00020UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000020 */
+#define ADC_AWD2CR_AWD2CH_6            (0x00040UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000040 */
+#define ADC_AWD2CR_AWD2CH_7            (0x00080UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000080 */
+#define ADC_AWD2CR_AWD2CH_8            (0x00100UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000100 */
+#define ADC_AWD2CR_AWD2CH_9            (0x00200UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000200 */
+#define ADC_AWD2CR_AWD2CH_10           (0x00400UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000400 */
+#define ADC_AWD2CR_AWD2CH_11           (0x00800UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00000800 */
+#define ADC_AWD2CR_AWD2CH_12           (0x01000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00001000 */
+#define ADC_AWD2CR_AWD2CH_13           (0x02000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00002000 */
+#define ADC_AWD2CR_AWD2CH_14           (0x04000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00004000 */
+#define ADC_AWD2CR_AWD2CH_15           (0x08000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00008000 */
+#define ADC_AWD2CR_AWD2CH_16           (0x10000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00010000 */
+#define ADC_AWD2CR_AWD2CH_17           (0x20000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00020000 */
+#define ADC_AWD2CR_AWD2CH_18           (0x40000UL << ADC_AWD2CR_AWD2CH_Pos)    /*!< 0x00040000 */
+
+/********************  Bit definition for ADC_AWD3CR register  ****************/
+#define ADC_AWD3CR_AWD3CH_Pos          (0U)
+#define ADC_AWD3CR_AWD3CH_Msk          (0x7FFFFUL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x0007FFFF */
+#define ADC_AWD3CR_AWD3CH              ADC_AWD3CR_AWD3CH_Msk                   /*!< ADC analog watchdog 3 monitored channel selection */
+#define ADC_AWD3CR_AWD3CH_0            (0x00001UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000001 */
+#define ADC_AWD3CR_AWD3CH_1            (0x00002UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000002 */
+#define ADC_AWD3CR_AWD3CH_2            (0x00004UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000004 */
+#define ADC_AWD3CR_AWD3CH_3            (0x00008UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000008 */
+#define ADC_AWD3CR_AWD3CH_4            (0x00010UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000010 */
+#define ADC_AWD3CR_AWD3CH_5            (0x00020UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000020 */
+#define ADC_AWD3CR_AWD3CH_6            (0x00040UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000040 */
+#define ADC_AWD3CR_AWD3CH_7            (0x00080UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000080 */
+#define ADC_AWD3CR_AWD3CH_8            (0x00100UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000100 */
+#define ADC_AWD3CR_AWD3CH_9            (0x00200UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000200 */
+#define ADC_AWD3CR_AWD3CH_10           (0x00400UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000400 */
+#define ADC_AWD3CR_AWD3CH_11           (0x00800UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00000800 */
+#define ADC_AWD3CR_AWD3CH_12           (0x01000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00001000 */
+#define ADC_AWD3CR_AWD3CH_13           (0x02000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00002000 */
+#define ADC_AWD3CR_AWD3CH_14           (0x04000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00004000 */
+#define ADC_AWD3CR_AWD3CH_15           (0x08000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00008000 */
+#define ADC_AWD3CR_AWD3CH_16           (0x10000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00010000 */
+#define ADC_AWD3CR_AWD3CH_17           (0x20000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00020000 */
+#define ADC_AWD3CR_AWD3CH_18           (0x40000UL << ADC_AWD3CR_AWD3CH_Pos)    /*!< 0x00040000 */
+
+/********************  Bit definition for ADC_CALFACT register  ***************/
+#define ADC_CALFACT_CALFACT_Pos        (0U)
+#define ADC_CALFACT_CALFACT_Msk        (0x7FUL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x0000007F */
+#define ADC_CALFACT_CALFACT            ADC_CALFACT_CALFACT_Msk                 /*!< ADC calibration factor in single-ended mode */
+#define ADC_CALFACT_CALFACT_0          (0x01UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000001 */
+#define ADC_CALFACT_CALFACT_1          (0x02UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000002 */
+#define ADC_CALFACT_CALFACT_2          (0x04UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000004 */
+#define ADC_CALFACT_CALFACT_3          (0x08UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000008 */
+#define ADC_CALFACT_CALFACT_4          (0x10UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000010 */
+#define ADC_CALFACT_CALFACT_5          (0x20UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000020 */
+#define ADC_CALFACT_CALFACT_6          (0x40UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000040 */
+
+/*************************  ADC Common registers  *****************************/
+/********************  Bit definition for ADC_CCR register  *******************/
+#define ADC_CCR_PRESC_Pos              (18U)
+#define ADC_CCR_PRESC_Msk              (0xFUL << ADC_CCR_PRESC_Pos)            /*!< 0x003C0000 */
+#define ADC_CCR_PRESC                  ADC_CCR_PRESC_Msk                       /*!< ADC common clock prescaler, only for clock source asynchronous */
+#define ADC_CCR_PRESC_0                (0x1UL << ADC_CCR_PRESC_Pos)            /*!< 0x00040000 */
+#define ADC_CCR_PRESC_1                (0x2UL << ADC_CCR_PRESC_Pos)            /*!< 0x00080000 */
+#define ADC_CCR_PRESC_2                (0x4UL << ADC_CCR_PRESC_Pos)            /*!< 0x00100000 */
+#define ADC_CCR_PRESC_3                (0x8UL << ADC_CCR_PRESC_Pos)            /*!< 0x00200000 */
+
+#define ADC_CCR_VREFEN_Pos             (22U)
+#define ADC_CCR_VREFEN_Msk             (0x1UL << ADC_CCR_VREFEN_Pos)           /*!< 0x00400000 */
+#define ADC_CCR_VREFEN                 ADC_CCR_VREFEN_Msk                      /*!< ADC internal path to VrefInt enable */
+#define ADC_CCR_TSEN_Pos               (23U)
+#define ADC_CCR_TSEN_Msk               (0x1UL << ADC_CCR_TSEN_Pos)             /*!< 0x00800000 */
+#define ADC_CCR_TSEN                   ADC_CCR_TSEN_Msk                        /*!< ADC internal path to temperature sensor enable */
+#define ADC_CCR_VBATEN_Pos             (24U)
+#define ADC_CCR_VBATEN_Msk             (0x1UL << ADC_CCR_VBATEN_Pos)           /*!< 0x01000000 */
+#define ADC_CCR_VBATEN                 ADC_CCR_VBATEN_Msk                      /*!< ADC internal path to battery voltage enable */
+
+/* Legacy */
+#define ADC_CCR_LFMEN_Pos              (25U)
+#define ADC_CCR_LFMEN_Msk              (0x1UL << ADC_CCR_LFMEN_Pos)            /*!< 0x02000000 */
+#define ADC_CCR_LFMEN                  ADC_CCR_LFMEN_Msk                       /*!< Legacy feature, useless on STM32G0 (ADC common clock low frequency mode is automatically managed by ADC peripheral on STM32G0) */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos            (0U)
+#define CRC_DR_DR_Msk            (0xFFFFFFFFUL << CRC_DR_DR_Pos)                /*!< 0xFFFFFFFF */
+#define CRC_DR_DR                CRC_DR_DR_Msk                                  /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos          (0U)
+#define CRC_IDR_IDR_Msk          (0xFFFFFFFFUL << CRC_IDR_IDR_Pos)              /*!< 0xFFFFFFFF */
+#define CRC_IDR_IDR              CRC_IDR_IDR_Msk                                /*!< General-purpose 32-bits data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos         (0U)
+#define CRC_CR_RESET_Msk         (0x1UL << CRC_CR_RESET_Pos)                    /*!< 0x00000001 */
+#define CRC_CR_RESET             CRC_CR_RESET_Msk                               /*!< RESET the CRC computation unit bit */
+#define CRC_CR_POLYSIZE_Pos      (3U)
+#define CRC_CR_POLYSIZE_Msk      (0x3UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000018 */
+#define CRC_CR_POLYSIZE          CRC_CR_POLYSIZE_Msk                            /*!< Polynomial size bits */
+#define CRC_CR_POLYSIZE_0        (0x1UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000008 */
+#define CRC_CR_POLYSIZE_1        (0x2UL << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000010 */
+#define CRC_CR_REV_IN_Pos        (5U)
+#define CRC_CR_REV_IN_Msk        (0x3UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000060 */
+#define CRC_CR_REV_IN            CRC_CR_REV_IN_Msk                              /*!< REV_IN Reverse Input Data bits */
+#define CRC_CR_REV_IN_0          (0x1UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000020 */
+#define CRC_CR_REV_IN_1          (0x2UL << CRC_CR_REV_IN_Pos)                   /*!< 0x00000040 */
+#define CRC_CR_REV_OUT_Pos       (7U)
+#define CRC_CR_REV_OUT_Msk       (0x1UL << CRC_CR_REV_OUT_Pos)                  /*!< 0x00000080 */
+#define CRC_CR_REV_OUT           CRC_CR_REV_OUT_Msk                             /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define CRC_INIT_INIT_Pos        (0U)
+#define CRC_INIT_INIT_Msk        (0xFFFFFFFFUL << CRC_INIT_INIT_Pos)            /*!< 0xFFFFFFFF */
+#define CRC_INIT_INIT            CRC_INIT_INIT_Msk                              /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define CRC_POL_POL_Pos          (0U)
+#define CRC_POL_POL_Msk          (0xFFFFFFFFUL << CRC_POL_POL_Pos)              /*!< 0xFFFFFFFF */
+#define CRC_POL_POL              CRC_POL_POL_Msk                                /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Advanced Encryption Standard (AES)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for AES_CR register  *********************/
+#define AES_CR_EN_Pos            (0U)
+#define AES_CR_EN_Msk            (0x1UL << AES_CR_EN_Pos)                       /*!< 0x00000001 */
+#define AES_CR_EN                AES_CR_EN_Msk                                  /*!< AES Enable */
+#define AES_CR_DATATYPE_Pos      (1U)
+#define AES_CR_DATATYPE_Msk      (0x3UL << AES_CR_DATATYPE_Pos)                 /*!< 0x00000006 */
+#define AES_CR_DATATYPE          AES_CR_DATATYPE_Msk                            /*!< Data type selection */
+#define AES_CR_DATATYPE_0        (0x1UL << AES_CR_DATATYPE_Pos)                 /*!< 0x00000002 */
+#define AES_CR_DATATYPE_1        (0x2UL << AES_CR_DATATYPE_Pos)                 /*!< 0x00000004 */
+
+#define AES_CR_MODE_Pos          (3U)
+#define AES_CR_MODE_Msk          (0x3UL << AES_CR_MODE_Pos)                     /*!< 0x00000018 */
+#define AES_CR_MODE              AES_CR_MODE_Msk                                /*!< AES Mode Of Operation */
+#define AES_CR_MODE_0            (0x1UL << AES_CR_MODE_Pos)                     /*!< 0x00000008 */
+#define AES_CR_MODE_1            (0x2UL << AES_CR_MODE_Pos)                     /*!< 0x00000010 */
+
+#define AES_CR_CHMOD_Pos         (5U)
+#define AES_CR_CHMOD_Msk         (0x803UL << AES_CR_CHMOD_Pos)                  /*!< 0x00010060 */
+#define AES_CR_CHMOD             AES_CR_CHMOD_Msk                               /*!< AES Chaining Mode */
+#define AES_CR_CHMOD_0           (0x001UL << AES_CR_CHMOD_Pos)                  /*!< 0x00000020 */
+#define AES_CR_CHMOD_1           (0x002UL << AES_CR_CHMOD_Pos)                  /*!< 0x00000040 */
+#define AES_CR_CHMOD_2           (0x800UL << AES_CR_CHMOD_Pos)                  /*!< 0x00010000 */
+
+#define AES_CR_CCFC_Pos          (7U)
+#define AES_CR_CCFC_Msk          (0x1UL << AES_CR_CCFC_Pos)                     /*!< 0x00000080 */
+#define AES_CR_CCFC              AES_CR_CCFC_Msk                                /*!< Computation Complete Flag Clear */
+#define AES_CR_ERRC_Pos          (8U)
+#define AES_CR_ERRC_Msk          (0x1UL << AES_CR_ERRC_Pos)                     /*!< 0x00000100 */
+#define AES_CR_ERRC              AES_CR_ERRC_Msk                                /*!< Error Clear */
+#define AES_CR_CCFIE_Pos         (9U)
+#define AES_CR_CCFIE_Msk         (0x1UL << AES_CR_CCFIE_Pos)                    /*!< 0x00000200 */
+#define AES_CR_CCFIE             AES_CR_CCFIE_Msk                               /*!< Computation Complete Flag Interrupt Enable */
+#define AES_CR_ERRIE_Pos         (10U)
+#define AES_CR_ERRIE_Msk         (0x1UL << AES_CR_ERRIE_Pos)                    /*!< 0x00000400 */
+#define AES_CR_ERRIE             AES_CR_ERRIE_Msk                               /*!< Error Interrupt Enable */
+#define AES_CR_DMAINEN_Pos       (11U)
+#define AES_CR_DMAINEN_Msk       (0x1UL << AES_CR_DMAINEN_Pos)                  /*!< 0x00000800 */
+#define AES_CR_DMAINEN           AES_CR_DMAINEN_Msk                             /*!< Enable data input phase DMA management  */
+#define AES_CR_DMAOUTEN_Pos      (12U)
+#define AES_CR_DMAOUTEN_Msk      (0x1UL << AES_CR_DMAOUTEN_Pos)                 /*!< 0x00001000 */
+#define AES_CR_DMAOUTEN          AES_CR_DMAOUTEN_Msk                            /*!< Enable data output phase DMA management */
+
+#define AES_CR_NPBLB_Pos         (20U)
+#define AES_CR_NPBLB_Msk         (0xFUL << AES_CR_NPBLB_Pos)                    /*!< 0x00F00000 */
+#define AES_CR_NPBLB             AES_CR_NPBLB_Msk                               /*!< Number of padding bytes in last block of payload. */
+#define AES_CR_NPBLB_0           (0x1UL << AES_CR_NPBLB_Pos)                    /*!< 0x00100000 */
+#define AES_CR_NPBLB_1           (0x2UL << AES_CR_NPBLB_Pos)                    /*!< 0x00200000 */
+#define AES_CR_NPBLB_2           (0x4UL << AES_CR_NPBLB_Pos)                    /*!< 0x00400000 */
+#define AES_CR_NPBLB_3           (0x8UL << AES_CR_NPBLB_Pos)                    /*!< 0x00800000 */
+
+#define AES_CR_GCMPH_Pos         (13U)
+#define AES_CR_GCMPH_Msk         (0x3UL << AES_CR_GCMPH_Pos)                    /*!< 0x00006000 */
+#define AES_CR_GCMPH             AES_CR_GCMPH_Msk                               /*!< GCM Phase */
+#define AES_CR_GCMPH_0           (0x1UL << AES_CR_GCMPH_Pos)                    /*!< 0x00002000 */
+#define AES_CR_GCMPH_1           (0x2UL << AES_CR_GCMPH_Pos)                    /*!< 0x00004000 */
+
+#define AES_CR_KEYSIZE_Pos       (18U)
+#define AES_CR_KEYSIZE_Msk       (0x1UL << AES_CR_KEYSIZE_Pos)                  /*!< 0x00040000 */
+#define AES_CR_KEYSIZE           AES_CR_KEYSIZE_Msk                             /*!< Key size selection */
+
+/*******************  Bit definition for AES_SR register  *********************/
+#define AES_SR_CCF_Pos           (0U)
+#define AES_SR_CCF_Msk           (0x1UL << AES_SR_CCF_Pos)                      /*!< 0x00000001 */
+#define AES_SR_CCF               AES_SR_CCF_Msk                                 /*!< Computation Complete Flag */
+#define AES_SR_RDERR_Pos         (1U)
+#define AES_SR_RDERR_Msk         (0x1UL << AES_SR_RDERR_Pos)                    /*!< 0x00000002 */
+#define AES_SR_RDERR             AES_SR_RDERR_Msk                               /*!< Read Error Flag */
+#define AES_SR_WRERR_Pos         (2U)
+#define AES_SR_WRERR_Msk         (0x1UL << AES_SR_WRERR_Pos)                    /*!< 0x00000004 */
+#define AES_SR_WRERR             AES_SR_WRERR_Msk                               /*!< Write Error Flag */
+#define AES_SR_BUSY_Pos          (3U)
+#define AES_SR_BUSY_Msk          (0x1UL << AES_SR_BUSY_Pos)                     /*!< 0x00000008 */
+#define AES_SR_BUSY              AES_SR_BUSY_Msk                                /*!< Busy Flag */
+
+/*******************  Bit definition for AES_DINR register  *******************/
+#define AES_DINR_Pos             (0U)
+#define AES_DINR_Msk             (0xFFFFFFFFUL << AES_DINR_Pos)                 /*!< 0xFFFFFFFF */
+#define AES_DINR                 AES_DINR_Msk                                   /*!< AES Data Input Register */
+
+/*******************  Bit definition for AES_DOUTR register  ******************/
+#define AES_DOUTR_Pos            (0U)
+#define AES_DOUTR_Msk            (0xFFFFFFFFUL << AES_DOUTR_Pos)                /*!< 0xFFFFFFFF */
+#define AES_DOUTR                AES_DOUTR_Msk                                  /*!< AES Data Output Register */
+
+/*******************  Bit definition for AES_KEYR0 register  ******************/
+#define AES_KEYR0_Pos            (0U)
+#define AES_KEYR0_Msk            (0xFFFFFFFFUL << AES_KEYR0_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR0                AES_KEYR0_Msk                                  /*!< AES Key Register 0 */
+
+/*******************  Bit definition for AES_KEYR1 register  ******************/
+#define AES_KEYR1_Pos            (0U)
+#define AES_KEYR1_Msk            (0xFFFFFFFFUL << AES_KEYR1_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR1                AES_KEYR1_Msk                                  /*!< AES Key Register 1 */
+
+/*******************  Bit definition for AES_KEYR2 register  ******************/
+#define AES_KEYR2_Pos            (0U)
+#define AES_KEYR2_Msk            (0xFFFFFFFFUL << AES_KEYR2_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR2                AES_KEYR2_Msk                                  /*!< AES Key Register 2 */
+
+/*******************  Bit definition for AES_KEYR3 register  ******************/
+#define AES_KEYR3_Pos            (0U)
+#define AES_KEYR3_Msk            (0xFFFFFFFFUL << AES_KEYR3_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR3                AES_KEYR3_Msk                                  /*!< AES Key Register 3 */
+
+/*******************  Bit definition for AES_KEYR4 register  ******************/
+#define AES_KEYR4_Pos            (0U)
+#define AES_KEYR4_Msk            (0xFFFFFFFFUL << AES_KEYR4_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR4                AES_KEYR4_Msk                                  /*!< AES Key Register 4 */
+
+/*******************  Bit definition for AES_KEYR5 register  ******************/
+#define AES_KEYR5_Pos            (0U)
+#define AES_KEYR5_Msk            (0xFFFFFFFFUL << AES_KEYR5_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR5                AES_KEYR5_Msk                                  /*!< AES Key Register 5 */
+
+/*******************  Bit definition for AES_KEYR6 register  ******************/
+#define AES_KEYR6_Pos            (0U)
+#define AES_KEYR6_Msk            (0xFFFFFFFFUL << AES_KEYR6_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR6                AES_KEYR6_Msk                                  /*!< AES Key Register 6 */
+
+/*******************  Bit definition for AES_KEYR7 register  ******************/
+#define AES_KEYR7_Pos            (0U)
+#define AES_KEYR7_Msk            (0xFFFFFFFFUL << AES_KEYR7_Pos)                /*!< 0xFFFFFFFF */
+#define AES_KEYR7                AES_KEYR7_Msk                                  /*!< AES Key Register 7 */
+
+/*******************  Bit definition for AES_IVR0 register   ******************/
+#define AES_IVR0_Pos             (0U)
+#define AES_IVR0_Msk             (0xFFFFFFFFUL << AES_IVR0_Pos)                 /*!< 0xFFFFFFFF */
+#define AES_IVR0                 AES_IVR0_Msk                                   /*!< AES Initialization Vector Register 0 */
+
+/*******************  Bit definition for AES_IVR1 register   ******************/
+#define AES_IVR1_Pos             (0U)
+#define AES_IVR1_Msk             (0xFFFFFFFFUL << AES_IVR1_Pos)                 /*!< 0xFFFFFFFF */
+#define AES_IVR1                 AES_IVR1_Msk                                   /*!< AES Initialization Vector Register 1 */
+
+/*******************  Bit definition for AES_IVR2 register   ******************/
+#define AES_IVR2_Pos             (0U)
+#define AES_IVR2_Msk             (0xFFFFFFFFUL << AES_IVR2_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR2                 AES_IVR2_Msk                                  /*!< AES Initialization Vector Register 2 */
+
+/*******************  Bit definition for AES_IVR3 register   ******************/
+#define AES_IVR3_Pos             (0U)
+#define AES_IVR3_Msk             (0xFFFFFFFFUL << AES_IVR3_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR3                 AES_IVR3_Msk                                  /*!< AES Initialization Vector Register 3 */
+
+/*******************  Bit definition for AES_SUSP0R register  ******************/
+#define AES_SUSP0R_Pos           (0U)
+#define AES_SUSP0R_Msk           (0xFFFFFFFFUL << AES_SUSP0R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP0R               AES_SUSP0R_Msk                                /*!< AES Suspend registers 0 */
+
+/*******************  Bit definition for AES_SUSP1R register  ******************/
+#define AES_SUSP1R_Pos           (0U)
+#define AES_SUSP1R_Msk           (0xFFFFFFFFUL << AES_SUSP1R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP1R               AES_SUSP1R_Msk                                /*!< AES Suspend registers 1 */
+
+/*******************  Bit definition for AES_SUSP2R register  ******************/
+#define AES_SUSP2R_Pos           (0U)
+#define AES_SUSP2R_Msk           (0xFFFFFFFFUL << AES_SUSP2R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP2R               AES_SUSP2R_Msk                                /*!< AES Suspend registers 2 */
+
+/*******************  Bit definition for AES_SUSP3R register  ******************/
+#define AES_SUSP3R_Pos           (0U)
+#define AES_SUSP3R_Msk           (0xFFFFFFFFUL << AES_SUSP3R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP3R               AES_SUSP3R_Msk                                /*!< AES Suspend registers 3 */
+
+/*******************  Bit definition for AES_SUSP4R register  ******************/
+#define AES_SUSP4R_Pos           (0U)
+#define AES_SUSP4R_Msk           (0xFFFFFFFFUL << AES_SUSP4R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP4R               AES_SUSP4R_Msk                                /*!< AES Suspend registers 4 */
+
+/*******************  Bit definition for AES_SUSP5R register  ******************/
+#define AES_SUSP5R_Pos           (0U)
+#define AES_SUSP5R_Msk           (0xFFFFFFFFUL << AES_SUSP5R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP5R               AES_SUSP5R_Msk                                /*!< AES Suspend registers 5 */
+
+/*******************  Bit definition for AES_SUSP6R register  ******************/
+#define AES_SUSP6R_Pos           (0U)
+#define AES_SUSP6R_Msk           (0xFFFFFFFFUL << AES_SUSP6R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP6R               AES_SUSP6R_Msk                                /*!< AES Suspend registers 6 */
+
+/*******************  Bit definition for AES_SUSP7R register  ******************/
+#define AES_SUSP7R_Pos           (0U)
+#define AES_SUSP7R_Msk           (0xFFFFFFFFUL << AES_SUSP7R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP7R               AES_SUSP7R_Msk                                /*!< AES Suspend registers 7 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Digital to Analog Converter                           */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions
+*/
+#define DAC_ADDITIONAL_TRIGGERS_SUPPORT
+
+/********************  Bit definition for DAC_CR register  ********************/
+#define DAC_CR_EN1_Pos              (0U)
+#define DAC_CR_EN1_Msk              (0x1UL << DAC_CR_EN1_Pos)                  /*!< 0x00000001 */
+#define DAC_CR_EN1                  DAC_CR_EN1_Msk                             /*!<DAC channel1 enable */
+#define DAC_CR_TEN1_Pos             (1U)
+#define DAC_CR_TEN1_Msk             (0x1UL << DAC_CR_TEN1_Pos)                 /*!< 0x00000002 */
+#define DAC_CR_TEN1                 DAC_CR_TEN1_Msk                            /*!<DAC channel1 Trigger enable */
+
+#define DAC_CR_TSEL1_Pos            (2U)
+#define DAC_CR_TSEL1_Msk            (0xFUL << DAC_CR_TSEL1_Pos)                /*!< 0x0000003C */
+#define DAC_CR_TSEL1                DAC_CR_TSEL1_Msk                           /*!<TSEL1[3:0] (DAC channel1 Trigger selection) */
+#define DAC_CR_TSEL1_0              (0x1UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000004 */
+#define DAC_CR_TSEL1_1              (0x2UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000008 */
+#define DAC_CR_TSEL1_2              (0x4UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000010 */
+#define DAC_CR_TSEL1_3              (0x8UL << DAC_CR_TSEL1_Pos)                /*!< 0x00000020 */
+
+#define DAC_CR_WAVE1_Pos            (6U)
+#define DAC_CR_WAVE1_Msk            (0x3UL << DAC_CR_WAVE1_Pos)                /*!< 0x000000C0 */
+#define DAC_CR_WAVE1                DAC_CR_WAVE1_Msk                           /*!<WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define DAC_CR_WAVE1_0              (0x1UL << DAC_CR_WAVE1_Pos)                /*!< 0x00000040 */
+#define DAC_CR_WAVE1_1              (0x2UL << DAC_CR_WAVE1_Pos)                /*!< 0x00000080 */
+
+#define DAC_CR_MAMP1_Pos            (8U)
+#define DAC_CR_MAMP1_Msk            (0xFUL << DAC_CR_MAMP1_Pos)                /*!< 0x00000F00 */
+#define DAC_CR_MAMP1                DAC_CR_MAMP1_Msk                           /*!<MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define DAC_CR_MAMP1_0              (0x1UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000100 */
+#define DAC_CR_MAMP1_1              (0x2UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000200 */
+#define DAC_CR_MAMP1_2              (0x4UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000400 */
+#define DAC_CR_MAMP1_3              (0x8UL << DAC_CR_MAMP1_Pos)                /*!< 0x00000800 */
+
+#define DAC_CR_DMAEN1_Pos           (12U)
+#define DAC_CR_DMAEN1_Msk           (0x1UL << DAC_CR_DMAEN1_Pos)               /*!< 0x00001000 */
+#define DAC_CR_DMAEN1               DAC_CR_DMAEN1_Msk                          /*!<DAC channel1 DMA enable */
+#define DAC_CR_DMAUDRIE1_Pos        (13U)
+#define DAC_CR_DMAUDRIE1_Msk        (0x1UL << DAC_CR_DMAUDRIE1_Pos)            /*!< 0x00002000 */
+#define DAC_CR_DMAUDRIE1            DAC_CR_DMAUDRIE1_Msk                       /*!<DAC channel 1 DMA underrun interrupt enable  >*/
+#define DAC_CR_CEN1_Pos             (14U)
+#define DAC_CR_CEN1_Msk             (0x1UL << DAC_CR_CEN1_Pos)                 /*!< 0x00004000 */
+#define DAC_CR_CEN1                 DAC_CR_CEN1_Msk                            /*!<DAC channel 1 calibration enable >*/
+
+#define DAC_CR_EN2_Pos              (16U)
+#define DAC_CR_EN2_Msk              (0x1UL << DAC_CR_EN2_Pos)                  /*!< 0x00010000 */
+#define DAC_CR_EN2                  DAC_CR_EN2_Msk                             /*!<DAC channel2 enable */
+#define DAC_CR_TEN2_Pos             (17U)
+#define DAC_CR_TEN2_Msk             (0x1UL << DAC_CR_TEN2_Pos)                 /*!< 0x00020000 */
+#define DAC_CR_TEN2                 DAC_CR_TEN2_Msk                            /*!<DAC channel2 Trigger enable */
+
+#define DAC_CR_TSEL2_Pos            (18U)
+#define DAC_CR_TSEL2_Msk            (0xFUL << DAC_CR_TSEL2_Pos)                /*!< 0x003C0000 */
+#define DAC_CR_TSEL2                DAC_CR_TSEL2_Msk                           /*!<TSEL2[2:0] (DAC channel2 Trigger selection) */
+#define DAC_CR_TSEL2_0              (0x1UL << DAC_CR_TSEL2_Pos)                /*!< 0x00040000 */
+#define DAC_CR_TSEL2_1              (0x2UL << DAC_CR_TSEL2_Pos)                /*!< 0x00080000 */
+#define DAC_CR_TSEL2_2              (0x4UL << DAC_CR_TSEL2_Pos)                /*!< 0x00100000 */
+#define DAC_CR_TSEL2_3              (0x8UL << DAC_CR_TSEL2_Pos)                /*!< 0x00200000 */
+
+#define DAC_CR_WAVE2_Pos            (22U)
+#define DAC_CR_WAVE2_Msk            (0x3UL << DAC_CR_WAVE2_Pos)                /*!< 0x00C00000 */
+#define DAC_CR_WAVE2                DAC_CR_WAVE2_Msk                           /*!<WAVE2[1:0] (DAC channel2 noise/triangle wave generation enable) */
+#define DAC_CR_WAVE2_0              (0x1UL << DAC_CR_WAVE2_Pos)                /*!< 0x00400000 */
+#define DAC_CR_WAVE2_1              (0x2UL << DAC_CR_WAVE2_Pos)                /*!< 0x00800000 */
+
+#define DAC_CR_MAMP2_Pos            (24U)
+#define DAC_CR_MAMP2_Msk            (0xFUL << DAC_CR_MAMP2_Pos)                /*!< 0x0F000000 */
+#define DAC_CR_MAMP2                DAC_CR_MAMP2_Msk                           /*!<MAMP2[3:0] (DAC channel2 Mask/Amplitude selector) */
+#define DAC_CR_MAMP2_0              (0x1UL << DAC_CR_MAMP2_Pos)                /*!< 0x01000000 */
+#define DAC_CR_MAMP2_1              (0x2UL << DAC_CR_MAMP2_Pos)                /*!< 0x02000000 */
+#define DAC_CR_MAMP2_2              (0x4UL << DAC_CR_MAMP2_Pos)                /*!< 0x04000000 */
+#define DAC_CR_MAMP2_3              (0x8UL << DAC_CR_MAMP2_Pos)                /*!< 0x08000000 */
+
+#define DAC_CR_DMAEN2_Pos           (28U)
+#define DAC_CR_DMAEN2_Msk           (0x1UL << DAC_CR_DMAEN2_Pos)               /*!< 0x10000000 */
+#define DAC_CR_DMAEN2               DAC_CR_DMAEN2_Msk                          /*!<DAC channel2 DMA enabled */
+#define DAC_CR_DMAUDRIE2_Pos        (29U)
+#define DAC_CR_DMAUDRIE2_Msk        (0x1UL << DAC_CR_DMAUDRIE2_Pos)            /*!< 0x20000000 */
+#define DAC_CR_DMAUDRIE2            DAC_CR_DMAUDRIE2_Msk                       /*!<DAC channel2 DMA underrun interrupt enable  >*/
+#define DAC_CR_CEN2_Pos             (30U)
+#define DAC_CR_CEN2_Msk             (0x1UL << DAC_CR_CEN2_Pos)                 /*!< 0x40000000 */
+#define DAC_CR_CEN2                 DAC_CR_CEN2_Msk                            /*!<DAC channel2 calibration enable >*/
+
+/*****************  Bit definition for DAC_SWTRIGR register  ******************/
+#define DAC_SWTRIGR_SWTRIG1_Pos     (0U)
+#define DAC_SWTRIGR_SWTRIG1_Msk     (0x1UL << DAC_SWTRIGR_SWTRIG1_Pos)         /*!< 0x00000001 */
+#define DAC_SWTRIGR_SWTRIG1         DAC_SWTRIGR_SWTRIG1_Msk                    /*!<DAC channel1 software trigger */
+#define DAC_SWTRIGR_SWTRIG2_Pos     (1U)
+#define DAC_SWTRIGR_SWTRIG2_Msk     (0x1UL << DAC_SWTRIGR_SWTRIG2_Pos)         /*!< 0x00000002 */
+#define DAC_SWTRIGR_SWTRIG2         DAC_SWTRIGR_SWTRIG2_Msk                    /*!<DAC channel2 software trigger */
+
+/*****************  Bit definition for DAC_DHR12R1 register  ******************/
+#define DAC_DHR12R1_DACC1DHR_Pos    (0U)
+#define DAC_DHR12R1_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12R1_DACC1DHR_Pos)      /*!< 0x00000FFF */
+#define DAC_DHR12R1_DACC1DHR        DAC_DHR12R1_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L1 register  ******************/
+#define DAC_DHR12L1_DACC1DHR_Pos    (4U)
+#define DAC_DHR12L1_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12L1_DACC1DHR_Pos)      /*!< 0x0000FFF0 */
+#define DAC_DHR12L1_DACC1DHR        DAC_DHR12L1_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R1 register  ******************/
+#define DAC_DHR8R1_DACC1DHR_Pos     (0U)
+#define DAC_DHR8R1_DACC1DHR_Msk     (0xFFUL << DAC_DHR8R1_DACC1DHR_Pos)        /*!< 0x000000FF */
+#define DAC_DHR8R1_DACC1DHR         DAC_DHR8R1_DACC1DHR_Msk                    /*!<DAC channel1 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12R2 register  ******************/
+#define DAC_DHR12R2_DACC2DHR_Pos    (0U)
+#define DAC_DHR12R2_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12R2_DACC2DHR_Pos)      /*!< 0x00000FFF */
+#define DAC_DHR12R2_DACC2DHR        DAC_DHR12R2_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L2 register  ******************/
+#define DAC_DHR12L2_DACC2DHR_Pos    (4U)
+#define DAC_DHR12L2_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12L2_DACC2DHR_Pos)      /*!< 0x0000FFF0 */
+#define DAC_DHR12L2_DACC2DHR        DAC_DHR12L2_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R2 register  ******************/
+#define DAC_DHR8R2_DACC2DHR_Pos     (0U)
+#define DAC_DHR8R2_DACC2DHR_Msk     (0xFFUL << DAC_DHR8R2_DACC2DHR_Pos)        /*!< 0x000000FF */
+#define DAC_DHR8R2_DACC2DHR         DAC_DHR8R2_DACC2DHR_Msk                    /*!<DAC channel2 8-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12RD register  ******************/
+#define DAC_DHR12RD_DACC1DHR_Pos    (0U)
+#define DAC_DHR12RD_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12RD_DACC1DHR_Pos)      /*!< 0x00000FFF */
+#define DAC_DHR12RD_DACC1DHR        DAC_DHR12RD_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Right aligned data */
+#define DAC_DHR12RD_DACC2DHR_Pos    (16U)
+#define DAC_DHR12RD_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12RD_DACC2DHR_Pos)      /*!< 0x0FFF0000 */
+#define DAC_DHR12RD_DACC2DHR        DAC_DHR12RD_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12LD register  ******************/
+#define DAC_DHR12LD_DACC1DHR_Pos    (4U)
+#define DAC_DHR12LD_DACC1DHR_Msk    (0xFFFUL << DAC_DHR12LD_DACC1DHR_Pos)      /*!< 0x0000FFF0 */
+#define DAC_DHR12LD_DACC1DHR        DAC_DHR12LD_DACC1DHR_Msk                   /*!<DAC channel1 12-bit Left aligned data */
+#define DAC_DHR12LD_DACC2DHR_Pos    (20U)
+#define DAC_DHR12LD_DACC2DHR_Msk    (0xFFFUL << DAC_DHR12LD_DACC2DHR_Pos)      /*!< 0xFFF00000 */
+#define DAC_DHR12LD_DACC2DHR        DAC_DHR12LD_DACC2DHR_Msk                   /*!<DAC channel2 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8RD register  ******************/
+#define DAC_DHR8RD_DACC1DHR_Pos     (0U)
+#define DAC_DHR8RD_DACC1DHR_Msk     (0xFFUL << DAC_DHR8RD_DACC1DHR_Pos)        /*!< 0x000000FF */
+#define DAC_DHR8RD_DACC1DHR         DAC_DHR8RD_DACC1DHR_Msk                    /*!<DAC channel1 8-bit Right aligned data */
+#define DAC_DHR8RD_DACC2DHR_Pos     (8U)
+#define DAC_DHR8RD_DACC2DHR_Msk     (0xFFUL << DAC_DHR8RD_DACC2DHR_Pos)        /*!< 0x0000FF00 */
+#define DAC_DHR8RD_DACC2DHR         DAC_DHR8RD_DACC2DHR_Msk                    /*!<DAC channel2 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define DAC_DOR1_DACC1DOR_Pos       (0U)
+#define DAC_DOR1_DACC1DOR_Msk       (0xFFFUL << DAC_DOR1_DACC1DOR_Pos)         /*!< 0x00000FFF */
+#define DAC_DOR1_DACC1DOR           DAC_DOR1_DACC1DOR_Msk                      /*!<DAC channel1 data output */
+
+/*******************  Bit definition for DAC_DOR2 register  *******************/
+#define DAC_DOR2_DACC2DOR_Pos       (0U)
+#define DAC_DOR2_DACC2DOR_Msk       (0xFFFUL << DAC_DOR2_DACC2DOR_Pos)         /*!< 0x00000FFF */
+#define DAC_DOR2_DACC2DOR           DAC_DOR2_DACC2DOR_Msk                      /*!<DAC channel2 data output */
+
+/********************  Bit definition for DAC_SR register  ********************/
+#define DAC_SR_DMAUDR1_Pos          (13U)
+#define DAC_SR_DMAUDR1_Msk          (0x1UL << DAC_SR_DMAUDR1_Pos)              /*!< 0x00002000 */
+#define DAC_SR_DMAUDR1              DAC_SR_DMAUDR1_Msk                         /*!<DAC channel1 DMA underrun flag */
+#define DAC_SR_CAL_FLAG1_Pos        (14U)
+#define DAC_SR_CAL_FLAG1_Msk        (0x1UL << DAC_SR_CAL_FLAG1_Pos)            /*!< 0x00004000 */
+#define DAC_SR_CAL_FLAG1            DAC_SR_CAL_FLAG1_Msk                       /*!<DAC channel1 calibration offset status */
+#define DAC_SR_BWST1_Pos            (15U)
+#define DAC_SR_BWST1_Msk            (0x1UL << DAC_SR_BWST1_Pos)                /*!< 0x00008000 */
+#define DAC_SR_BWST1                DAC_SR_BWST1_Msk                           /*!<DAC channel1 busy writing sample time flag */
+
+#define DAC_SR_DMAUDR2_Pos          (29U)
+#define DAC_SR_DMAUDR2_Msk          (0x1UL << DAC_SR_DMAUDR2_Pos)              /*!< 0x20000000 */
+#define DAC_SR_DMAUDR2              DAC_SR_DMAUDR2_Msk                         /*!<DAC channel2 DMA underrun flag */
+#define DAC_SR_CAL_FLAG2_Pos        (30U)
+#define DAC_SR_CAL_FLAG2_Msk        (0x1UL << DAC_SR_CAL_FLAG2_Pos)            /*!< 0x40000000 */
+#define DAC_SR_CAL_FLAG2            DAC_SR_CAL_FLAG2_Msk                       /*!<DAC channel2 calibration offset status */
+#define DAC_SR_BWST2_Pos            (31U)
+#define DAC_SR_BWST2_Msk            (0x1UL << DAC_SR_BWST2_Pos)                /*!< 0x80000000 */
+#define DAC_SR_BWST2                DAC_SR_BWST2_Msk                           /*!<DAC channel2 busy writing sample time flag */
+
+/*******************  Bit definition for DAC_CCR register  ********************/
+#define DAC_CCR_OTRIM1_Pos          (0U)
+#define DAC_CCR_OTRIM1_Msk          (0x1FUL << DAC_CCR_OTRIM1_Pos)             /*!< 0x0000001F */
+#define DAC_CCR_OTRIM1              DAC_CCR_OTRIM1_Msk                         /*!<DAC channel1 offset trimming value */
+#define DAC_CCR_OTRIM2_Pos          (16U)
+#define DAC_CCR_OTRIM2_Msk          (0x1FUL << DAC_CCR_OTRIM2_Pos)             /*!< 0x001F0000 */
+#define DAC_CCR_OTRIM2              DAC_CCR_OTRIM2_Msk                         /*!<DAC channel2 offset trimming value */
+
+/*******************  Bit definition for DAC_MCR register  *******************/
+#define DAC_MCR_MODE1_Pos           (0U)
+#define DAC_MCR_MODE1_Msk           (0x7UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000007 */
+#define DAC_MCR_MODE1               DAC_MCR_MODE1_Msk                          /*!<MODE1[2:0] (DAC channel1 mode) */
+#define DAC_MCR_MODE1_0             (0x1UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000001 */
+#define DAC_MCR_MODE1_1             (0x2UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000002 */
+#define DAC_MCR_MODE1_2             (0x4UL << DAC_MCR_MODE1_Pos)               /*!< 0x00000004 */
+
+#define DAC_MCR_MODE2_Pos           (16U)
+#define DAC_MCR_MODE2_Msk           (0x7UL << DAC_MCR_MODE2_Pos)               /*!< 0x00070000 */
+#define DAC_MCR_MODE2               DAC_MCR_MODE2_Msk                          /*!<MODE2[2:0] (DAC channel2 mode) */
+#define DAC_MCR_MODE2_0             (0x1UL << DAC_MCR_MODE2_Pos)               /*!< 0x00010000 */
+#define DAC_MCR_MODE2_1             (0x2UL << DAC_MCR_MODE2_Pos)               /*!< 0x00020000 */
+#define DAC_MCR_MODE2_2             (0x4UL << DAC_MCR_MODE2_Pos)               /*!< 0x00040000 */
+
+/******************  Bit definition for DAC_SHSR1 register  ******************/
+#define DAC_SHSR1_TSAMPLE1_Pos      (0U)
+#define DAC_SHSR1_TSAMPLE1_Msk      (0x3FFUL << DAC_SHSR1_TSAMPLE1_Pos)        /*!< 0x000003FF */
+#define DAC_SHSR1_TSAMPLE1          DAC_SHSR1_TSAMPLE1_Msk                     /*!<DAC channel1 sample time */
+
+/******************  Bit definition for DAC_SHSR2 register  ******************/
+#define DAC_SHSR2_TSAMPLE2_Pos      (0U)
+#define DAC_SHSR2_TSAMPLE2_Msk      (0x3FFUL << DAC_SHSR2_TSAMPLE2_Pos)        /*!< 0x000003FF */
+#define DAC_SHSR2_TSAMPLE2          DAC_SHSR2_TSAMPLE2_Msk                     /*!<DAC channel2 sample time */
+
+/******************  Bit definition for DAC_SHHR register  ******************/
+#define DAC_SHHR_THOLD1_Pos         (0U)
+#define DAC_SHHR_THOLD1_Msk         (0x3FFUL << DAC_SHHR_THOLD1_Pos)           /*!< 0x000003FF */
+#define DAC_SHHR_THOLD1             DAC_SHHR_THOLD1_Msk                        /*!<DAC channel1 hold time */
+#define DAC_SHHR_THOLD2_Pos         (16U)
+#define DAC_SHHR_THOLD2_Msk         (0x3FFUL << DAC_SHHR_THOLD2_Pos)           /*!< 0x03FF0000 */
+#define DAC_SHHR_THOLD2             DAC_SHHR_THOLD2_Msk                        /*!<DAC channel2 hold time */
+
+/******************  Bit definition for DAC_SHRR register  ******************/
+#define DAC_SHRR_TREFRESH1_Pos      (0U)
+#define DAC_SHRR_TREFRESH1_Msk      (0xFFUL << DAC_SHRR_TREFRESH1_Pos)         /*!< 0x000000FF */
+#define DAC_SHRR_TREFRESH1          DAC_SHRR_TREFRESH1_Msk                     /*!<DAC channel1 refresh time */
+#define DAC_SHRR_TREFRESH2_Pos      (16U)
+#define DAC_SHRR_TREFRESH2_Msk      (0xFFUL << DAC_SHRR_TREFRESH2_Pos)         /*!< 0x00FF0000 */
+#define DAC_SHRR_TREFRESH2          DAC_SHRR_TREFRESH2_Msk                     /*!<DAC channel2 refresh time */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 Debug MCU                                  */
+/*                                                                            */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define DMA_ISR_GIF1_Pos       (0U)
+#define DMA_ISR_GIF1_Msk       (0x1UL << DMA_ISR_GIF1_Pos)                     /*!< 0x00000001 */
+#define DMA_ISR_GIF1           DMA_ISR_GIF1_Msk                                /*!< Channel 1 Global interrupt flag */
+#define DMA_ISR_TCIF1_Pos      (1U)
+#define DMA_ISR_TCIF1_Msk      (0x1UL << DMA_ISR_TCIF1_Pos)                    /*!< 0x00000002 */
+#define DMA_ISR_TCIF1          DMA_ISR_TCIF1_Msk                               /*!< Channel 1 Transfer Complete flag */
+#define DMA_ISR_HTIF1_Pos      (2U)
+#define DMA_ISR_HTIF1_Msk      (0x1UL << DMA_ISR_HTIF1_Pos)                    /*!< 0x00000004 */
+#define DMA_ISR_HTIF1          DMA_ISR_HTIF1_Msk                               /*!< Channel 1 Half Transfer flag */
+#define DMA_ISR_TEIF1_Pos      (3U)
+#define DMA_ISR_TEIF1_Msk      (0x1UL << DMA_ISR_TEIF1_Pos)                    /*!< 0x00000008 */
+#define DMA_ISR_TEIF1          DMA_ISR_TEIF1_Msk                               /*!< Channel 1 Transfer Error flag */
+#define DMA_ISR_GIF2_Pos       (4U)
+#define DMA_ISR_GIF2_Msk       (0x1UL << DMA_ISR_GIF2_Pos)                     /*!< 0x00000010 */
+#define DMA_ISR_GIF2           DMA_ISR_GIF2_Msk                                /*!< Channel 2 Global interrupt flag */
+#define DMA_ISR_TCIF2_Pos      (5U)
+#define DMA_ISR_TCIF2_Msk      (0x1UL << DMA_ISR_TCIF2_Pos)                    /*!< 0x00000020 */
+#define DMA_ISR_TCIF2          DMA_ISR_TCIF2_Msk                               /*!< Channel 2 Transfer Complete flag */
+#define DMA_ISR_HTIF2_Pos      (6U)
+#define DMA_ISR_HTIF2_Msk      (0x1UL << DMA_ISR_HTIF2_Pos)                    /*!< 0x00000040 */
+#define DMA_ISR_HTIF2          DMA_ISR_HTIF2_Msk                               /*!< Channel 2 Half Transfer flag */
+#define DMA_ISR_TEIF2_Pos      (7U)
+#define DMA_ISR_TEIF2_Msk      (0x1UL << DMA_ISR_TEIF2_Pos)                    /*!< 0x00000080 */
+#define DMA_ISR_TEIF2          DMA_ISR_TEIF2_Msk                               /*!< Channel 2 Transfer Error flag */
+#define DMA_ISR_GIF3_Pos       (8U)
+#define DMA_ISR_GIF3_Msk       (0x1UL << DMA_ISR_GIF3_Pos)                     /*!< 0x00000100 */
+#define DMA_ISR_GIF3           DMA_ISR_GIF3_Msk                                /*!< Channel 3 Global interrupt flag */
+#define DMA_ISR_TCIF3_Pos      (9U)
+#define DMA_ISR_TCIF3_Msk      (0x1UL << DMA_ISR_TCIF3_Pos)                    /*!< 0x00000200 */
+#define DMA_ISR_TCIF3          DMA_ISR_TCIF3_Msk                               /*!< Channel 3 Transfer Complete flag */
+#define DMA_ISR_HTIF3_Pos      (10U)
+#define DMA_ISR_HTIF3_Msk      (0x1UL << DMA_ISR_HTIF3_Pos)                    /*!< 0x00000400 */
+#define DMA_ISR_HTIF3          DMA_ISR_HTIF3_Msk                               /*!< Channel 3 Half Transfer flag */
+#define DMA_ISR_TEIF3_Pos      (11U)
+#define DMA_ISR_TEIF3_Msk      (0x1UL << DMA_ISR_TEIF3_Pos)                    /*!< 0x00000800 */
+#define DMA_ISR_TEIF3          DMA_ISR_TEIF3_Msk                               /*!< Channel 3 Transfer Error flag */
+#define DMA_ISR_GIF4_Pos       (12U)
+#define DMA_ISR_GIF4_Msk       (0x1UL << DMA_ISR_GIF4_Pos)                     /*!< 0x00001000 */
+#define DMA_ISR_GIF4           DMA_ISR_GIF4_Msk                                /*!< Channel 4 Global interrupt flag */
+#define DMA_ISR_TCIF4_Pos      (13U)
+#define DMA_ISR_TCIF4_Msk      (0x1UL << DMA_ISR_TCIF4_Pos)                    /*!< 0x00002000 */
+#define DMA_ISR_TCIF4          DMA_ISR_TCIF4_Msk                               /*!< Channel 4 Transfer Complete flag */
+#define DMA_ISR_HTIF4_Pos      (14U)
+#define DMA_ISR_HTIF4_Msk      (0x1UL << DMA_ISR_HTIF4_Pos)                    /*!< 0x00004000 */
+#define DMA_ISR_HTIF4          DMA_ISR_HTIF4_Msk                               /*!< Channel 4 Half Transfer flag */
+#define DMA_ISR_TEIF4_Pos      (15U)
+#define DMA_ISR_TEIF4_Msk      (0x1UL << DMA_ISR_TEIF4_Pos)                    /*!< 0x00008000 */
+#define DMA_ISR_TEIF4          DMA_ISR_TEIF4_Msk                               /*!< Channel 4 Transfer Error flag */
+#define DMA_ISR_GIF5_Pos       (16U)
+#define DMA_ISR_GIF5_Msk       (0x1UL << DMA_ISR_GIF5_Pos)                     /*!< 0x00010000 */
+#define DMA_ISR_GIF5           DMA_ISR_GIF5_Msk                                /*!< Channel 5 Global interrupt flag */
+#define DMA_ISR_TCIF5_Pos      (17U)
+#define DMA_ISR_TCIF5_Msk      (0x1UL << DMA_ISR_TCIF5_Pos)                    /*!< 0x00020000 */
+#define DMA_ISR_TCIF5          DMA_ISR_TCIF5_Msk                               /*!< Channel 5 Transfer Complete flag */
+#define DMA_ISR_HTIF5_Pos      (18U)
+#define DMA_ISR_HTIF5_Msk      (0x1UL << DMA_ISR_HTIF5_Pos)                    /*!< 0x00040000 */
+#define DMA_ISR_HTIF5          DMA_ISR_HTIF5_Msk                               /*!< Channel 5 Half Transfer flag */
+#define DMA_ISR_TEIF5_Pos      (19U)
+#define DMA_ISR_TEIF5_Msk      (0x1UL << DMA_ISR_TEIF5_Pos)                    /*!< 0x00080000 */
+#define DMA_ISR_TEIF5          DMA_ISR_TEIF5_Msk                               /*!< Channel 5 Transfer Error flag */
+#define DMA_ISR_GIF6_Pos       (20U)
+#define DMA_ISR_GIF6_Msk       (0x1UL << DMA_ISR_GIF6_Pos)                     /*!< 0x00100000 */
+#define DMA_ISR_GIF6           DMA_ISR_GIF6_Msk                                /*!< Channel 6 Global interrupt flag */
+#define DMA_ISR_TCIF6_Pos      (21U)
+#define DMA_ISR_TCIF6_Msk      (0x1UL << DMA_ISR_TCIF6_Pos)                    /*!< 0x00200000 */
+#define DMA_ISR_TCIF6          DMA_ISR_TCIF6_Msk                               /*!< Channel 6 Transfer Complete flag */
+#define DMA_ISR_HTIF6_Pos      (22U)
+#define DMA_ISR_HTIF6_Msk      (0x1UL << DMA_ISR_HTIF6_Pos)                    /*!< 0x00400000 */
+#define DMA_ISR_HTIF6          DMA_ISR_HTIF6_Msk                               /*!< Channel 6 Half Transfer flag */
+#define DMA_ISR_TEIF6_Pos      (23U)
+#define DMA_ISR_TEIF6_Msk      (0x1UL << DMA_ISR_TEIF6_Pos)                    /*!< 0x00800000 */
+#define DMA_ISR_TEIF6          DMA_ISR_TEIF6_Msk                               /*!< Channel 6 Transfer Error flag */
+#define DMA_ISR_GIF7_Pos       (24U)
+#define DMA_ISR_GIF7_Msk       (0x1UL << DMA_ISR_GIF7_Pos)                     /*!< 0x01000000 */
+#define DMA_ISR_GIF7           DMA_ISR_GIF7_Msk                                /*!< Channel 7 Global interrupt flag */
+#define DMA_ISR_TCIF7_Pos      (25U)
+#define DMA_ISR_TCIF7_Msk      (0x1UL << DMA_ISR_TCIF7_Pos)                    /*!< 0x02000000 */
+#define DMA_ISR_TCIF7          DMA_ISR_TCIF7_Msk                               /*!< Channel 7 Transfer Complete flag */
+#define DMA_ISR_HTIF7_Pos      (26U)
+#define DMA_ISR_HTIF7_Msk      (0x1UL << DMA_ISR_HTIF7_Pos)                    /*!< 0x04000000 */
+#define DMA_ISR_HTIF7          DMA_ISR_HTIF7_Msk                               /*!< Channel 7 Half Transfer flag */
+#define DMA_ISR_TEIF7_Pos      (27U)
+#define DMA_ISR_TEIF7_Msk      (0x1UL << DMA_ISR_TEIF7_Pos)                    /*!< 0x08000000 */
+#define DMA_ISR_TEIF7          DMA_ISR_TEIF7_Msk                               /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define DMA_IFCR_CGIF1_Pos     (0U)
+#define DMA_IFCR_CGIF1_Msk     (0x1UL << DMA_IFCR_CGIF1_Pos)                   /*!< 0x00000001 */
+#define DMA_IFCR_CGIF1         DMA_IFCR_CGIF1_Msk                              /*!< Channel 1 Global interrupt clearr */
+#define DMA_IFCR_CTCIF1_Pos    (1U)
+#define DMA_IFCR_CTCIF1_Msk    (0x1UL << DMA_IFCR_CTCIF1_Pos)                  /*!< 0x00000002 */
+#define DMA_IFCR_CTCIF1        DMA_IFCR_CTCIF1_Msk                             /*!< Channel 1 Transfer Complete clear */
+#define DMA_IFCR_CHTIF1_Pos    (2U)
+#define DMA_IFCR_CHTIF1_Msk    (0x1UL << DMA_IFCR_CHTIF1_Pos)                  /*!< 0x00000004 */
+#define DMA_IFCR_CHTIF1        DMA_IFCR_CHTIF1_Msk                             /*!< Channel 1 Half Transfer clear */
+#define DMA_IFCR_CTEIF1_Pos    (3U)
+#define DMA_IFCR_CTEIF1_Msk    (0x1UL << DMA_IFCR_CTEIF1_Pos)                  /*!< 0x00000008 */
+#define DMA_IFCR_CTEIF1        DMA_IFCR_CTEIF1_Msk                             /*!< Channel 1 Transfer Error clear */
+#define DMA_IFCR_CGIF2_Pos     (4U)
+#define DMA_IFCR_CGIF2_Msk     (0x1UL << DMA_IFCR_CGIF2_Pos)                   /*!< 0x00000010 */
+#define DMA_IFCR_CGIF2         DMA_IFCR_CGIF2_Msk                              /*!< Channel 2 Global interrupt clear */
+#define DMA_IFCR_CTCIF2_Pos    (5U)
+#define DMA_IFCR_CTCIF2_Msk    (0x1UL << DMA_IFCR_CTCIF2_Pos)                  /*!< 0x00000020 */
+#define DMA_IFCR_CTCIF2        DMA_IFCR_CTCIF2_Msk                             /*!< Channel 2 Transfer Complete clear */
+#define DMA_IFCR_CHTIF2_Pos    (6U)
+#define DMA_IFCR_CHTIF2_Msk    (0x1UL << DMA_IFCR_CHTIF2_Pos)                  /*!< 0x00000040 */
+#define DMA_IFCR_CHTIF2        DMA_IFCR_CHTIF2_Msk                             /*!< Channel 2 Half Transfer clear */
+#define DMA_IFCR_CTEIF2_Pos    (7U)
+#define DMA_IFCR_CTEIF2_Msk    (0x1UL << DMA_IFCR_CTEIF2_Pos)                  /*!< 0x00000080 */
+#define DMA_IFCR_CTEIF2        DMA_IFCR_CTEIF2_Msk                             /*!< Channel 2 Transfer Error clear */
+#define DMA_IFCR_CGIF3_Pos     (8U)
+#define DMA_IFCR_CGIF3_Msk     (0x1UL << DMA_IFCR_CGIF3_Pos)                   /*!< 0x00000100 */
+#define DMA_IFCR_CGIF3         DMA_IFCR_CGIF3_Msk                              /*!< Channel 3 Global interrupt clear */
+#define DMA_IFCR_CTCIF3_Pos    (9U)
+#define DMA_IFCR_CTCIF3_Msk    (0x1UL << DMA_IFCR_CTCIF3_Pos)                  /*!< 0x00000200 */
+#define DMA_IFCR_CTCIF3        DMA_IFCR_CTCIF3_Msk                             /*!< Channel 3 Transfer Complete clear */
+#define DMA_IFCR_CHTIF3_Pos    (10U)
+#define DMA_IFCR_CHTIF3_Msk    (0x1UL << DMA_IFCR_CHTIF3_Pos)                  /*!< 0x00000400 */
+#define DMA_IFCR_CHTIF3        DMA_IFCR_CHTIF3_Msk                             /*!< Channel 3 Half Transfer clear */
+#define DMA_IFCR_CTEIF3_Pos    (11U)
+#define DMA_IFCR_CTEIF3_Msk    (0x1UL << DMA_IFCR_CTEIF3_Pos)                  /*!< 0x00000800 */
+#define DMA_IFCR_CTEIF3        DMA_IFCR_CTEIF3_Msk                             /*!< Channel 3 Transfer Error clear */
+#define DMA_IFCR_CGIF4_Pos     (12U)
+#define DMA_IFCR_CGIF4_Msk     (0x1UL << DMA_IFCR_CGIF4_Pos)                   /*!< 0x00001000 */
+#define DMA_IFCR_CGIF4         DMA_IFCR_CGIF4_Msk                              /*!< Channel 4 Global interrupt clear */
+#define DMA_IFCR_CTCIF4_Pos    (13U)
+#define DMA_IFCR_CTCIF4_Msk    (0x1UL << DMA_IFCR_CTCIF4_Pos)                  /*!< 0x00002000 */
+#define DMA_IFCR_CTCIF4        DMA_IFCR_CTCIF4_Msk                             /*!< Channel 4 Transfer Complete clear */
+#define DMA_IFCR_CHTIF4_Pos    (14U)
+#define DMA_IFCR_CHTIF4_Msk    (0x1UL << DMA_IFCR_CHTIF4_Pos)                  /*!< 0x00004000 */
+#define DMA_IFCR_CHTIF4        DMA_IFCR_CHTIF4_Msk                             /*!< Channel 4 Half Transfer clear */
+#define DMA_IFCR_CTEIF4_Pos    (15U)
+#define DMA_IFCR_CTEIF4_Msk    (0x1UL << DMA_IFCR_CTEIF4_Pos)                  /*!< 0x00008000 */
+#define DMA_IFCR_CTEIF4        DMA_IFCR_CTEIF4_Msk                             /*!< Channel 4 Transfer Error clear */
+#define DMA_IFCR_CGIF5_Pos     (16U)
+#define DMA_IFCR_CGIF5_Msk     (0x1UL << DMA_IFCR_CGIF5_Pos)                   /*!< 0x00010000 */
+#define DMA_IFCR_CGIF5         DMA_IFCR_CGIF5_Msk                              /*!< Channel 5 Global interrupt clear */
+#define DMA_IFCR_CTCIF5_Pos    (17U)
+#define DMA_IFCR_CTCIF5_Msk    (0x1UL << DMA_IFCR_CTCIF5_Pos)                  /*!< 0x00020000 */
+#define DMA_IFCR_CTCIF5        DMA_IFCR_CTCIF5_Msk                             /*!< Channel 5 Transfer Complete clear */
+#define DMA_IFCR_CHTIF5_Pos    (18U)
+#define DMA_IFCR_CHTIF5_Msk    (0x1UL << DMA_IFCR_CHTIF5_Pos)                  /*!< 0x00040000 */
+#define DMA_IFCR_CHTIF5        DMA_IFCR_CHTIF5_Msk                             /*!< Channel 5 Half Transfer clear */
+#define DMA_IFCR_CTEIF5_Pos    (19U)
+#define DMA_IFCR_CTEIF5_Msk    (0x1UL << DMA_IFCR_CTEIF5_Pos)                  /*!< 0x00080000 */
+#define DMA_IFCR_CTEIF5        DMA_IFCR_CTEIF5_Msk                             /*!< Channel 5 Transfer Error clear */
+#define DMA_IFCR_CGIF6_Pos     (20U)
+#define DMA_IFCR_CGIF6_Msk     (0x1UL << DMA_IFCR_CGIF6_Pos)                   /*!< 0x00100000 */
+#define DMA_IFCR_CGIF6         DMA_IFCR_CGIF6_Msk                              /*!< Channel 6 Global interrupt clear */
+#define DMA_IFCR_CTCIF6_Pos    (21U)
+#define DMA_IFCR_CTCIF6_Msk    (0x1UL << DMA_IFCR_CTCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_IFCR_CTCIF6        DMA_IFCR_CTCIF6_Msk                             /*!< Channel 6 Transfer Complete clear */
+#define DMA_IFCR_CHTIF6_Pos    (22U)
+#define DMA_IFCR_CHTIF6_Msk    (0x1UL << DMA_IFCR_CHTIF6_Pos)                  /*!< 0x00400000 */
+#define DMA_IFCR_CHTIF6        DMA_IFCR_CHTIF6_Msk                             /*!< Channel 6 Half Transfer clear */
+#define DMA_IFCR_CTEIF6_Pos    (23U)
+#define DMA_IFCR_CTEIF6_Msk    (0x1UL << DMA_IFCR_CTEIF6_Pos)                  /*!< 0x00800000 */
+#define DMA_IFCR_CTEIF6        DMA_IFCR_CTEIF6_Msk                             /*!< Channel 6 Transfer Error clear */
+#define DMA_IFCR_CGIF7_Pos     (24U)
+#define DMA_IFCR_CGIF7_Msk     (0x1UL << DMA_IFCR_CGIF7_Pos)                   /*!< 0x01000000 */
+#define DMA_IFCR_CGIF7         DMA_IFCR_CGIF7_Msk                              /*!< Channel 7 Global interrupt clear */
+#define DMA_IFCR_CTCIF7_Pos    (25U)
+#define DMA_IFCR_CTCIF7_Msk    (0x1UL << DMA_IFCR_CTCIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_IFCR_CTCIF7        DMA_IFCR_CTCIF7_Msk                             /*!< Channel 7 Transfer Complete clear */
+#define DMA_IFCR_CHTIF7_Pos    (26U)
+#define DMA_IFCR_CHTIF7_Msk    (0x1UL << DMA_IFCR_CHTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_IFCR_CHTIF7        DMA_IFCR_CHTIF7_Msk                             /*!< Channel 7 Half Transfer clear */
+#define DMA_IFCR_CTEIF7_Pos    (27U)
+#define DMA_IFCR_CTEIF7_Msk    (0x1UL << DMA_IFCR_CTEIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_IFCR_CTEIF7        DMA_IFCR_CTEIF7_Msk                             /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define DMA_CCR_EN_Pos         (0U)
+#define DMA_CCR_EN_Msk         (0x1UL << DMA_CCR_EN_Pos)                       /*!< 0x00000001 */
+#define DMA_CCR_EN             DMA_CCR_EN_Msk                                  /*!< Channel enable                      */
+#define DMA_CCR_TCIE_Pos       (1U)
+#define DMA_CCR_TCIE_Msk       (0x1UL << DMA_CCR_TCIE_Pos)                     /*!< 0x00000002 */
+#define DMA_CCR_TCIE           DMA_CCR_TCIE_Msk                                /*!< Transfer complete interrupt enable  */
+#define DMA_CCR_HTIE_Pos       (2U)
+#define DMA_CCR_HTIE_Msk       (0x1UL << DMA_CCR_HTIE_Pos)                     /*!< 0x00000004 */
+#define DMA_CCR_HTIE           DMA_CCR_HTIE_Msk                                /*!< Half Transfer interrupt enable      */
+#define DMA_CCR_TEIE_Pos       (3U)
+#define DMA_CCR_TEIE_Msk       (0x1UL << DMA_CCR_TEIE_Pos)                     /*!< 0x00000008 */
+#define DMA_CCR_TEIE           DMA_CCR_TEIE_Msk                                /*!< Transfer error interrupt enable     */
+#define DMA_CCR_DIR_Pos        (4U)
+#define DMA_CCR_DIR_Msk        (0x1UL << DMA_CCR_DIR_Pos)                      /*!< 0x00000010 */
+#define DMA_CCR_DIR            DMA_CCR_DIR_Msk                                 /*!< Data transfer direction             */
+#define DMA_CCR_CIRC_Pos       (5U)
+#define DMA_CCR_CIRC_Msk       (0x1UL << DMA_CCR_CIRC_Pos)                     /*!< 0x00000020 */
+#define DMA_CCR_CIRC           DMA_CCR_CIRC_Msk                                /*!< Circular mode                       */
+#define DMA_CCR_PINC_Pos       (6U)
+#define DMA_CCR_PINC_Msk       (0x1UL << DMA_CCR_PINC_Pos)                     /*!< 0x00000040 */
+#define DMA_CCR_PINC           DMA_CCR_PINC_Msk                                /*!< Peripheral increment mode           */
+#define DMA_CCR_MINC_Pos       (7U)
+#define DMA_CCR_MINC_Msk       (0x1UL << DMA_CCR_MINC_Pos)                     /*!< 0x00000080 */
+#define DMA_CCR_MINC           DMA_CCR_MINC_Msk                                /*!< Memory increment mode               */
+
+#define DMA_CCR_PSIZE_Pos      (8U)
+#define DMA_CCR_PSIZE_Msk      (0x3UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000300 */
+#define DMA_CCR_PSIZE          DMA_CCR_PSIZE_Msk                               /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define DMA_CCR_PSIZE_0        (0x1UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000100 */
+#define DMA_CCR_PSIZE_1        (0x2UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000200 */
+
+#define DMA_CCR_MSIZE_Pos      (10U)
+#define DMA_CCR_MSIZE_Msk      (0x3UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000C00 */
+#define DMA_CCR_MSIZE          DMA_CCR_MSIZE_Msk                               /*!< MSIZE[1:0] bits (Memory size)       */
+#define DMA_CCR_MSIZE_0        (0x1UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000400 */
+#define DMA_CCR_MSIZE_1        (0x2UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000800 */
+
+#define DMA_CCR_PL_Pos         (12U)
+#define DMA_CCR_PL_Msk         (0x3UL << DMA_CCR_PL_Pos)                       /*!< 0x00003000 */
+#define DMA_CCR_PL             DMA_CCR_PL_Msk                                  /*!< PL[1:0] bits(Channel Priority level)*/
+#define DMA_CCR_PL_0           (0x1UL << DMA_CCR_PL_Pos)                       /*!< 0x00001000 */
+#define DMA_CCR_PL_1           (0x2UL << DMA_CCR_PL_Pos)                        /*!< 0x00002000 */
+
+#define DMA_CCR_MEM2MEM_Pos    (14U)
+#define DMA_CCR_MEM2MEM_Msk    (0x1UL << DMA_CCR_MEM2MEM_Pos)                  /*!< 0x00004000 */
+#define DMA_CCR_MEM2MEM        DMA_CCR_MEM2MEM_Msk                             /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define DMA_CNDTR_NDT_Pos      (0U)
+#define DMA_CNDTR_NDT_Msk      (0xFFFFUL << DMA_CNDTR_NDT_Pos)                 /*!< 0x0000FFFF */
+#define DMA_CNDTR_NDT          DMA_CNDTR_NDT_Msk                               /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define DMA_CPAR_PA_Pos        (0U)
+#define DMA_CPAR_PA_Msk        (0xFFFFFFFFUL << DMA_CPAR_PA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CPAR_PA            DMA_CPAR_PA_Msk                                 /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define DMA_CMAR_MA_Pos        (0U)
+#define DMA_CMAR_MA_Msk        (0xFFFFFFFFUL << DMA_CMAR_MA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CMAR_MA            DMA_CMAR_MA_Msk                                 /*!< Memory Address                      */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMAMUX Controller                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMAMUX_CxCR register  **************/
+#define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
+#define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
+#define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_CxCR_DMAREQ_ID_2                (0x04UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_CxCR_DMAREQ_ID_3                (0x08UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_CxCR_DMAREQ_ID_4                (0x10UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_CxCR_DMAREQ_ID_5                (0x20UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
+#define DMAMUX_CxCR_DMAREQ_ID_6                (0x40UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000040 */
+#define DMAMUX_CxCR_DMAREQ_ID_7                (0x80UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000080 */
+#define DMAMUX_CxCR_SOIE_Pos                   (8U)
+#define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk             /*!< Synchro overrun interrupt enable     */
+#define DMAMUX_CxCR_EGE_Pos                    (9U)
+#define DMAMUX_CxCR_EGE_Msk                    (0x1UL << DMAMUX_CxCR_EGE_Pos)   /*!< 0x00000200 */
+#define DMAMUX_CxCR_EGE                        DMAMUX_CxCR_EGE_Msk              /*!< Event generation interrupt enable    */
+#define DMAMUX_CxCR_SE_Pos                     (16U)
+#define DMAMUX_CxCR_SE_Msk                     (0x1UL << DMAMUX_CxCR_SE_Pos)    /*!< 0x00010000 */
+#define DMAMUX_CxCR_SE                         DMAMUX_CxCR_SE_Msk               /*!< Synchronization enable               */
+#define DMAMUX_CxCR_SPOL_Pos                   (17U)
+#define DMAMUX_CxCR_SPOL_Msk                   (0x3UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00060000 */
+#define DMAMUX_CxCR_SPOL                       DMAMUX_CxCR_SPOL_Msk             /*!< Synchronization polarity             */
+#define DMAMUX_CxCR_SPOL_0                     (0x1UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00020000 */
+#define DMAMUX_CxCR_SPOL_1                     (0x2UL << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00040000 */
+#define DMAMUX_CxCR_NBREQ_Pos                  (19U)
+#define DMAMUX_CxCR_NBREQ_Msk                  (0x1FUL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_CxCR_NBREQ                      DMAMUX_CxCR_NBREQ_Msk             /*!< Number of request                    */
+#define DMAMUX_CxCR_NBREQ_0                    (0x01UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_CxCR_NBREQ_1                    (0x02UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_CxCR_NBREQ_2                    (0x04UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_CxCR_NBREQ_3                    (0x08UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_CxCR_NBREQ_4                    (0x10UL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00800000 */
+#define DMAMUX_CxCR_SYNC_ID_Pos                (24U)
+#define DMAMUX_CxCR_SYNC_ID_Msk                (0x1FUL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x1F000000 */
+#define DMAMUX_CxCR_SYNC_ID                    DMAMUX_CxCR_SYNC_ID_Msk             /*!< Synchronization ID                   */
+#define DMAMUX_CxCR_SYNC_ID_0                  (0x01UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x01000000 */
+#define DMAMUX_CxCR_SYNC_ID_1                  (0x02UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x02000000 */
+#define DMAMUX_CxCR_SYNC_ID_2                  (0x04UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x04000000 */
+#define DMAMUX_CxCR_SYNC_ID_3                  (0x08UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x08000000 */
+#define DMAMUX_CxCR_SYNC_ID_4                  (0x10UL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x10000000 */
+
+/*******************  Bits definition for DMAMUX_CSR register  **************/
+#define DMAMUX_CSR_SOF0_Pos                    (0U)
+#define DMAMUX_CSR_SOF0_Msk                    (0x1UL << DMAMUX_CSR_SOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CSR_SOF0                        DMAMUX_CSR_SOF0_Msk             /*!< Synchronization Overrun Flag 0       */
+#define DMAMUX_CSR_SOF1_Pos                    (1U)
+#define DMAMUX_CSR_SOF1_Msk                    (0x1UL << DMAMUX_CSR_SOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CSR_SOF1                        DMAMUX_CSR_SOF1_Msk             /*!< Synchronization Overrun Flag 1       */
+#define DMAMUX_CSR_SOF2_Pos                    (2U)
+#define DMAMUX_CSR_SOF2_Msk                    (0x1UL << DMAMUX_CSR_SOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CSR_SOF2                        DMAMUX_CSR_SOF2_Msk             /*!< Synchronization Overrun Flag 2       */
+#define DMAMUX_CSR_SOF3_Pos                    (3U)
+#define DMAMUX_CSR_SOF3_Msk                    (0x1UL << DMAMUX_CSR_SOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CSR_SOF3                        DMAMUX_CSR_SOF3_Msk             /*!< Synchronization Overrun Flag 3       */
+#define DMAMUX_CSR_SOF4_Pos                    (4U)
+#define DMAMUX_CSR_SOF4_Msk                    (0x1UL << DMAMUX_CSR_SOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CSR_SOF4                        DMAMUX_CSR_SOF4_Msk             /*!< Synchronization Overrun Flag 4       */
+#define DMAMUX_CSR_SOF5_Pos                    (5U)
+#define DMAMUX_CSR_SOF5_Msk                    (0x1UL << DMAMUX_CSR_SOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CSR_SOF5                        DMAMUX_CSR_SOF5_Msk             /*!< Synchronization Overrun Flag 5       */
+#define DMAMUX_CSR_SOF6_Pos                    (6U)
+#define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+
+/********************  Bits definition for DMAMUX_CFR register  **************/
+#define DMAMUX_CFR_CSOF0_Pos                   (0U)
+#define DMAMUX_CFR_CSOF0_Msk                   (0x1UL << DMAMUX_CFR_CSOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CFR_CSOF0                       DMAMUX_CFR_CSOF0_Msk             /*!< Clear Overrun Flag 0                 */
+#define DMAMUX_CFR_CSOF1_Pos                   (1U)
+#define DMAMUX_CFR_CSOF1_Msk                   (0x1UL << DMAMUX_CFR_CSOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CFR_CSOF1                       DMAMUX_CFR_CSOF1_Msk             /*!< Clear Overrun Flag 1                 */
+#define DMAMUX_CFR_CSOF2_Pos                   (2U)
+#define DMAMUX_CFR_CSOF2_Msk                   (0x1UL << DMAMUX_CFR_CSOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CFR_CSOF2                       DMAMUX_CFR_CSOF2_Msk             /*!< Clear Overrun Flag 2                 */
+#define DMAMUX_CFR_CSOF3_Pos                   (3U)
+#define DMAMUX_CFR_CSOF3_Msk                   (0x1UL << DMAMUX_CFR_CSOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CFR_CSOF3                       DMAMUX_CFR_CSOF3_Msk             /*!< Clear Overrun Flag 3                 */
+#define DMAMUX_CFR_CSOF4_Pos                   (4U)
+#define DMAMUX_CFR_CSOF4_Msk                   (0x1UL << DMAMUX_CFR_CSOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CFR_CSOF4                       DMAMUX_CFR_CSOF4_Msk             /*!< Clear Overrun Flag 4                 */
+#define DMAMUX_CFR_CSOF5_Pos                   (5U)
+#define DMAMUX_CFR_CSOF5_Msk                   (0x1UL << DMAMUX_CFR_CSOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CFR_CSOF5                       DMAMUX_CFR_CSOF5_Msk             /*!< Clear Overrun Flag 5                 */
+#define DMAMUX_CFR_CSOF6_Pos                   (6U)
+#define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk             /*!< Clear Overrun Flag 6                 */
+
+/********************  Bits definition for DMAMUX_RGxCR register  ************/
+#define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
+#define DMAMUX_RGxCR_SIG_ID_Msk                (0x1FUL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x0000001F */
+#define DMAMUX_RGxCR_SIG_ID                    DMAMUX_RGxCR_SIG_ID_Msk             /*!< Signal ID                         */
+#define DMAMUX_RGxCR_SIG_ID_0                  (0x01UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGxCR_SIG_ID_1                  (0x02UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGxCR_SIG_ID_2                  (0x04UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGxCR_SIG_ID_3                  (0x08UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGxCR_SIG_ID_4                  (0x10UL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_RGxCR_OIE_Pos                   (8U)
+#define DMAMUX_RGxCR_OIE_Msk                   (0x1UL << DMAMUX_RGxCR_OIE_Pos)  /*!< 0x00000100 */
+#define DMAMUX_RGxCR_OIE                       DMAMUX_RGxCR_OIE_Msk             /*!< Overrun interrupt enable             */
+#define DMAMUX_RGxCR_GE_Pos                    (16U)
+#define DMAMUX_RGxCR_GE_Msk                    (0x1UL << DMAMUX_RGxCR_GE_Pos)   /*!< 0x00010000 */
+#define DMAMUX_RGxCR_GE                        DMAMUX_RGxCR_GE_Msk              /*!< Generation enable                    */
+#define DMAMUX_RGxCR_GPOL_Pos                  (17U)
+#define DMAMUX_RGxCR_GPOL_Msk                  (0x3UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_RGxCR_GPOL                      DMAMUX_RGxCR_GPOL_Msk            /*!< Generation polarity                  */
+#define DMAMUX_RGxCR_GPOL_0                    (0x1UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00020000 */
+#define DMAMUX_RGxCR_GPOL_1                    (0x2UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00040000 */
+#define DMAMUX_RGxCR_GNBREQ_Pos                (19U)
+#define DMAMUX_RGxCR_GNBREQ_Msk                (0x1FUL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_RGxCR_GNBREQ                    DMAMUX_RGxCR_GNBREQ_Msk             /*!< Number of request                 */
+#define DMAMUX_RGxCR_GNBREQ_0                  (0x01UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_RGxCR_GNBREQ_1                  (0x02UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_RGxCR_GNBREQ_2                  (0x04UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_RGxCR_GNBREQ_3                  (0x08UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_RGxCR_GNBREQ_4                  (0x10UL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00800000 */
+
+/********************  Bits definition for DMAMUX_RGSR register  **************/
+#define DMAMUX_RGSR_OF0_Pos                    (0U)
+#define DMAMUX_RGSR_OF0_Msk                    (0x1UL << DMAMUX_RGSR_OF0_Pos)   /*!< 0x00000001 */
+#define DMAMUX_RGSR_OF0                        DMAMUX_RGSR_OF0_Msk              /*!< Overrun flag 0                       */
+#define DMAMUX_RGSR_OF1_Pos                    (1U)
+#define DMAMUX_RGSR_OF1_Msk                    (0x1UL << DMAMUX_RGSR_OF1_Pos)   /*!< 0x00000002 */
+#define DMAMUX_RGSR_OF1                        DMAMUX_RGSR_OF1_Msk              /*!< Overrun flag 1                       */
+#define DMAMUX_RGSR_OF2_Pos                    (2U)
+#define DMAMUX_RGSR_OF2_Msk                    (0x1UL << DMAMUX_RGSR_OF2_Pos)   /*!< 0x00000004 */
+#define DMAMUX_RGSR_OF2                        DMAMUX_RGSR_OF2_Msk              /*!< Overrun flag 2                       */
+#define DMAMUX_RGSR_OF3_Pos                    (3U)
+#define DMAMUX_RGSR_OF3_Msk                    (0x1UL << DMAMUX_RGSR_OF3_Pos)   /*!< 0x00000008 */
+#define DMAMUX_RGSR_OF3                        DMAMUX_RGSR_OF3_Msk              /*!< Overrun flag 3                       */
+
+/********************  Bits definition for DMAMUX_RGCFR register  **************/
+#define DMAMUX_RGCFR_COF0_Pos                  (0U)
+#define DMAMUX_RGCFR_COF0_Msk                  (0x1UL << DMAMUX_RGCFR_COF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGCFR_COF0                      DMAMUX_RGCFR_COF0_Msk            /*!< Clear Overrun flag 0                 */
+#define DMAMUX_RGCFR_COF1_Pos                  (1U)
+#define DMAMUX_RGCFR_COF1_Msk                  (0x1UL << DMAMUX_RGCFR_COF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGCFR_COF1                      DMAMUX_RGCFR_COF1_Msk            /*!< Clear Overrun flag 1                 */
+#define DMAMUX_RGCFR_COF2_Pos                  (2U)
+#define DMAMUX_RGCFR_COF2_Msk                  (0x1UL << DMAMUX_RGCFR_COF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGCFR_COF2                      DMAMUX_RGCFR_COF2_Msk            /*!< Clear Overrun flag 2                 */
+#define DMAMUX_RGCFR_COF3_Pos                  (3U)
+#define DMAMUX_RGCFR_COF3_Msk                  (0x1UL << DMAMUX_RGCFR_COF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGCFR_COF3                      DMAMUX_RGCFR_COF3_Msk            /*!< Clear Overrun flag 3                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for EXTI_RTSR1 register  ******************/
+#define EXTI_RTSR1_RT0_Pos           (0U)
+#define EXTI_RTSR1_RT0_Msk           (0x1UL << EXTI_RTSR1_RT0_Pos)             /*!< 0x00000001 */
+#define EXTI_RTSR1_RT0               EXTI_RTSR1_RT0_Msk                        /*!< Rising trigger configuration for input line 0 */
+#define EXTI_RTSR1_RT1_Pos           (1U)
+#define EXTI_RTSR1_RT1_Msk           (0x1UL << EXTI_RTSR1_RT1_Pos)             /*!< 0x00000002 */
+#define EXTI_RTSR1_RT1               EXTI_RTSR1_RT1_Msk                        /*!< Rising trigger configuration for input line 1 */
+#define EXTI_RTSR1_RT2_Pos           (2U)
+#define EXTI_RTSR1_RT2_Msk           (0x1UL << EXTI_RTSR1_RT2_Pos)             /*!< 0x00000004 */
+#define EXTI_RTSR1_RT2               EXTI_RTSR1_RT2_Msk                        /*!< Rising trigger configuration for input line 2 */
+#define EXTI_RTSR1_RT3_Pos           (3U)
+#define EXTI_RTSR1_RT3_Msk           (0x1UL << EXTI_RTSR1_RT3_Pos)             /*!< 0x00000008 */
+#define EXTI_RTSR1_RT3               EXTI_RTSR1_RT3_Msk                        /*!< Rising trigger configuration for input line 3 */
+#define EXTI_RTSR1_RT4_Pos           (4U)
+#define EXTI_RTSR1_RT4_Msk           (0x1UL << EXTI_RTSR1_RT4_Pos)             /*!< 0x00000010 */
+#define EXTI_RTSR1_RT4               EXTI_RTSR1_RT4_Msk                        /*!< Rising trigger configuration for input line 4 */
+#define EXTI_RTSR1_RT5_Pos           (5U)
+#define EXTI_RTSR1_RT5_Msk           (0x1UL << EXTI_RTSR1_RT5_Pos)             /*!< 0x00000020 */
+#define EXTI_RTSR1_RT5               EXTI_RTSR1_RT5_Msk                        /*!< Rising trigger configuration for input line 5 */
+#define EXTI_RTSR1_RT6_Pos           (6U)
+#define EXTI_RTSR1_RT6_Msk           (0x1UL << EXTI_RTSR1_RT6_Pos)             /*!< 0x00000040 */
+#define EXTI_RTSR1_RT6               EXTI_RTSR1_RT6_Msk                        /*!< Rising trigger configuration for input line 6 */
+#define EXTI_RTSR1_RT7_Pos           (7U)
+#define EXTI_RTSR1_RT7_Msk           (0x1UL << EXTI_RTSR1_RT7_Pos)             /*!< 0x00000080 */
+#define EXTI_RTSR1_RT7               EXTI_RTSR1_RT7_Msk                        /*!< Rising trigger configuration for input line 7 */
+#define EXTI_RTSR1_RT8_Pos           (8U)
+#define EXTI_RTSR1_RT8_Msk           (0x1UL << EXTI_RTSR1_RT8_Pos)             /*!< 0x00000100 */
+#define EXTI_RTSR1_RT8               EXTI_RTSR1_RT8_Msk                        /*!< Rising trigger configuration for input line 8 */
+#define EXTI_RTSR1_RT9_Pos           (9U)
+#define EXTI_RTSR1_RT9_Msk           (0x1UL << EXTI_RTSR1_RT9_Pos)             /*!< 0x00000200 */
+#define EXTI_RTSR1_RT9               EXTI_RTSR1_RT9_Msk                        /*!< Rising trigger configuration for input line 9 */
+#define EXTI_RTSR1_RT10_Pos          (10U)
+#define EXTI_RTSR1_RT10_Msk          (0x1UL << EXTI_RTSR1_RT10_Pos)            /*!< 0x00000400 */
+#define EXTI_RTSR1_RT10              EXTI_RTSR1_RT10_Msk                       /*!< Rising trigger configuration for input line 10 */
+#define EXTI_RTSR1_RT11_Pos          (11U)
+#define EXTI_RTSR1_RT11_Msk          (0x1UL << EXTI_RTSR1_RT11_Pos)            /*!< 0x00000800 */
+#define EXTI_RTSR1_RT11              EXTI_RTSR1_RT11_Msk                       /*!< Rising trigger configuration for input line 11 */
+#define EXTI_RTSR1_RT12_Pos          (12U)
+#define EXTI_RTSR1_RT12_Msk          (0x1UL << EXTI_RTSR1_RT12_Pos)            /*!< 0x00001000 */
+#define EXTI_RTSR1_RT12              EXTI_RTSR1_RT12_Msk                       /*!< Rising trigger configuration for input line 12 */
+#define EXTI_RTSR1_RT13_Pos          (13U)
+#define EXTI_RTSR1_RT13_Msk          (0x1UL << EXTI_RTSR1_RT13_Pos)            /*!< 0x00002000 */
+#define EXTI_RTSR1_RT13              EXTI_RTSR1_RT13_Msk                       /*!< Rising trigger configuration for input line 13 */
+#define EXTI_RTSR1_RT14_Pos          (14U)
+#define EXTI_RTSR1_RT14_Msk          (0x1UL << EXTI_RTSR1_RT14_Pos)            /*!< 0x00004000 */
+#define EXTI_RTSR1_RT14              EXTI_RTSR1_RT14_Msk                       /*!< Rising trigger configuration for input line 14 */
+#define EXTI_RTSR1_RT15_Pos          (15U)
+#define EXTI_RTSR1_RT15_Msk          (0x1UL << EXTI_RTSR1_RT15_Pos)            /*!< 0x00008000 */
+#define EXTI_RTSR1_RT15              EXTI_RTSR1_RT15_Msk                       /*!< Rising trigger configuration for input line 15 */
+#define EXTI_RTSR1_RT16_Pos          (16U)
+#define EXTI_RTSR1_RT16_Msk          (0x1UL << EXTI_RTSR1_RT16_Pos)            /*!< 0x00010000 */
+#define EXTI_RTSR1_RT16              EXTI_RTSR1_RT16_Msk                       /*!< Rising trigger configuration for input line 16 */
+#define EXTI_RTSR1_RT17_Pos          (17U)
+#define EXTI_RTSR1_RT17_Msk          (0x1UL << EXTI_RTSR1_RT17_Pos)            /*!< 0x00020000 */
+#define EXTI_RTSR1_RT17              EXTI_RTSR1_RT17_Msk                       /*!< Rising trigger configuration for input line 17 */
+#define EXTI_RTSR1_RT18_Pos          (18U)
+#define EXTI_RTSR1_RT18_Msk          (0x1UL << EXTI_RTSR1_RT18_Pos)            /*!< 0x00040000 */
+#define EXTI_RTSR1_RT18              EXTI_RTSR1_RT18_Msk                       /*!< Rising trigger configuration for input line 18 */
+
+/******************  Bit definition for EXTI_FTSR1 register  ******************/
+#define EXTI_FTSR1_FT0_Pos           (0U)
+#define EXTI_FTSR1_FT0_Msk           (0x1UL << EXTI_FTSR1_FT0_Pos)             /*!< 0x00000001 */
+#define EXTI_FTSR1_FT0               EXTI_FTSR1_FT0_Msk                        /*!< Falling trigger configuration for input line 0 */
+#define EXTI_FTSR1_FT1_Pos           (1U)
+#define EXTI_FTSR1_FT1_Msk           (0x1UL << EXTI_FTSR1_FT1_Pos)             /*!< 0x00000002 */
+#define EXTI_FTSR1_FT1               EXTI_FTSR1_FT1_Msk                        /*!< Falling trigger configuration for input line 1 */
+#define EXTI_FTSR1_FT2_Pos           (2U)
+#define EXTI_FTSR1_FT2_Msk           (0x1UL << EXTI_FTSR1_FT2_Pos)             /*!< 0x00000004 */
+#define EXTI_FTSR1_FT2               EXTI_FTSR1_FT2_Msk                        /*!< Falling trigger configuration for input line 2 */
+#define EXTI_FTSR1_FT3_Pos           (3U)
+#define EXTI_FTSR1_FT3_Msk           (0x1UL << EXTI_FTSR1_FT3_Pos)             /*!< 0x00000008 */
+#define EXTI_FTSR1_FT3               EXTI_FTSR1_FT3_Msk                        /*!< Falling trigger configuration for input line 3 */
+#define EXTI_FTSR1_FT4_Pos           (4U)
+#define EXTI_FTSR1_FT4_Msk           (0x1UL << EXTI_FTSR1_FT4_Pos)             /*!< 0x00000010 */
+#define EXTI_FTSR1_FT4               EXTI_FTSR1_FT4_Msk                        /*!< Falling trigger configuration for input line 4 */
+#define EXTI_FTSR1_FT5_Pos           (5U)
+#define EXTI_FTSR1_FT5_Msk           (0x1UL << EXTI_FTSR1_FT5_Pos)             /*!< 0x00000020 */
+#define EXTI_FTSR1_FT5               EXTI_FTSR1_FT5_Msk                        /*!< Falling trigger configuration for input line 5 */
+#define EXTI_FTSR1_FT6_Pos           (6U)
+#define EXTI_FTSR1_FT6_Msk           (0x1UL << EXTI_FTSR1_FT6_Pos)             /*!< 0x00000040 */
+#define EXTI_FTSR1_FT6               EXTI_FTSR1_FT6_Msk                        /*!< Falling trigger configuration for input line 6 */
+#define EXTI_FTSR1_FT7_Pos           (7U)
+#define EXTI_FTSR1_FT7_Msk           (0x1UL << EXTI_FTSR1_FT7_Pos)             /*!< 0x00000080 */
+#define EXTI_FTSR1_FT7               EXTI_FTSR1_FT7_Msk                        /*!< Falling trigger configuration for input line 7 */
+#define EXTI_FTSR1_FT8_Pos           (8U)
+#define EXTI_FTSR1_FT8_Msk           (0x1UL << EXTI_FTSR1_FT8_Pos)             /*!< 0x00000100 */
+#define EXTI_FTSR1_FT8               EXTI_FTSR1_FT8_Msk                        /*!< Falling trigger configuration for input line 8 */
+#define EXTI_FTSR1_FT9_Pos           (9U)
+#define EXTI_FTSR1_FT9_Msk           (0x1UL << EXTI_FTSR1_FT9_Pos)             /*!< 0x00000200 */
+#define EXTI_FTSR1_FT9               EXTI_FTSR1_FT9_Msk                        /*!< Falling trigger configuration for input line 9 */
+#define EXTI_FTSR1_FT10_Pos          (10U)
+#define EXTI_FTSR1_FT10_Msk          (0x1UL << EXTI_FTSR1_FT10_Pos)            /*!< 0x00000400 */
+#define EXTI_FTSR1_FT10              EXTI_FTSR1_FT10_Msk                       /*!< Falling trigger configuration for input line 10 */
+#define EXTI_FTSR1_FT11_Pos          (11U)
+#define EXTI_FTSR1_FT11_Msk          (0x1UL << EXTI_FTSR1_FT11_Pos)            /*!< 0x00000800 */
+#define EXTI_FTSR1_FT11              EXTI_FTSR1_FT11_Msk                       /*!< Falling trigger configuration for input line 11 */
+#define EXTI_FTSR1_FT12_Pos          (12U)
+#define EXTI_FTSR1_FT12_Msk          (0x1UL << EXTI_FTSR1_FT12_Pos)            /*!< 0x00001000 */
+#define EXTI_FTSR1_FT12              EXTI_FTSR1_FT12_Msk                       /*!< Falling trigger configuration for input line 12 */
+#define EXTI_FTSR1_FT13_Pos          (13U)
+#define EXTI_FTSR1_FT13_Msk          (0x1UL << EXTI_FTSR1_FT13_Pos)            /*!< 0x00002000 */
+#define EXTI_FTSR1_FT13              EXTI_FTSR1_FT13_Msk                       /*!< Falling trigger configuration for input line 13 */
+#define EXTI_FTSR1_FT14_Pos          (14U)
+#define EXTI_FTSR1_FT14_Msk          (0x1UL << EXTI_FTSR1_FT14_Pos)            /*!< 0x00004000 */
+#define EXTI_FTSR1_FT14              EXTI_FTSR1_FT14_Msk                       /*!< Falling trigger configuration for input line 14 */
+#define EXTI_FTSR1_FT15_Pos          (15U)
+#define EXTI_FTSR1_FT15_Msk          (0x1UL << EXTI_FTSR1_FT15_Pos)            /*!< 0x00008000 */
+#define EXTI_FTSR1_FT15              EXTI_FTSR1_FT15_Msk                       /*!< Falling trigger configuration for input line 15 */
+#define EXTI_FTSR1_FT16_Pos          (16U)
+#define EXTI_FTSR1_FT16_Msk          (0x1UL << EXTI_FTSR1_FT16_Pos)            /*!< 0x00010000 */
+#define EXTI_FTSR1_FT16              EXTI_FTSR1_FT16_Msk                       /*!< Falling trigger configuration for input line 16 */
+#define EXTI_FTSR1_FT17_Pos          (17U)
+#define EXTI_FTSR1_FT17_Msk          (0x1UL << EXTI_FTSR1_FT17_Pos)            /*!< 0x00020000 */
+#define EXTI_FTSR1_FT17              EXTI_FTSR1_FT17_Msk                       /*!< Falling trigger configuration for input line 17 */
+#define EXTI_FTSR1_FT18_Pos          (18U)
+#define EXTI_FTSR1_FT18_Msk          (0x1UL << EXTI_FTSR1_FT18_Pos)            /*!< 0x00040000 */
+#define EXTI_FTSR1_FT18              EXTI_FTSR1_FT18_Msk                       /*!< Falling trigger configuration for input line 18 */
+
+/******************  Bit definition for EXTI_SWIER1 register  *****************/
+#define EXTI_SWIER1_SWI0_Pos         (0U)
+#define EXTI_SWIER1_SWI0_Msk         (0x1UL << EXTI_SWIER1_SWI0_Pos)           /*!< 0x00000001 */
+#define EXTI_SWIER1_SWI0             EXTI_SWIER1_SWI0_Msk                      /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER1_SWI1_Pos         (1U)
+#define EXTI_SWIER1_SWI1_Msk         (0x1UL << EXTI_SWIER1_SWI1_Pos)           /*!< 0x00000002 */
+#define EXTI_SWIER1_SWI1             EXTI_SWIER1_SWI1_Msk                      /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER1_SWI2_Pos         (2U)
+#define EXTI_SWIER1_SWI2_Msk         (0x1UL << EXTI_SWIER1_SWI2_Pos)           /*!< 0x00000004 */
+#define EXTI_SWIER1_SWI2             EXTI_SWIER1_SWI2_Msk                      /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER1_SWI3_Pos         (3U)
+#define EXTI_SWIER1_SWI3_Msk         (0x1UL << EXTI_SWIER1_SWI3_Pos)           /*!< 0x00000008 */
+#define EXTI_SWIER1_SWI3             EXTI_SWIER1_SWI3_Msk                      /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER1_SWI4_Pos         (4U)
+#define EXTI_SWIER1_SWI4_Msk         (0x1UL << EXTI_SWIER1_SWI4_Pos)           /*!< 0x00000010 */
+#define EXTI_SWIER1_SWI4             EXTI_SWIER1_SWI4_Msk                      /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER1_SWI5_Pos         (5U)
+#define EXTI_SWIER1_SWI5_Msk         (0x1UL << EXTI_SWIER1_SWI5_Pos)           /*!< 0x00000020 */
+#define EXTI_SWIER1_SWI5             EXTI_SWIER1_SWI5_Msk                      /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER1_SWI6_Pos         (6U)
+#define EXTI_SWIER1_SWI6_Msk         (0x1UL << EXTI_SWIER1_SWI6_Pos)           /*!< 0x00000040 */
+#define EXTI_SWIER1_SWI6             EXTI_SWIER1_SWI6_Msk                      /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER1_SWI7_Pos         (7U)
+#define EXTI_SWIER1_SWI7_Msk         (0x1UL << EXTI_SWIER1_SWI7_Pos)           /*!< 0x00000080 */
+#define EXTI_SWIER1_SWI7             EXTI_SWIER1_SWI7_Msk                      /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER1_SWI8_Pos         (8U)
+#define EXTI_SWIER1_SWI8_Msk         (0x1UL << EXTI_SWIER1_SWI8_Pos)           /*!< 0x00000100 */
+#define EXTI_SWIER1_SWI8             EXTI_SWIER1_SWI8_Msk                      /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER1_SWI9_Pos         (9U)
+#define EXTI_SWIER1_SWI9_Msk         (0x1UL << EXTI_SWIER1_SWI9_Pos)           /*!< 0x00000200 */
+#define EXTI_SWIER1_SWI9             EXTI_SWIER1_SWI9_Msk                      /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER1_SWI10_Pos        (10U)
+#define EXTI_SWIER1_SWI10_Msk        (0x1UL << EXTI_SWIER1_SWI10_Pos)          /*!< 0x00000400 */
+#define EXTI_SWIER1_SWI10            EXTI_SWIER1_SWI10_Msk                     /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER1_SWI11_Pos        (11U)
+#define EXTI_SWIER1_SWI11_Msk        (0x1UL << EXTI_SWIER1_SWI11_Pos)          /*!< 0x00000800 */
+#define EXTI_SWIER1_SWI11            EXTI_SWIER1_SWI11_Msk                     /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER1_SWI12_Pos        (12U)
+#define EXTI_SWIER1_SWI12_Msk        (0x1UL << EXTI_SWIER1_SWI12_Pos)          /*!< 0x00001000 */
+#define EXTI_SWIER1_SWI12            EXTI_SWIER1_SWI12_Msk                     /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER1_SWI13_Pos        (13U)
+#define EXTI_SWIER1_SWI13_Msk        (0x1UL << EXTI_SWIER1_SWI13_Pos)          /*!< 0x00002000 */
+#define EXTI_SWIER1_SWI13            EXTI_SWIER1_SWI13_Msk                     /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER1_SWI14_Pos        (14U)
+#define EXTI_SWIER1_SWI14_Msk        (0x1UL << EXTI_SWIER1_SWI14_Pos)          /*!< 0x00004000 */
+#define EXTI_SWIER1_SWI14            EXTI_SWIER1_SWI14_Msk                     /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER1_SWI15_Pos        (15U)
+#define EXTI_SWIER1_SWI15_Msk        (0x1UL << EXTI_SWIER1_SWI15_Pos)          /*!< 0x00008000 */
+#define EXTI_SWIER1_SWI15            EXTI_SWIER1_SWI15_Msk                     /*!< Software Interrupt on line 15 */
+#define EXTI_SWIER1_SWI16_Pos        (16U)
+#define EXTI_SWIER1_SWI16_Msk        (0x1UL << EXTI_SWIER1_SWI16_Pos)          /*!< 0x00010000 */
+#define EXTI_SWIER1_SWI16            EXTI_SWIER1_SWI16_Msk                     /*!< Software Interrupt on line 16 */
+#define EXTI_SWIER1_SWI17_Pos        (17U)
+#define EXTI_SWIER1_SWI17_Msk        (0x1UL << EXTI_SWIER1_SWI17_Pos)          /*!< 0x00020000 */
+#define EXTI_SWIER1_SWI17            EXTI_SWIER1_SWI17_Msk                     /*!< Software Interrupt on line 17 */
+#define EXTI_SWIER1_SWI18_Pos        (18U)
+#define EXTI_SWIER1_SWI18_Msk        (0x1UL << EXTI_SWIER1_SWI18_Pos)          /*!< 0x00040000 */
+#define EXTI_SWIER1_SWI18            EXTI_SWIER1_SWI18_Msk                     /*!< Software Interrupt on line 18 */
+
+/*******************  Bit definition for EXTI_RPR1 register  ******************/
+#define EXTI_RPR1_RPIF0_Pos          (0U)
+#define EXTI_RPR1_RPIF0_Msk          (0x1UL << EXTI_RPR1_RPIF0_Pos)            /*!< 0x00000001 */
+#define EXTI_RPR1_RPIF0              EXTI_RPR1_RPIF0_Msk                       /*!< Rising Pending Interrupt Flag on line 0 */
+#define EXTI_RPR1_RPIF1_Pos          (1U)
+#define EXTI_RPR1_RPIF1_Msk          (0x1UL << EXTI_RPR1_RPIF1_Pos)            /*!< 0x00000002 */
+#define EXTI_RPR1_RPIF1              EXTI_RPR1_RPIF1_Msk                       /*!< Rising Pending Interrupt Flag on line 1 */
+#define EXTI_RPR1_RPIF2_Pos          (2U)
+#define EXTI_RPR1_RPIF2_Msk          (0x1UL << EXTI_RPR1_RPIF2_Pos)            /*!< 0x00000004 */
+#define EXTI_RPR1_RPIF2              EXTI_RPR1_RPIF2_Msk                       /*!< Rising Pending Interrupt Flag on line 2 */
+#define EXTI_RPR1_RPIF3_Pos          (3U)
+#define EXTI_RPR1_RPIF3_Msk          (0x1UL << EXTI_RPR1_RPIF3_Pos)            /*!< 0x00000008 */
+#define EXTI_RPR1_RPIF3              EXTI_RPR1_RPIF3_Msk                       /*!< Rising Pending Interrupt Flag on line 3 */
+#define EXTI_RPR1_RPIF4_Pos          (4U)
+#define EXTI_RPR1_RPIF4_Msk          (0x1UL << EXTI_RPR1_RPIF4_Pos)            /*!< 0x00000010 */
+#define EXTI_RPR1_RPIF4              EXTI_RPR1_RPIF4_Msk                       /*!< Rising Pending Interrupt Flag on line 4 */
+#define EXTI_RPR1_RPIF5_Pos          (5U)
+#define EXTI_RPR1_RPIF5_Msk          (0x1UL << EXTI_RPR1_RPIF5_Pos)            /*!< 0x00000020 */
+#define EXTI_RPR1_RPIF5              EXTI_RPR1_RPIF5_Msk                       /*!< Rising Pending Interrupt Flag on line 5 */
+#define EXTI_RPR1_RPIF6_Pos          (6U)
+#define EXTI_RPR1_RPIF6_Msk          (0x1UL << EXTI_RPR1_RPIF6_Pos)            /*!< 0x00000040 */
+#define EXTI_RPR1_RPIF6              EXTI_RPR1_RPIF6_Msk                       /*!< Rising Pending Interrupt Flag on line 6 */
+#define EXTI_RPR1_RPIF7_Pos          (7U)
+#define EXTI_RPR1_RPIF7_Msk          (0x1UL << EXTI_RPR1_RPIF7_Pos)            /*!< 0x00000080 */
+#define EXTI_RPR1_RPIF7              EXTI_RPR1_RPIF7_Msk                       /*!< Rising Pending Interrupt Flag on line 7 */
+#define EXTI_RPR1_RPIF8_Pos          (8U)
+#define EXTI_RPR1_RPIF8_Msk          (0x1UL << EXTI_RPR1_RPIF8_Pos)            /*!< 0x00000100 */
+#define EXTI_RPR1_RPIF8              EXTI_RPR1_RPIF8_Msk                       /*!< Rising Pending Interrupt Flag on line 8 */
+#define EXTI_RPR1_RPIF9_Pos          (9U)
+#define EXTI_RPR1_RPIF9_Msk          (0x1UL << EXTI_RPR1_RPIF9_Pos)            /*!< 0x00000200 */
+#define EXTI_RPR1_RPIF9              EXTI_RPR1_RPIF9_Msk                       /*!< Rising Pending Interrupt Flag on line 9 */
+#define EXTI_RPR1_RPIF10_Pos         (10U)
+#define EXTI_RPR1_RPIF10_Msk         (0x1UL << EXTI_RPR1_RPIF10_Pos)           /*!< 0x00000400 */
+#define EXTI_RPR1_RPIF10             EXTI_RPR1_RPIF10_Msk                      /*!< Rising Pending Interrupt Flag on line 10 */
+#define EXTI_RPR1_RPIF11_Pos         (11U)
+#define EXTI_RPR1_RPIF11_Msk         (0x1UL << EXTI_RPR1_RPIF11_Pos)           /*!< 0x00000800 */
+#define EXTI_RPR1_RPIF11             EXTI_RPR1_RPIF11_Msk                      /*!< Rising Pending Interrupt Flag on line 11 */
+#define EXTI_RPR1_RPIF12_Pos         (12U)
+#define EXTI_RPR1_RPIF12_Msk         (0x1UL << EXTI_RPR1_RPIF12_Pos)           /*!< 0x00001000 */
+#define EXTI_RPR1_RPIF12             EXTI_RPR1_RPIF12_Msk                      /*!< Rising Pending Interrupt Flag on line 12 */
+#define EXTI_RPR1_RPIF13_Pos         (13U)
+#define EXTI_RPR1_RPIF13_Msk         (0x1UL << EXTI_RPR1_RPIF13_Pos)           /*!< 0x00002000 */
+#define EXTI_RPR1_RPIF13             EXTI_RPR1_RPIF13_Msk                      /*!< Rising Pending Interrupt Flag on line 13 */
+#define EXTI_RPR1_RPIF14_Pos         (14U)
+#define EXTI_RPR1_RPIF14_Msk         (0x1UL << EXTI_RPR1_RPIF14_Pos)           /*!< 0x00004000 */
+#define EXTI_RPR1_RPIF14             EXTI_RPR1_RPIF14_Msk                      /*!< Rising Pending Interrupt Flag on line 14 */
+#define EXTI_RPR1_RPIF15_Pos         (15U)
+#define EXTI_RPR1_RPIF15_Msk         (0x1UL << EXTI_RPR1_RPIF15_Pos)           /*!< 0x00008000 */
+#define EXTI_RPR1_RPIF15             EXTI_RPR1_RPIF15_Msk                      /*!< Rising Pending Interrupt Flag on line 15 */
+#define EXTI_RPR1_RPIF16_Pos         (16U)
+#define EXTI_RPR1_RPIF16_Msk         (0x1UL << EXTI_RPR1_RPIF16_Pos)           /*!< 0x00010000 */
+#define EXTI_RPR1_RPIF16             EXTI_RPR1_RPIF16_Msk                      /*!< Rising Pending Interrupt Flag on line 16 */
+#define EXTI_RPR1_RPIF17_Pos         (17U)
+#define EXTI_RPR1_RPIF17_Msk         (0x1UL << EXTI_RPR1_RPIF17_Pos)           /*!< 0x00020000 */
+#define EXTI_RPR1_RPIF17             EXTI_RPR1_RPIF17_Msk                      /*!< Rising Pending Interrupt Flag on line 17 */
+#define EXTI_RPR1_RPIF18_Pos         (18U)
+#define EXTI_RPR1_RPIF18_Msk         (0x1UL << EXTI_RPR1_RPIF18_Pos)           /*!< 0x00040000 */
+#define EXTI_RPR1_RPIF18             EXTI_RPR1_RPIF18_Msk                      /*!< Rising Pending Interrupt Flag on line 18 */
+
+/*******************  Bit definition for EXTI_FPR1 register  ******************/
+#define EXTI_FPR1_FPIF0_Pos          (0U)
+#define EXTI_FPR1_FPIF0_Msk          (0x1UL << EXTI_FPR1_FPIF0_Pos)            /*!< 0x00000001 */
+#define EXTI_FPR1_FPIF0              EXTI_FPR1_FPIF0_Msk                       /*!< Falling Pending Interrupt Flag on line 0 */
+#define EXTI_FPR1_FPIF1_Pos          (1U)
+#define EXTI_FPR1_FPIF1_Msk          (0x1UL << EXTI_FPR1_FPIF1_Pos)            /*!< 0x00000002 */
+#define EXTI_FPR1_FPIF1              EXTI_FPR1_FPIF1_Msk                       /*!< Falling Pending Interrupt Flag on line 1 */
+#define EXTI_FPR1_FPIF2_Pos          (2U)
+#define EXTI_FPR1_FPIF2_Msk          (0x1UL << EXTI_FPR1_FPIF2_Pos)            /*!< 0x00000004 */
+#define EXTI_FPR1_FPIF2              EXTI_FPR1_FPIF2_Msk                       /*!< Falling Pending Interrupt Flag on line 2 */
+#define EXTI_FPR1_FPIF3_Pos          (3U)
+#define EXTI_FPR1_FPIF3_Msk          (0x1UL << EXTI_FPR1_FPIF3_Pos)            /*!< 0x00000008 */
+#define EXTI_FPR1_FPIF3              EXTI_FPR1_FPIF3_Msk                       /*!< Falling Pending Interrupt Flag on line 3 */
+#define EXTI_FPR1_FPIF4_Pos          (4U)
+#define EXTI_FPR1_FPIF4_Msk          (0x1UL << EXTI_FPR1_FPIF4_Pos)            /*!< 0x00000010 */
+#define EXTI_FPR1_FPIF4              EXTI_FPR1_FPIF4_Msk                       /*!< Falling Pending Interrupt Flag on line 4 */
+#define EXTI_FPR1_FPIF5_Pos          (5U)
+#define EXTI_FPR1_FPIF5_Msk          (0x1UL << EXTI_FPR1_FPIF5_Pos)            /*!< 0x00000020 */
+#define EXTI_FPR1_FPIF5              EXTI_FPR1_FPIF5_Msk                       /*!< Falling Pending Interrupt Flag on line 5 */
+#define EXTI_FPR1_FPIF6_Pos          (6U)
+#define EXTI_FPR1_FPIF6_Msk          (0x1UL << EXTI_FPR1_FPIF6_Pos)            /*!< 0x00000040 */
+#define EXTI_FPR1_FPIF6              EXTI_FPR1_FPIF6_Msk                       /*!< Falling Pending Interrupt Flag on line 6 */
+#define EXTI_FPR1_FPIF7_Pos          (7U)
+#define EXTI_FPR1_FPIF7_Msk          (0x1UL << EXTI_FPR1_FPIF7_Pos)            /*!< 0x00000080 */
+#define EXTI_FPR1_FPIF7              EXTI_FPR1_FPIF7_Msk                       /*!< Falling Pending Interrupt Flag on line 7 */
+#define EXTI_FPR1_FPIF8_Pos          (8U)
+#define EXTI_FPR1_FPIF8_Msk          (0x1UL << EXTI_FPR1_FPIF8_Pos)            /*!< 0x00000100 */
+#define EXTI_FPR1_FPIF8              EXTI_FPR1_FPIF8_Msk                       /*!< Falling Pending Interrupt Flag on line 8 */
+#define EXTI_FPR1_FPIF9_Pos          (9U)
+#define EXTI_FPR1_FPIF9_Msk          (0x1UL << EXTI_FPR1_FPIF9_Pos)            /*!< 0x00000200 */
+#define EXTI_FPR1_FPIF9              EXTI_FPR1_FPIF9_Msk                       /*!< Falling Pending Interrupt Flag on line 9 */
+#define EXTI_FPR1_FPIF10_Pos         (10U)
+#define EXTI_FPR1_FPIF10_Msk         (0x1UL << EXTI_FPR1_FPIF10_Pos)           /*!< 0x00000400 */
+#define EXTI_FPR1_FPIF10             EXTI_FPR1_FPIF10_Msk                      /*!< Falling Pending Interrupt Flag on line 10 */
+#define EXTI_FPR1_FPIF11_Pos         (11U)
+#define EXTI_FPR1_FPIF11_Msk         (0x1UL << EXTI_FPR1_FPIF11_Pos)           /*!< 0x00000800 */
+#define EXTI_FPR1_FPIF11             EXTI_FPR1_FPIF11_Msk                      /*!< Falling Pending Interrupt Flag on line 11 */
+#define EXTI_FPR1_FPIF12_Pos         (12U)
+#define EXTI_FPR1_FPIF12_Msk         (0x1UL << EXTI_FPR1_FPIF12_Pos)           /*!< 0x00001000 */
+#define EXTI_FPR1_FPIF12             EXTI_FPR1_FPIF12_Msk                      /*!< Falling Pending Interrupt Flag on line 12 */
+#define EXTI_FPR1_FPIF13_Pos         (13U)
+#define EXTI_FPR1_FPIF13_Msk         (0x1UL << EXTI_FPR1_FPIF13_Pos)           /*!< 0x00002000 */
+#define EXTI_FPR1_FPIF13             EXTI_FPR1_FPIF13_Msk                      /*!< Falling Pending Interrupt Flag on line 13 */
+#define EXTI_FPR1_FPIF14_Pos         (14U)
+#define EXTI_FPR1_FPIF14_Msk         (0x1UL << EXTI_FPR1_FPIF14_Pos)           /*!< 0x00004000 */
+#define EXTI_FPR1_FPIF14             EXTI_FPR1_FPIF14_Msk                      /*!< Falling Pending Interrupt Flag on line 14 */
+#define EXTI_FPR1_FPIF15_Pos         (15U)
+#define EXTI_FPR1_FPIF15_Msk         (0x1UL << EXTI_FPR1_FPIF15_Pos)           /*!< 0x00008000 */
+#define EXTI_FPR1_FPIF15             EXTI_FPR1_FPIF15_Msk                      /*!< Falling Pending Interrupt Flag on line 15 */
+#define EXTI_FPR1_FPIF16_Pos         (16U)
+#define EXTI_FPR1_FPIF16_Msk         (0x1UL << EXTI_FPR1_FPIF16_Pos)           /*!< 0x00010000 */
+#define EXTI_FPR1_FPIF16             EXTI_FPR1_FPIF16_Msk                      /*!< Falling Pending Interrupt Flag on line 16 */
+#define EXTI_FPR1_FPIF17_Pos         (17U)
+#define EXTI_FPR1_FPIF17_Msk         (0x1UL << EXTI_FPR1_FPIF17_Pos)           /*!< 0x00020000 */
+#define EXTI_FPR1_FPIF17             EXTI_FPR1_FPIF17_Msk                      /*!< Falling Pending Interrupt Flag on line 17 */
+#define EXTI_FPR1_FPIF18_Pos         (18U)
+#define EXTI_FPR1_FPIF18_Msk         (0x1UL << EXTI_FPR1_FPIF18_Pos)           /*!< 0x00040000 */
+#define EXTI_FPR1_FPIF18             EXTI_FPR1_FPIF18_Msk                      /*!< Falling Pending Interrupt Flag on line 18 */
+
+/*****************  Bit definition for EXTI_EXTICR1 register  **************/
+#define EXTI_EXTICR1_EXTI0_Pos       (0U)
+#define EXTI_EXTICR1_EXTI0_Msk       (0x7UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR1_EXTI0           EXTI_EXTICR1_EXTI0_Msk                    /*!< EXTI 0 configuration */
+#define EXTI_EXTICR1_EXTI0_0         (0x1UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR1_EXTI0_1         (0x2UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR1_EXTI0_2         (0x4UL << EXTI_EXTICR1_EXTI0_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR1_EXTI1_Pos       (8U)
+#define EXTI_EXTICR1_EXTI1_Msk       (0x7UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR1_EXTI1           EXTI_EXTICR1_EXTI1_Msk                    /*!< EXTI 1 configuration */
+#define EXTI_EXTICR1_EXTI1_0         (0x1UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR1_EXTI1_1         (0x2UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR1_EXTI1_2         (0x4UL << EXTI_EXTICR1_EXTI1_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR1_EXTI2_Pos       (16U)
+#define EXTI_EXTICR1_EXTI2_Msk       (0x7UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00070000 */
+#define EXTI_EXTICR1_EXTI2           EXTI_EXTICR1_EXTI2_Msk                    /*!< EXTI 2 configuration */
+#define EXTI_EXTICR1_EXTI2_0         (0x1UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00010000 */
+#define EXTI_EXTICR1_EXTI2_1         (0x2UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00020000 */
+#define EXTI_EXTICR1_EXTI2_2         (0x4UL << EXTI_EXTICR1_EXTI2_Pos)         /*!< 0x00040000 */
+#define EXTI_EXTICR1_EXTI3_Pos       (24U)
+#define EXTI_EXTICR1_EXTI3_Msk       (0x7UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x07000000 */
+#define EXTI_EXTICR1_EXTI3           EXTI_EXTICR1_EXTI3_Msk                    /*!< EXTI 3 configuration */
+#define EXTI_EXTICR1_EXTI3_0         (0x1UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x01000000 */
+#define EXTI_EXTICR1_EXTI3_1         (0x2UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x02000000 */
+#define EXTI_EXTICR1_EXTI3_2         (0x4UL << EXTI_EXTICR1_EXTI3_Pos)         /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR2 register  **************/
+#define EXTI_EXTICR2_EXTI4_Pos       (0U)
+#define EXTI_EXTICR2_EXTI4_Msk       (0x7UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR2_EXTI4           EXTI_EXTICR2_EXTI4_Msk                    /*!< EXTI 4 configuration */
+#define EXTI_EXTICR2_EXTI4_0         (0x1UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR2_EXTI4_1         (0x2UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR2_EXTI4_2         (0x4UL << EXTI_EXTICR2_EXTI4_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR2_EXTI5_Pos       (8U)
+#define EXTI_EXTICR2_EXTI5_Msk       (0x7UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR2_EXTI5           EXTI_EXTICR2_EXTI5_Msk                    /*!< EXTI 5 configuration */
+#define EXTI_EXTICR2_EXTI5_0         (0x1UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR2_EXTI5_1         (0x2UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR2_EXTI5_2         (0x4UL << EXTI_EXTICR2_EXTI5_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR2_EXTI6_Pos       (16U)
+#define EXTI_EXTICR2_EXTI6_Msk       (0x7UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00070000 */
+#define EXTI_EXTICR2_EXTI6           EXTI_EXTICR2_EXTI6_Msk                    /*!< EXTI 6 configuration */
+#define EXTI_EXTICR2_EXTI6_0         (0x1UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00010000 */
+#define EXTI_EXTICR2_EXTI6_1         (0x2UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00020000 */
+#define EXTI_EXTICR2_EXTI6_2         (0x4UL << EXTI_EXTICR2_EXTI6_Pos)         /*!< 0x00040000 */
+#define EXTI_EXTICR2_EXTI7_Pos       (24U)
+#define EXTI_EXTICR2_EXTI7_Msk       (0x7UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x07000000 */
+#define EXTI_EXTICR2_EXTI7           EXTI_EXTICR2_EXTI7_Msk                    /*!< EXTI 7 configuration */
+#define EXTI_EXTICR2_EXTI7_0         (0x1UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x01000000 */
+#define EXTI_EXTICR2_EXTI7_1         (0x2UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x02000000 */
+#define EXTI_EXTICR2_EXTI7_2         (0x4UL << EXTI_EXTICR2_EXTI7_Pos)         /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR3 register  **************/
+#define EXTI_EXTICR3_EXTI8_Pos       (0U)
+#define EXTI_EXTICR3_EXTI8_Msk       (0x7UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000007 */
+#define EXTI_EXTICR3_EXTI8           EXTI_EXTICR3_EXTI8_Msk                    /*!< EXTI 8 configuration */
+#define EXTI_EXTICR3_EXTI8_0         (0x1UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000001 */
+#define EXTI_EXTICR3_EXTI8_1         (0x2UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000002 */
+#define EXTI_EXTICR3_EXTI8_2         (0x4UL << EXTI_EXTICR3_EXTI8_Pos)         /*!< 0x00000004 */
+#define EXTI_EXTICR3_EXTI9_Pos       (8U)
+#define EXTI_EXTICR3_EXTI9_Msk       (0x7UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000700 */
+#define EXTI_EXTICR3_EXTI9           EXTI_EXTICR3_EXTI9_Msk                    /*!< EXTI 9 configuration */
+#define EXTI_EXTICR3_EXTI9_0         (0x1UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000100 */
+#define EXTI_EXTICR3_EXTI9_1         (0x2UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000200 */
+#define EXTI_EXTICR3_EXTI9_2         (0x4UL << EXTI_EXTICR3_EXTI9_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR3_EXTI10_Pos      (16U)
+#define EXTI_EXTICR3_EXTI10_Msk      (0x7UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00070000 */
+#define EXTI_EXTICR3_EXTI10          EXTI_EXTICR3_EXTI10_Msk                   /*!< EXTI 10 configuration */
+#define EXTI_EXTICR3_EXTI10_0        (0x1UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00010000 */
+#define EXTI_EXTICR3_EXTI10_1        (0x2UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00020000 */
+#define EXTI_EXTICR3_EXTI10_2        (0x4UL << EXTI_EXTICR3_EXTI10_Pos)        /*!< 0x00040000 */
+#define EXTI_EXTICR3_EXTI11_Pos      (24U)
+#define EXTI_EXTICR3_EXTI11_Msk      (0x7UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x07000000 */
+#define EXTI_EXTICR3_EXTI11          EXTI_EXTICR3_EXTI11_Msk                   /*!< EXTI 11 configuration */
+#define EXTI_EXTICR3_EXTI11_0        (0x1UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x01000000 */
+#define EXTI_EXTICR3_EXTI11_1        (0x2UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x02000000 */
+#define EXTI_EXTICR3_EXTI11_2        (0x4UL << EXTI_EXTICR3_EXTI11_Pos)        /*!< 0x04000000 */
+
+/*****************  Bit definition for EXTI_EXTICR4 register  **************/
+#define EXTI_EXTICR4_EXTI12_Pos      (0U)
+#define EXTI_EXTICR4_EXTI12_Msk      (0x7UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000007 */
+#define EXTI_EXTICR4_EXTI12          EXTI_EXTICR4_EXTI12_Msk                   /*!< EXTI 12 configuration */
+#define EXTI_EXTICR4_EXTI12_0        (0x1UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000001 */
+#define EXTI_EXTICR4_EXTI12_1        (0x2UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000002 */
+#define EXTI_EXTICR4_EXTI12_2        (0x4UL << EXTI_EXTICR4_EXTI12_Pos)        /*!< 0x00000004 */
+#define EXTI_EXTICR4_EXTI13_Pos      (8U)
+#define EXTI_EXTICR4_EXTI13_Msk      (0x7UL << EXTI_EXTICR4_EXTI13_Pos)        /*!< 0x00000700 */
+#define EXTI_EXTICR4_EXTI13          EXTI_EXTICR4_EXTI13_Msk                   /*!< EXTI 13 configuration */
+#define EXTI_EXTICR4_EXTI13_0        (0x1UL << EXTI_EXTICR4_EXTI13_Pos)        /*!< 0x00000100 */
+#define EXTI_EXTICR4_EXTI13_1        (0x2UL << EXTI_EXTICR4_EXTI13_Pos)       /*!< 0x00000200 */
+#define EXTI_EXTICR4_EXTI13_2        (0x4UL << EXTI_EXTICR4_EXTI13_Pos)         /*!< 0x00000400 */
+#define EXTI_EXTICR4_EXTI14_Pos      (16U)
+#define EXTI_EXTICR4_EXTI14_Msk      (0x7UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00070000 */
+#define EXTI_EXTICR4_EXTI14          EXTI_EXTICR4_EXTI14_Msk                   /*!< EXTI 14 configuration */
+#define EXTI_EXTICR4_EXTI14_0        (0x1UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00010000 */
+#define EXTI_EXTICR4_EXTI14_1        (0x2UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00020000 */
+#define EXTI_EXTICR4_EXTI14_2        (0x4UL << EXTI_EXTICR4_EXTI14_Pos)        /*!< 0x00040000 */
+#define EXTI_EXTICR4_EXTI15_Pos      (24U)
+#define EXTI_EXTICR4_EXTI15_Msk      (0x7UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x07000000 */
+#define EXTI_EXTICR4_EXTI15          EXTI_EXTICR4_EXTI15_Msk                   /*!< EXTI 15 configuration */
+#define EXTI_EXTICR4_EXTI15_0        (0x1UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x01000000 */
+#define EXTI_EXTICR4_EXTI15_1        (0x2UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x02000000 */
+#define EXTI_EXTICR4_EXTI15_2        (0x4UL << EXTI_EXTICR4_EXTI15_Pos)        /*!< 0x04000000 */
+
+/*******************  Bit definition for EXTI_IMR1 register  ******************/
+#define EXTI_IMR1_IM0_Pos            (0U)
+#define EXTI_IMR1_IM0_Msk            (0x1UL << EXTI_IMR1_IM0_Pos)              /*!< 0x00000001 */
+#define EXTI_IMR1_IM0                EXTI_IMR1_IM0_Msk                         /*!< Interrupt Mask on line 0 */
+#define EXTI_IMR1_IM1_Pos            (1U)
+#define EXTI_IMR1_IM1_Msk            (0x1UL << EXTI_IMR1_IM1_Pos)              /*!< 0x00000002 */
+#define EXTI_IMR1_IM1                EXTI_IMR1_IM1_Msk                         /*!< Interrupt Mask on line 1 */
+#define EXTI_IMR1_IM2_Pos            (2U)
+#define EXTI_IMR1_IM2_Msk            (0x1UL << EXTI_IMR1_IM2_Pos)              /*!< 0x00000004 */
+#define EXTI_IMR1_IM2                EXTI_IMR1_IM2_Msk                         /*!< Interrupt Mask on line 2 */
+#define EXTI_IMR1_IM3_Pos            (3U)
+#define EXTI_IMR1_IM3_Msk            (0x1UL << EXTI_IMR1_IM3_Pos)              /*!< 0x00000008 */
+#define EXTI_IMR1_IM3                EXTI_IMR1_IM3_Msk                         /*!< Interrupt Mask on line 3 */
+#define EXTI_IMR1_IM4_Pos            (4U)
+#define EXTI_IMR1_IM4_Msk            (0x1UL << EXTI_IMR1_IM4_Pos)              /*!< 0x00000010 */
+#define EXTI_IMR1_IM4                EXTI_IMR1_IM4_Msk                         /*!< Interrupt Mask on line 4 */
+#define EXTI_IMR1_IM5_Pos            (5U)
+#define EXTI_IMR1_IM5_Msk            (0x1UL << EXTI_IMR1_IM5_Pos)              /*!< 0x00000020 */
+#define EXTI_IMR1_IM5                EXTI_IMR1_IM5_Msk                         /*!< Interrupt Mask on line 5 */
+#define EXTI_IMR1_IM6_Pos            (6U)
+#define EXTI_IMR1_IM6_Msk            (0x1UL << EXTI_IMR1_IM6_Pos)              /*!< 0x00000040 */
+#define EXTI_IMR1_IM6                EXTI_IMR1_IM6_Msk                         /*!< Interrupt Mask on line 6 */
+#define EXTI_IMR1_IM7_Pos            (7U)
+#define EXTI_IMR1_IM7_Msk            (0x1UL << EXTI_IMR1_IM7_Pos)              /*!< 0x00000080 */
+#define EXTI_IMR1_IM7                EXTI_IMR1_IM7_Msk                         /*!< Interrupt Mask on line 7 */
+#define EXTI_IMR1_IM8_Pos            (8U)
+#define EXTI_IMR1_IM8_Msk            (0x1UL << EXTI_IMR1_IM8_Pos)              /*!< 0x00000100 */
+#define EXTI_IMR1_IM8                EXTI_IMR1_IM8_Msk                         /*!< Interrupt Mask on line 8 */
+#define EXTI_IMR1_IM9_Pos            (9U)
+#define EXTI_IMR1_IM9_Msk            (0x1UL << EXTI_IMR1_IM9_Pos)              /*!< 0x00000200 */
+#define EXTI_IMR1_IM9                EXTI_IMR1_IM9_Msk                         /*!< Interrupt Mask on line 9 */
+#define EXTI_IMR1_IM10_Pos           (10U)
+#define EXTI_IMR1_IM10_Msk           (0x1UL << EXTI_IMR1_IM10_Pos)             /*!< 0x00000400 */
+#define EXTI_IMR1_IM10               EXTI_IMR1_IM10_Msk                        /*!< Interrupt Mask on line 10 */
+#define EXTI_IMR1_IM11_Pos           (11U)
+#define EXTI_IMR1_IM11_Msk           (0x1UL << EXTI_IMR1_IM11_Pos)             /*!< 0x00000800 */
+#define EXTI_IMR1_IM11               EXTI_IMR1_IM11_Msk                        /*!< Interrupt Mask on line 11 */
+#define EXTI_IMR1_IM12_Pos           (12U)
+#define EXTI_IMR1_IM12_Msk           (0x1UL << EXTI_IMR1_IM12_Pos)             /*!< 0x00001000 */
+#define EXTI_IMR1_IM12               EXTI_IMR1_IM12_Msk                        /*!< Interrupt Mask on line 12 */
+#define EXTI_IMR1_IM13_Pos           (13U)
+#define EXTI_IMR1_IM13_Msk           (0x1UL << EXTI_IMR1_IM13_Pos)             /*!< 0x00002000 */
+#define EXTI_IMR1_IM13               EXTI_IMR1_IM13_Msk                        /*!< Interrupt Mask on line 13 */
+#define EXTI_IMR1_IM14_Pos           (14U)
+#define EXTI_IMR1_IM14_Msk           (0x1UL << EXTI_IMR1_IM14_Pos)             /*!< 0x00004000 */
+#define EXTI_IMR1_IM14               EXTI_IMR1_IM14_Msk                        /*!< Interrupt Mask on line 14 */
+#define EXTI_IMR1_IM15_Pos           (15U)
+#define EXTI_IMR1_IM15_Msk           (0x1UL << EXTI_IMR1_IM15_Pos)             /*!< 0x00008000 */
+#define EXTI_IMR1_IM15               EXTI_IMR1_IM15_Msk                        /*!< Interrupt Mask on line 15 */
+#define EXTI_IMR1_IM16_Pos           (16U)
+#define EXTI_IMR1_IM16_Msk           (0x1UL << EXTI_IMR1_IM16_Pos)             /*!< 0x00010000 */
+#define EXTI_IMR1_IM16               EXTI_IMR1_IM16_Msk                        /*!< Interrupt Mask on line 16 */
+#define EXTI_IMR1_IM17_Pos           (17U)
+#define EXTI_IMR1_IM17_Msk           (0x1UL << EXTI_IMR1_IM17_Pos)             /*!< 0x00020000 */
+#define EXTI_IMR1_IM17               EXTI_IMR1_IM17_Msk                        /*!< Interrupt Mask on line 17 */
+#define EXTI_IMR1_IM18_Pos           (18U)
+#define EXTI_IMR1_IM18_Msk           (0x1UL << EXTI_IMR1_IM18_Pos)             /*!< 0x00040000 */
+#define EXTI_IMR1_IM18               EXTI_IMR1_IM18_Msk                        /*!< Interrupt Mask on line 18 */
+#define EXTI_IMR1_IM19_Pos           (19U)
+#define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
+#define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
+#define EXTI_IMR1_IM21_Pos           (21U)
+#define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
+#define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
+#define EXTI_IMR1_IM23_Pos           (23U)
+#define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
+#define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
+#define EXTI_IMR1_IM25_Pos           (25U)
+#define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
+#define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
+#define EXTI_IMR1_IM28_Pos           (28U)
+#define EXTI_IMR1_IM28_Msk           (0x1UL << EXTI_IMR1_IM28_Pos)             /*!< 0x10000000 */
+#define EXTI_IMR1_IM28               EXTI_IMR1_IM28_Msk                        /*!< Interrupt Mask on line 28 */
+#define EXTI_IMR1_IM29_Pos           (29U)
+#define EXTI_IMR1_IM29_Msk           (0x1UL << EXTI_IMR1_IM29_Pos)             /*!< 0x20000000 */
+#define EXTI_IMR1_IM29               EXTI_IMR1_IM29_Msk                        /*!< Interrupt Mask on line 29 */
+#define EXTI_IMR1_IM30_Pos           (30U)
+#define EXTI_IMR1_IM30_Msk           (0x1UL << EXTI_IMR1_IM30_Pos)             /*!< 0x40000000 */
+#define EXTI_IMR1_IM30               EXTI_IMR1_IM30_Msk                        /*!< Interrupt Mask on line 30 */
+#define EXTI_IMR1_IM31_Pos           (31U)
+#define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
+#define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
+#define EXTI_IMR1_IM_Pos             (0U)
+#define EXTI_IMR1_IM_Msk             (0xF2AFFFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xF6AFFFFF */
+#define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
+
+
+/*******************  Bit definition for EXTI_EMR1 register  ******************/
+#define EXTI_EMR1_EM0_Pos            (0U)
+#define EXTI_EMR1_EM0_Msk            (0x1UL << EXTI_EMR1_EM0_Pos)              /*!< 0x00000001 */
+#define EXTI_EMR1_EM0                EXTI_EMR1_EM0_Msk                         /*!< Event Mask on line 0 */
+#define EXTI_EMR1_EM1_Pos            (1U)
+#define EXTI_EMR1_EM1_Msk            (0x1UL << EXTI_EMR1_EM1_Pos)              /*!< 0x00000002 */
+#define EXTI_EMR1_EM1                EXTI_EMR1_EM1_Msk                         /*!< Event Mask on line 1 */
+#define EXTI_EMR1_EM2_Pos            (2U)
+#define EXTI_EMR1_EM2_Msk            (0x1UL << EXTI_EMR1_EM2_Pos)              /*!< 0x00000004 */
+#define EXTI_EMR1_EM2                EXTI_EMR1_EM2_Msk                         /*!< Event Mask on line 2 */
+#define EXTI_EMR1_EM3_Pos            (3U)
+#define EXTI_EMR1_EM3_Msk            (0x1UL << EXTI_EMR1_EM3_Pos)              /*!< 0x00000008 */
+#define EXTI_EMR1_EM3                EXTI_EMR1_EM3_Msk                         /*!< Event Mask on line 3 */
+#define EXTI_EMR1_EM4_Pos            (4U)
+#define EXTI_EMR1_EM4_Msk            (0x1UL << EXTI_EMR1_EM4_Pos)              /*!< 0x00000010 */
+#define EXTI_EMR1_EM4                EXTI_EMR1_EM4_Msk                         /*!< Event Mask on line 4 */
+#define EXTI_EMR1_EM5_Pos            (5U)
+#define EXTI_EMR1_EM5_Msk            (0x1UL << EXTI_EMR1_EM5_Pos)              /*!< 0x00000020 */
+#define EXTI_EMR1_EM5                EXTI_EMR1_EM5_Msk                         /*!< Event Mask on line 5 */
+#define EXTI_EMR1_EM6_Pos            (6U)
+#define EXTI_EMR1_EM6_Msk            (0x1UL << EXTI_EMR1_EM6_Pos)              /*!< 0x00000040 */
+#define EXTI_EMR1_EM6                EXTI_EMR1_EM6_Msk                         /*!< Event Mask on line 6 */
+#define EXTI_EMR1_EM7_Pos            (7U)
+#define EXTI_EMR1_EM7_Msk            (0x1UL << EXTI_EMR1_EM7_Pos)              /*!< 0x00000080 */
+#define EXTI_EMR1_EM7                EXTI_EMR1_EM7_Msk                         /*!< Event Mask on line 7 */
+#define EXTI_EMR1_EM8_Pos            (8U)
+#define EXTI_EMR1_EM8_Msk            (0x1UL << EXTI_EMR1_EM8_Pos)              /*!< 0x00000100 */
+#define EXTI_EMR1_EM8                EXTI_EMR1_EM8_Msk                         /*!< Event Mask on line 8 */
+#define EXTI_EMR1_EM9_Pos            (9U)
+#define EXTI_EMR1_EM9_Msk            (0x1UL << EXTI_EMR1_EM9_Pos)              /*!< 0x00000200 */
+#define EXTI_EMR1_EM9                EXTI_EMR1_EM9_Msk                         /*!< Event Mask on line 9 */
+#define EXTI_EMR1_EM10_Pos           (10U)
+#define EXTI_EMR1_EM10_Msk           (0x1UL << EXTI_EMR1_EM10_Pos)             /*!< 0x00000400 */
+#define EXTI_EMR1_EM10               EXTI_EMR1_EM10_Msk                        /*!< Event Mask on line 10 */
+#define EXTI_EMR1_EM11_Pos           (11U)
+#define EXTI_EMR1_EM11_Msk           (0x1UL << EXTI_EMR1_EM11_Pos)             /*!< 0x00000800 */
+#define EXTI_EMR1_EM11               EXTI_EMR1_EM11_Msk                        /*!< Event Mask on line 11 */
+#define EXTI_EMR1_EM12_Pos           (12U)
+#define EXTI_EMR1_EM12_Msk           (0x1UL << EXTI_EMR1_EM12_Pos)             /*!< 0x00001000 */
+#define EXTI_EMR1_EM12               EXTI_EMR1_EM12_Msk                        /*!< Event Mask on line 12 */
+#define EXTI_EMR1_EM13_Pos           (13U)
+#define EXTI_EMR1_EM13_Msk           (0x1UL << EXTI_EMR1_EM13_Pos)             /*!< 0x00002000 */
+#define EXTI_EMR1_EM13               EXTI_EMR1_EM13_Msk                        /*!< Event Mask on line 13 */
+#define EXTI_EMR1_EM14_Pos           (14U)
+#define EXTI_EMR1_EM14_Msk           (0x1UL << EXTI_EMR1_EM14_Pos)             /*!< 0x00004000 */
+#define EXTI_EMR1_EM14               EXTI_EMR1_EM14_Msk                        /*!< Event Mask on line 14 */
+#define EXTI_EMR1_EM15_Pos           (15U)
+#define EXTI_EMR1_EM15_Msk           (0x1UL << EXTI_EMR1_EM15_Pos)             /*!< 0x00008000 */
+#define EXTI_EMR1_EM15               EXTI_EMR1_EM15_Msk                        /*!< Event Mask on line 15 */
+#define EXTI_EMR1_EM16_Pos           (16U)
+#define EXTI_EMR1_EM16_Msk           (0x1UL << EXTI_EMR1_EM16_Pos)             /*!< 0x00010000 */
+#define EXTI_EMR1_EM16               EXTI_EMR1_EM16_Msk                        /*!< Event Mask on line 16 */
+#define EXTI_EMR1_EM17_Pos           (17U)
+#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
+#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
+#define EXTI_EMR1_EM18_Pos           (18U)
+#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
+#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
+#define EXTI_EMR1_EM19_Pos           (19U)
+#define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
+#define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
+#define EXTI_EMR1_EM21_Pos           (21U)
+#define EXTI_EMR1_EM21_Msk           (0x1UL << EXTI_EMR1_EM21_Pos)             /*!< 0x00200000 */
+#define EXTI_EMR1_EM21               EXTI_EMR1_EM21_Msk                        /*!< Event Mask on line 21 */
+#define EXTI_EMR1_EM23_Pos           (23U)
+#define EXTI_EMR1_EM23_Msk           (0x1UL << EXTI_EMR1_EM23_Pos)             /*!< 0x00800000 */
+#define EXTI_EMR1_EM23               EXTI_EMR1_EM23_Msk                        /*!< Event Mask on line 23 */
+#define EXTI_EMR1_EM25_Pos           (25U)
+#define EXTI_EMR1_EM25_Msk           (0x1UL << EXTI_EMR1_EM25_Pos)             /*!< 0x02000000 */
+#define EXTI_EMR1_EM25               EXTI_EMR1_EM25_Msk                        /*!< Event Mask on line 25 */
+#define EXTI_EMR1_EM28_Pos           (28U)
+#define EXTI_EMR1_EM28_Msk           (0x1UL << EXTI_EMR1_EM28_Pos)             /*!< 0x10000000 */
+#define EXTI_EMR1_EM28               EXTI_EMR1_EM28_Msk                        /*!< Event Mask on line 28 */
+#define EXTI_EMR1_EM29_Pos           (29U)
+#define EXTI_EMR1_EM29_Msk           (0x1UL << EXTI_EMR1_EM29_Pos)             /*!< 0x20000000 */
+#define EXTI_EMR1_EM29               EXTI_EMR1_EM29_Msk                        /*!< Event Mask on line 29 */
+#define EXTI_EMR1_EM30_Pos           (30U)
+#define EXTI_EMR1_EM30_Msk           (0x1UL << EXTI_EMR1_EM30_Pos)             /*!< 0x40000000 */
+#define EXTI_EMR1_EM30               EXTI_EMR1_EM30_Msk                        /*!< Event Mask on line 30 */
+#define EXTI_EMR1_EM31_Pos           (31U)
+#define EXTI_EMR1_EM31_Msk           (0x1UL << EXTI_EMR1_EM31_Pos)             /*!< 0x80000000 */
+#define EXTI_EMR1_EM31               EXTI_EMR1_EM31_Msk                        /*!< Event Mask on line 31 */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+#define GPIO_NRST_CONFIG_SUPPORT         /*!< GPIO feature available only on specific devices: Configure NRST pin */
+#define FLASH_SECURABLE_MEMORY_SUPPORT   /*!< Flash feature available only on specific devices: allow to secure memory */
+#define FLASH_PCROP_SUPPORT              /*!< Flash feature available only on specific devices: proprietary code read protection areas selected by option */
+
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos                  (0U)
+#define FLASH_ACR_LATENCY_Msk                  (0x7UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY                      FLASH_ACR_LATENCY_Msk
+#define FLASH_ACR_LATENCY_0                    (0x1UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000001 */
+#define FLASH_ACR_LATENCY_1                    (0x2UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000002 */
+#define FLASH_ACR_LATENCY_2                    (0x4UL << FLASH_ACR_LATENCY_Pos) /*!< 0x00000004 */
+#define FLASH_ACR_PRFTEN_Pos                   (8U)
+#define FLASH_ACR_PRFTEN_Msk                   (0x1UL << FLASH_ACR_PRFTEN_Pos)  /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN                       FLASH_ACR_PRFTEN_Msk
+#define FLASH_ACR_ICEN_Pos                     (9U)
+#define FLASH_ACR_ICEN_Msk                     (0x1UL << FLASH_ACR_ICEN_Pos)    /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                         FLASH_ACR_ICEN_Msk
+#define FLASH_ACR_ICRST_Pos                    (11U)
+#define FLASH_ACR_ICRST_Msk                    (0x1UL << FLASH_ACR_ICRST_Pos)   /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                        FLASH_ACR_ICRST_Msk
+#define FLASH_ACR_PROGEMPTY_Pos                (16U)
+#define FLASH_ACR_PROGEMPTY_Msk                (0x1UL << FLASH_ACR_PROGEMPTY_Pos) /*!< 0x00010000 */
+#define FLASH_ACR_PROGEMPTY                    FLASH_ACR_PROGEMPTY_Msk
+#define FLASH_ACR_DBG_SWEN_Pos                 (18U)
+#define FLASH_ACR_DBG_SWEN_Msk                 (0x1UL << FLASH_ACR_DBG_SWEN_Pos) /*!< 0x00040000 */
+#define FLASH_ACR_DBG_SWEN                     FLASH_ACR_DBG_SWEN_Msk
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos                       (0U)
+#define FLASH_SR_EOP_Msk                       (0x1UL << FLASH_SR_EOP_Pos)      /*!< 0x00000001 */
+#define FLASH_SR_EOP                           FLASH_SR_EOP_Msk
+#define FLASH_SR_OPERR_Pos                     (1U)
+#define FLASH_SR_OPERR_Msk                     (0x1UL << FLASH_SR_OPERR_Pos)    /*!< 0x00000002 */
+#define FLASH_SR_OPERR                         FLASH_SR_OPERR_Msk
+#define FLASH_SR_PROGERR_Pos                   (3U)
+#define FLASH_SR_PROGERR_Msk                   (0x1UL << FLASH_SR_PROGERR_Pos)  /*!< 0x00000008 */
+#define FLASH_SR_PROGERR                       FLASH_SR_PROGERR_Msk
+#define FLASH_SR_WRPERR_Pos                    (4U)
+#define FLASH_SR_WRPERR_Msk                    (0x1UL << FLASH_SR_WRPERR_Pos)   /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                        FLASH_SR_WRPERR_Msk
+#define FLASH_SR_PGAERR_Pos                    (5U)
+#define FLASH_SR_PGAERR_Msk                    (0x1UL << FLASH_SR_PGAERR_Pos)   /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                        FLASH_SR_PGAERR_Msk
+#define FLASH_SR_SIZERR_Pos                    (6U)
+#define FLASH_SR_SIZERR_Msk                    (0x1UL << FLASH_SR_SIZERR_Pos)   /*!< 0x00000040 */
+#define FLASH_SR_SIZERR                        FLASH_SR_SIZERR_Msk
+#define FLASH_SR_PGSERR_Pos                    (7U)
+#define FLASH_SR_PGSERR_Msk                    (0x1UL << FLASH_SR_PGSERR_Pos)   /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                        FLASH_SR_PGSERR_Msk
+#define FLASH_SR_MISERR_Pos                    (8U)
+#define FLASH_SR_MISERR_Msk                    (0x1UL << FLASH_SR_MISERR_Pos)   /*!< 0x00000100 */
+#define FLASH_SR_MISERR                        FLASH_SR_MISERR_Msk
+#define FLASH_SR_FASTERR_Pos                   (9U)
+#define FLASH_SR_FASTERR_Msk                   (0x1UL << FLASH_SR_FASTERR_Pos)  /*!< 0x00000200 */
+#define FLASH_SR_FASTERR                       FLASH_SR_FASTERR_Msk
+#define FLASH_SR_RDERR_Pos                     (14U)
+#define FLASH_SR_RDERR_Msk                     (0x1UL << FLASH_SR_RDERR_Pos)    /*!< 0x00004000 */
+#define FLASH_SR_RDERR                         FLASH_SR_RDERR_Msk
+#define FLASH_SR_OPTVERR_Pos                   (15U)
+#define FLASH_SR_OPTVERR_Msk                   (0x1UL << FLASH_SR_OPTVERR_Pos)  /*!< 0x00008000 */
+#define FLASH_SR_OPTVERR                       FLASH_SR_OPTVERR_Msk
+#define FLASH_SR_BSY1_Pos                      (16U)
+#define FLASH_SR_BSY1_Msk                      (0x1UL << FLASH_SR_BSY1_Pos)     /*!< 0x00010000 */
+#define FLASH_SR_BSY1                          FLASH_SR_BSY1_Msk
+#define FLASH_SR_CFGBSY_Pos                    (18U)
+#define FLASH_SR_CFGBSY_Msk                    (0x1UL << FLASH_SR_CFGBSY_Pos)   /*!< 0x00040000 */
+#define FLASH_SR_CFGBSY                        FLASH_SR_CFGBSY_Msk
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                        (0U)
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
+#define FLASH_CR_PG                            FLASH_CR_PG_Msk
+#define FLASH_CR_PER_Pos                       (1U)
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
+#define FLASH_CR_PER                           FLASH_CR_PER_Msk
+#define FLASH_CR_MER1_Pos                      (2U)
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
+#define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
+#define FLASH_CR_PNB_Pos                       (3U)
+#define FLASH_CR_PNB_Msk                       (0x1FUL << FLASH_CR_PNB_Pos)       /*!< 0x000000F8 */
+#define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
+#define FLASH_CR_STRT_Pos                      (16U)
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
+#define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
+#define FLASH_CR_OPTSTRT_Pos                   (17U)
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
+#define FLASH_CR_FSTPG_Pos                     (18U)
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
+#define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
+#define FLASH_CR_EOPIE_Pos                     (24U)
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
+#define FLASH_CR_ERRIE_Pos                     (25U)
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
+#define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
+#define FLASH_CR_RDERRIE_Pos                   (26U)
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
+#define FLASH_CR_OBL_LAUNCH_Pos                (27U)
+#define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
+#define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
+#define FLASH_CR_SEC_PROT_Pos                  (28U)
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
+#define FLASH_CR_OPTLOCK_Pos                   (30U)
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
+#define FLASH_CR_LOCK_Pos                      (31U)
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
+#define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
+
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos                (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
+#define FLASH_ECCR_SYSF_ECC_Pos                (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
+#define FLASH_ECCR_ECCCIE_Pos                  (24U)
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
+#define FLASH_ECCR_ECCC_Pos                    (30U)
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
+#define FLASH_ECCR_ECCD_Pos                    (31U)
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
+
+/*******************  Bits definition for FLASH_OPTR register  ****************/
+#define FLASH_OPTR_RDP_Pos                     (0U)
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
+#define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
+#define FLASH_OPTR_BOR_EN_Pos                  (8U)
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
+#define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
+#define FLASH_OPTR_nRST_STOP_Pos               (13U)
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
+#define FLASH_OPTR_nRST_STDBY_Pos              (14U)
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
+#define FLASH_OPTR_nRST_SHDW_Pos               (15U)
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
+#define FLASH_OPTR_IWDG_SW_Pos                 (16U)
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
+#define FLASH_OPTR_IWDG_STOP_Pos               (17U)
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
+#define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
+#define FLASH_OPTR_WWDG_SW_Pos                 (19U)
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
+#define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
+#define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
+#define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
+#define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
+#define FLASH_OPTR_nBOOT1_Pos                  (25U)
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
+#define FLASH_OPTR_nBOOT0_Pos                  (26U)
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
+#define FLASH_OPTR_NRST_MODE_Pos               (27U)
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
+#define FLASH_OPTR_IRHEN_Pos                   (29U)
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
+
+/******************  Bits definition for FLASH_PCROP1ASR register  ************/
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x7FUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)   /*!< 0x0000007F */
+#define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
+
+/******************  Bits definition for FLASH_PCROP1AER register  ************/
+#define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x7FUL << FLASH_PCROP1AER_PCROP1A_END_Pos)    /*!< 0x0000007F */
+#define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
+#define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
+
+/******************  Bits definition for FLASH_WRP1AR register  ***************/
+#define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
+#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x1FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000001F */
+#define FLASH_WRP1AR_WRP1A_STRT                FLASH_WRP1AR_WRP1A_STRT_Msk
+#define FLASH_WRP1AR_WRP1A_END_Pos             (16U)
+#define FLASH_WRP1AR_WRP1A_END_Msk             (0x1FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x001F0000 */
+#define FLASH_WRP1AR_WRP1A_END                 FLASH_WRP1AR_WRP1A_END_Msk
+
+/******************  Bits definition for FLASH_WRP1BR register  ***************/
+#define FLASH_WRP1BR_WRP1B_STRT_Pos            (0U)
+#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x1FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000001F */
+#define FLASH_WRP1BR_WRP1B_STRT                FLASH_WRP1BR_WRP1B_STRT_Msk
+#define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
+#define FLASH_WRP1BR_WRP1B_END_Msk             (0x1FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x001F0000 */
+#define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
+
+/******************  Bits definition for FLASH_PCROP1BSR register  ************/
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x7FUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)   /*!< 0x0000007F */
+#define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
+
+/******************  Bits definition for FLASH_PCROP1BER register  ************/
+#define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x7FUL << FLASH_PCROP1BER_PCROP1B_END_Pos)    /*!< 0x0000007F */
+#define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
+
+/******************  Bits definition for FLASH_SECR register  *****************/
+#define FLASH_SECR_SEC_SIZE_Pos                (0U)
+#define FLASH_SECR_SEC_SIZE_Msk                (0x3FUL << FLASH_SECR_SEC_SIZE_Pos) /*!< 0x0000003F */
+#define FLASH_SECR_SEC_SIZE                    FLASH_SECR_SEC_SIZE_Msk
+#define FLASH_SECR_BOOT_LOCK_Pos               (16U)
+#define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
+#define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0_Pos           (0U)
+#define GPIO_MODER_MODE0_Msk           (0x3UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000003 */
+#define GPIO_MODER_MODE0               GPIO_MODER_MODE0_Msk
+#define GPIO_MODER_MODE0_0             (0x1UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000001 */
+#define GPIO_MODER_MODE0_1             (0x2UL << GPIO_MODER_MODE0_Pos)          /*!< 0x00000002 */
+#define GPIO_MODER_MODE1_Pos           (2U)
+#define GPIO_MODER_MODE1_Msk           (0x3UL << GPIO_MODER_MODE1_Pos)          /*!< 0x0000000C */
+#define GPIO_MODER_MODE1               GPIO_MODER_MODE1_Msk
+#define GPIO_MODER_MODE1_0             (0x1UL << GPIO_MODER_MODE1_Pos)          /*!< 0x00000004 */
+#define GPIO_MODER_MODE1_1             (0x2UL << GPIO_MODER_MODE1_Pos)          /*!< 0x00000008 */
+#define GPIO_MODER_MODE2_Pos           (4U)
+#define GPIO_MODER_MODE2_Msk           (0x3UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000030 */
+#define GPIO_MODER_MODE2               GPIO_MODER_MODE2_Msk
+#define GPIO_MODER_MODE2_0             (0x1UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000010 */
+#define GPIO_MODER_MODE2_1             (0x2UL << GPIO_MODER_MODE2_Pos)          /*!< 0x00000020 */
+#define GPIO_MODER_MODE3_Pos           (6U)
+#define GPIO_MODER_MODE3_Msk           (0x3UL << GPIO_MODER_MODE3_Pos)          /*!< 0x000000C0 */
+#define GPIO_MODER_MODE3               GPIO_MODER_MODE3_Msk
+#define GPIO_MODER_MODE3_0             (0x1UL << GPIO_MODER_MODE3_Pos)          /*!< 0x00000040 */
+#define GPIO_MODER_MODE3_1             (0x2UL << GPIO_MODER_MODE3_Pos)          /*!< 0x00000080 */
+#define GPIO_MODER_MODE4_Pos           (8U)
+#define GPIO_MODER_MODE4_Msk           (0x3UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000300 */
+#define GPIO_MODER_MODE4               GPIO_MODER_MODE4_Msk
+#define GPIO_MODER_MODE4_0             (0x1UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000100 */
+#define GPIO_MODER_MODE4_1             (0x2UL << GPIO_MODER_MODE4_Pos)          /*!< 0x00000200 */
+#define GPIO_MODER_MODE5_Pos           (10U)
+#define GPIO_MODER_MODE5_Msk           (0x3UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000C00 */
+#define GPIO_MODER_MODE5               GPIO_MODER_MODE5_Msk
+#define GPIO_MODER_MODE5_0             (0x1UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000400 */
+#define GPIO_MODER_MODE5_1             (0x2UL << GPIO_MODER_MODE5_Pos)          /*!< 0x00000800 */
+#define GPIO_MODER_MODE6_Pos           (12U)
+#define GPIO_MODER_MODE6_Msk           (0x3UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00003000 */
+#define GPIO_MODER_MODE6               GPIO_MODER_MODE6_Msk
+#define GPIO_MODER_MODE6_0             (0x1UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00001000 */
+#define GPIO_MODER_MODE6_1             (0x2UL << GPIO_MODER_MODE6_Pos)          /*!< 0x00002000 */
+#define GPIO_MODER_MODE7_Pos           (14U)
+#define GPIO_MODER_MODE7_Msk           (0x3UL << GPIO_MODER_MODE7_Pos)          /*!< 0x0000C000 */
+#define GPIO_MODER_MODE7               GPIO_MODER_MODE7_Msk
+#define GPIO_MODER_MODE7_0             (0x1UL << GPIO_MODER_MODE7_Pos)          /*!< 0x00004000 */
+#define GPIO_MODER_MODE7_1             (0x2UL << GPIO_MODER_MODE7_Pos)          /*!< 0x00008000 */
+#define GPIO_MODER_MODE8_Pos           (16U)
+#define GPIO_MODER_MODE8_Msk           (0x3UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00030000 */
+#define GPIO_MODER_MODE8               GPIO_MODER_MODE8_Msk
+#define GPIO_MODER_MODE8_0             (0x1UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00010000 */
+#define GPIO_MODER_MODE8_1             (0x2UL << GPIO_MODER_MODE8_Pos)          /*!< 0x00020000 */
+#define GPIO_MODER_MODE9_Pos           (18U)
+#define GPIO_MODER_MODE9_Msk           (0x3UL << GPIO_MODER_MODE9_Pos)          /*!< 0x000C0000 */
+#define GPIO_MODER_MODE9               GPIO_MODER_MODE9_Msk
+#define GPIO_MODER_MODE9_0             (0x1UL << GPIO_MODER_MODE9_Pos)          /*!< 0x00040000 */
+#define GPIO_MODER_MODE9_1             (0x2UL << GPIO_MODER_MODE9_Pos)          /*!< 0x00080000 */
+#define GPIO_MODER_MODE10_Pos          (20U)
+#define GPIO_MODER_MODE10_Msk          (0x3UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00300000 */
+#define GPIO_MODER_MODE10              GPIO_MODER_MODE10_Msk
+#define GPIO_MODER_MODE10_0            (0x1UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00100000 */
+#define GPIO_MODER_MODE10_1            (0x2UL << GPIO_MODER_MODE10_Pos)         /*!< 0x00200000 */
+#define GPIO_MODER_MODE11_Pos          (22U)
+#define GPIO_MODER_MODE11_Msk          (0x3UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00C00000 */
+#define GPIO_MODER_MODE11              GPIO_MODER_MODE11_Msk
+#define GPIO_MODER_MODE11_0            (0x1UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00400000 */
+#define GPIO_MODER_MODE11_1            (0x2UL << GPIO_MODER_MODE11_Pos)         /*!< 0x00800000 */
+#define GPIO_MODER_MODE12_Pos          (24U)
+#define GPIO_MODER_MODE12_Msk          (0x3UL << GPIO_MODER_MODE12_Pos)         /*!< 0x03000000 */
+#define GPIO_MODER_MODE12              GPIO_MODER_MODE12_Msk
+#define GPIO_MODER_MODE12_0            (0x1UL << GPIO_MODER_MODE12_Pos)         /*!< 0x01000000 */
+#define GPIO_MODER_MODE12_1            (0x2UL << GPIO_MODER_MODE12_Pos)         /*!< 0x02000000 */
+#define GPIO_MODER_MODE13_Pos          (26U)
+#define GPIO_MODER_MODE13_Msk          (0x3UL << GPIO_MODER_MODE13_Pos)         /*!< 0x0C000000 */
+#define GPIO_MODER_MODE13              GPIO_MODER_MODE13_Msk
+#define GPIO_MODER_MODE13_0            (0x1UL << GPIO_MODER_MODE13_Pos)         /*!< 0x04000000 */
+#define GPIO_MODER_MODE13_1            (0x2UL << GPIO_MODER_MODE13_Pos)         /*!< 0x08000000 */
+#define GPIO_MODER_MODE14_Pos          (28U)
+#define GPIO_MODER_MODE14_Msk          (0x3UL << GPIO_MODER_MODE14_Pos)         /*!< 0x30000000 */
+#define GPIO_MODER_MODE14              GPIO_MODER_MODE14_Msk
+#define GPIO_MODER_MODE14_0            (0x1UL << GPIO_MODER_MODE14_Pos)         /*!< 0x10000000 */
+#define GPIO_MODER_MODE14_1            (0x2UL << GPIO_MODER_MODE14_Pos)         /*!< 0x20000000 */
+#define GPIO_MODER_MODE15_Pos          (30U)
+#define GPIO_MODER_MODE15_Msk          (0x3UL << GPIO_MODER_MODE15_Pos)         /*!< 0xC0000000 */
+#define GPIO_MODER_MODE15              GPIO_MODER_MODE15_Msk
+#define GPIO_MODER_MODE15_0            (0x1UL << GPIO_MODER_MODE15_Pos)         /*!< 0x40000000 */
+#define GPIO_MODER_MODE15_1            (0x2UL << GPIO_MODER_MODE15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos            (0U)
+#define GPIO_OTYPER_OT0_Msk            (0x1UL << GPIO_OTYPER_OT0_Pos)           /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                GPIO_OTYPER_OT0_Msk
+#define GPIO_OTYPER_OT1_Pos            (1U)
+#define GPIO_OTYPER_OT1_Msk            (0x1UL << GPIO_OTYPER_OT1_Pos)           /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                GPIO_OTYPER_OT1_Msk
+#define GPIO_OTYPER_OT2_Pos            (2U)
+#define GPIO_OTYPER_OT2_Msk            (0x1UL << GPIO_OTYPER_OT2_Pos)           /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                GPIO_OTYPER_OT2_Msk
+#define GPIO_OTYPER_OT3_Pos            (3U)
+#define GPIO_OTYPER_OT3_Msk            (0x1UL << GPIO_OTYPER_OT3_Pos)           /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                GPIO_OTYPER_OT3_Msk
+#define GPIO_OTYPER_OT4_Pos            (4U)
+#define GPIO_OTYPER_OT4_Msk            (0x1UL << GPIO_OTYPER_OT4_Pos)           /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                GPIO_OTYPER_OT4_Msk
+#define GPIO_OTYPER_OT5_Pos            (5U)
+#define GPIO_OTYPER_OT5_Msk            (0x1UL << GPIO_OTYPER_OT5_Pos)           /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                GPIO_OTYPER_OT5_Msk
+#define GPIO_OTYPER_OT6_Pos            (6U)
+#define GPIO_OTYPER_OT6_Msk            (0x1UL << GPIO_OTYPER_OT6_Pos)           /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                GPIO_OTYPER_OT6_Msk
+#define GPIO_OTYPER_OT7_Pos            (7U)
+#define GPIO_OTYPER_OT7_Msk            (0x1UL << GPIO_OTYPER_OT7_Pos)           /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                GPIO_OTYPER_OT7_Msk
+#define GPIO_OTYPER_OT8_Pos            (8U)
+#define GPIO_OTYPER_OT8_Msk            (0x1UL << GPIO_OTYPER_OT8_Pos)           /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                GPIO_OTYPER_OT8_Msk
+#define GPIO_OTYPER_OT9_Pos            (9U)
+#define GPIO_OTYPER_OT9_Msk            (0x1UL << GPIO_OTYPER_OT9_Pos)           /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                GPIO_OTYPER_OT9_Msk
+#define GPIO_OTYPER_OT10_Pos           (10U)
+#define GPIO_OTYPER_OT10_Msk           (0x1UL << GPIO_OTYPER_OT10_Pos)          /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10               GPIO_OTYPER_OT10_Msk
+#define GPIO_OTYPER_OT11_Pos           (11U)
+#define GPIO_OTYPER_OT11_Msk           (0x1UL << GPIO_OTYPER_OT11_Pos)          /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11               GPIO_OTYPER_OT11_Msk
+#define GPIO_OTYPER_OT12_Pos           (12U)
+#define GPIO_OTYPER_OT12_Msk           (0x1UL << GPIO_OTYPER_OT12_Pos)          /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12               GPIO_OTYPER_OT12_Msk
+#define GPIO_OTYPER_OT13_Pos           (13U)
+#define GPIO_OTYPER_OT13_Msk           (0x1UL << GPIO_OTYPER_OT13_Pos)          /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13               GPIO_OTYPER_OT13_Msk
+#define GPIO_OTYPER_OT14_Pos           (14U)
+#define GPIO_OTYPER_OT14_Msk           (0x1UL << GPIO_OTYPER_OT14_Pos)          /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14               GPIO_OTYPER_OT14_Msk
+#define GPIO_OTYPER_OT15_Pos           (15U)
+#define GPIO_OTYPER_OT15_Msk           (0x1UL << GPIO_OTYPER_OT15_Pos)          /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15               GPIO_OTYPER_OT15_Msk
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos       (0U)
+#define GPIO_OSPEEDR_OSPEED0_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0           GPIO_OSPEEDR_OSPEED0_Msk
+#define GPIO_OSPEEDR_OSPEED0_0         (0x1UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1         (0x2UL << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos       (2U)
+#define GPIO_OSPEEDR_OSPEED1_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1           GPIO_OSPEEDR_OSPEED1_Msk
+#define GPIO_OSPEEDR_OSPEED1_0         (0x1UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1         (0x2UL << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos       (4U)
+#define GPIO_OSPEEDR_OSPEED2_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2           GPIO_OSPEEDR_OSPEED2_Msk
+#define GPIO_OSPEEDR_OSPEED2_0         (0x1UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1         (0x2UL << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos       (6U)
+#define GPIO_OSPEEDR_OSPEED3_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3           GPIO_OSPEEDR_OSPEED3_Msk
+#define GPIO_OSPEEDR_OSPEED3_0         (0x1UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1         (0x2UL << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos       (8U)
+#define GPIO_OSPEEDR_OSPEED4_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4           GPIO_OSPEEDR_OSPEED4_Msk
+#define GPIO_OSPEEDR_OSPEED4_0         (0x1UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1         (0x2UL << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos       (10U)
+#define GPIO_OSPEEDR_OSPEED5_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5           GPIO_OSPEEDR_OSPEED5_Msk
+#define GPIO_OSPEEDR_OSPEED5_0         (0x1UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1         (0x2UL << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos       (12U)
+#define GPIO_OSPEEDR_OSPEED6_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6           GPIO_OSPEEDR_OSPEED6_Msk
+#define GPIO_OSPEEDR_OSPEED6_0         (0x1UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1         (0x2UL << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos       (14U)
+#define GPIO_OSPEEDR_OSPEED7_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7           GPIO_OSPEEDR_OSPEED7_Msk
+#define GPIO_OSPEEDR_OSPEED7_0         (0x1UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1         (0x2UL << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos       (16U)
+#define GPIO_OSPEEDR_OSPEED8_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8           GPIO_OSPEEDR_OSPEED8_Msk
+#define GPIO_OSPEEDR_OSPEED8_0         (0x1UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1         (0x2UL << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos       (18U)
+#define GPIO_OSPEEDR_OSPEED9_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9           GPIO_OSPEEDR_OSPEED9_Msk
+#define GPIO_OSPEEDR_OSPEED9_0         (0x1UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1         (0x2UL << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos      (20U)
+#define GPIO_OSPEEDR_OSPEED10_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10          GPIO_OSPEEDR_OSPEED10_Msk
+#define GPIO_OSPEEDR_OSPEED10_0        (0x1UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1        (0x2UL << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos      (22U)
+#define GPIO_OSPEEDR_OSPEED11_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11          GPIO_OSPEEDR_OSPEED11_Msk
+#define GPIO_OSPEEDR_OSPEED11_0        (0x1UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1        (0x2UL << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos      (24U)
+#define GPIO_OSPEEDR_OSPEED12_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12          GPIO_OSPEEDR_OSPEED12_Msk
+#define GPIO_OSPEEDR_OSPEED12_0        (0x1UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1        (0x2UL << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos      (26U)
+#define GPIO_OSPEEDR_OSPEED13_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13          GPIO_OSPEEDR_OSPEED13_Msk
+#define GPIO_OSPEEDR_OSPEED13_0        (0x1UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1        (0x2UL << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos      (28U)
+#define GPIO_OSPEEDR_OSPEED14_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14          GPIO_OSPEEDR_OSPEED14_Msk
+#define GPIO_OSPEEDR_OSPEED14_0        (0x1UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1        (0x2UL << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos      (30U)
+#define GPIO_OSPEEDR_OSPEED15_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15          GPIO_OSPEEDR_OSPEED15_Msk
+#define GPIO_OSPEEDR_OSPEED15_0        (0x1UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1        (0x2UL << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos           (0U)
+#define GPIO_PUPDR_PUPD0_Msk           (0x3UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0               GPIO_PUPDR_PUPD0_Msk
+#define GPIO_PUPDR_PUPD0_0             (0x1UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1             (0x2UL << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos           (2U)
+#define GPIO_PUPDR_PUPD1_Msk           (0x3UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1               GPIO_PUPDR_PUPD1_Msk
+#define GPIO_PUPDR_PUPD1_0             (0x1UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1             (0x2UL << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos           (4U)
+#define GPIO_PUPDR_PUPD2_Msk           (0x3UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2               GPIO_PUPDR_PUPD2_Msk
+#define GPIO_PUPDR_PUPD2_0             (0x1UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1             (0x2UL << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos           (6U)
+#define GPIO_PUPDR_PUPD3_Msk           (0x3UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3               GPIO_PUPDR_PUPD3_Msk
+#define GPIO_PUPDR_PUPD3_0             (0x1UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1             (0x2UL << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos           (8U)
+#define GPIO_PUPDR_PUPD4_Msk           (0x3UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4               GPIO_PUPDR_PUPD4_Msk
+#define GPIO_PUPDR_PUPD4_0             (0x1UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1             (0x2UL << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos           (10U)
+#define GPIO_PUPDR_PUPD5_Msk           (0x3UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5               GPIO_PUPDR_PUPD5_Msk
+#define GPIO_PUPDR_PUPD5_0             (0x1UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1             (0x2UL << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos           (12U)
+#define GPIO_PUPDR_PUPD6_Msk           (0x3UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6               GPIO_PUPDR_PUPD6_Msk
+#define GPIO_PUPDR_PUPD6_0             (0x1UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1             (0x2UL << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos           (14U)
+#define GPIO_PUPDR_PUPD7_Msk           (0x3UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7               GPIO_PUPDR_PUPD7_Msk
+#define GPIO_PUPDR_PUPD7_0             (0x1UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1             (0x2UL << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos           (16U)
+#define GPIO_PUPDR_PUPD8_Msk           (0x3UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8               GPIO_PUPDR_PUPD8_Msk
+#define GPIO_PUPDR_PUPD8_0             (0x1UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1             (0x2UL << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos           (18U)
+#define GPIO_PUPDR_PUPD9_Msk           (0x3UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9               GPIO_PUPDR_PUPD9_Msk
+#define GPIO_PUPDR_PUPD9_0             (0x1UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1             (0x2UL << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos          (20U)
+#define GPIO_PUPDR_PUPD10_Msk          (0x3UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10              GPIO_PUPDR_PUPD10_Msk
+#define GPIO_PUPDR_PUPD10_0            (0x1UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1            (0x2UL << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos          (22U)
+#define GPIO_PUPDR_PUPD11_Msk          (0x3UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11              GPIO_PUPDR_PUPD11_Msk
+#define GPIO_PUPDR_PUPD11_0            (0x1UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1            (0x2UL << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos          (24U)
+#define GPIO_PUPDR_PUPD12_Msk          (0x3UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12              GPIO_PUPDR_PUPD12_Msk
+#define GPIO_PUPDR_PUPD12_0            (0x1UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1            (0x2UL << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos          (26U)
+#define GPIO_PUPDR_PUPD13_Msk          (0x3UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13              GPIO_PUPDR_PUPD13_Msk
+#define GPIO_PUPDR_PUPD13_0            (0x1UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1            (0x2UL << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos          (28U)
+#define GPIO_PUPDR_PUPD14_Msk          (0x3UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14              GPIO_PUPDR_PUPD14_Msk
+#define GPIO_PUPDR_PUPD14_0            (0x1UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1            (0x2UL << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos          (30U)
+#define GPIO_PUPDR_PUPD15_Msk          (0x3UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15              GPIO_PUPDR_PUPD15_Msk
+#define GPIO_PUPDR_PUPD15_0            (0x1UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1            (0x2UL << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos               (0U)
+#define GPIO_IDR_ID0_Msk               (0x1UL << GPIO_IDR_ID0_Pos)              /*!< 0x00000001 */
+#define GPIO_IDR_ID0                   GPIO_IDR_ID0_Msk
+#define GPIO_IDR_ID1_Pos               (1U)
+#define GPIO_IDR_ID1_Msk               (0x1UL << GPIO_IDR_ID1_Pos)              /*!< 0x00000002 */
+#define GPIO_IDR_ID1                   GPIO_IDR_ID1_Msk
+#define GPIO_IDR_ID2_Pos               (2U)
+#define GPIO_IDR_ID2_Msk               (0x1UL << GPIO_IDR_ID2_Pos)              /*!< 0x00000004 */
+#define GPIO_IDR_ID2                   GPIO_IDR_ID2_Msk
+#define GPIO_IDR_ID3_Pos               (3U)
+#define GPIO_IDR_ID3_Msk               (0x1UL << GPIO_IDR_ID3_Pos)              /*!< 0x00000008 */
+#define GPIO_IDR_ID3                   GPIO_IDR_ID3_Msk
+#define GPIO_IDR_ID4_Pos               (4U)
+#define GPIO_IDR_ID4_Msk               (0x1UL << GPIO_IDR_ID4_Pos)              /*!< 0x00000010 */
+#define GPIO_IDR_ID4                   GPIO_IDR_ID4_Msk
+#define GPIO_IDR_ID5_Pos               (5U)
+#define GPIO_IDR_ID5_Msk               (0x1UL << GPIO_IDR_ID5_Pos)              /*!< 0x00000020 */
+#define GPIO_IDR_ID5                   GPIO_IDR_ID5_Msk
+#define GPIO_IDR_ID6_Pos               (6U)
+#define GPIO_IDR_ID6_Msk               (0x1UL << GPIO_IDR_ID6_Pos)              /*!< 0x00000040 */
+#define GPIO_IDR_ID6                   GPIO_IDR_ID6_Msk
+#define GPIO_IDR_ID7_Pos               (7U)
+#define GPIO_IDR_ID7_Msk               (0x1UL << GPIO_IDR_ID7_Pos)              /*!< 0x00000080 */
+#define GPIO_IDR_ID7                   GPIO_IDR_ID7_Msk
+#define GPIO_IDR_ID8_Pos               (8U)
+#define GPIO_IDR_ID8_Msk               (0x1UL << GPIO_IDR_ID8_Pos)              /*!< 0x00000100 */
+#define GPIO_IDR_ID8                   GPIO_IDR_ID8_Msk
+#define GPIO_IDR_ID9_Pos               (9U)
+#define GPIO_IDR_ID9_Msk               (0x1UL << GPIO_IDR_ID9_Pos)              /*!< 0x00000200 */
+#define GPIO_IDR_ID9                   GPIO_IDR_ID9_Msk
+#define GPIO_IDR_ID10_Pos              (10U)
+#define GPIO_IDR_ID10_Msk              (0x1UL << GPIO_IDR_ID10_Pos)             /*!< 0x00000400 */
+#define GPIO_IDR_ID10                  GPIO_IDR_ID10_Msk
+#define GPIO_IDR_ID11_Pos              (11U)
+#define GPIO_IDR_ID11_Msk              (0x1UL << GPIO_IDR_ID11_Pos)             /*!< 0x00000800 */
+#define GPIO_IDR_ID11                  GPIO_IDR_ID11_Msk
+#define GPIO_IDR_ID12_Pos              (12U)
+#define GPIO_IDR_ID12_Msk              (0x1UL << GPIO_IDR_ID12_Pos)             /*!< 0x00001000 */
+#define GPIO_IDR_ID12                  GPIO_IDR_ID12_Msk
+#define GPIO_IDR_ID13_Pos              (13U)
+#define GPIO_IDR_ID13_Msk              (0x1UL << GPIO_IDR_ID13_Pos)             /*!< 0x00002000 */
+#define GPIO_IDR_ID13                  GPIO_IDR_ID13_Msk
+#define GPIO_IDR_ID14_Pos              (14U)
+#define GPIO_IDR_ID14_Msk              (0x1UL << GPIO_IDR_ID14_Pos)             /*!< 0x00004000 */
+#define GPIO_IDR_ID14                  GPIO_IDR_ID14_Msk
+#define GPIO_IDR_ID15_Pos              (15U)
+#define GPIO_IDR_ID15_Msk              (0x1UL << GPIO_IDR_ID15_Pos)             /*!< 0x00008000 */
+#define GPIO_IDR_ID15                  GPIO_IDR_ID15_Msk
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos               (0U)
+#define GPIO_ODR_OD0_Msk               (0x1UL << GPIO_ODR_OD0_Pos)              /*!< 0x00000001 */
+#define GPIO_ODR_OD0                   GPIO_ODR_OD0_Msk
+#define GPIO_ODR_OD1_Pos               (1U)
+#define GPIO_ODR_OD1_Msk               (0x1UL << GPIO_ODR_OD1_Pos)              /*!< 0x00000002 */
+#define GPIO_ODR_OD1                   GPIO_ODR_OD1_Msk
+#define GPIO_ODR_OD2_Pos               (2U)
+#define GPIO_ODR_OD2_Msk               (0x1UL << GPIO_ODR_OD2_Pos)              /*!< 0x00000004 */
+#define GPIO_ODR_OD2                   GPIO_ODR_OD2_Msk
+#define GPIO_ODR_OD3_Pos               (3U)
+#define GPIO_ODR_OD3_Msk               (0x1UL << GPIO_ODR_OD3_Pos)              /*!< 0x00000008 */
+#define GPIO_ODR_OD3                   GPIO_ODR_OD3_Msk
+#define GPIO_ODR_OD4_Pos               (4U)
+#define GPIO_ODR_OD4_Msk               (0x1UL << GPIO_ODR_OD4_Pos)              /*!< 0x00000010 */
+#define GPIO_ODR_OD4                   GPIO_ODR_OD4_Msk
+#define GPIO_ODR_OD5_Pos               (5U)
+#define GPIO_ODR_OD5_Msk               (0x1UL << GPIO_ODR_OD5_Pos)              /*!< 0x00000020 */
+#define GPIO_ODR_OD5                   GPIO_ODR_OD5_Msk
+#define GPIO_ODR_OD6_Pos               (6U)
+#define GPIO_ODR_OD6_Msk               (0x1UL << GPIO_ODR_OD6_Pos)              /*!< 0x00000040 */
+#define GPIO_ODR_OD6                   GPIO_ODR_OD6_Msk
+#define GPIO_ODR_OD7_Pos               (7U)
+#define GPIO_ODR_OD7_Msk               (0x1UL << GPIO_ODR_OD7_Pos)              /*!< 0x00000080 */
+#define GPIO_ODR_OD7                   GPIO_ODR_OD7_Msk
+#define GPIO_ODR_OD8_Pos               (8U)
+#define GPIO_ODR_OD8_Msk               (0x1UL << GPIO_ODR_OD8_Pos)              /*!< 0x00000100 */
+#define GPIO_ODR_OD8                   GPIO_ODR_OD8_Msk
+#define GPIO_ODR_OD9_Pos               (9U)
+#define GPIO_ODR_OD9_Msk               (0x1UL << GPIO_ODR_OD9_Pos)              /*!< 0x00000200 */
+#define GPIO_ODR_OD9                   GPIO_ODR_OD9_Msk
+#define GPIO_ODR_OD10_Pos              (10U)
+#define GPIO_ODR_OD10_Msk              (0x1UL << GPIO_ODR_OD10_Pos)             /*!< 0x00000400 */
+#define GPIO_ODR_OD10                  GPIO_ODR_OD10_Msk
+#define GPIO_ODR_OD11_Pos              (11U)
+#define GPIO_ODR_OD11_Msk              (0x1UL << GPIO_ODR_OD11_Pos)             /*!< 0x00000800 */
+#define GPIO_ODR_OD11                  GPIO_ODR_OD11_Msk
+#define GPIO_ODR_OD12_Pos              (12U)
+#define GPIO_ODR_OD12_Msk              (0x1UL << GPIO_ODR_OD12_Pos)             /*!< 0x00001000 */
+#define GPIO_ODR_OD12                  GPIO_ODR_OD12_Msk
+#define GPIO_ODR_OD13_Pos              (13U)
+#define GPIO_ODR_OD13_Msk              (0x1UL << GPIO_ODR_OD13_Pos)             /*!< 0x00002000 */
+#define GPIO_ODR_OD13                  GPIO_ODR_OD13_Msk
+#define GPIO_ODR_OD14_Pos              (14U)
+#define GPIO_ODR_OD14_Msk              (0x1UL << GPIO_ODR_OD14_Pos)             /*!< 0x00004000 */
+#define GPIO_ODR_OD14                  GPIO_ODR_OD14_Msk
+#define GPIO_ODR_OD15_Pos              (15U)
+#define GPIO_ODR_OD15_Msk              (0x1UL << GPIO_ODR_OD15_Pos)             /*!< 0x00008000 */
+#define GPIO_ODR_OD15                  GPIO_ODR_OD15_Msk
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos              (0U)
+#define GPIO_BSRR_BS0_Msk              (0x1UL << GPIO_BSRR_BS0_Pos)             /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                  GPIO_BSRR_BS0_Msk
+#define GPIO_BSRR_BS1_Pos              (1U)
+#define GPIO_BSRR_BS1_Msk              (0x1UL << GPIO_BSRR_BS1_Pos)             /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                  GPIO_BSRR_BS1_Msk
+#define GPIO_BSRR_BS2_Pos              (2U)
+#define GPIO_BSRR_BS2_Msk              (0x1UL << GPIO_BSRR_BS2_Pos)             /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                  GPIO_BSRR_BS2_Msk
+#define GPIO_BSRR_BS3_Pos              (3U)
+#define GPIO_BSRR_BS3_Msk              (0x1UL << GPIO_BSRR_BS3_Pos)             /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                  GPIO_BSRR_BS3_Msk
+#define GPIO_BSRR_BS4_Pos              (4U)
+#define GPIO_BSRR_BS4_Msk              (0x1UL << GPIO_BSRR_BS4_Pos)             /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                  GPIO_BSRR_BS4_Msk
+#define GPIO_BSRR_BS5_Pos              (5U)
+#define GPIO_BSRR_BS5_Msk              (0x1UL << GPIO_BSRR_BS5_Pos)             /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                  GPIO_BSRR_BS5_Msk
+#define GPIO_BSRR_BS6_Pos              (6U)
+#define GPIO_BSRR_BS6_Msk              (0x1UL << GPIO_BSRR_BS6_Pos)             /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                  GPIO_BSRR_BS6_Msk
+#define GPIO_BSRR_BS7_Pos              (7U)
+#define GPIO_BSRR_BS7_Msk              (0x1UL << GPIO_BSRR_BS7_Pos)             /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                  GPIO_BSRR_BS7_Msk
+#define GPIO_BSRR_BS8_Pos              (8U)
+#define GPIO_BSRR_BS8_Msk              (0x1UL << GPIO_BSRR_BS8_Pos)             /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                  GPIO_BSRR_BS8_Msk
+#define GPIO_BSRR_BS9_Pos              (9U)
+#define GPIO_BSRR_BS9_Msk              (0x1UL << GPIO_BSRR_BS9_Pos)             /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                  GPIO_BSRR_BS9_Msk
+#define GPIO_BSRR_BS10_Pos             (10U)
+#define GPIO_BSRR_BS10_Msk             (0x1UL << GPIO_BSRR_BS10_Pos)            /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                 GPIO_BSRR_BS10_Msk
+#define GPIO_BSRR_BS11_Pos             (11U)
+#define GPIO_BSRR_BS11_Msk             (0x1UL << GPIO_BSRR_BS11_Pos)            /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                 GPIO_BSRR_BS11_Msk
+#define GPIO_BSRR_BS12_Pos             (12U)
+#define GPIO_BSRR_BS12_Msk             (0x1UL << GPIO_BSRR_BS12_Pos)            /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                 GPIO_BSRR_BS12_Msk
+#define GPIO_BSRR_BS13_Pos             (13U)
+#define GPIO_BSRR_BS13_Msk             (0x1UL << GPIO_BSRR_BS13_Pos)            /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                 GPIO_BSRR_BS13_Msk
+#define GPIO_BSRR_BS14_Pos             (14U)
+#define GPIO_BSRR_BS14_Msk             (0x1UL << GPIO_BSRR_BS14_Pos)            /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                 GPIO_BSRR_BS14_Msk
+#define GPIO_BSRR_BS15_Pos             (15U)
+#define GPIO_BSRR_BS15_Msk             (0x1UL << GPIO_BSRR_BS15_Pos)            /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                 GPIO_BSRR_BS15_Msk
+#define GPIO_BSRR_BR0_Pos              (16U)
+#define GPIO_BSRR_BR0_Msk              (0x1UL << GPIO_BSRR_BR0_Pos)             /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                  GPIO_BSRR_BR0_Msk
+#define GPIO_BSRR_BR1_Pos              (17U)
+#define GPIO_BSRR_BR1_Msk              (0x1UL << GPIO_BSRR_BR1_Pos)             /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                  GPIO_BSRR_BR1_Msk
+#define GPIO_BSRR_BR2_Pos              (18U)
+#define GPIO_BSRR_BR2_Msk              (0x1UL << GPIO_BSRR_BR2_Pos)             /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                  GPIO_BSRR_BR2_Msk
+#define GPIO_BSRR_BR3_Pos              (19U)
+#define GPIO_BSRR_BR3_Msk              (0x1UL << GPIO_BSRR_BR3_Pos)             /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                  GPIO_BSRR_BR3_Msk
+#define GPIO_BSRR_BR4_Pos              (20U)
+#define GPIO_BSRR_BR4_Msk              (0x1UL << GPIO_BSRR_BR4_Pos)             /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                  GPIO_BSRR_BR4_Msk
+#define GPIO_BSRR_BR5_Pos              (21U)
+#define GPIO_BSRR_BR5_Msk              (0x1UL << GPIO_BSRR_BR5_Pos)             /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                  GPIO_BSRR_BR5_Msk
+#define GPIO_BSRR_BR6_Pos              (22U)
+#define GPIO_BSRR_BR6_Msk              (0x1UL << GPIO_BSRR_BR6_Pos)             /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                  GPIO_BSRR_BR6_Msk
+#define GPIO_BSRR_BR7_Pos              (23U)
+#define GPIO_BSRR_BR7_Msk              (0x1UL << GPIO_BSRR_BR7_Pos)             /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                  GPIO_BSRR_BR7_Msk
+#define GPIO_BSRR_BR8_Pos              (24U)
+#define GPIO_BSRR_BR8_Msk              (0x1UL << GPIO_BSRR_BR8_Pos)             /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                  GPIO_BSRR_BR8_Msk
+#define GPIO_BSRR_BR9_Pos              (25U)
+#define GPIO_BSRR_BR9_Msk              (0x1UL << GPIO_BSRR_BR9_Pos)             /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                  GPIO_BSRR_BR9_Msk
+#define GPIO_BSRR_BR10_Pos             (26U)
+#define GPIO_BSRR_BR10_Msk             (0x1UL << GPIO_BSRR_BR10_Pos)            /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                 GPIO_BSRR_BR10_Msk
+#define GPIO_BSRR_BR11_Pos             (27U)
+#define GPIO_BSRR_BR11_Msk             (0x1UL << GPIO_BSRR_BR11_Pos)            /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                 GPIO_BSRR_BR11_Msk
+#define GPIO_BSRR_BR12_Pos             (28U)
+#define GPIO_BSRR_BR12_Msk             (0x1UL << GPIO_BSRR_BR12_Pos)            /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                 GPIO_BSRR_BR12_Msk
+#define GPIO_BSRR_BR13_Pos             (29U)
+#define GPIO_BSRR_BR13_Msk             (0x1UL << GPIO_BSRR_BR13_Pos)            /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                 GPIO_BSRR_BR13_Msk
+#define GPIO_BSRR_BR14_Pos             (30U)
+#define GPIO_BSRR_BR14_Msk             (0x1UL << GPIO_BSRR_BR14_Pos)            /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                 GPIO_BSRR_BR14_Msk
+#define GPIO_BSRR_BR15_Pos             (31U)
+#define GPIO_BSRR_BR15_Msk             (0x1UL << GPIO_BSRR_BR15_Pos)            /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                 GPIO_BSRR_BR15_Msk
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos             (0U)
+#define GPIO_LCKR_LCK0_Msk             (0x1UL << GPIO_LCKR_LCK0_Pos)            /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                 GPIO_LCKR_LCK0_Msk
+#define GPIO_LCKR_LCK1_Pos             (1U)
+#define GPIO_LCKR_LCK1_Msk             (0x1UL << GPIO_LCKR_LCK1_Pos)            /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                 GPIO_LCKR_LCK1_Msk
+#define GPIO_LCKR_LCK2_Pos             (2U)
+#define GPIO_LCKR_LCK2_Msk             (0x1UL << GPIO_LCKR_LCK2_Pos)            /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                 GPIO_LCKR_LCK2_Msk
+#define GPIO_LCKR_LCK3_Pos             (3U)
+#define GPIO_LCKR_LCK3_Msk             (0x1UL << GPIO_LCKR_LCK3_Pos)            /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                 GPIO_LCKR_LCK3_Msk
+#define GPIO_LCKR_LCK4_Pos             (4U)
+#define GPIO_LCKR_LCK4_Msk             (0x1UL << GPIO_LCKR_LCK4_Pos)            /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                 GPIO_LCKR_LCK4_Msk
+#define GPIO_LCKR_LCK5_Pos             (5U)
+#define GPIO_LCKR_LCK5_Msk             (0x1UL << GPIO_LCKR_LCK5_Pos)            /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                 GPIO_LCKR_LCK5_Msk
+#define GPIO_LCKR_LCK6_Pos             (6U)
+#define GPIO_LCKR_LCK6_Msk             (0x1UL << GPIO_LCKR_LCK6_Pos)            /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                 GPIO_LCKR_LCK6_Msk
+#define GPIO_LCKR_LCK7_Pos             (7U)
+#define GPIO_LCKR_LCK7_Msk             (0x1UL << GPIO_LCKR_LCK7_Pos)            /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                 GPIO_LCKR_LCK7_Msk
+#define GPIO_LCKR_LCK8_Pos             (8U)
+#define GPIO_LCKR_LCK8_Msk             (0x1UL << GPIO_LCKR_LCK8_Pos)            /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                 GPIO_LCKR_LCK8_Msk
+#define GPIO_LCKR_LCK9_Pos             (9U)
+#define GPIO_LCKR_LCK9_Msk             (0x1UL << GPIO_LCKR_LCK9_Pos)            /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                 GPIO_LCKR_LCK9_Msk
+#define GPIO_LCKR_LCK10_Pos            (10U)
+#define GPIO_LCKR_LCK10_Msk            (0x1UL << GPIO_LCKR_LCK10_Pos)           /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                GPIO_LCKR_LCK10_Msk
+#define GPIO_LCKR_LCK11_Pos            (11U)
+#define GPIO_LCKR_LCK11_Msk            (0x1UL << GPIO_LCKR_LCK11_Pos)           /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                GPIO_LCKR_LCK11_Msk
+#define GPIO_LCKR_LCK12_Pos            (12U)
+#define GPIO_LCKR_LCK12_Msk            (0x1UL << GPIO_LCKR_LCK12_Pos)           /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                GPIO_LCKR_LCK12_Msk
+#define GPIO_LCKR_LCK13_Pos            (13U)
+#define GPIO_LCKR_LCK13_Msk            (0x1UL << GPIO_LCKR_LCK13_Pos)           /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                GPIO_LCKR_LCK13_Msk
+#define GPIO_LCKR_LCK14_Pos            (14U)
+#define GPIO_LCKR_LCK14_Msk            (0x1UL << GPIO_LCKR_LCK14_Pos)           /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                GPIO_LCKR_LCK14_Msk
+#define GPIO_LCKR_LCK15_Pos            (15U)
+#define GPIO_LCKR_LCK15_Msk            (0x1UL << GPIO_LCKR_LCK15_Pos)           /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                GPIO_LCKR_LCK15_Msk
+#define GPIO_LCKR_LCKK_Pos             (16U)
+#define GPIO_LCKR_LCKK_Msk             (0x1UL << GPIO_LCKR_LCKK_Pos)            /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                 GPIO_LCKR_LCKK_Msk
+
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos           (0U)
+#define GPIO_AFRL_AFSEL0_Msk           (0xFUL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0               GPIO_AFRL_AFSEL0_Msk
+#define GPIO_AFRL_AFSEL0_0             (0x1UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1             (0x2UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2             (0x4UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3             (0x8UL << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos           (4U)
+#define GPIO_AFRL_AFSEL1_Msk           (0xFUL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1               GPIO_AFRL_AFSEL1_Msk
+#define GPIO_AFRL_AFSEL1_0             (0x1UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1             (0x2UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2             (0x4UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3             (0x8UL << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos           (8U)
+#define GPIO_AFRL_AFSEL2_Msk           (0xFUL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2               GPIO_AFRL_AFSEL2_Msk
+#define GPIO_AFRL_AFSEL2_0             (0x1UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1             (0x2UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2             (0x4UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3             (0x8UL << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos           (12U)
+#define GPIO_AFRL_AFSEL3_Msk           (0xFUL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3               GPIO_AFRL_AFSEL3_Msk
+#define GPIO_AFRL_AFSEL3_0             (0x1UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1             (0x2UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2             (0x4UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3             (0x8UL << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos           (16U)
+#define GPIO_AFRL_AFSEL4_Msk           (0xFUL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4               GPIO_AFRL_AFSEL4_Msk
+#define GPIO_AFRL_AFSEL4_0             (0x1UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1             (0x2UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2             (0x4UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3             (0x8UL << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos           (20U)
+#define GPIO_AFRL_AFSEL5_Msk           (0xFUL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5               GPIO_AFRL_AFSEL5_Msk
+#define GPIO_AFRL_AFSEL5_0             (0x1UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1             (0x2UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2             (0x4UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3             (0x8UL << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos           (24U)
+#define GPIO_AFRL_AFSEL6_Msk           (0xFUL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6               GPIO_AFRL_AFSEL6_Msk
+#define GPIO_AFRL_AFSEL6_0             (0x1UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1             (0x2UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2             (0x4UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3             (0x8UL << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos           (28U)
+#define GPIO_AFRL_AFSEL7_Msk           (0xFUL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7               GPIO_AFRL_AFSEL7_Msk
+#define GPIO_AFRL_AFSEL7_0             (0x1UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1             (0x2UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2             (0x4UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3             (0x8UL << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x80000000 */
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos           (0U)
+#define GPIO_AFRH_AFSEL8_Msk           (0xFUL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8               GPIO_AFRH_AFSEL8_Msk
+#define GPIO_AFRH_AFSEL8_0             (0x1UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1             (0x2UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2             (0x4UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3             (0x8UL << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos           (4U)
+#define GPIO_AFRH_AFSEL9_Msk           (0xFUL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9               GPIO_AFRH_AFSEL9_Msk
+#define GPIO_AFRH_AFSEL9_0             (0x1UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1             (0x2UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2             (0x4UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3             (0x8UL << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos          (8U)
+#define GPIO_AFRH_AFSEL10_Msk          (0xFUL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10              GPIO_AFRH_AFSEL10_Msk
+#define GPIO_AFRH_AFSEL10_0            (0x1UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1            (0x2UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2            (0x4UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3            (0x8UL << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos          (12U)
+#define GPIO_AFRH_AFSEL11_Msk          (0xFUL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11              GPIO_AFRH_AFSEL11_Msk
+#define GPIO_AFRH_AFSEL11_0            (0x1UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1            (0x2UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2            (0x4UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3            (0x8UL << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos          (16U)
+#define GPIO_AFRH_AFSEL12_Msk          (0xFUL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12              GPIO_AFRH_AFSEL12_Msk
+#define GPIO_AFRH_AFSEL12_0            (0x1UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1            (0x2UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2            (0x4UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3            (0x8UL << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos          (20U)
+#define GPIO_AFRH_AFSEL13_Msk          (0xFUL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13              GPIO_AFRH_AFSEL13_Msk
+#define GPIO_AFRH_AFSEL13_0            (0x1UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1            (0x2UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2            (0x4UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3            (0x8UL << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos          (24U)
+#define GPIO_AFRH_AFSEL14_Msk          (0xFUL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14              GPIO_AFRH_AFSEL14_Msk
+#define GPIO_AFRH_AFSEL14_0            (0x1UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1            (0x2UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2            (0x4UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3            (0x8UL << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos          (28U)
+#define GPIO_AFRH_AFSEL15_Msk          (0xFUL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15              GPIO_AFRH_AFSEL15_Msk
+#define GPIO_AFRH_AFSEL15_0            (0x1UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1            (0x2UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2            (0x4UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3            (0x8UL << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_BRR register  ******************/
+#define GPIO_BRR_BR0_Pos               (0U)
+#define GPIO_BRR_BR0_Msk               (0x1UL << GPIO_BRR_BR0_Pos)              /*!< 0x00000001 */
+#define GPIO_BRR_BR0                   GPIO_BRR_BR0_Msk
+#define GPIO_BRR_BR1_Pos               (1U)
+#define GPIO_BRR_BR1_Msk               (0x1UL << GPIO_BRR_BR1_Pos)              /*!< 0x00000002 */
+#define GPIO_BRR_BR1                   GPIO_BRR_BR1_Msk
+#define GPIO_BRR_BR2_Pos               (2U)
+#define GPIO_BRR_BR2_Msk               (0x1UL << GPIO_BRR_BR2_Pos)              /*!< 0x00000004 */
+#define GPIO_BRR_BR2                   GPIO_BRR_BR2_Msk
+#define GPIO_BRR_BR3_Pos               (3U)
+#define GPIO_BRR_BR3_Msk               (0x1UL << GPIO_BRR_BR3_Pos)              /*!< 0x00000008 */
+#define GPIO_BRR_BR3                   GPIO_BRR_BR3_Msk
+#define GPIO_BRR_BR4_Pos               (4U)
+#define GPIO_BRR_BR4_Msk               (0x1UL << GPIO_BRR_BR4_Pos)              /*!< 0x00000010 */
+#define GPIO_BRR_BR4                   GPIO_BRR_BR4_Msk
+#define GPIO_BRR_BR5_Pos               (5U)
+#define GPIO_BRR_BR5_Msk               (0x1UL << GPIO_BRR_BR5_Pos)              /*!< 0x00000020 */
+#define GPIO_BRR_BR5                   GPIO_BRR_BR5_Msk
+#define GPIO_BRR_BR6_Pos               (6U)
+#define GPIO_BRR_BR6_Msk               (0x1UL << GPIO_BRR_BR6_Pos)              /*!< 0x00000040 */
+#define GPIO_BRR_BR6                   GPIO_BRR_BR6_Msk
+#define GPIO_BRR_BR7_Pos               (7U)
+#define GPIO_BRR_BR7_Msk               (0x1UL << GPIO_BRR_BR7_Pos)              /*!< 0x00000080 */
+#define GPIO_BRR_BR7                   GPIO_BRR_BR7_Msk
+#define GPIO_BRR_BR8_Pos               (8U)
+#define GPIO_BRR_BR8_Msk               (0x1UL << GPIO_BRR_BR8_Pos)              /*!< 0x00000100 */
+#define GPIO_BRR_BR8                   GPIO_BRR_BR8_Msk
+#define GPIO_BRR_BR9_Pos               (9U)
+#define GPIO_BRR_BR9_Msk               (0x1UL << GPIO_BRR_BR9_Pos)              /*!< 0x00000200 */
+#define GPIO_BRR_BR9                   GPIO_BRR_BR9_Msk
+#define GPIO_BRR_BR10_Pos              (10U)
+#define GPIO_BRR_BR10_Msk              (0x1UL << GPIO_BRR_BR10_Pos)             /*!< 0x00000400 */
+#define GPIO_BRR_BR10                  GPIO_BRR_BR10_Msk
+#define GPIO_BRR_BR11_Pos              (11U)
+#define GPIO_BRR_BR11_Msk              (0x1UL << GPIO_BRR_BR11_Pos)             /*!< 0x00000800 */
+#define GPIO_BRR_BR11                  GPIO_BRR_BR11_Msk
+#define GPIO_BRR_BR12_Pos              (12U)
+#define GPIO_BRR_BR12_Msk              (0x1UL << GPIO_BRR_BR12_Pos)             /*!< 0x00001000 */
+#define GPIO_BRR_BR12                  GPIO_BRR_BR12_Msk
+#define GPIO_BRR_BR13_Pos              (13U)
+#define GPIO_BRR_BR13_Msk              (0x1UL << GPIO_BRR_BR13_Pos)             /*!< 0x00002000 */
+#define GPIO_BRR_BR13                  GPIO_BRR_BR13_Msk
+#define GPIO_BRR_BR14_Pos              (14U)
+#define GPIO_BRR_BR14_Msk              (0x1UL << GPIO_BRR_BR14_Pos)             /*!< 0x00004000 */
+#define GPIO_BRR_BR14                  GPIO_BRR_BR14_Msk
+#define GPIO_BRR_BR15_Pos              (15U)
+#define GPIO_BRR_BR15_Msk              (0x1UL << GPIO_BRR_BR15_Pos)             /*!< 0x00008000 */
+#define GPIO_BRR_BR15                  GPIO_BRR_BR15_Msk
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define I2C_CR1_PE_Pos               (0U)
+#define I2C_CR1_PE_Msk               (0x1UL << I2C_CR1_PE_Pos)                 /*!< 0x00000001 */
+#define I2C_CR1_PE                   I2C_CR1_PE_Msk                            /*!< Peripheral enable */
+#define I2C_CR1_TXIE_Pos             (1U)
+#define I2C_CR1_TXIE_Msk             (0x1UL << I2C_CR1_TXIE_Pos)               /*!< 0x00000002 */
+#define I2C_CR1_TXIE                 I2C_CR1_TXIE_Msk                          /*!< TX interrupt enable */
+#define I2C_CR1_RXIE_Pos             (2U)
+#define I2C_CR1_RXIE_Msk             (0x1UL << I2C_CR1_RXIE_Pos)               /*!< 0x00000004 */
+#define I2C_CR1_RXIE                 I2C_CR1_RXIE_Msk                          /*!< RX interrupt enable */
+#define I2C_CR1_ADDRIE_Pos           (3U)
+#define I2C_CR1_ADDRIE_Msk           (0x1UL << I2C_CR1_ADDRIE_Pos)             /*!< 0x00000008 */
+#define I2C_CR1_ADDRIE               I2C_CR1_ADDRIE_Msk                        /*!< Address match interrupt enable */
+#define I2C_CR1_NACKIE_Pos           (4U)
+#define I2C_CR1_NACKIE_Msk           (0x1UL << I2C_CR1_NACKIE_Pos)             /*!< 0x00000010 */
+#define I2C_CR1_NACKIE               I2C_CR1_NACKIE_Msk                        /*!< NACK received interrupt enable */
+#define I2C_CR1_STOPIE_Pos           (5U)
+#define I2C_CR1_STOPIE_Msk           (0x1UL << I2C_CR1_STOPIE_Pos)             /*!< 0x00000020 */
+#define I2C_CR1_STOPIE               I2C_CR1_STOPIE_Msk                        /*!< STOP detection interrupt enable */
+#define I2C_CR1_TCIE_Pos             (6U)
+#define I2C_CR1_TCIE_Msk             (0x1UL << I2C_CR1_TCIE_Pos)               /*!< 0x00000040 */
+#define I2C_CR1_TCIE                 I2C_CR1_TCIE_Msk                          /*!< Transfer complete interrupt enable */
+#define I2C_CR1_ERRIE_Pos            (7U)
+#define I2C_CR1_ERRIE_Msk            (0x1UL << I2C_CR1_ERRIE_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_ERRIE                I2C_CR1_ERRIE_Msk                         /*!< Errors interrupt enable */
+#define I2C_CR1_DNF_Pos              (8U)
+#define I2C_CR1_DNF_Msk              (0xFUL << I2C_CR1_DNF_Pos)                /*!< 0x00000F00 */
+#define I2C_CR1_DNF                  I2C_CR1_DNF_Msk                           /*!< Digital noise filter */
+#define I2C_CR1_ANFOFF_Pos           (12U)
+#define I2C_CR1_ANFOFF_Msk           (0x1UL << I2C_CR1_ANFOFF_Pos)             /*!< 0x00001000 */
+#define I2C_CR1_ANFOFF               I2C_CR1_ANFOFF_Msk                        /*!< Analog noise filter OFF */
+#define I2C_CR1_SWRST_Pos            (13U)
+#define I2C_CR1_SWRST_Msk            (0x1UL << I2C_CR1_SWRST_Pos)              /*!< 0x00002000 */
+#define I2C_CR1_SWRST                I2C_CR1_SWRST_Msk                         /*!< Software reset */
+#define I2C_CR1_TXDMAEN_Pos          (14U)
+#define I2C_CR1_TXDMAEN_Msk          (0x1UL << I2C_CR1_TXDMAEN_Pos)            /*!< 0x00004000 */
+#define I2C_CR1_TXDMAEN              I2C_CR1_TXDMAEN_Msk                       /*!< DMA transmission requests enable */
+#define I2C_CR1_RXDMAEN_Pos          (15U)
+#define I2C_CR1_RXDMAEN_Msk          (0x1UL << I2C_CR1_RXDMAEN_Pos)            /*!< 0x00008000 */
+#define I2C_CR1_RXDMAEN              I2C_CR1_RXDMAEN_Msk                       /*!< DMA reception requests enable */
+#define I2C_CR1_SBC_Pos              (16U)
+#define I2C_CR1_SBC_Msk              (0x1UL << I2C_CR1_SBC_Pos)                /*!< 0x00010000 */
+#define I2C_CR1_SBC                  I2C_CR1_SBC_Msk                           /*!< Slave byte control */
+#define I2C_CR1_NOSTRETCH_Pos        (17U)
+#define I2C_CR1_NOSTRETCH_Msk        (0x1UL << I2C_CR1_NOSTRETCH_Pos)          /*!< 0x00020000 */
+#define I2C_CR1_NOSTRETCH            I2C_CR1_NOSTRETCH_Msk                     /*!< Clock stretching disable */
+#define I2C_CR1_WUPEN_Pos            (18U)
+#define I2C_CR1_WUPEN_Msk            (0x1UL << I2C_CR1_WUPEN_Pos)              /*!< 0x00040000 */
+#define I2C_CR1_WUPEN                I2C_CR1_WUPEN_Msk                         /*!< Wakeup from STOP enable */
+#define I2C_CR1_GCEN_Pos             (19U)
+#define I2C_CR1_GCEN_Msk             (0x1UL << I2C_CR1_GCEN_Pos)               /*!< 0x00080000 */
+#define I2C_CR1_GCEN                 I2C_CR1_GCEN_Msk                          /*!< General call enable */
+#define I2C_CR1_SMBHEN_Pos           (20U)
+#define I2C_CR1_SMBHEN_Msk           (0x1UL << I2C_CR1_SMBHEN_Pos)             /*!< 0x00100000 */
+#define I2C_CR1_SMBHEN               I2C_CR1_SMBHEN_Msk                        /*!< SMBus host address enable */
+#define I2C_CR1_SMBDEN_Pos           (21U)
+#define I2C_CR1_SMBDEN_Msk           (0x1UL << I2C_CR1_SMBDEN_Pos)             /*!< 0x00200000 */
+#define I2C_CR1_SMBDEN               I2C_CR1_SMBDEN_Msk                        /*!< SMBus device default address enable */
+#define I2C_CR1_ALERTEN_Pos          (22U)
+#define I2C_CR1_ALERTEN_Msk          (0x1UL << I2C_CR1_ALERTEN_Pos)            /*!< 0x00400000 */
+#define I2C_CR1_ALERTEN              I2C_CR1_ALERTEN_Msk                       /*!< SMBus alert enable */
+#define I2C_CR1_PECEN_Pos            (23U)
+#define I2C_CR1_PECEN_Msk            (0x1UL << I2C_CR1_PECEN_Pos)              /*!< 0x00800000 */
+#define I2C_CR1_PECEN                I2C_CR1_PECEN_Msk                         /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_SADD_Pos             (0U)
+#define I2C_CR2_SADD_Msk             (0x3FFUL << I2C_CR2_SADD_Pos)             /*!< 0x000003FF */
+#define I2C_CR2_SADD                 I2C_CR2_SADD_Msk                          /*!< Slave address (master mode) */
+#define I2C_CR2_RD_WRN_Pos           (10U)
+#define I2C_CR2_RD_WRN_Msk           (0x1UL << I2C_CR2_RD_WRN_Pos)             /*!< 0x00000400 */
+#define I2C_CR2_RD_WRN               I2C_CR2_RD_WRN_Msk                        /*!< Transfer direction (master mode) */
+#define I2C_CR2_ADD10_Pos            (11U)
+#define I2C_CR2_ADD10_Msk            (0x1UL << I2C_CR2_ADD10_Pos)              /*!< 0x00000800 */
+#define I2C_CR2_ADD10                I2C_CR2_ADD10_Msk                         /*!< 10-bit addressing mode (master mode) */
+#define I2C_CR2_HEAD10R_Pos          (12U)
+#define I2C_CR2_HEAD10R_Msk          (0x1UL << I2C_CR2_HEAD10R_Pos)            /*!< 0x00001000 */
+#define I2C_CR2_HEAD10R              I2C_CR2_HEAD10R_Msk                       /*!< 10-bit address header only read direction (master mode) */
+#define I2C_CR2_START_Pos            (13U)
+#define I2C_CR2_START_Msk            (0x1UL << I2C_CR2_START_Pos)              /*!< 0x00002000 */
+#define I2C_CR2_START                I2C_CR2_START_Msk                         /*!< START generation */
+#define I2C_CR2_STOP_Pos             (14U)
+#define I2C_CR2_STOP_Msk             (0x1UL << I2C_CR2_STOP_Pos)               /*!< 0x00004000 */
+#define I2C_CR2_STOP                 I2C_CR2_STOP_Msk                          /*!< STOP generation (master mode) */
+#define I2C_CR2_NACK_Pos             (15U)
+#define I2C_CR2_NACK_Msk             (0x1UL << I2C_CR2_NACK_Pos)               /*!< 0x00008000 */
+#define I2C_CR2_NACK                 I2C_CR2_NACK_Msk                          /*!< NACK generation (slave mode) */
+#define I2C_CR2_NBYTES_Pos           (16U)
+#define I2C_CR2_NBYTES_Msk           (0xFFUL << I2C_CR2_NBYTES_Pos)            /*!< 0x00FF0000 */
+#define I2C_CR2_NBYTES               I2C_CR2_NBYTES_Msk                        /*!< Number of bytes */
+#define I2C_CR2_RELOAD_Pos           (24U)
+#define I2C_CR2_RELOAD_Msk           (0x1UL << I2C_CR2_RELOAD_Pos)             /*!< 0x01000000 */
+#define I2C_CR2_RELOAD               I2C_CR2_RELOAD_Msk                        /*!< NBYTES reload mode */
+#define I2C_CR2_AUTOEND_Pos          (25U)
+#define I2C_CR2_AUTOEND_Msk          (0x1UL << I2C_CR2_AUTOEND_Pos)            /*!< 0x02000000 */
+#define I2C_CR2_AUTOEND              I2C_CR2_AUTOEND_Msk                       /*!< Automatic end mode (master mode) */
+#define I2C_CR2_PECBYTE_Pos          (26U)
+#define I2C_CR2_PECBYTE_Msk          (0x1UL << I2C_CR2_PECBYTE_Pos)            /*!< 0x04000000 */
+#define I2C_CR2_PECBYTE              I2C_CR2_PECBYTE_Msk                       /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define I2C_OAR1_OA1_Pos             (0U)
+#define I2C_OAR1_OA1_Msk             (0x3FFUL << I2C_OAR1_OA1_Pos)             /*!< 0x000003FF */
+#define I2C_OAR1_OA1                 I2C_OAR1_OA1_Msk                          /*!< Interface own address 1 */
+#define I2C_OAR1_OA1MODE_Pos         (10U)
+#define I2C_OAR1_OA1MODE_Msk         (0x1UL << I2C_OAR1_OA1MODE_Pos)           /*!< 0x00000400 */
+#define I2C_OAR1_OA1MODE             I2C_OAR1_OA1MODE_Msk                      /*!< Own address 1 10-bit mode */
+#define I2C_OAR1_OA1EN_Pos           (15U)
+#define I2C_OAR1_OA1EN_Msk           (0x1UL << I2C_OAR1_OA1EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR1_OA1EN               I2C_OAR1_OA1EN_Msk                        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define I2C_OAR2_OA2_Pos             (1U)
+#define I2C_OAR2_OA2_Msk             (0x7FUL << I2C_OAR2_OA2_Pos)              /*!< 0x000000FE */
+#define I2C_OAR2_OA2                 I2C_OAR2_OA2_Msk                          /*!< Interface own address 2 */
+#define I2C_OAR2_OA2MSK_Pos          (8U)
+#define I2C_OAR2_OA2MSK_Msk          (0x7UL << I2C_OAR2_OA2MSK_Pos)            /*!< 0x00000700 */
+#define I2C_OAR2_OA2MSK              I2C_OAR2_OA2MSK_Msk                       /*!< Own address 2 masks */
+#define I2C_OAR2_OA2NOMASK           (0U)                                      /*!< No mask                                        */
+#define I2C_OAR2_OA2MASK01_Pos       (8U)
+#define I2C_OAR2_OA2MASK01_Msk       (0x1UL << I2C_OAR2_OA2MASK01_Pos)         /*!< 0x00000100 */
+#define I2C_OAR2_OA2MASK01           I2C_OAR2_OA2MASK01_Msk                    /*!< OA2[1] is masked, Only OA2[7:2] are compared   */
+#define I2C_OAR2_OA2MASK02_Pos       (9U)
+#define I2C_OAR2_OA2MASK02_Msk       (0x1UL << I2C_OAR2_OA2MASK02_Pos)         /*!< 0x00000200 */
+#define I2C_OAR2_OA2MASK02           I2C_OAR2_OA2MASK02_Msk                    /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define I2C_OAR2_OA2MASK03_Pos       (8U)
+#define I2C_OAR2_OA2MASK03_Msk       (0x3UL << I2C_OAR2_OA2MASK03_Pos)         /*!< 0x00000300 */
+#define I2C_OAR2_OA2MASK03           I2C_OAR2_OA2MASK03_Msk                    /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define I2C_OAR2_OA2MASK04_Pos       (10U)
+#define I2C_OAR2_OA2MASK04_Msk       (0x1UL << I2C_OAR2_OA2MASK04_Pos)         /*!< 0x00000400 */
+#define I2C_OAR2_OA2MASK04           I2C_OAR2_OA2MASK04_Msk                    /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define I2C_OAR2_OA2MASK05_Pos       (8U)
+#define I2C_OAR2_OA2MASK05_Msk       (0x5UL << I2C_OAR2_OA2MASK05_Pos)         /*!< 0x00000500 */
+#define I2C_OAR2_OA2MASK05           I2C_OAR2_OA2MASK05_Msk                    /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define I2C_OAR2_OA2MASK06_Pos       (9U)
+#define I2C_OAR2_OA2MASK06_Msk       (0x3UL << I2C_OAR2_OA2MASK06_Pos)         /*!< 0x00000600 */
+#define I2C_OAR2_OA2MASK06           I2C_OAR2_OA2MASK06_Msk                    /*!< OA2[6:1] is masked, Only OA2[7] are compared   */
+#define I2C_OAR2_OA2MASK07_Pos       (8U)
+#define I2C_OAR2_OA2MASK07_Msk       (0x7UL << I2C_OAR2_OA2MASK07_Pos)         /*!< 0x00000700 */
+#define I2C_OAR2_OA2MASK07           I2C_OAR2_OA2MASK07_Msk                    /*!< OA2[7:1] is masked, No comparison is done      */
+#define I2C_OAR2_OA2EN_Pos           (15U)
+#define I2C_OAR2_OA2EN_Msk           (0x1UL << I2C_OAR2_OA2EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR2_OA2EN               I2C_OAR2_OA2EN_Msk                        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define I2C_TIMINGR_SCLL_Pos         (0U)
+#define I2C_TIMINGR_SCLL_Msk         (0xFFUL << I2C_TIMINGR_SCLL_Pos)          /*!< 0x000000FF */
+#define I2C_TIMINGR_SCLL             I2C_TIMINGR_SCLL_Msk                      /*!< SCL low period (master mode) */
+#define I2C_TIMINGR_SCLH_Pos         (8U)
+#define I2C_TIMINGR_SCLH_Msk         (0xFFUL << I2C_TIMINGR_SCLH_Pos)          /*!< 0x0000FF00 */
+#define I2C_TIMINGR_SCLH             I2C_TIMINGR_SCLH_Msk                      /*!< SCL high period (master mode) */
+#define I2C_TIMINGR_SDADEL_Pos       (16U)
+#define I2C_TIMINGR_SDADEL_Msk       (0xFUL << I2C_TIMINGR_SDADEL_Pos)         /*!< 0x000F0000 */
+#define I2C_TIMINGR_SDADEL           I2C_TIMINGR_SDADEL_Msk                    /*!< Data hold time */
+#define I2C_TIMINGR_SCLDEL_Pos       (20U)
+#define I2C_TIMINGR_SCLDEL_Msk       (0xFUL << I2C_TIMINGR_SCLDEL_Pos)         /*!< 0x00F00000 */
+#define I2C_TIMINGR_SCLDEL           I2C_TIMINGR_SCLDEL_Msk                    /*!< Data setup time */
+#define I2C_TIMINGR_PRESC_Pos        (28U)
+#define I2C_TIMINGR_PRESC_Msk        (0xFUL << I2C_TIMINGR_PRESC_Pos)          /*!< 0xF0000000 */
+#define I2C_TIMINGR_PRESC            I2C_TIMINGR_PRESC_Msk                     /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define I2C_TIMEOUTR_TIMEOUTA_Pos    (0U)
+#define I2C_TIMEOUTR_TIMEOUTA_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTA_Pos)    /*!< 0x00000FFF */
+#define I2C_TIMEOUTR_TIMEOUTA        I2C_TIMEOUTR_TIMEOUTA_Msk                 /*!< Bus timeout A */
+#define I2C_TIMEOUTR_TIDLE_Pos       (12U)
+#define I2C_TIMEOUTR_TIDLE_Msk       (0x1UL << I2C_TIMEOUTR_TIDLE_Pos)         /*!< 0x00001000 */
+#define I2C_TIMEOUTR_TIDLE           I2C_TIMEOUTR_TIDLE_Msk                    /*!< Idle clock timeout detection */
+#define I2C_TIMEOUTR_TIMOUTEN_Pos    (15U)
+#define I2C_TIMEOUTR_TIMOUTEN_Msk    (0x1UL << I2C_TIMEOUTR_TIMOUTEN_Pos)      /*!< 0x00008000 */
+#define I2C_TIMEOUTR_TIMOUTEN        I2C_TIMEOUTR_TIMOUTEN_Msk                 /*!< Clock timeout enable */
+#define I2C_TIMEOUTR_TIMEOUTB_Pos    (16U)
+#define I2C_TIMEOUTR_TIMEOUTB_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTB_Pos)    /*!< 0x0FFF0000 */
+#define I2C_TIMEOUTR_TIMEOUTB        I2C_TIMEOUTR_TIMEOUTB_Msk                 /*!< Bus timeout B*/
+#define I2C_TIMEOUTR_TEXTEN_Pos      (31U)
+#define I2C_TIMEOUTR_TEXTEN_Msk      (0x1UL << I2C_TIMEOUTR_TEXTEN_Pos)        /*!< 0x80000000 */
+#define I2C_TIMEOUTR_TEXTEN          I2C_TIMEOUTR_TEXTEN_Msk                   /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define I2C_ISR_TXE_Pos              (0U)
+#define I2C_ISR_TXE_Msk              (0x1UL << I2C_ISR_TXE_Pos)                /*!< 0x00000001 */
+#define I2C_ISR_TXE                  I2C_ISR_TXE_Msk                           /*!< Transmit data register empty */
+#define I2C_ISR_TXIS_Pos             (1U)
+#define I2C_ISR_TXIS_Msk             (0x1UL << I2C_ISR_TXIS_Pos)               /*!< 0x00000002 */
+#define I2C_ISR_TXIS                 I2C_ISR_TXIS_Msk                          /*!< Transmit interrupt status */
+#define I2C_ISR_RXNE_Pos             (2U)
+#define I2C_ISR_RXNE_Msk             (0x1UL << I2C_ISR_RXNE_Pos)               /*!< 0x00000004 */
+#define I2C_ISR_RXNE                 I2C_ISR_RXNE_Msk                          /*!< Receive data register not empty */
+#define I2C_ISR_ADDR_Pos             (3U)
+#define I2C_ISR_ADDR_Msk             (0x1UL << I2C_ISR_ADDR_Pos)               /*!< 0x00000008 */
+#define I2C_ISR_ADDR                 I2C_ISR_ADDR_Msk                          /*!< Address matched (slave mode)*/
+#define I2C_ISR_NACKF_Pos            (4U)
+#define I2C_ISR_NACKF_Msk            (0x1UL << I2C_ISR_NACKF_Pos)              /*!< 0x00000010 */
+#define I2C_ISR_NACKF                I2C_ISR_NACKF_Msk                         /*!< NACK received flag */
+#define I2C_ISR_STOPF_Pos            (5U)
+#define I2C_ISR_STOPF_Msk            (0x1UL << I2C_ISR_STOPF_Pos)              /*!< 0x00000020 */
+#define I2C_ISR_STOPF                I2C_ISR_STOPF_Msk                         /*!< STOP detection flag */
+#define I2C_ISR_TC_Pos               (6U)
+#define I2C_ISR_TC_Msk               (0x1UL << I2C_ISR_TC_Pos)                 /*!< 0x00000040 */
+#define I2C_ISR_TC                   I2C_ISR_TC_Msk                            /*!< Transfer complete (master mode) */
+#define I2C_ISR_TCR_Pos              (7U)
+#define I2C_ISR_TCR_Msk              (0x1UL << I2C_ISR_TCR_Pos)                /*!< 0x00000080 */
+#define I2C_ISR_TCR                  I2C_ISR_TCR_Msk                           /*!< Transfer complete reload */
+#define I2C_ISR_BERR_Pos             (8U)
+#define I2C_ISR_BERR_Msk             (0x1UL << I2C_ISR_BERR_Pos)               /*!< 0x00000100 */
+#define I2C_ISR_BERR                 I2C_ISR_BERR_Msk                          /*!< Bus error */
+#define I2C_ISR_ARLO_Pos             (9U)
+#define I2C_ISR_ARLO_Msk             (0x1UL << I2C_ISR_ARLO_Pos)               /*!< 0x00000200 */
+#define I2C_ISR_ARLO                 I2C_ISR_ARLO_Msk                          /*!< Arbitration lost */
+#define I2C_ISR_OVR_Pos              (10U)
+#define I2C_ISR_OVR_Msk              (0x1UL << I2C_ISR_OVR_Pos)                /*!< 0x00000400 */
+#define I2C_ISR_OVR                  I2C_ISR_OVR_Msk                           /*!< Overrun/Underrun */
+#define I2C_ISR_PECERR_Pos           (11U)
+#define I2C_ISR_PECERR_Msk           (0x1UL << I2C_ISR_PECERR_Pos)             /*!< 0x00000800 */
+#define I2C_ISR_PECERR               I2C_ISR_PECERR_Msk                        /*!< PEC error in reception */
+#define I2C_ISR_TIMEOUT_Pos          (12U)
+#define I2C_ISR_TIMEOUT_Msk          (0x1UL << I2C_ISR_TIMEOUT_Pos)            /*!< 0x00001000 */
+#define I2C_ISR_TIMEOUT              I2C_ISR_TIMEOUT_Msk                       /*!< Timeout or Tlow detection flag */
+#define I2C_ISR_ALERT_Pos            (13U)
+#define I2C_ISR_ALERT_Msk            (0x1UL << I2C_ISR_ALERT_Pos)              /*!< 0x00002000 */
+#define I2C_ISR_ALERT                I2C_ISR_ALERT_Msk                         /*!< SMBus alert */
+#define I2C_ISR_BUSY_Pos             (15U)
+#define I2C_ISR_BUSY_Msk             (0x1UL << I2C_ISR_BUSY_Pos)               /*!< 0x00008000 */
+#define I2C_ISR_BUSY                 I2C_ISR_BUSY_Msk                          /*!< Bus busy */
+#define I2C_ISR_DIR_Pos              (16U)
+#define I2C_ISR_DIR_Msk              (0x1UL << I2C_ISR_DIR_Pos)                /*!< 0x00010000 */
+#define I2C_ISR_DIR                  I2C_ISR_DIR_Msk                           /*!< Transfer direction (slave mode) */
+#define I2C_ISR_ADDCODE_Pos          (17U)
+#define I2C_ISR_ADDCODE_Msk          (0x7FUL << I2C_ISR_ADDCODE_Pos)           /*!< 0x00FE0000 */
+#define I2C_ISR_ADDCODE              I2C_ISR_ADDCODE_Msk                       /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define I2C_ICR_ADDRCF_Pos           (3U)
+#define I2C_ICR_ADDRCF_Msk           (0x1UL << I2C_ICR_ADDRCF_Pos)             /*!< 0x00000008 */
+#define I2C_ICR_ADDRCF               I2C_ICR_ADDRCF_Msk                        /*!< Address matched clear flag */
+#define I2C_ICR_NACKCF_Pos           (4U)
+#define I2C_ICR_NACKCF_Msk           (0x1UL << I2C_ICR_NACKCF_Pos)             /*!< 0x00000010 */
+#define I2C_ICR_NACKCF               I2C_ICR_NACKCF_Msk                        /*!< NACK clear flag */
+#define I2C_ICR_STOPCF_Pos           (5U)
+#define I2C_ICR_STOPCF_Msk           (0x1UL << I2C_ICR_STOPCF_Pos)             /*!< 0x00000020 */
+#define I2C_ICR_STOPCF               I2C_ICR_STOPCF_Msk                        /*!< STOP detection clear flag */
+#define I2C_ICR_BERRCF_Pos           (8U)
+#define I2C_ICR_BERRCF_Msk           (0x1UL << I2C_ICR_BERRCF_Pos)             /*!< 0x00000100 */
+#define I2C_ICR_BERRCF               I2C_ICR_BERRCF_Msk                        /*!< Bus error clear flag */
+#define I2C_ICR_ARLOCF_Pos           (9U)
+#define I2C_ICR_ARLOCF_Msk           (0x1UL << I2C_ICR_ARLOCF_Pos)             /*!< 0x00000200 */
+#define I2C_ICR_ARLOCF               I2C_ICR_ARLOCF_Msk                        /*!< Arbitration lost clear flag */
+#define I2C_ICR_OVRCF_Pos            (10U)
+#define I2C_ICR_OVRCF_Msk            (0x1UL << I2C_ICR_OVRCF_Pos)              /*!< 0x00000400 */
+#define I2C_ICR_OVRCF                I2C_ICR_OVRCF_Msk                         /*!< Overrun/Underrun clear flag */
+#define I2C_ICR_PECCF_Pos            (11U)
+#define I2C_ICR_PECCF_Msk            (0x1UL << I2C_ICR_PECCF_Pos)              /*!< 0x00000800 */
+#define I2C_ICR_PECCF                I2C_ICR_PECCF_Msk                         /*!< PAC error clear flag */
+#define I2C_ICR_TIMOUTCF_Pos         (12U)
+#define I2C_ICR_TIMOUTCF_Msk         (0x1UL << I2C_ICR_TIMOUTCF_Pos)           /*!< 0x00001000 */
+#define I2C_ICR_TIMOUTCF             I2C_ICR_TIMOUTCF_Msk                      /*!< Timeout clear flag */
+#define I2C_ICR_ALERTCF_Pos          (13U)
+#define I2C_ICR_ALERTCF_Msk          (0x1UL << I2C_ICR_ALERTCF_Pos)            /*!< 0x00002000 */
+#define I2C_ICR_ALERTCF              I2C_ICR_ALERTCF_Msk                       /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define I2C_PECR_PEC_Pos             (0U)
+#define I2C_PECR_PEC_Msk             (0xFFUL << I2C_PECR_PEC_Pos)              /*!< 0x000000FF */
+#define I2C_PECR_PEC                 I2C_PECR_PEC_Msk                          /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define I2C_RXDR_RXDATA_Pos          (0U)
+#define I2C_RXDR_RXDATA_Msk          (0xFFUL << I2C_RXDR_RXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_RXDR_RXDATA              I2C_RXDR_RXDATA_Msk                       /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define I2C_TXDR_TXDATA_Pos          (0U)
+#define I2C_TXDR_TXDATA_Msk          (0xFFUL << I2C_TXDR_TXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_TXDR_TXDATA              I2C_TXDR_TXDATA_Msk                       /*!< 8-bit transmit data */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos      (0U)
+#define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
+#define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos       (0U)
+#define IWDG_PR_PR_Msk       (0x7UL << IWDG_PR_PR_Pos)                         /*!< 0x00000007 */
+#define IWDG_PR_PR           IWDG_PR_PR_Msk                                    /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0         (0x1UL << IWDG_PR_PR_Pos)                         /*!< 0x00000001 */
+#define IWDG_PR_PR_1         (0x2UL << IWDG_PR_PR_Pos)                         /*!< 0x00000002 */
+#define IWDG_PR_PR_2         (0x4UL << IWDG_PR_PR_Pos)                         /*!< 0x00000004 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos      (0U)
+#define IWDG_RLR_RL_Msk      (0xFFFUL << IWDG_RLR_RL_Pos)                      /*!< 0x00000FFF */
+#define IWDG_RLR_RL          IWDG_RLR_RL_Msk                                   /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos      (0U)
+#define IWDG_SR_PVU_Msk      (0x1UL << IWDG_SR_PVU_Pos)                        /*!< 0x00000001 */
+#define IWDG_SR_PVU          IWDG_SR_PVU_Msk                                   /*!< Watchdog prescaler value update */
+#define IWDG_SR_RVU_Pos      (1U)
+#define IWDG_SR_RVU_Msk      (0x1UL << IWDG_SR_RVU_Pos)                        /*!< 0x00000002 */
+#define IWDG_SR_RVU          IWDG_SR_RVU_Msk                                   /*!< Watchdog counter reload value update */
+#define IWDG_SR_WVU_Pos      (2U)
+#define IWDG_SR_WVU_Msk      (0x1UL << IWDG_SR_WVU_Pos)                        /*!< 0x00000004 */
+#define IWDG_SR_WVU          IWDG_SR_WVU_Msk                                   /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_WINR_WIN_Pos    (0U)
+#define IWDG_WINR_WIN_Msk    (0xFFFUL << IWDG_WINR_WIN_Pos)                    /*!< 0x00000FFF */
+#define IWDG_WINR_WIN        IWDG_WINR_WIN_Msk                                 /*!< Watchdog counter window value */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Power Control                                       */
+/*                                                                            */
+/******************************************************************************/
+#define PWR_PVD_SUPPORT                       /*!< PWR feature available only on specific devices: Power Voltage Detection feature */
+#define PWR_BOR_SUPPORT                       /*!< PWR feature available only on specific devices: Brown-Out Reset feature         */
+#define PWR_SHDW_SUPPORT                      /*!< PWR feature available only on specific devices: Shutdown mode */
+
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define PWR_CR1_LPMS_Pos          (0U)
+#define PWR_CR1_LPMS_Msk          (0x7UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000007 */
+#define PWR_CR1_LPMS              PWR_CR1_LPMS_Msk                             /*!< Low Power Mode Selection */
+#define PWR_CR1_LPMS_0            (0x1UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000001 */
+#define PWR_CR1_LPMS_1            (0x2UL << PWR_CR1_LPMS_Pos)                  /*!< 0x00000002 */
+#define PWR_CR1_LPMS_2            (0x4UL << PWR_CR1_LPMS_Pos)                   /*!< 0x00000004 */
+#define PWR_CR1_FPD_STOP_Pos      (3U)
+#define PWR_CR1_FPD_STOP_Msk      (0x1UL << PWR_CR1_FPD_STOP_Pos)              /*!< 0x00000008 */
+#define PWR_CR1_FPD_STOP          PWR_CR1_FPD_STOP_Msk                         /*!< Flash power down mode during stop */
+#define PWR_CR1_FPD_LPRUN_Pos     (4U)
+#define PWR_CR1_FPD_LPRUN_Msk     (0x1UL << PWR_CR1_FPD_LPRUN_Pos)             /*!< 0x00000010 */
+#define PWR_CR1_FPD_LPRUN         PWR_CR1_FPD_LPRUN_Msk                        /*!< Flash power down mode during run */
+#define PWR_CR1_FPD_LPSLP_Pos     (5U)
+#define PWR_CR1_FPD_LPSLP_Msk     (0x1UL << PWR_CR1_FPD_LPSLP_Pos)             /*!< 0x00000020 */
+#define PWR_CR1_FPD_LPSLP         PWR_CR1_FPD_LPSLP_Msk                        /*!< Flash power down mode during sleep */
+#define PWR_CR1_DBP_Pos           (8U)
+#define PWR_CR1_DBP_Msk           (0x1UL << PWR_CR1_DBP_Pos)                   /*!< 0x00000100 */
+#define PWR_CR1_DBP               PWR_CR1_DBP_Msk                              /*!< Disable Backup Domain write protection */
+#define PWR_CR1_VOS_Pos           (9U)
+#define PWR_CR1_VOS_Msk           (0x3UL << PWR_CR1_VOS_Pos)                   /*!< 0x00000600 */
+#define PWR_CR1_VOS               PWR_CR1_VOS_Msk                              /*!< Voltage scaling */
+#define PWR_CR1_VOS_0             (0x1UL << PWR_CR1_VOS_Pos)                   /*!< Voltage scaling bit 0 */
+#define PWR_CR1_VOS_1             (0x2UL << PWR_CR1_VOS_Pos)                   /*!< Voltage scaling bit 1 */
+#define PWR_CR1_LPR_Pos           (14U)
+#define PWR_CR1_LPR_Msk           (0x1UL << PWR_CR1_LPR_Pos)                   /*!< 0x00004000 */
+#define PWR_CR1_LPR               PWR_CR1_LPR_Msk                              /*!< Regulator Low-Power Run mode */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define PWR_CR2_PVDE_Pos          (0U)
+#define PWR_CR2_PVDE_Msk          (0x1UL << PWR_CR2_PVDE_Pos)                  /*!< 0x00000001 */
+#define PWR_CR2_PVDE              PWR_CR2_PVDE_Msk                             /*!< Programmable Voltage Detector Enable */
+#define PWR_CR2_PVDFT_Pos         (1U)
+#define PWR_CR2_PVDFT_Msk         (0x7UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x0000000E */
+#define PWR_CR2_PVDFT             PWR_CR2_PVDFT_Msk                            /*!< PVD Falling Threshold Selection bit field */
+#define PWR_CR2_PVDFT_0           (0x1UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x00000002 */
+#define PWR_CR2_PVDFT_1           (0x2UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x00000004 */
+#define PWR_CR2_PVDFT_2           (0x4UL << PWR_CR2_PVDFT_Pos)                 /*!< 0x00000008 */
+#define PWR_CR2_PVDRT_Pos         (4U)
+#define PWR_CR2_PVDRT_Msk         (0x7UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000070 */
+#define PWR_CR2_PVDRT             PWR_CR2_PVDRT_Msk                            /*!< PVD Rising Threshold Selection bit field */
+#define PWR_CR2_PVDRT_0           (0x1UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000010 */
+#define PWR_CR2_PVDRT_1           (0x2UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000020 */
+#define PWR_CR2_PVDRT_2           (0x4UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000040 */
+
+/********************  Bit definition for PWR_CR3 register  ********************/
+#define PWR_CR3_EWUP_Pos          (0U)
+#define PWR_CR3_EWUP_Msk          (0x2BUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000002B */
+#define PWR_CR3_EWUP              PWR_CR3_EWUP_Msk                             /*!< Enable all Wake-Up Pins  */
+#define PWR_CR3_EWUP1_Pos         (0U)
+#define PWR_CR3_EWUP1_Msk         (0x1UL << PWR_CR3_EWUP1_Pos)                 /*!< 0x00000001 */
+#define PWR_CR3_EWUP1             PWR_CR3_EWUP1_Msk                            /*!< Enable WKUP pin 1 */
+#define PWR_CR3_EWUP2_Pos         (1U)
+#define PWR_CR3_EWUP2_Msk         (0x1UL << PWR_CR3_EWUP2_Pos)                 /*!< 0x00000002 */
+#define PWR_CR3_EWUP2             PWR_CR3_EWUP2_Msk                            /*!< Enable WKUP pin 2 */
+#define PWR_CR3_EWUP4_Pos         (3U)
+#define PWR_CR3_EWUP4_Msk         (0x1UL << PWR_CR3_EWUP4_Pos)                 /*!< 0x00000008 */
+#define PWR_CR3_EWUP4             PWR_CR3_EWUP4_Msk                            /*!< Enable WKUP pin 4 */
+#define PWR_CR3_EWUP6_Pos         (5U)
+#define PWR_CR3_EWUP6_Msk         (0x1UL << PWR_CR3_EWUP6_Pos)                 /*!< 0x00000020 */
+#define PWR_CR3_EWUP6             PWR_CR3_EWUP6_Msk                            /*!< Enable WKUP pin 6 */
+#define PWR_CR3_RRS_Pos           (8U)
+#define PWR_CR3_RRS_Msk           (0x1UL << PWR_CR3_RRS_Pos)                   /*!< 0x00000100 */
+#define PWR_CR3_RRS               PWR_CR3_RRS_Msk                              /*!< RAM retention in Standby mode */
+#define PWR_CR3_ENB_ULP_Pos       (9U)
+#define PWR_CR3_ENB_ULP_Msk       (0x1UL << PWR_CR3_ENB_ULP_Pos)               /*!< 0x00000200 */
+#define PWR_CR3_ENB_ULP           PWR_CR3_ENB_ULP_Msk                          /*!< Enable sampling resistor bridge in the LPMU_RESET block */
+#define PWR_CR3_APC_Pos           (10U)
+#define PWR_CR3_APC_Msk           (0x1UL << PWR_CR3_APC_Pos)                   /*!< 0x00000400 */
+#define PWR_CR3_APC               PWR_CR3_APC_Msk                              /*!< Apply pull-up and pull-down configuration */
+#define PWR_CR3_EIWUL_Pos         (15U)
+#define PWR_CR3_EIWUL_Msk         (0x1UL << PWR_CR3_EIWUL_Pos)                 /*!< 0x00008000 */
+#define PWR_CR3_EIWUL             PWR_CR3_EIWUL_Msk                            /*!< Enable Internal Wake-up line */
+
+/********************  Bit definition for PWR_CR4 register  ********************/
+#define PWR_CR4_WP_Pos            (0U)
+#define PWR_CR4_WP_Msk            (0x2BUL << PWR_CR4_WP_Pos)                   /*!< 0x0000002B */
+#define PWR_CR4_WP                PWR_CR4_WP_Msk                               /*!< all Wake-Up Pin polarity */
+#define PWR_CR4_WP1_Pos           (0U)
+#define PWR_CR4_WP1_Msk           (0x1UL << PWR_CR4_WP1_Pos)                   /*!< 0x00000001 */
+#define PWR_CR4_WP1               PWR_CR4_WP1_Msk                              /*!< Wake-Up Pin 1 polarity */
+#define PWR_CR4_WP2_Pos           (1U)
+#define PWR_CR4_WP2_Msk           (0x1UL << PWR_CR4_WP2_Pos)                   /*!< 0x00000002 */
+#define PWR_CR4_WP2               PWR_CR4_WP2_Msk                              /*!< Wake-Up Pin 2 polarity */
+#define PWR_CR4_WP4_Pos           (3U)
+#define PWR_CR4_WP4_Msk           (0x1UL << PWR_CR4_WP4_Pos)                   /*!< 0x00000008 */
+#define PWR_CR4_WP4               PWR_CR4_WP4_Msk                              /*!< Wake-Up Pin 4 polarity */
+#define PWR_CR4_WP6_Pos           (5U)
+#define PWR_CR4_WP6_Msk           (0x1UL << PWR_CR4_WP6_Pos)                   /*!< 0x00000020 */
+#define PWR_CR4_WP6               PWR_CR4_WP6_Msk                              /*!< Wake-Up Pin 6 polarity */
+#define PWR_CR4_VBE_Pos           (8U)
+#define PWR_CR4_VBE_Msk           (0x1UL << PWR_CR4_VBE_Pos)                   /*!< 0x00000100 */
+#define PWR_CR4_VBE               PWR_CR4_VBE_Msk                              /*!< VBAT Battery charging Enable  */
+#define PWR_CR4_VBRS_Pos          (9U)
+#define PWR_CR4_VBRS_Msk          (0x1UL << PWR_CR4_VBRS_Pos)                  /*!< 0x00000200 */
+#define PWR_CR4_VBRS              PWR_CR4_VBRS_Msk                             /*!< VBAT Battery charging Resistor Selection */
+
+/********************  Bit definition for PWR_SR1 register  ********************/
+#define PWR_SR1_WUF_Pos           (0U)
+#define PWR_SR1_WUF_Msk           (0x2BUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000002B */
+#define PWR_SR1_WUF               PWR_SR1_WUF_Msk                              /*!< Wakeup Flags  */
+#define PWR_SR1_WUF1_Pos          (0U)
+#define PWR_SR1_WUF1_Msk          (0x1UL << PWR_SR1_WUF1_Pos)                  /*!< 0x00000001 */
+#define PWR_SR1_WUF1              PWR_SR1_WUF1_Msk                             /*!< Wakeup Flag 1 */
+#define PWR_SR1_WUF2_Pos          (1U)
+#define PWR_SR1_WUF2_Msk          (0x1UL << PWR_SR1_WUF2_Pos)                  /*!< 0x00000002 */
+#define PWR_SR1_WUF2              PWR_SR1_WUF2_Msk                             /*!< Wakeup Flag 2 */
+#define PWR_SR1_WUF4_Pos          (3U)
+#define PWR_SR1_WUF4_Msk          (0x1UL << PWR_SR1_WUF4_Pos)                  /*!< 0x00000008 */
+#define PWR_SR1_WUF4              PWR_SR1_WUF4_Msk                             /*!< Wakeup Flag 4 */
+#define PWR_SR1_WUF6_Pos          (5U)
+#define PWR_SR1_WUF6_Msk          (0x1UL << PWR_SR1_WUF6_Pos)                  /*!< 0x00000020 */
+#define PWR_SR1_WUF6              PWR_SR1_WUF6_Msk                             /*!< Wakeup Flag 6 */
+#define PWR_SR1_SBF_Pos           (8U)
+#define PWR_SR1_SBF_Msk           (0x1UL << PWR_SR1_SBF_Pos)                   /*!< 0x00000100 */
+#define PWR_SR1_SBF               PWR_SR1_SBF_Msk                              /*!< Standby Flag  */
+#define PWR_SR1_WUFI_Pos          (15U)
+#define PWR_SR1_WUFI_Msk          (0x1UL << PWR_SR1_WUFI_Pos)                  /*!< 0x00008000 */
+#define PWR_SR1_WUFI              PWR_SR1_WUFI_Msk                             /*!< Wakeup Flag Internal */
+
+/********************  Bit definition for PWR_SR2 register  ********************/
+#define PWR_SR2_FLASH_RDY_Pos     (7U)
+#define PWR_SR2_FLASH_RDY_Msk     (0x1UL << PWR_SR2_FLASH_RDY_Pos)             /*!< 0x00000080 */
+#define PWR_SR2_FLASH_RDY         PWR_SR2_FLASH_RDY_Msk                        /*!< Flash Ready */
+#define PWR_SR2_REGLPS_Pos        (8U)
+#define PWR_SR2_REGLPS_Msk        (0x1UL << PWR_SR2_REGLPS_Pos)                /*!< 0x00000100 */
+#define PWR_SR2_REGLPS            PWR_SR2_REGLPS_Msk                           /*!< Regulator Low Power started */
+#define PWR_SR2_REGLPF_Pos        (9U)
+#define PWR_SR2_REGLPF_Msk        (0x1UL << PWR_SR2_REGLPF_Pos)                /*!< 0x00000200 */
+#define PWR_SR2_REGLPF            PWR_SR2_REGLPF_Msk                           /*!< Regulator Low Power flag    */
+#define PWR_SR2_VOSF_Pos          (10U)
+#define PWR_SR2_VOSF_Msk          (0x1UL << PWR_SR2_VOSF_Pos)                  /*!< 0x00000400 */
+#define PWR_SR2_VOSF              PWR_SR2_VOSF_Msk                             /*!< Voltage Scaling Flag */
+#define PWR_SR2_PVDO_Pos          (11U)
+#define PWR_SR2_PVDO_Msk          (0x1UL << PWR_SR2_PVDO_Pos)                  /*!< 0x00000800 */
+#define PWR_SR2_PVDO              PWR_SR2_PVDO_Msk                             /*!< Power voltage detector output */
+
+/********************  Bit definition for PWR_SCR register  ********************/
+#define PWR_SCR_CWUF_Pos          (0U)
+#define PWR_SCR_CWUF_Msk          (0x2BUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000002B */
+#define PWR_SCR_CWUF              PWR_SCR_CWUF_Msk                             /*!< Clear Wake-up Flags  */
+#define PWR_SCR_CWUF1_Pos         (0U)
+#define PWR_SCR_CWUF1_Msk         (0x1UL << PWR_SCR_CWUF1_Pos)                 /*!< 0x00000001 */
+#define PWR_SCR_CWUF1             PWR_SCR_CWUF1_Msk                            /*!< Clear Wake-up Flag 1 */
+#define PWR_SCR_CWUF2_Pos         (1U)
+#define PWR_SCR_CWUF2_Msk         (0x1UL << PWR_SCR_CWUF2_Pos)                 /*!< 0x00000002 */
+#define PWR_SCR_CWUF2             PWR_SCR_CWUF2_Msk                            /*!< Clear Wake-up Flag 2 */
+#define PWR_SCR_CWUF4_Pos         (3U)
+#define PWR_SCR_CWUF4_Msk         (0x1UL << PWR_SCR_CWUF4_Pos)                 /*!< 0x00000008 */
+#define PWR_SCR_CWUF4             PWR_SCR_CWUF4_Msk                            /*!< Clear Wake-up Flag 4 */
+#define PWR_SCR_CWUF6_Pos         (5U)
+#define PWR_SCR_CWUF6_Msk         (0x1UL << PWR_SCR_CWUF6_Pos)                 /*!< 0x00000020 */
+#define PWR_SCR_CWUF6             PWR_SCR_CWUF6_Msk                            /*!< Clear Wake-up Flag 6 */
+#define PWR_SCR_CSBF_Pos          (8U)
+#define PWR_SCR_CSBF_Msk          (0x1UL << PWR_SCR_CSBF_Pos)                  /*!< 0x00000100 */
+#define PWR_SCR_CSBF              PWR_SCR_CSBF_Msk                             /*!< Clear Standby Flag  */
+
+/********************  Bit definition for PWR_PUCRA register  *****************/
+#define PWR_PUCRA_PU0_Pos         (0U)
+#define PWR_PUCRA_PU0_Msk         (0x1UL << PWR_PUCRA_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRA_PU0             PWR_PUCRA_PU0_Msk                            /*!< Pin PA0 Pull-Up set */
+#define PWR_PUCRA_PU1_Pos         (1U)
+#define PWR_PUCRA_PU1_Msk         (0x1UL << PWR_PUCRA_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRA_PU1             PWR_PUCRA_PU1_Msk                            /*!< Pin PA1 Pull-Up set */
+#define PWR_PUCRA_PU2_Pos         (2U)
+#define PWR_PUCRA_PU2_Msk         (0x1UL << PWR_PUCRA_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRA_PU2             PWR_PUCRA_PU2_Msk                            /*!< Pin PA2 Pull-Up set */
+#define PWR_PUCRA_PU3_Pos         (3U)
+#define PWR_PUCRA_PU3_Msk         (0x1UL << PWR_PUCRA_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRA_PU3             PWR_PUCRA_PU3_Msk                            /*!< Pin PA3 Pull-Up set */
+#define PWR_PUCRA_PU4_Pos         (4U)
+#define PWR_PUCRA_PU4_Msk         (0x1UL << PWR_PUCRA_PU4_Pos)                 /*!< 0x00000010 */
+#define PWR_PUCRA_PU4             PWR_PUCRA_PU4_Msk                            /*!< Pin PA4 Pull-Up set */
+#define PWR_PUCRA_PU5_Pos         (5U)
+#define PWR_PUCRA_PU5_Msk         (0x1UL << PWR_PUCRA_PU5_Pos)                 /*!< 0x00000020 */
+#define PWR_PUCRA_PU5             PWR_PUCRA_PU5_Msk                            /*!< Pin PA5 Pull-Up set */
+#define PWR_PUCRA_PU6_Pos         (6U)
+#define PWR_PUCRA_PU6_Msk         (0x1UL << PWR_PUCRA_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRA_PU6             PWR_PUCRA_PU6_Msk                            /*!< Pin PA6 Pull-Up set */
+#define PWR_PUCRA_PU7_Pos         (7U)
+#define PWR_PUCRA_PU7_Msk         (0x1UL << PWR_PUCRA_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRA_PU7             PWR_PUCRA_PU7_Msk                            /*!< Pin PA7 Pull-Up set */
+#define PWR_PUCRA_PU8_Pos         (8U)
+#define PWR_PUCRA_PU8_Msk         (0x1UL << PWR_PUCRA_PU8_Pos)                 /*!< 0x00000100 */
+#define PWR_PUCRA_PU8             PWR_PUCRA_PU8_Msk                            /*!< Pin PA8 Pull-Up set */
+#define PWR_PUCRA_PU9_Pos         (9U)
+#define PWR_PUCRA_PU9_Msk         (0x1UL << PWR_PUCRA_PU9_Pos)                 /*!< 0x00000200 */
+#define PWR_PUCRA_PU9             PWR_PUCRA_PU9_Msk                            /*!< Pin PA9 Pull-Up set */
+#define PWR_PUCRA_PU10_Pos        (10U)
+#define PWR_PUCRA_PU10_Msk        (0x1UL << PWR_PUCRA_PU10_Pos)                /*!< 0x00000400 */
+#define PWR_PUCRA_PU10            PWR_PUCRA_PU10_Msk                           /*!< Pin PA10 Pull-Up set */
+#define PWR_PUCRA_PU11_Pos        (11U)
+#define PWR_PUCRA_PU11_Msk        (0x1UL << PWR_PUCRA_PU11_Pos)                /*!< 0x00000800 */
+#define PWR_PUCRA_PU11            PWR_PUCRA_PU11_Msk                           /*!< Pin PA11 Pull-Up set */
+#define PWR_PUCRA_PU12_Pos        (12U)
+#define PWR_PUCRA_PU12_Msk        (0x1UL << PWR_PUCRA_PU12_Pos)                /*!< 0x00001000 */
+#define PWR_PUCRA_PU12            PWR_PUCRA_PU12_Msk                           /*!< Pin PA12 Pull-Up set */
+#define PWR_PUCRA_PU13_Pos        (13U)
+#define PWR_PUCRA_PU13_Msk        (0x1UL << PWR_PUCRA_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRA_PU13            PWR_PUCRA_PU13_Msk                           /*!< Pin PA13 Pull-Up set */
+#define PWR_PUCRA_PU14_Pos        (14U)
+#define PWR_PUCRA_PU14_Msk        (0x1UL << PWR_PUCRA_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRA_PU14            PWR_PUCRA_PU14_Msk                           /*!< Pin PA14 Pull-Up set */
+#define PWR_PUCRA_PU15_Pos        (15U)
+#define PWR_PUCRA_PU15_Msk        (0x1UL << PWR_PUCRA_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRA_PU15            PWR_PUCRA_PU15_Msk                           /*!< Pin PA15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRA register  *****************/
+#define PWR_PDCRA_PD0_Pos         (0U)
+#define PWR_PDCRA_PD0_Msk         (0x1UL << PWR_PDCRA_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRA_PD0             PWR_PDCRA_PD0_Msk                            /*!< Pin PA0 Pull-Down set */
+#define PWR_PDCRA_PD1_Pos         (1U)
+#define PWR_PDCRA_PD1_Msk         (0x1UL << PWR_PDCRA_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRA_PD1             PWR_PDCRA_PD1_Msk                            /*!< Pin PA1 Pull-Down set */
+#define PWR_PDCRA_PD2_Pos         (2U)
+#define PWR_PDCRA_PD2_Msk         (0x1UL << PWR_PDCRA_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRA_PD2             PWR_PDCRA_PD2_Msk                            /*!< Pin PA2 Pull-Down set */
+#define PWR_PDCRA_PD3_Pos         (3U)
+#define PWR_PDCRA_PD3_Msk         (0x1UL << PWR_PDCRA_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRA_PD3             PWR_PDCRA_PD3_Msk                            /*!< Pin PA3 Pull-Down set */
+#define PWR_PDCRA_PD4_Pos         (4U)
+#define PWR_PDCRA_PD4_Msk         (0x1UL << PWR_PDCRA_PD4_Pos)                 /*!< 0x00000010 */
+#define PWR_PDCRA_PD4             PWR_PDCRA_PD4_Msk                            /*!< Pin PA4 Pull-Down set */
+#define PWR_PDCRA_PD5_Pos         (5U)
+#define PWR_PDCRA_PD5_Msk         (0x1UL << PWR_PDCRA_PD5_Pos)                 /*!< 0x00000020 */
+#define PWR_PDCRA_PD5             PWR_PDCRA_PD5_Msk                            /*!< Pin PA5 Pull-Down set */
+#define PWR_PDCRA_PD6_Pos         (6U)
+#define PWR_PDCRA_PD6_Msk         (0x1UL << PWR_PDCRA_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRA_PD6             PWR_PDCRA_PD6_Msk                            /*!< Pin PA6 Pull-Down set */
+#define PWR_PDCRA_PD7_Pos         (7U)
+#define PWR_PDCRA_PD7_Msk         (0x1UL << PWR_PDCRA_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRA_PD7             PWR_PDCRA_PD7_Msk                            /*!< Pin PA7 Pull-Down set */
+#define PWR_PDCRA_PD8_Pos         (8U)
+#define PWR_PDCRA_PD8_Msk         (0x1UL << PWR_PDCRA_PD8_Pos)                 /*!< 0x00000100 */
+#define PWR_PDCRA_PD8             PWR_PDCRA_PD8_Msk                            /*!< Pin PA8 Pull-Down set */
+#define PWR_PDCRA_PD9_Pos         (9U)
+#define PWR_PDCRA_PD9_Msk         (0x1UL << PWR_PDCRA_PD9_Pos)                 /*!< 0x00000200 */
+#define PWR_PDCRA_PD9             PWR_PDCRA_PD9_Msk                            /*!< Pin PA9 Pull-Down set */
+#define PWR_PDCRA_PD10_Pos        (10U)
+#define PWR_PDCRA_PD10_Msk        (0x1UL << PWR_PDCRA_PD10_Pos)                /*!< 0x00000400 */
+#define PWR_PDCRA_PD10            PWR_PDCRA_PD10_Msk                           /*!< Pin PA10 Pull-Down set */
+#define PWR_PDCRA_PD11_Pos        (11U)
+#define PWR_PDCRA_PD11_Msk        (0x1UL << PWR_PDCRA_PD11_Pos)                /*!< 0x00000800 */
+#define PWR_PDCRA_PD11            PWR_PDCRA_PD11_Msk                           /*!< Pin PA11 Pull-Down set */
+#define PWR_PDCRA_PD12_Pos        (12U)
+#define PWR_PDCRA_PD12_Msk        (0x1UL << PWR_PDCRA_PD12_Pos)                /*!< 0x00001000 */
+#define PWR_PDCRA_PD12            PWR_PDCRA_PD12_Msk                           /*!< Pin PA12 Pull-Down set */
+#define PWR_PDCRA_PD13_Pos        (13U)
+#define PWR_PDCRA_PD13_Msk        (0x1UL << PWR_PDCRA_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRA_PD13            PWR_PDCRA_PD13_Msk                           /*!< Pin PA13 Pull-Down set */
+#define PWR_PDCRA_PD14_Pos        (14U)
+#define PWR_PDCRA_PD14_Msk        (0x1UL << PWR_PDCRA_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRA_PD14            PWR_PDCRA_PD14_Msk                           /*!< Pin PA14 Pull-Down set */
+#define PWR_PDCRA_PD15_Pos        (15U)
+#define PWR_PDCRA_PD15_Msk        (0x1UL << PWR_PDCRA_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRA_PD15            PWR_PDCRA_PD15_Msk                           /*!< Pin PA15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRB register  *****************/
+#define PWR_PUCRB_PU0_Pos         (0U)
+#define PWR_PUCRB_PU0_Msk         (0x1UL << PWR_PUCRB_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRB_PU0             PWR_PUCRB_PU0_Msk                            /*!< Pin PB0 Pull-Up set */
+#define PWR_PUCRB_PU1_Pos         (1U)
+#define PWR_PUCRB_PU1_Msk         (0x1UL << PWR_PUCRB_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRB_PU1             PWR_PUCRB_PU1_Msk                            /*!< Pin PB1 Pull-Up set */
+#define PWR_PUCRB_PU2_Pos         (2U)
+#define PWR_PUCRB_PU2_Msk         (0x1UL << PWR_PUCRB_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRB_PU2             PWR_PUCRB_PU2_Msk                            /*!< Pin PB2 Pull-Up set */
+#define PWR_PUCRB_PU3_Pos         (3U)
+#define PWR_PUCRB_PU3_Msk         (0x1UL << PWR_PUCRB_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRB_PU3             PWR_PUCRB_PU3_Msk                            /*!< Pin PB3 Pull-Up set */
+#define PWR_PUCRB_PU4_Pos         (4U)
+#define PWR_PUCRB_PU4_Msk         (0x1UL << PWR_PUCRB_PU4_Pos)                 /*!< 0x00000010 */
+#define PWR_PUCRB_PU4             PWR_PUCRB_PU4_Msk                            /*!< Pin PB4 Pull-Up set */
+#define PWR_PUCRB_PU5_Pos         (5U)
+#define PWR_PUCRB_PU5_Msk         (0x1UL << PWR_PUCRB_PU5_Pos)                 /*!< 0x00000020 */
+#define PWR_PUCRB_PU5             PWR_PUCRB_PU5_Msk                            /*!< Pin PB5 Pull-Up set */
+#define PWR_PUCRB_PU6_Pos         (6U)
+#define PWR_PUCRB_PU6_Msk         (0x1UL << PWR_PUCRB_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRB_PU6             PWR_PUCRB_PU6_Msk                            /*!< Pin PB6 Pull-Up set */
+#define PWR_PUCRB_PU7_Pos         (7U)
+#define PWR_PUCRB_PU7_Msk         (0x1UL << PWR_PUCRB_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRB_PU7             PWR_PUCRB_PU7_Msk                            /*!< Pin PB7 Pull-Up set */
+#define PWR_PUCRB_PU8_Pos         (8U)
+#define PWR_PUCRB_PU8_Msk         (0x1UL << PWR_PUCRB_PU8_Pos)                 /*!< 0x00000100 */
+#define PWR_PUCRB_PU8             PWR_PUCRB_PU8_Msk                            /*!< Pin PB8 Pull-Up set */
+#define PWR_PUCRB_PU9_Pos         (9U)
+#define PWR_PUCRB_PU9_Msk         (0x1UL << PWR_PUCRB_PU9_Pos)                 /*!< 0x00000200 */
+#define PWR_PUCRB_PU9             PWR_PUCRB_PU9_Msk                            /*!< Pin PB9 Pull-Up set */
+#define PWR_PUCRB_PU10_Pos        (10U)
+#define PWR_PUCRB_PU10_Msk        (0x1UL << PWR_PUCRB_PU10_Pos)                /*!< 0x00000400 */
+#define PWR_PUCRB_PU10            PWR_PUCRB_PU10_Msk                           /*!< Pin PB10 Pull-Up set */
+#define PWR_PUCRB_PU11_Pos        (11U)
+#define PWR_PUCRB_PU11_Msk        (0x1UL << PWR_PUCRB_PU11_Pos)                /*!< 0x00000800 */
+#define PWR_PUCRB_PU11            PWR_PUCRB_PU11_Msk                           /*!< Pin PB11 Pull-Up set */
+#define PWR_PUCRB_PU12_Pos        (12U)
+#define PWR_PUCRB_PU12_Msk        (0x1UL << PWR_PUCRB_PU12_Pos)                /*!< 0x00001000 */
+#define PWR_PUCRB_PU12            PWR_PUCRB_PU12_Msk                           /*!< Pin PB12 Pull-Up set */
+#define PWR_PUCRB_PU13_Pos        (13U)
+#define PWR_PUCRB_PU13_Msk        (0x1UL << PWR_PUCRB_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRB_PU13            PWR_PUCRB_PU13_Msk                           /*!< Pin PB13 Pull-Up set */
+#define PWR_PUCRB_PU14_Pos        (14U)
+#define PWR_PUCRB_PU14_Msk        (0x1UL << PWR_PUCRB_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRB_PU14            PWR_PUCRB_PU14_Msk                           /*!< Pin PB14 Pull-Up set */
+#define PWR_PUCRB_PU15_Pos        (15U)
+#define PWR_PUCRB_PU15_Msk        (0x1UL << PWR_PUCRB_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRB_PU15            PWR_PUCRB_PU15_Msk                           /*!< Pin PB15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRB register  *****************/
+#define PWR_PDCRB_PD0_Pos         (0U)
+#define PWR_PDCRB_PD0_Msk         (0x1UL << PWR_PDCRB_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRB_PD0             PWR_PDCRB_PD0_Msk                            /*!< Pin PB0 Pull-Down set */
+#define PWR_PDCRB_PD1_Pos         (1U)
+#define PWR_PDCRB_PD1_Msk         (0x1UL << PWR_PDCRB_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRB_PD1             PWR_PDCRB_PD1_Msk                            /*!< Pin PB1 Pull-Down set */
+#define PWR_PDCRB_PD2_Pos         (2U)
+#define PWR_PDCRB_PD2_Msk         (0x1UL << PWR_PDCRB_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRB_PD2             PWR_PDCRB_PD2_Msk                            /*!< Pin PB2 Pull-Down set */
+#define PWR_PDCRB_PD3_Pos         (3U)
+#define PWR_PDCRB_PD3_Msk         (0x1UL << PWR_PDCRB_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRB_PD3             PWR_PDCRB_PD3_Msk                            /*!< Pin PB3 Pull-Down set */
+#define PWR_PDCRB_PD4_Pos         (4U)
+#define PWR_PDCRB_PD4_Msk         (0x1UL << PWR_PDCRB_PD4_Pos)                 /*!< 0x00000010 */
+#define PWR_PDCRB_PD4             PWR_PDCRB_PD4_Msk                            /*!< Pin PB4 Pull-Down set */
+#define PWR_PDCRB_PD5_Pos         (5U)
+#define PWR_PDCRB_PD5_Msk         (0x1UL << PWR_PDCRB_PD5_Pos)                 /*!< 0x00000020 */
+#define PWR_PDCRB_PD5             PWR_PDCRB_PD5_Msk                            /*!< Pin PB5 Pull-Down set */
+#define PWR_PDCRB_PD6_Pos         (6U)
+#define PWR_PDCRB_PD6_Msk         (0x1UL << PWR_PDCRB_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRB_PD6             PWR_PDCRB_PD6_Msk                            /*!< Pin PB6 Pull-Down set */
+#define PWR_PDCRB_PD7_Pos         (7U)
+#define PWR_PDCRB_PD7_Msk         (0x1UL << PWR_PDCRB_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRB_PD7             PWR_PDCRB_PD7_Msk                            /*!< Pin PB7 Pull-Down set */
+#define PWR_PDCRB_PD8_Pos         (8U)
+#define PWR_PDCRB_PD8_Msk         (0x1UL << PWR_PDCRB_PD8_Pos)                 /*!< 0x00000100 */
+#define PWR_PDCRB_PD8             PWR_PDCRB_PD8_Msk                            /*!< Pin PB8 Pull-Down set */
+#define PWR_PDCRB_PD9_Pos         (9U)
+#define PWR_PDCRB_PD9_Msk         (0x1UL << PWR_PDCRB_PD9_Pos)                 /*!< 0x00000200 */
+#define PWR_PDCRB_PD9             PWR_PDCRB_PD9_Msk                            /*!< Pin PB9 Pull-Down set */
+#define PWR_PDCRB_PD10_Pos        (10U)
+#define PWR_PDCRB_PD10_Msk        (0x1UL << PWR_PDCRB_PD10_Pos)                /*!< 0x00000400 */
+#define PWR_PDCRB_PD10            PWR_PDCRB_PD10_Msk                           /*!< Pin PB10 Pull-Down set */
+#define PWR_PDCRB_PD11_Pos        (11U)
+#define PWR_PDCRB_PD11_Msk        (0x1UL << PWR_PDCRB_PD11_Pos)                /*!< 0x00000800 */
+#define PWR_PDCRB_PD11            PWR_PDCRB_PD11_Msk                           /*!< Pin PB11 Pull-Down set */
+#define PWR_PDCRB_PD12_Pos        (12U)
+#define PWR_PDCRB_PD12_Msk        (0x1UL << PWR_PDCRB_PD12_Pos)                /*!< 0x00001000 */
+#define PWR_PDCRB_PD12            PWR_PDCRB_PD12_Msk                           /*!< Pin PB12 Pull-Down set */
+#define PWR_PDCRB_PD13_Pos        (13U)
+#define PWR_PDCRB_PD13_Msk        (0x1UL << PWR_PDCRB_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRB_PD13            PWR_PDCRB_PD13_Msk                           /*!< Pin PB13 Pull-Down set */
+#define PWR_PDCRB_PD14_Pos        (14U)
+#define PWR_PDCRB_PD14_Msk        (0x1UL << PWR_PDCRB_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRB_PD14            PWR_PDCRB_PD14_Msk                           /*!< Pin PB14 Pull-Down set */
+#define PWR_PDCRB_PD15_Pos        (15U)
+#define PWR_PDCRB_PD15_Msk        (0x1UL << PWR_PDCRB_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRB_PD15            PWR_PDCRB_PD15_Msk                           /*!< Pin PB15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRC register  *****************/
+#define PWR_PUCRC_PU6_Pos         (6U)
+#define PWR_PUCRC_PU6_Msk         (0x1UL << PWR_PUCRC_PU6_Pos)                 /*!< 0x00000040 */
+#define PWR_PUCRC_PU6             PWR_PUCRC_PU6_Msk                            /*!< Pin PC6 Pull-Up set */
+#define PWR_PUCRC_PU7_Pos         (7U)
+#define PWR_PUCRC_PU7_Msk         (0x1UL << PWR_PUCRC_PU7_Pos)                 /*!< 0x00000080 */
+#define PWR_PUCRC_PU7             PWR_PUCRC_PU7_Msk                            /*!< Pin PC7 Pull-Up set */
+#define PWR_PUCRC_PU13_Pos        (13U)
+#define PWR_PUCRC_PU13_Msk        (0x1UL << PWR_PUCRC_PU13_Pos)                /*!< 0x00002000 */
+#define PWR_PUCRC_PU13            PWR_PUCRC_PU13_Msk                           /*!< Pin PC13 Pull-Up set */
+#define PWR_PUCRC_PU14_Pos        (14U)
+#define PWR_PUCRC_PU14_Msk        (0x1UL << PWR_PUCRC_PU14_Pos)                /*!< 0x00004000 */
+#define PWR_PUCRC_PU14            PWR_PUCRC_PU14_Msk                           /*!< Pin PC14 Pull-Up set */
+#define PWR_PUCRC_PU15_Pos        (15U)
+#define PWR_PUCRC_PU15_Msk        (0x1UL << PWR_PUCRC_PU15_Pos)                /*!< 0x00008000 */
+#define PWR_PUCRC_PU15            PWR_PUCRC_PU15_Msk                           /*!< Pin PC15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRC register  *****************/
+#define PWR_PDCRC_PD6_Pos         (6U)
+#define PWR_PDCRC_PD6_Msk         (0x1UL << PWR_PDCRC_PD6_Pos)                 /*!< 0x00000040 */
+#define PWR_PDCRC_PD6             PWR_PDCRC_PD6_Msk                            /*!< Pin PC6 Pull-Down set */
+#define PWR_PDCRC_PD7_Pos         (7U)
+#define PWR_PDCRC_PD7_Msk         (0x1UL << PWR_PDCRC_PD7_Pos)                 /*!< 0x00000080 */
+#define PWR_PDCRC_PD7             PWR_PDCRC_PD7_Msk                            /*!< Pin PC7 Pull-Down set */
+#define PWR_PDCRC_PD13_Pos        (13U)
+#define PWR_PDCRC_PD13_Msk        (0x1UL << PWR_PDCRC_PD13_Pos)                /*!< 0x00002000 */
+#define PWR_PDCRC_PD13            PWR_PDCRC_PD13_Msk                           /*!< Pin PC13 Pull-Down set */
+#define PWR_PDCRC_PD14_Pos        (14U)
+#define PWR_PDCRC_PD14_Msk        (0x1UL << PWR_PDCRC_PD14_Pos)                /*!< 0x00004000 */
+#define PWR_PDCRC_PD14            PWR_PDCRC_PD14_Msk                           /*!< Pin PC14 Pull-Down set */
+#define PWR_PDCRC_PD15_Pos        (15U)
+#define PWR_PDCRC_PD15_Msk        (0x1UL << PWR_PDCRC_PD15_Pos)                /*!< 0x00008000 */
+#define PWR_PDCRC_PD15            PWR_PDCRC_PD15_Msk                           /*!< Pin PC15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRD register  *****************/
+#define PWR_PUCRD_PU0_Pos         (0U)
+#define PWR_PUCRD_PU0_Msk         (0x1UL << PWR_PUCRD_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRD_PU0             PWR_PUCRD_PU0_Msk                            /*!< Pin PD0 Pull-Up set */
+#define PWR_PUCRD_PU1_Pos         (1U)
+#define PWR_PUCRD_PU1_Msk         (0x1UL << PWR_PUCRD_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRD_PU1             PWR_PUCRD_PU1_Msk                            /*!< Pin PD1 Pull-Up set */
+#define PWR_PUCRD_PU2_Pos         (2U)
+#define PWR_PUCRD_PU2_Msk         (0x1UL << PWR_PUCRD_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRD_PU2             PWR_PUCRD_PU2_Msk                            /*!< Pin PD2 Pull-Up set */
+#define PWR_PUCRD_PU3_Pos         (3U)
+#define PWR_PUCRD_PU3_Msk         (0x1UL << PWR_PUCRD_PU3_Pos)                 /*!< 0x00000008 */
+#define PWR_PUCRD_PU3             PWR_PUCRD_PU3_Msk                            /*!< Pin PD3 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRD register  *****************/
+#define PWR_PDCRD_PD0_Pos         (0U)
+#define PWR_PDCRD_PD0_Msk         (0x1UL << PWR_PDCRD_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRD_PD0             PWR_PDCRD_PD0_Msk                            /*!< Pin PD0 Pull-Down set */
+#define PWR_PDCRD_PD1_Pos         (1U)
+#define PWR_PDCRD_PD1_Msk         (0x1UL << PWR_PDCRD_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRD_PD1             PWR_PDCRD_PD1_Msk                            /*!< Pin PD1 Pull-Down set */
+#define PWR_PDCRD_PD2_Pos         (2U)
+#define PWR_PDCRD_PD2_Msk         (0x1UL << PWR_PDCRD_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRD_PD2             PWR_PDCRD_PD2_Msk                            /*!< Pin PD2 Pull-Down set */
+#define PWR_PDCRD_PD3_Pos         (3U)
+#define PWR_PDCRD_PD3_Msk         (0x1UL << PWR_PDCRD_PD3_Pos)                 /*!< 0x00000008 */
+#define PWR_PDCRD_PD3             PWR_PDCRD_PD3_Msk                            /*!< Pin PD3 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRF register  *****************/
+#define PWR_PUCRF_PU0_Pos         (0U)
+#define PWR_PUCRF_PU0_Msk         (0x1UL << PWR_PUCRF_PU0_Pos)                 /*!< 0x00000001 */
+#define PWR_PUCRF_PU0             PWR_PUCRF_PU0_Msk                            /*!< Pin PF0 Pull-Up set */
+#define PWR_PUCRF_PU1_Pos         (1U)
+#define PWR_PUCRF_PU1_Msk         (0x1UL << PWR_PUCRF_PU1_Pos)                 /*!< 0x00000002 */
+#define PWR_PUCRF_PU1             PWR_PUCRF_PU1_Msk                            /*!< Pin PF1 Pull-Up set */
+#define PWR_PUCRF_PU2_Pos         (2U)
+#define PWR_PUCRF_PU2_Msk         (0x1UL << PWR_PUCRF_PU2_Pos)                 /*!< 0x00000004 */
+#define PWR_PUCRF_PU2             PWR_PUCRF_PU2_Msk                            /*!< Pin PF2 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRF register  *****************/
+#define PWR_PDCRF_PD0_Pos         (0U)
+#define PWR_PDCRF_PD0_Msk         (0x1UL << PWR_PDCRF_PD0_Pos)                 /*!< 0x00000001 */
+#define PWR_PDCRF_PD0             PWR_PDCRF_PD0_Msk                            /*!< Pin PF0 Pull-Down set */
+#define PWR_PDCRF_PD1_Pos         (1U)
+#define PWR_PDCRF_PD1_Msk         (0x1UL << PWR_PDCRF_PD1_Pos)                 /*!< 0x00000002 */
+#define PWR_PDCRF_PD1             PWR_PDCRF_PD1_Msk                            /*!< Pin PF1 Pull-Down set */
+#define PWR_PDCRF_PD2_Pos         (2U)
+#define PWR_PDCRF_PD2_Msk         (0x1UL << PWR_PDCRF_PD2_Pos)                 /*!< 0x00000004 */
+#define PWR_PDCRF_PD2             PWR_PDCRF_PD2_Msk                            /*!< Pin PF2 Pull-Down set */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Reset and Clock Control                          */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
+*/
+#define RCC_PLLQ_SUPPORT
+
+/********************  Bit definition for RCC_CR register  *****************/
+#define RCC_CR_HSION_Pos                 (8U)
+#define RCC_CR_HSION_Msk                 (0x1UL << RCC_CR_HSION_Pos)           /*!< 0x00000100 */
+#define RCC_CR_HSION                     RCC_CR_HSION_Msk                      /*!< Internal High Speed clock enable */
+#define RCC_CR_HSIKERON_Pos              (9U)
+#define RCC_CR_HSIKERON_Msk              (0x1UL << RCC_CR_HSIKERON_Pos)        /*!< 0x00000200 */
+#define RCC_CR_HSIKERON                  RCC_CR_HSIKERON_Msk                   /*!< Internal High Speed clock enable for some IPs Kernel */
+#define RCC_CR_HSIRDY_Pos                (10U)
+#define RCC_CR_HSIRDY_Msk                (0x1UL << RCC_CR_HSIRDY_Pos)          /*!< 0x00000400 */
+#define RCC_CR_HSIRDY                    RCC_CR_HSIRDY_Msk                     /*!< Internal High Speed clock ready flag */
+#define RCC_CR_HSIDIV_Pos                (11U)
+#define RCC_CR_HSIDIV_Msk                (0x7UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00003800 */
+#define RCC_CR_HSIDIV                    RCC_CR_HSIDIV_Msk                     /*!< HSIDIV[13:11] Internal High Speed clock division factor */
+#define RCC_CR_HSIDIV_0                  (0x1UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00000800 */
+#define RCC_CR_HSIDIV_1                  (0x2UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00001000 */
+#define RCC_CR_HSIDIV_2                  (0x4UL << RCC_CR_HSIDIV_Pos)          /*!< 0x00002000 */
+#define RCC_CR_HSEON_Pos                 (16U)
+#define RCC_CR_HSEON_Msk                 (0x1UL << RCC_CR_HSEON_Pos)           /*!< 0x00010000 */
+#define RCC_CR_HSEON                     RCC_CR_HSEON_Msk                      /*!< External High Speed clock enable */
+#define RCC_CR_HSERDY_Pos                (17U)
+#define RCC_CR_HSERDY_Msk                (0x1UL << RCC_CR_HSERDY_Pos)          /*!< 0x00020000 */
+#define RCC_CR_HSERDY                    RCC_CR_HSERDY_Msk                     /*!< External High Speed clock ready */
+#define RCC_CR_HSEBYP_Pos                (18U)
+#define RCC_CR_HSEBYP_Msk                (0x1UL << RCC_CR_HSEBYP_Pos)          /*!< 0x00040000 */
+#define RCC_CR_HSEBYP                    RCC_CR_HSEBYP_Msk                     /*!< External High Speed clock Bypass */
+#define RCC_CR_CSSON_Pos                 (19U)
+#define RCC_CR_CSSON_Msk                 (0x1UL << RCC_CR_CSSON_Pos)           /*!< 0x00080000 */
+#define RCC_CR_CSSON                     RCC_CR_CSSON_Msk                      /*!< HSE Clock Security System enable */
+
+#define RCC_CR_PLLON_Pos                 (24U)
+#define RCC_CR_PLLON_Msk                 (0x1UL << RCC_CR_PLLON_Pos)           /*!< 0x01000000 */
+#define RCC_CR_PLLON                     RCC_CR_PLLON_Msk                      /*!< System PLL clock enable */
+#define RCC_CR_PLLRDY_Pos                (25U)
+#define RCC_CR_PLLRDY_Msk                (0x1UL << RCC_CR_PLLRDY_Pos)          /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                    RCC_CR_PLLRDY_Msk                     /*!< System PLL clock ready */
+
+/********************  Bit definition for RCC_ICSCR register  ***************/
+/*!< HSICAL configuration */
+#define RCC_ICSCR_HSICAL_Pos             (0U)
+#define RCC_ICSCR_HSICAL_Msk             (0xFFUL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x000000FF */
+#define RCC_ICSCR_HSICAL                 RCC_ICSCR_HSICAL_Msk                  /*!< HSICAL[7:0] bits */
+#define RCC_ICSCR_HSICAL_0               (0x01UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000001 */
+#define RCC_ICSCR_HSICAL_1               (0x02UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000002 */
+#define RCC_ICSCR_HSICAL_2               (0x04UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000004 */
+#define RCC_ICSCR_HSICAL_3               (0x08UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000008 */
+#define RCC_ICSCR_HSICAL_4               (0x10UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000010 */
+#define RCC_ICSCR_HSICAL_5               (0x20UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000020 */
+#define RCC_ICSCR_HSICAL_6               (0x40UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000040 */
+#define RCC_ICSCR_HSICAL_7               (0x80UL << RCC_ICSCR_HSICAL_Pos)      /*!< 0x00000080 */
+
+/*!< HSITRIM configuration */
+#define RCC_ICSCR_HSITRIM_Pos            (8U)
+#define RCC_ICSCR_HSITRIM_Msk            (0x7FUL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00007F00 */
+#define RCC_ICSCR_HSITRIM                RCC_ICSCR_HSITRIM_Msk                 /*!< HSITRIM[14:8] bits */
+#define RCC_ICSCR_HSITRIM_0              (0x01UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000100 */
+#define RCC_ICSCR_HSITRIM_1              (0x02UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000200 */
+#define RCC_ICSCR_HSITRIM_2              (0x04UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000400 */
+#define RCC_ICSCR_HSITRIM_3              (0x08UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00000800 */
+#define RCC_ICSCR_HSITRIM_4              (0x10UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00001000 */
+#define RCC_ICSCR_HSITRIM_5              (0x20UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00002000 */
+#define RCC_ICSCR_HSITRIM_6              (0x40UL << RCC_ICSCR_HSITRIM_Pos)     /*!< 0x00004000 */
+
+/********************  Bit definition for RCC_CFGR register  ***************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                (0U)
+#define RCC_CFGR_SW_Msk                (0x7UL << RCC_CFGR_SW_Pos)              /*!< 0x00000007 */
+#define RCC_CFGR_SW                    RCC_CFGR_SW_Msk                         /*!< SW[2:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                  (0x1UL << RCC_CFGR_SW_Pos)              /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                  (0x2UL << RCC_CFGR_SW_Pos)              /*!< 0x00000002 */
+#define RCC_CFGR_SW_2                  (0x4UL << RCC_CFGR_SW_Pos)              /*!< 0x00000004 */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos               (3U)
+#define RCC_CFGR_SWS_Msk               (0x7UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000038 */
+#define RCC_CFGR_SWS                   RCC_CFGR_SWS_Msk                        /*!< SWS[2:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                 (0x1UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000008 */
+#define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
+#define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos              (8U)
+#define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
+#define RCC_CFGR_HPRE                  RCC_CFGR_HPRE_Msk                       /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                (0x1UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000100 */
+#define RCC_CFGR_HPRE_1                (0x2UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000200 */
+#define RCC_CFGR_HPRE_2                (0x4UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000400 */
+#define RCC_CFGR_HPRE_3                (0x8UL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000800 */
+
+/*!< PPRE configuration */
+#define RCC_CFGR_PPRE_Pos              (12U)
+#define RCC_CFGR_PPRE_Msk              (0x7UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00007000 */
+#define RCC_CFGR_PPRE                  RCC_CFGR_PPRE_Msk                       /*!< PRE1[2:0] bits (APB prescaler) */
+#define RCC_CFGR_PPRE_0                (0x1UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00001000 */
+#define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
+#define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
+
+
+/*!< MCOSEL configuration */
+#define RCC_CFGR_MCOSEL_Pos            (24U)
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
+#define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
+#define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
+#define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
+#define RCC_CFGR_MCOSEL_2              (0x4UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x04000000 */
+
+/*!< MCO Prescaler configuration */
+#define RCC_CFGR_MCOPRE_Pos            (28U)
+#define RCC_CFGR_MCOPRE_Msk            (0x7UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE                RCC_CFGR_MCOPRE_Msk                     /*!< MCO prescaler [2:0] */
+#define RCC_CFGR_MCOPRE_0              (0x1UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x10000000 */
+#define RCC_CFGR_MCOPRE_1              (0x2UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x20000000 */
+#define RCC_CFGR_MCOPRE_2              (0x4UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLSRC_Pos           (0U)
+#define RCC_PLLCFGR_PLLSRC_Msk           (0x3UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC               RCC_PLLCFGR_PLLSRC_Msk
+#define RCC_PLLCFGR_PLLSRC_0             (0x1UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLSRC_1             (0x2UL << RCC_PLLCFGR_PLLSRC_Pos)     /*!< 0x00000002 */
+
+#define RCC_PLLCFGR_PLLSRC_NONE          (0x00000000UL)                        /*!< No clock sent to PLL      */
+#define RCC_PLLCFGR_PLLSRC_HSI_Pos       (1U)
+#define RCC_PLLCFGR_PLLSRC_HSI_Msk       (0x1UL << RCC_PLLCFGR_PLLSRC_HSI_Pos) /*!< 0x00000002 */
+#define RCC_PLLCFGR_PLLSRC_HSI           RCC_PLLCFGR_PLLSRC_HSI_Msk            /*!< HSI source clock selected */
+#define RCC_PLLCFGR_PLLSRC_HSE_Pos       (0U)
+#define RCC_PLLCFGR_PLLSRC_HSE_Msk       (0x3UL << RCC_PLLCFGR_PLLSRC_HSE_Pos) /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC_HSE           RCC_PLLCFGR_PLLSRC_HSE_Msk            /*!< HSE source clock selected */
+
+#define RCC_PLLCFGR_PLLM_Pos             (4U)
+#define RCC_PLLCFGR_PLLM_Msk             (0x7UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000070 */
+#define RCC_PLLCFGR_PLLM                 RCC_PLLCFGR_PLLM_Msk
+#define RCC_PLLCFGR_PLLM_0               (0x1UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_1               (0x2UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000020 */
+#define RCC_PLLCFGR_PLLM_2               (0x4UL << RCC_PLLCFGR_PLLM_Pos)       /*!< 0x00000040 */
+
+#define RCC_PLLCFGR_PLLN_Pos             (8U)
+#define RCC_PLLCFGR_PLLN_Msk             (0x7FUL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00007F00 */
+#define RCC_PLLCFGR_PLLN                 RCC_PLLCFGR_PLLN_Msk
+#define RCC_PLLCFGR_PLLN_0               (0x01UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_1               (0x02UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_2               (0x04UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_3               (0x08UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_4               (0x10UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_5               (0x20UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_6               (0x40UL << RCC_PLLCFGR_PLLN_Pos)      /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLPEN_Pos           (16U)
+#define RCC_PLLCFGR_PLLPEN_Msk           (0x1UL << RCC_PLLCFGR_PLLPEN_Pos)     /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLPEN               RCC_PLLCFGR_PLLPEN_Msk
+
+#define RCC_PLLCFGR_PLLP_Pos              (17U)
+#define RCC_PLLCFGR_PLLP_Msk              (0x1FUL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x003E0000 */
+#define RCC_PLLCFGR_PLLP                  RCC_PLLCFGR_PLLP_Msk
+#define RCC_PLLCFGR_PLLP_0                (0x01UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00020000 */
+#define RCC_PLLCFGR_PLLP_1                (0x02UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00040000 */
+#define RCC_PLLCFGR_PLLP_2                (0x04UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00080000 */
+#define RCC_PLLCFGR_PLLP_3                (0x08UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00100000 */
+#define RCC_PLLCFGR_PLLP_4                (0x10UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00200000 */
+
+#define RCC_PLLCFGR_PLLQEN_Pos           (24U)
+#define RCC_PLLCFGR_PLLQEN_Msk           (0x1UL << RCC_PLLCFGR_PLLQEN_Pos)     /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQEN               RCC_PLLCFGR_PLLQEN_Msk
+
+#define RCC_PLLCFGR_PLLQ_Pos             (25U)
+#define RCC_PLLCFGR_PLLQ_Msk             (0x7UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x0E000000 */
+#define RCC_PLLCFGR_PLLQ                 RCC_PLLCFGR_PLLQ_Msk
+#define RCC_PLLCFGR_PLLQ_0               (0x1UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_1               (0x2UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_2               (0x4UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x08000000 */
+
+#define RCC_PLLCFGR_PLLREN_Pos           (28U)
+#define RCC_PLLCFGR_PLLREN_Msk           (0x1UL << RCC_PLLCFGR_PLLREN_Pos)     /*!< 0x10000000 */
+#define RCC_PLLCFGR_PLLREN               RCC_PLLCFGR_PLLREN_Msk
+
+#define RCC_PLLCFGR_PLLR_Pos             (29U)
+#define RCC_PLLCFGR_PLLR_Msk             (0x7UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0xE0000000 */
+#define RCC_PLLCFGR_PLLR                 RCC_PLLCFGR_PLLR_Msk
+#define RCC_PLLCFGR_PLLR_0               (0x1UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x20000000 */
+#define RCC_PLLCFGR_PLLR_1               (0x2UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x40000000 */
+#define RCC_PLLCFGR_PLLR_2               (0x4UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIER register  ******************/
+#define RCC_CIER_LSIRDYIE_Pos            (0U)
+#define RCC_CIER_LSIRDYIE_Msk            (0x1UL << RCC_CIER_LSIRDYIE_Pos)      /*!< 0x00000001 */
+#define RCC_CIER_LSIRDYIE                RCC_CIER_LSIRDYIE_Msk
+#define RCC_CIER_LSERDYIE_Pos            (1U)
+#define RCC_CIER_LSERDYIE_Msk            (0x1UL << RCC_CIER_LSERDYIE_Pos)      /*!< 0x00000002 */
+#define RCC_CIER_LSERDYIE                RCC_CIER_LSERDYIE_Msk
+#define RCC_CIER_HSIRDYIE_Pos            (3U)
+#define RCC_CIER_HSIRDYIE_Msk            (0x1UL << RCC_CIER_HSIRDYIE_Pos)      /*!< 0x00000008 */
+#define RCC_CIER_HSIRDYIE                RCC_CIER_HSIRDYIE_Msk
+#define RCC_CIER_HSERDYIE_Pos            (4U)
+#define RCC_CIER_HSERDYIE_Msk            (0x1UL << RCC_CIER_HSERDYIE_Pos)      /*!< 0x00000010 */
+#define RCC_CIER_HSERDYIE                RCC_CIER_HSERDYIE_Msk
+#define RCC_CIER_PLLRDYIE_Pos            (5U)
+#define RCC_CIER_PLLRDYIE_Msk            (0x1UL << RCC_CIER_PLLRDYIE_Pos)      /*!< 0x00000020 */
+#define RCC_CIER_PLLRDYIE                RCC_CIER_PLLRDYIE_Msk
+
+/********************  Bit definition for RCC_CIFR register  ******************/
+#define RCC_CIFR_LSIRDYF_Pos             (0U)
+#define RCC_CIFR_LSIRDYF_Msk             (0x1UL << RCC_CIFR_LSIRDYF_Pos)       /*!< 0x00000001 */
+#define RCC_CIFR_LSIRDYF                 RCC_CIFR_LSIRDYF_Msk
+#define RCC_CIFR_LSERDYF_Pos             (1U)
+#define RCC_CIFR_LSERDYF_Msk             (0x1UL << RCC_CIFR_LSERDYF_Pos)       /*!< 0x00000002 */
+#define RCC_CIFR_LSERDYF                 RCC_CIFR_LSERDYF_Msk
+#define RCC_CIFR_HSIRDYF_Pos             (3U)
+#define RCC_CIFR_HSIRDYF_Msk             (0x1UL << RCC_CIFR_HSIRDYF_Pos)       /*!< 0x00000008 */
+#define RCC_CIFR_HSIRDYF                 RCC_CIFR_HSIRDYF_Msk
+#define RCC_CIFR_HSERDYF_Pos             (4U)
+#define RCC_CIFR_HSERDYF_Msk             (0x1UL << RCC_CIFR_HSERDYF_Pos)       /*!< 0x00000010 */
+#define RCC_CIFR_HSERDYF                 RCC_CIFR_HSERDYF_Msk
+#define RCC_CIFR_PLLRDYF_Pos             (5U)
+#define RCC_CIFR_PLLRDYF_Msk             (0x1UL << RCC_CIFR_PLLRDYF_Pos)       /*!< 0x00000020 */
+#define RCC_CIFR_PLLRDYF                 RCC_CIFR_PLLRDYF_Msk
+#define RCC_CIFR_CSSF_Pos                (8U)
+#define RCC_CIFR_CSSF_Msk                (0x1UL << RCC_CIFR_CSSF_Pos)          /*!< 0x00000100 */
+#define RCC_CIFR_CSSF                    RCC_CIFR_CSSF_Msk
+#define RCC_CIFR_LSECSSF_Pos             (9U)
+#define RCC_CIFR_LSECSSF_Msk             (0x1UL << RCC_CIFR_LSECSSF_Pos)       /*!< 0x00000200 */
+#define RCC_CIFR_LSECSSF                 RCC_CIFR_LSECSSF_Msk
+
+/********************  Bit definition for RCC_CICR register  ******************/
+#define RCC_CICR_LSIRDYC_Pos             (0U)
+#define RCC_CICR_LSIRDYC_Msk             (0x1UL << RCC_CICR_LSIRDYC_Pos)       /*!< 0x00000001 */
+#define RCC_CICR_LSIRDYC                 RCC_CICR_LSIRDYC_Msk
+#define RCC_CICR_LSERDYC_Pos             (1U)
+#define RCC_CICR_LSERDYC_Msk             (0x1UL << RCC_CICR_LSERDYC_Pos)       /*!< 0x00000002 */
+#define RCC_CICR_LSERDYC                 RCC_CICR_LSERDYC_Msk
+#define RCC_CICR_HSIRDYC_Pos             (3U)
+#define RCC_CICR_HSIRDYC_Msk             (0x1UL << RCC_CICR_HSIRDYC_Pos)       /*!< 0x00000008 */
+#define RCC_CICR_HSIRDYC                 RCC_CICR_HSIRDYC_Msk
+#define RCC_CICR_HSERDYC_Pos             (4U)
+#define RCC_CICR_HSERDYC_Msk             (0x1UL << RCC_CICR_HSERDYC_Pos)       /*!< 0x00000010 */
+#define RCC_CICR_HSERDYC                 RCC_CICR_HSERDYC_Msk
+#define RCC_CICR_PLLRDYC_Pos             (5U)
+#define RCC_CICR_PLLRDYC_Msk             (0x1UL << RCC_CICR_PLLRDYC_Pos)       /*!< 0x00000020 */
+#define RCC_CICR_PLLRDYC                 RCC_CICR_PLLRDYC_Msk
+#define RCC_CICR_CSSC_Pos                (8U)
+#define RCC_CICR_CSSC_Msk                (0x1UL << RCC_CICR_CSSC_Pos)          /*!< 0x00000100 */
+#define RCC_CICR_CSSC                    RCC_CICR_CSSC_Msk
+#define RCC_CICR_LSECSSC_Pos             (9U)
+#define RCC_CICR_LSECSSC_Msk             (0x1UL << RCC_CICR_LSECSSC_Pos)       /*!< 0x00000200 */
+#define RCC_CICR_LSECSSC                 RCC_CICR_LSECSSC_Msk
+
+/********************  Bit definition for RCC_IOPRSTR register  ****************/
+#define RCC_IOPRSTR_GPIOARST_Pos         (0U)
+#define RCC_IOPRSTR_GPIOARST_Msk         (0x1UL << RCC_IOPRSTR_GPIOARST_Pos)   /*!< 0x00000001 */
+#define RCC_IOPRSTR_GPIOARST             RCC_IOPRSTR_GPIOARST_Msk
+#define RCC_IOPRSTR_GPIOBRST_Pos         (1U)
+#define RCC_IOPRSTR_GPIOBRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOBRST_Pos)   /*!< 0x00000002 */
+#define RCC_IOPRSTR_GPIOBRST             RCC_IOPRSTR_GPIOBRST_Msk
+#define RCC_IOPRSTR_GPIOCRST_Pos         (2U)
+#define RCC_IOPRSTR_GPIOCRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOCRST_Pos)   /*!< 0x00000004 */
+#define RCC_IOPRSTR_GPIOCRST             RCC_IOPRSTR_GPIOCRST_Msk
+#define RCC_IOPRSTR_GPIODRST_Pos         (3U)
+#define RCC_IOPRSTR_GPIODRST_Msk         (0x1UL << RCC_IOPRSTR_GPIODRST_Pos)   /*!< 0x00000008 */
+#define RCC_IOPRSTR_GPIODRST             RCC_IOPRSTR_GPIODRST_Msk
+#define RCC_IOPRSTR_GPIOFRST_Pos         (5U)
+#define RCC_IOPRSTR_GPIOFRST_Msk         (0x1UL << RCC_IOPRSTR_GPIOFRST_Pos)   /*!< 0x00000020 */
+#define RCC_IOPRSTR_GPIOFRST             RCC_IOPRSTR_GPIOFRST_Msk
+
+/********************  Bit definition for RCC_AHBRSTR register  ***************/
+#define RCC_AHBRSTR_DMA1RST_Pos          (0U)
+#define RCC_AHBRSTR_DMA1RST_Msk          (0x1UL << RCC_AHBRSTR_DMA1RST_Pos)    /*!< 0x00000001 */
+#define RCC_AHBRSTR_DMA1RST              RCC_AHBRSTR_DMA1RST_Msk
+#define RCC_AHBRSTR_FLASHRST_Pos         (8U)
+#define RCC_AHBRSTR_FLASHRST_Msk         (0x1UL << RCC_AHBRSTR_FLASHRST_Pos)   /*!< 0x00000100 */
+#define RCC_AHBRSTR_FLASHRST             RCC_AHBRSTR_FLASHRST_Msk
+#define RCC_AHBRSTR_CRCRST_Pos           (12U)
+#define RCC_AHBRSTR_CRCRST_Msk           (0x1UL << RCC_AHBRSTR_CRCRST_Pos)     /*!< 0x00001000 */
+#define RCC_AHBRSTR_CRCRST               RCC_AHBRSTR_CRCRST_Msk
+#define RCC_AHBRSTR_AESRST_Pos           (16U)
+#define RCC_AHBRSTR_AESRST_Msk           (0x1UL << RCC_AHBRSTR_AESRST_Pos)     /*!< 0x00010000 */
+#define RCC_AHBRSTR_AESRST               RCC_AHBRSTR_AESRST_Msk
+#define RCC_AHBRSTR_RNGRST_Pos           (18U)
+#define RCC_AHBRSTR_RNGRST_Msk           (0x1UL << RCC_AHBRSTR_RNGRST_Pos)     /*!< 0x00040000 */
+#define RCC_AHBRSTR_RNGRST               RCC_AHBRSTR_RNGRST_Msk
+
+/********************  Bit definition for RCC_APBRSTR1 register  **************/
+#define RCC_APBRSTR1_TIM2RST_Pos         (0U)
+#define RCC_APBRSTR1_TIM2RST_Msk         (0x1UL << RCC_APBRSTR1_TIM2RST_Pos)   /*!< 0x00000001 */
+#define RCC_APBRSTR1_TIM2RST             RCC_APBRSTR1_TIM2RST_Msk
+#define RCC_APBRSTR1_TIM3RST_Pos         (1U)
+#define RCC_APBRSTR1_TIM3RST_Msk         (0x1UL << RCC_APBRSTR1_TIM3RST_Pos)   /*!< 0x00000002 */
+#define RCC_APBRSTR1_TIM3RST             RCC_APBRSTR1_TIM3RST_Msk
+#define RCC_APBRSTR1_TIM6RST_Pos         (4U)
+#define RCC_APBRSTR1_TIM6RST_Msk         (0x1UL << RCC_APBRSTR1_TIM6RST_Pos)   /*!< 0x00000010 */
+#define RCC_APBRSTR1_TIM6RST             RCC_APBRSTR1_TIM6RST_Msk
+#define RCC_APBRSTR1_TIM7RST_Pos         (5U)
+#define RCC_APBRSTR1_TIM7RST_Msk         (0x1UL << RCC_APBRSTR1_TIM7RST_Pos)   /*!< 0x00000020 */
+#define RCC_APBRSTR1_TIM7RST             RCC_APBRSTR1_TIM7RST_Msk
+#define RCC_APBRSTR1_SPI2RST_Pos         (14U)
+#define RCC_APBRSTR1_SPI2RST_Msk         (0x1UL << RCC_APBRSTR1_SPI2RST_Pos)   /*!< 0x00004000 */
+#define RCC_APBRSTR1_SPI2RST             RCC_APBRSTR1_SPI2RST_Msk
+#define RCC_APBRSTR1_USART2RST_Pos       (17U)
+#define RCC_APBRSTR1_USART2RST_Msk       (0x1UL << RCC_APBRSTR1_USART2RST_Pos) /*!< 0x00020000 */
+#define RCC_APBRSTR1_USART2RST           RCC_APBRSTR1_USART2RST_Msk
+#define RCC_APBRSTR1_LPUART1RST_Pos      (20U)
+#define RCC_APBRSTR1_LPUART1RST_Msk      (0x1UL << RCC_APBRSTR1_LPUART1RST_Pos) /*!< 0x00100000 */
+#define RCC_APBRSTR1_LPUART1RST          RCC_APBRSTR1_LPUART1RST_Msk
+#define RCC_APBRSTR1_I2C1RST_Pos         (21U)
+#define RCC_APBRSTR1_I2C1RST_Msk         (0x1UL << RCC_APBRSTR1_I2C1RST_Pos)    /*!< 0x00200000 */
+#define RCC_APBRSTR1_I2C1RST             RCC_APBRSTR1_I2C1RST_Msk
+#define RCC_APBRSTR1_I2C2RST_Pos         (22U)
+#define RCC_APBRSTR1_I2C2RST_Msk         (0x1UL << RCC_APBRSTR1_I2C2RST_Pos)    /*!< 0x00400000 */
+#define RCC_APBRSTR1_I2C2RST             RCC_APBRSTR1_I2C2RST_Msk
+#define RCC_APBRSTR1_DBGRST_Pos          (27U)
+#define RCC_APBRSTR1_DBGRST_Msk          (0x1UL << RCC_APBRSTR1_DBGRST_Pos)     /*!< 0x08000000 */
+#define RCC_APBRSTR1_DBGRST              RCC_APBRSTR1_DBGRST_Msk
+#define RCC_APBRSTR1_PWRRST_Pos          (28U)
+#define RCC_APBRSTR1_PWRRST_Msk          (0x1UL << RCC_APBRSTR1_PWRRST_Pos)     /*!< 0x10000000 */
+#define RCC_APBRSTR1_PWRRST              RCC_APBRSTR1_PWRRST_Msk
+#define RCC_APBRSTR1_DAC1RST_Pos         (29U)
+#define RCC_APBRSTR1_DAC1RST_Msk         (0x1UL << RCC_APBRSTR1_DAC1RST_Pos)    /*!< 0x20000000 */
+#define RCC_APBRSTR1_DAC1RST             RCC_APBRSTR1_DAC1RST_Msk
+#define RCC_APBRSTR1_LPTIM2RST_Pos       (30U)
+#define RCC_APBRSTR1_LPTIM2RST_Msk       (0x1UL << RCC_APBRSTR1_LPTIM2RST_Pos)  /*!< 0x40000000 */
+#define RCC_APBRSTR1_LPTIM2RST           RCC_APBRSTR1_LPTIM2RST_Msk
+#define RCC_APBRSTR1_LPTIM1RST_Pos       (31U)
+#define RCC_APBRSTR1_LPTIM1RST_Msk       (0x1UL << RCC_APBRSTR1_LPTIM1RST_Pos)  /*!< 0x80000000 */
+#define RCC_APBRSTR1_LPTIM1RST           RCC_APBRSTR1_LPTIM1RST_Msk
+
+/********************  Bit definition for RCC_APBRSTR2 register  **************/
+#define RCC_APBRSTR2_SYSCFGRST_Pos       (0U)
+#define RCC_APBRSTR2_SYSCFGRST_Msk       (0x1UL << RCC_APBRSTR2_SYSCFGRST_Pos)  /*!< 0x00000001 */
+#define RCC_APBRSTR2_SYSCFGRST           RCC_APBRSTR2_SYSCFGRST_Msk
+#define RCC_APBRSTR2_TIM1RST_Pos         (11U)
+#define RCC_APBRSTR2_TIM1RST_Msk         (0x1UL << RCC_APBRSTR2_TIM1RST_Pos)    /*!< 0x00000800 */
+#define RCC_APBRSTR2_TIM1RST             RCC_APBRSTR2_TIM1RST_Msk
+#define RCC_APBRSTR2_SPI1RST_Pos         (12U)
+#define RCC_APBRSTR2_SPI1RST_Msk         (0x1UL << RCC_APBRSTR2_SPI1RST_Pos)    /*!< 0x00001000 */
+#define RCC_APBRSTR2_SPI1RST             RCC_APBRSTR2_SPI1RST_Msk
+#define RCC_APBRSTR2_USART1RST_Pos       (14U)
+#define RCC_APBRSTR2_USART1RST_Msk       (0x1UL << RCC_APBRSTR2_USART1RST_Pos)  /*!< 0x00004000 */
+#define RCC_APBRSTR2_USART1RST           RCC_APBRSTR2_USART1RST_Msk
+#define RCC_APBRSTR2_TIM14RST_Pos        (15U)
+#define RCC_APBRSTR2_TIM14RST_Msk        (0x1UL << RCC_APBRSTR2_TIM14RST_Pos)   /*!< 0x00008000 */
+#define RCC_APBRSTR2_TIM14RST            RCC_APBRSTR2_TIM14RST_Msk
+#define RCC_APBRSTR2_TIM15RST_Pos        (16U)
+#define RCC_APBRSTR2_TIM15RST_Msk        (0x1UL << RCC_APBRSTR2_TIM15RST_Pos)   /*!< 0x00010000 */
+#define RCC_APBRSTR2_TIM15RST            RCC_APBRSTR2_TIM15RST_Msk
+#define RCC_APBRSTR2_TIM16RST_Pos        (17U)
+#define RCC_APBRSTR2_TIM16RST_Msk        (0x1UL << RCC_APBRSTR2_TIM16RST_Pos)   /*!< 0x00020000 */
+#define RCC_APBRSTR2_TIM16RST            RCC_APBRSTR2_TIM16RST_Msk
+#define RCC_APBRSTR2_TIM17RST_Pos        (18U)
+#define RCC_APBRSTR2_TIM17RST_Msk        (0x1UL << RCC_APBRSTR2_TIM17RST_Pos)   /*!< 0x00040000 */
+#define RCC_APBRSTR2_TIM17RST            RCC_APBRSTR2_TIM17RST_Msk
+#define RCC_APBRSTR2_ADCRST_Pos          (20U)
+#define RCC_APBRSTR2_ADCRST_Msk          (0x1UL << RCC_APBRSTR2_ADCRST_Pos)     /*!< 0x00100000 */
+#define RCC_APBRSTR2_ADCRST              RCC_APBRSTR2_ADCRST_Msk
+
+/********************  Bit definition for RCC_IOPENR register  ****************/
+#define RCC_IOPENR_GPIOAEN_Pos           (0U)
+#define RCC_IOPENR_GPIOAEN_Msk           (0x1UL << RCC_IOPENR_GPIOAEN_Pos)      /*!< 0x00000001 */
+#define RCC_IOPENR_GPIOAEN               RCC_IOPENR_GPIOAEN_Msk
+#define RCC_IOPENR_GPIOBEN_Pos           (1U)
+#define RCC_IOPENR_GPIOBEN_Msk           (0x1UL << RCC_IOPENR_GPIOBEN_Pos)      /*!< 0x00000002 */
+#define RCC_IOPENR_GPIOBEN               RCC_IOPENR_GPIOBEN_Msk
+#define RCC_IOPENR_GPIOCEN_Pos           (2U)
+#define RCC_IOPENR_GPIOCEN_Msk           (0x1UL << RCC_IOPENR_GPIOCEN_Pos)      /*!< 0x00000004 */
+#define RCC_IOPENR_GPIOCEN               RCC_IOPENR_GPIOCEN_Msk
+#define RCC_IOPENR_GPIODEN_Pos           (3U)
+#define RCC_IOPENR_GPIODEN_Msk           (0x1UL << RCC_IOPENR_GPIODEN_Pos)      /*!< 0x00000008 */
+#define RCC_IOPENR_GPIODEN               RCC_IOPENR_GPIODEN_Msk
+#define RCC_IOPENR_GPIOFEN_Pos           (5U)
+#define RCC_IOPENR_GPIOFEN_Msk           (0x1UL << RCC_IOPENR_GPIOFEN_Pos)      /*!< 0x00000020 */
+#define RCC_IOPENR_GPIOFEN               RCC_IOPENR_GPIOFEN_Msk
+
+/********************  Bit definition for RCC_AHBENR register  ****************/
+#define RCC_AHBENR_DMA1EN_Pos            (0U)
+#define RCC_AHBENR_DMA1EN_Msk            (0x1UL << RCC_AHBENR_DMA1EN_Pos)       /*!< 0x00000001 */
+#define RCC_AHBENR_DMA1EN                RCC_AHBENR_DMA1EN_Msk
+#define RCC_AHBENR_FLASHEN_Pos           (8U)
+#define RCC_AHBENR_FLASHEN_Msk           (0x1UL << RCC_AHBENR_FLASHEN_Pos)      /*!< 0x00000100 */
+#define RCC_AHBENR_FLASHEN               RCC_AHBENR_FLASHEN_Msk
+#define RCC_AHBENR_CRCEN_Pos             (12U)
+#define RCC_AHBENR_CRCEN_Msk             (0x1UL << RCC_AHBENR_CRCEN_Pos)        /*!< 0x00001000 */
+#define RCC_AHBENR_CRCEN                 RCC_AHBENR_CRCEN_Msk
+#define RCC_AHBENR_AESEN_Pos             (16U)
+#define RCC_AHBENR_AESEN_Msk             (0x1UL << RCC_AHBENR_AESEN_Pos)        /*!< 0x00010000 */
+#define RCC_AHBENR_AESEN                 RCC_AHBENR_AESEN_Msk
+#define RCC_AHBENR_RNGEN_Pos             (18U)
+#define RCC_AHBENR_RNGEN_Msk             (0x1UL << RCC_AHBENR_RNGEN_Pos)        /*!< 0x00040000 */
+#define RCC_AHBENR_RNGEN                 RCC_AHBENR_RNGEN_Msk
+
+/********************  Bit definition for RCC_APBENR1 register  ***************/
+#define RCC_APBENR1_TIM2EN_Pos           (0U)
+#define RCC_APBENR1_TIM2EN_Msk           (0x1UL << RCC_APBENR1_TIM2EN_Pos)      /*!< 0x00000001 */
+#define RCC_APBENR1_TIM2EN               RCC_APBENR1_TIM2EN_Msk
+#define RCC_APBENR1_TIM3EN_Pos           (1U)
+#define RCC_APBENR1_TIM3EN_Msk           (0x1UL << RCC_APBENR1_TIM3EN_Pos)      /*!< 0x00000002 */
+#define RCC_APBENR1_TIM3EN               RCC_APBENR1_TIM3EN_Msk
+#define RCC_APBENR1_TIM6EN_Pos           (4U)
+#define RCC_APBENR1_TIM6EN_Msk           (0x1UL << RCC_APBENR1_TIM6EN_Pos)      /*!< 0x00000010 */
+#define RCC_APBENR1_TIM6EN               RCC_APBENR1_TIM6EN_Msk
+#define RCC_APBENR1_TIM7EN_Pos           (5U)
+#define RCC_APBENR1_TIM7EN_Msk           (0x1UL << RCC_APBENR1_TIM7EN_Pos)      /*!< 0x00000020 */
+#define RCC_APBENR1_TIM7EN               RCC_APBENR1_TIM7EN_Msk
+#define RCC_APBENR1_RTCAPBEN_Pos         (10U)
+#define RCC_APBENR1_RTCAPBEN_Msk         (0x1UL << RCC_APBENR1_RTCAPBEN_Pos)    /*!< 0x00000400 */
+#define RCC_APBENR1_RTCAPBEN             RCC_APBENR1_RTCAPBEN_Msk
+#define RCC_APBENR1_WWDGEN_Pos           (11U)
+#define RCC_APBENR1_WWDGEN_Msk           (0x1UL << RCC_APBENR1_WWDGEN_Pos)      /*!< 0x00000800 */
+#define RCC_APBENR1_WWDGEN               RCC_APBENR1_WWDGEN_Msk
+#define RCC_APBENR1_SPI2EN_Pos           (14U)
+#define RCC_APBENR1_SPI2EN_Msk           (0x1UL << RCC_APBENR1_SPI2EN_Pos)      /*!< 0x00004000 */
+#define RCC_APBENR1_SPI2EN               RCC_APBENR1_SPI2EN_Msk
+#define RCC_APBENR1_USART2EN_Pos         (17U)
+#define RCC_APBENR1_USART2EN_Msk         (0x1UL << RCC_APBENR1_USART2EN_Pos)    /*!< 0x00020000 */
+#define RCC_APBENR1_USART2EN             RCC_APBENR1_USART2EN_Msk
+#define RCC_APBENR1_LPUART1EN_Pos        (20U)
+#define RCC_APBENR1_LPUART1EN_Msk        (0x1UL << RCC_APBENR1_LPUART1EN_Pos)   /*!< 0x00100000 */
+#define RCC_APBENR1_LPUART1EN            RCC_APBENR1_LPUART1EN_Msk
+#define RCC_APBENR1_I2C1EN_Pos           (21U)
+#define RCC_APBENR1_I2C1EN_Msk           (0x1UL << RCC_APBENR1_I2C1EN_Pos)      /*!< 0x00200000 */
+#define RCC_APBENR1_I2C1EN               RCC_APBENR1_I2C1EN_Msk
+#define RCC_APBENR1_I2C2EN_Pos           (22U)
+#define RCC_APBENR1_I2C2EN_Msk           (0x1UL << RCC_APBENR1_I2C2EN_Pos)      /*!< 0x00400000 */
+#define RCC_APBENR1_I2C2EN               RCC_APBENR1_I2C2EN_Msk
+#define RCC_APBENR1_DBGEN_Pos            (27U)
+#define RCC_APBENR1_DBGEN_Msk            (0x1UL << RCC_APBENR1_DBGEN_Pos)       /*!< 0x08000000 */
+#define RCC_APBENR1_DBGEN                RCC_APBENR1_DBGEN_Msk
+#define RCC_APBENR1_PWREN_Pos            (28U)
+#define RCC_APBENR1_PWREN_Msk            (0x1UL << RCC_APBENR1_PWREN_Pos)       /*!< 0x10000000 */
+#define RCC_APBENR1_PWREN                RCC_APBENR1_PWREN_Msk
+#define RCC_APBENR1_DAC1EN_Pos           (29U)
+#define RCC_APBENR1_DAC1EN_Msk           (0x1UL << RCC_APBENR1_DAC1EN_Pos)      /*!< 0x20000000 */
+#define RCC_APBENR1_DAC1EN               RCC_APBENR1_DAC1EN_Msk
+#define RCC_APBENR1_LPTIM2EN_Pos         (30U)
+#define RCC_APBENR1_LPTIM2EN_Msk         (0x1UL << RCC_APBENR1_LPTIM2EN_Pos)    /*!< 0x40000000 */
+#define RCC_APBENR1_LPTIM2EN             RCC_APBENR1_LPTIM2EN_Msk
+#define RCC_APBENR1_LPTIM1EN_Pos         (31U)
+#define RCC_APBENR1_LPTIM1EN_Msk         (0x1UL << RCC_APBENR1_LPTIM1EN_Pos)    /*!< 0x80000000 */
+#define RCC_APBENR1_LPTIM1EN             RCC_APBENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_APBENR2 register  **************/
+#define RCC_APBENR2_SYSCFGEN_Pos         (0U)
+#define RCC_APBENR2_SYSCFGEN_Msk         (0x1UL << RCC_APBENR2_SYSCFGEN_Pos)    /*!< 0x00000001 */
+#define RCC_APBENR2_SYSCFGEN             RCC_APBENR2_SYSCFGEN_Msk
+#define RCC_APBENR2_TIM1EN_Pos           (11U)
+#define RCC_APBENR2_TIM1EN_Msk           (0x1UL << RCC_APBENR2_TIM1EN_Pos)      /*!< 0x00000800 */
+#define RCC_APBENR2_TIM1EN               RCC_APBENR2_TIM1EN_Msk
+#define RCC_APBENR2_SPI1EN_Pos           (12U)
+#define RCC_APBENR2_SPI1EN_Msk           (0x1UL << RCC_APBENR2_SPI1EN_Pos)      /*!< 0x00001000 */
+#define RCC_APBENR2_SPI1EN               RCC_APBENR2_SPI1EN_Msk
+#define RCC_APBENR2_USART1EN_Pos         (14U)
+#define RCC_APBENR2_USART1EN_Msk         (0x1UL << RCC_APBENR2_USART1EN_Pos)    /*!< 0x00004000 */
+#define RCC_APBENR2_USART1EN             RCC_APBENR2_USART1EN_Msk
+#define RCC_APBENR2_TIM14EN_Pos          (15U)
+#define RCC_APBENR2_TIM14EN_Msk          (0x1UL << RCC_APBENR2_TIM14EN_Pos)     /*!< 0x00008000 */
+#define RCC_APBENR2_TIM14EN              RCC_APBENR2_TIM14EN_Msk
+#define RCC_APBENR2_TIM15EN_Pos          (16U)
+#define RCC_APBENR2_TIM15EN_Msk          (0x1UL << RCC_APBENR2_TIM15EN_Pos)     /*!< 0x00010000 */
+#define RCC_APBENR2_TIM15EN              RCC_APBENR2_TIM15EN_Msk
+#define RCC_APBENR2_TIM16EN_Pos          (17U)
+#define RCC_APBENR2_TIM16EN_Msk          (0x1UL << RCC_APBENR2_TIM16EN_Pos)     /*!< 0x00020000 */
+#define RCC_APBENR2_TIM16EN              RCC_APBENR2_TIM16EN_Msk
+#define RCC_APBENR2_TIM17EN_Pos          (18U)
+#define RCC_APBENR2_TIM17EN_Msk          (0x1UL << RCC_APBENR2_TIM17EN_Pos)     /*!< 0x00040000 */
+#define RCC_APBENR2_TIM17EN              RCC_APBENR2_TIM17EN_Msk
+#define RCC_APBENR2_ADCEN_Pos            (20U)
+#define RCC_APBENR2_ADCEN_Msk            (0x1UL << RCC_APBENR2_ADCEN_Pos)       /*!< 0x00100000 */
+#define RCC_APBENR2_ADCEN                RCC_APBENR2_ADCEN_Msk
+
+/********************  Bit definition for RCC_IOPSMENR register  *************/
+#define RCC_IOPSMENR_GPIOASMEN_Pos       (0U)
+#define RCC_IOPSMENR_GPIOASMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOASMEN_Pos)  /*!< 0x00000001 */
+#define RCC_IOPSMENR_GPIOASMEN           RCC_IOPSMENR_GPIOASMEN_Msk
+#define RCC_IOPSMENR_GPIOBSMEN_Pos       (1U)
+#define RCC_IOPSMENR_GPIOBSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOBSMEN_Pos)  /*!< 0x00000002 */
+#define RCC_IOPSMENR_GPIOBSMEN           RCC_IOPSMENR_GPIOBSMEN_Msk
+#define RCC_IOPSMENR_GPIOCSMEN_Pos       (2U)
+#define RCC_IOPSMENR_GPIOCSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOCSMEN_Pos)  /*!< 0x00000004 */
+#define RCC_IOPSMENR_GPIOCSMEN           RCC_IOPSMENR_GPIOCSMEN_Msk
+#define RCC_IOPSMENR_GPIODSMEN_Pos       (3U)
+#define RCC_IOPSMENR_GPIODSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIODSMEN_Pos)  /*!< 0x00000008 */
+#define RCC_IOPSMENR_GPIODSMEN           RCC_IOPSMENR_GPIODSMEN_Msk
+#define RCC_IOPSMENR_GPIOFSMEN_Pos       (5U)
+#define RCC_IOPSMENR_GPIOFSMEN_Msk       (0x1UL << RCC_IOPSMENR_GPIOFSMEN_Pos)  /*!< 0x00000020 */
+#define RCC_IOPSMENR_GPIOFSMEN           RCC_IOPSMENR_GPIOFSMEN_Msk
+
+/********************  Bit definition for RCC_AHBSMENR register  *************/
+#define RCC_AHBSMENR_DMA1SMEN_Pos        (0U)
+#define RCC_AHBSMENR_DMA1SMEN_Msk        (0x1UL << RCC_AHBSMENR_DMA1SMEN_Pos)   /*!< 0x00000001 */
+#define RCC_AHBSMENR_DMA1SMEN            RCC_AHBSMENR_DMA1SMEN_Msk
+#define RCC_AHBSMENR_FLASHSMEN_Pos       (8U)
+#define RCC_AHBSMENR_FLASHSMEN_Msk       (0x1UL << RCC_AHBSMENR_FLASHSMEN_Pos)  /*!< 0x00000100 */
+#define RCC_AHBSMENR_FLASHSMEN           RCC_AHBSMENR_FLASHSMEN_Msk
+#define RCC_AHBSMENR_SRAMSMEN_Pos        (9U)
+#define RCC_AHBSMENR_SRAMSMEN_Msk        (0x1UL << RCC_AHBSMENR_SRAMSMEN_Pos)   /*!< 0x00000200 */
+#define RCC_AHBSMENR_SRAMSMEN            RCC_AHBSMENR_SRAMSMEN_Msk
+#define RCC_AHBSMENR_CRCSMEN_Pos         (12U)
+#define RCC_AHBSMENR_CRCSMEN_Msk         (0x1UL << RCC_AHBSMENR_CRCSMEN_Pos)    /*!< 0x00001000 */
+#define RCC_AHBSMENR_CRCSMEN             RCC_AHBSMENR_CRCSMEN_Msk
+#define RCC_AHBSMENR_AESSMEN_Pos         (16U)
+#define RCC_AHBSMENR_AESSMEN_Msk         (0x1UL << RCC_AHBSMENR_AESSMEN_Pos)    /*!< 0x00010000 */
+#define RCC_AHBSMENR_AESSMEN             RCC_AHBSMENR_AESSMEN_Msk
+#define RCC_AHBSMENR_RNGSMEN_Pos         (18U)
+#define RCC_AHBSMENR_RNGSMEN_Msk         (0x1UL << RCC_AHBSMENR_RNGSMEN_Pos)    /*!< 0x00040000 */
+#define RCC_AHBSMENR_RNGSMEN             RCC_AHBSMENR_RNGSMEN_Msk
+
+/********************  Bit definition for RCC_APBSMENR1 register  *************/
+#define RCC_APBSMENR1_TIM2SMEN_Pos       (0U)
+#define RCC_APBSMENR1_TIM2SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM2SMEN_Pos)  /*!< 0x00000001 */
+#define RCC_APBSMENR1_TIM2SMEN           RCC_APBSMENR1_TIM2SMEN_Msk
+#define RCC_APBSMENR1_TIM3SMEN_Pos       (1U)
+#define RCC_APBSMENR1_TIM3SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM3SMEN_Pos)  /*!< 0x00000002 */
+#define RCC_APBSMENR1_TIM3SMEN           RCC_APBSMENR1_TIM3SMEN_Msk
+#define RCC_APBSMENR1_TIM6SMEN_Pos       (4U)
+#define RCC_APBSMENR1_TIM6SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM6SMEN_Pos)  /*!< 0x00000010 */
+#define RCC_APBSMENR1_TIM6SMEN           RCC_APBSMENR1_TIM6SMEN_Msk
+#define RCC_APBSMENR1_TIM7SMEN_Pos       (5U)
+#define RCC_APBSMENR1_TIM7SMEN_Msk       (0x1UL << RCC_APBSMENR1_TIM7SMEN_Pos)  /*!< 0x00000020 */
+#define RCC_APBSMENR1_TIM7SMEN           RCC_APBSMENR1_TIM7SMEN_Msk
+#define RCC_APBSMENR1_RTCAPBSMEN_Pos     (10U)
+#define RCC_APBSMENR1_RTCAPBSMEN_Msk     (0x1UL << RCC_APBSMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_APBSMENR1_RTCAPBSMEN         RCC_APBSMENR1_RTCAPBSMEN_Msk
+#define RCC_APBSMENR1_WWDGSMEN_Pos       (11U)
+#define RCC_APBSMENR1_WWDGSMEN_Msk       (0x1UL << RCC_APBSMENR1_WWDGSMEN_Pos)   /*!< 0x00000800 */
+#define RCC_APBSMENR1_WWDGSMEN           RCC_APBSMENR1_WWDGSMEN_Msk
+#define RCC_APBSMENR1_SPI2SMEN_Pos       (14U)
+#define RCC_APBSMENR1_SPI2SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI2SMEN_Pos)   /*!< 0x00004000 */
+#define RCC_APBSMENR1_SPI2SMEN           RCC_APBSMENR1_SPI2SMEN_Msk
+#define RCC_APBSMENR1_USART2SMEN_Pos     (17U)
+#define RCC_APBSMENR1_USART2SMEN_Msk     (0x1UL << RCC_APBSMENR1_USART2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_APBSMENR1_USART2SMEN         RCC_APBSMENR1_USART2SMEN_Msk
+#define RCC_APBSMENR1_LPUART1SMEN_Pos    (20U)
+#define RCC_APBSMENR1_LPUART1SMEN_Msk    (0x1UL << RCC_APBSMENR1_LPUART1SMEN_Pos) /*!< 0x00100000 */
+#define RCC_APBSMENR1_LPUART1SMEN        RCC_APBSMENR1_LPUART1SMEN_Msk
+#define RCC_APBSMENR1_I2C1SMEN_Pos       (21U)
+#define RCC_APBSMENR1_I2C1SMEN_Msk       (0x1UL << RCC_APBSMENR1_I2C1SMEN_Pos)   /*!< 0x00200000 */
+#define RCC_APBSMENR1_I2C1SMEN           RCC_APBSMENR1_I2C1SMEN_Msk
+#define RCC_APBSMENR1_I2C2SMEN_Pos       (22U)
+#define RCC_APBSMENR1_I2C2SMEN_Msk       (0x1UL << RCC_APBSMENR1_I2C2SMEN_Pos)   /*!< 0x00400000 */
+#define RCC_APBSMENR1_I2C2SMEN           RCC_APBSMENR1_I2C2SMEN_Msk
+#define RCC_APBSMENR1_DBGSMEN_Pos        (27U)
+#define RCC_APBSMENR1_DBGSMEN_Msk        (0x1UL << RCC_APBSMENR1_DBGSMEN_Pos)    /*!< 0x08000000 */
+#define RCC_APBSMENR1_DBGSMEN            RCC_APBSMENR1_DBGSMEN_Msk
+#define RCC_APBSMENR1_PWRSMEN_Pos        (28U)
+#define RCC_APBSMENR1_PWRSMEN_Msk        (0x1UL << RCC_APBSMENR1_PWRSMEN_Pos)    /*!< 0x10000000 */
+#define RCC_APBSMENR1_PWRSMEN            RCC_APBSMENR1_PWRSMEN_Msk
+#define RCC_APBSMENR1_DAC1SMEN_Pos       (29U)
+#define RCC_APBSMENR1_DAC1SMEN_Msk       (0x1UL << RCC_APBSMENR1_DAC1SMEN_Pos)   /*!< 0x20000000 */
+#define RCC_APBSMENR1_DAC1SMEN           RCC_APBSMENR1_DAC1SMEN_Msk
+#define RCC_APBSMENR1_LPTIM2SMEN_Pos     (30U)
+#define RCC_APBSMENR1_LPTIM2SMEN_Msk     (0x1UL << RCC_APBSMENR1_LPTIM2SMEN_Pos) /*!< 0x40000000 */
+#define RCC_APBSMENR1_LPTIM2SMEN         RCC_APBSMENR1_LPTIM2SMEN_Msk
+#define RCC_APBSMENR1_LPTIM1SMEN_Pos     (31U)
+#define RCC_APBSMENR1_LPTIM1SMEN_Msk     (0x1UL << RCC_APBSMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_APBSMENR1_LPTIM1SMEN         RCC_APBSMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_APBSMENR2 register  *************/
+#define RCC_APBSMENR2_SYSCFGSMEN_Pos     (0U)
+#define RCC_APBSMENR2_SYSCFGSMEN_Msk     (0x1UL << RCC_APBSMENR2_SYSCFGSMEN_Pos) /*!< 0x00000001 */
+#define RCC_APBSMENR2_SYSCFGSMEN         RCC_APBSMENR2_SYSCFGSMEN_Msk
+#define RCC_APBSMENR2_TIM1SMEN_Pos       (11U)
+#define RCC_APBSMENR2_TIM1SMEN_Msk       (0x1UL << RCC_APBSMENR2_TIM1SMEN_Pos)  /*!< 0x00000800 */
+#define RCC_APBSMENR2_TIM1SMEN           RCC_APBSMENR2_TIM1SMEN_Msk
+#define RCC_APBSMENR2_SPI1SMEN_Pos       (12U)
+#define RCC_APBSMENR2_SPI1SMEN_Msk       (0x1UL << RCC_APBSMENR2_SPI1SMEN_Pos)  /*!< 0x00001000 */
+#define RCC_APBSMENR2_SPI1SMEN           RCC_APBSMENR2_SPI1SMEN_Msk
+#define RCC_APBSMENR2_USART1SMEN_Pos     (14U)
+#define RCC_APBSMENR2_USART1SMEN_Msk     (0x1UL << RCC_APBSMENR2_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_APBSMENR2_USART1SMEN         RCC_APBSMENR2_USART1SMEN_Msk
+#define RCC_APBSMENR2_TIM14SMEN_Pos      (15U)
+#define RCC_APBSMENR2_TIM14SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM14SMEN_Pos) /*!< 0x00008000 */
+#define RCC_APBSMENR2_TIM14SMEN          RCC_APBSMENR2_TIM14SMEN_Msk
+#define RCC_APBSMENR2_TIM15SMEN_Pos      (16U)
+#define RCC_APBSMENR2_TIM15SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM15SMEN_Pos) /*!< 0x00010000 */
+#define RCC_APBSMENR2_TIM15SMEN          RCC_APBSMENR2_TIM15SMEN_Msk
+#define RCC_APBSMENR2_TIM16SMEN_Pos      (17U)
+#define RCC_APBSMENR2_TIM16SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM16SMEN_Pos) /*!< 0x00020000 */
+#define RCC_APBSMENR2_TIM16SMEN          RCC_APBSMENR2_TIM16SMEN_Msk
+#define RCC_APBSMENR2_TIM17SMEN_Pos      (18U)
+#define RCC_APBSMENR2_TIM17SMEN_Msk      (0x1UL << RCC_APBSMENR2_TIM17SMEN_Pos) /*!< 0x00040000 */
+#define RCC_APBSMENR2_TIM17SMEN          RCC_APBSMENR2_TIM17SMEN_Msk
+#define RCC_APBSMENR2_ADCSMEN_Pos        (20U)
+#define RCC_APBSMENR2_ADCSMEN_Msk        (0x1UL << RCC_APBSMENR2_ADCSMEN_Pos)   /*!< 0x00100000 */
+#define RCC_APBSMENR2_ADCSMEN            RCC_APBSMENR2_ADCSMEN_Msk
+
+/********************  Bit definition for RCC_CCIPR register  ******************/
+#define RCC_CCIPR_USART1SEL_Pos          (0U)
+#define RCC_CCIPR_USART1SEL_Msk          (0x3UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000003 */
+#define RCC_CCIPR_USART1SEL              RCC_CCIPR_USART1SEL_Msk
+#define RCC_CCIPR_USART1SEL_0            (0x1UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000001 */
+#define RCC_CCIPR_USART1SEL_1            (0x2UL << RCC_CCIPR_USART1SEL_Pos)     /*!< 0x00000002 */
+
+
+
+#define RCC_CCIPR_LPUART1SEL_Pos         (10U)
+#define RCC_CCIPR_LPUART1SEL_Msk         (0x3UL << RCC_CCIPR_LPUART1SEL_Pos)    /*!< 0x00000C00 */
+#define RCC_CCIPR_LPUART1SEL             RCC_CCIPR_LPUART1SEL_Msk
+#define RCC_CCIPR_LPUART1SEL_0           (0x1UL << RCC_CCIPR_LPUART1SEL_Pos)    /*!< 0x00000400 */
+#define RCC_CCIPR_LPUART1SEL_1           (0x2UL << RCC_CCIPR_LPUART1SEL_Pos)    /*!< 0x00000800 */
+
+#define RCC_CCIPR_I2C1SEL_Pos            (12U)
+#define RCC_CCIPR_I2C1SEL_Msk            (0x3UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00003000 */
+#define RCC_CCIPR_I2C1SEL                RCC_CCIPR_I2C1SEL_Msk
+#define RCC_CCIPR_I2C1SEL_0              (0x1UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00001000 */
+#define RCC_CCIPR_I2C1SEL_1              (0x2UL << RCC_CCIPR_I2C1SEL_Pos)       /*!< 0x00002000 */
+
+#define RCC_CCIPR_I2S1SEL_Pos            (14U)
+#define RCC_CCIPR_I2S1SEL_Msk            (0x3UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x0000C000 */
+#define RCC_CCIPR_I2S1SEL                RCC_CCIPR_I2S1SEL_Msk
+#define RCC_CCIPR_I2S1SEL_0              (0x1UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x00004000 */
+#define RCC_CCIPR_I2S1SEL_1              (0x2UL << RCC_CCIPR_I2S1SEL_Pos)       /*!< 0x00008000 */
+
+#define RCC_CCIPR_LPTIM1SEL_Pos          (18U)
+#define RCC_CCIPR_LPTIM1SEL_Msk          (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x000C0000 */
+#define RCC_CCIPR_LPTIM1SEL              RCC_CCIPR_LPTIM1SEL_Msk
+#define RCC_CCIPR_LPTIM1SEL_0            (0x1UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x00040000 */
+#define RCC_CCIPR_LPTIM1SEL_1            (0x2UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x00080000 */
+
+#define RCC_CCIPR_LPTIM2SEL_Pos          (20U)
+#define RCC_CCIPR_LPTIM2SEL_Msk          (0x3UL << RCC_CCIPR_LPTIM2SEL_Pos)     /*!< 0x00300000 */
+#define RCC_CCIPR_LPTIM2SEL              RCC_CCIPR_LPTIM2SEL_Msk
+#define RCC_CCIPR_LPTIM2SEL_0            (0x1UL << RCC_CCIPR_LPTIM2SEL_Pos)     /*!< 0x00100000 */
+#define RCC_CCIPR_LPTIM2SEL_1            (0x2UL << RCC_CCIPR_LPTIM2SEL_Pos)     /*!< 0x00200000 */
+
+#define RCC_CCIPR_TIM1SEL_Pos            (22U)
+#define RCC_CCIPR_TIM1SEL_Msk            (0x1UL << RCC_CCIPR_TIM1SEL_Pos)       /*!< 0x00400000 */
+#define RCC_CCIPR_TIM1SEL                RCC_CCIPR_TIM1SEL_Msk
+
+#define RCC_CCIPR_TIM15SEL_Pos           (24U)
+#define RCC_CCIPR_TIM15SEL_Msk           (0x1UL << RCC_CCIPR_TIM15SEL_Pos)      /*!< 0x01000000 */
+#define RCC_CCIPR_TIM15SEL               RCC_CCIPR_TIM15SEL_Msk
+
+#define RCC_CCIPR_RNGSEL_Pos             (26U)
+#define RCC_CCIPR_RNGSEL_Msk             (0x3UL << RCC_CCIPR_RNGSEL_Pos)        /*!< 0x0C000000 */
+#define RCC_CCIPR_RNGSEL                 RCC_CCIPR_RNGSEL_Msk
+#define RCC_CCIPR_RNGSEL_0               (0x1UL << RCC_CCIPR_RNGSEL_Pos)        /*!< 0x04000000 */
+#define RCC_CCIPR_RNGSEL_1               (0x2UL << RCC_CCIPR_RNGSEL_Pos)        /*!< 0x08000000 */
+
+#define RCC_CCIPR_RNGDIV_Pos             (28U)
+#define RCC_CCIPR_RNGDIV_Msk             (0x3UL << RCC_CCIPR_RNGDIV_Pos)        /*!< 0x30000000 */
+#define RCC_CCIPR_RNGDIV                 RCC_CCIPR_RNGDIV_Msk
+#define RCC_CCIPR_RNGDIV_0               (0x1UL << RCC_CCIPR_RNGDIV_Pos)        /*!< 0x10000000 */
+#define RCC_CCIPR_RNGDIV_1               (0x2UL << RCC_CCIPR_RNGDIV_Pos)        /*!< 0x20000000 */
+
+#define RCC_CCIPR_ADCSEL_Pos             (30U)
+#define RCC_CCIPR_ADCSEL_Msk             (0x3UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0xC0000000 */
+#define RCC_CCIPR_ADCSEL                 RCC_CCIPR_ADCSEL_Msk
+#define RCC_CCIPR_ADCSEL_0               (0x1UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0x40000000 */
+#define RCC_CCIPR_ADCSEL_1               (0x2UL << RCC_CCIPR_ADCSEL_Pos)        /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos               (0U)
+#define RCC_BDCR_LSEON_Msk               (0x1UL << RCC_BDCR_LSEON_Pos)          /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                   RCC_BDCR_LSEON_Msk
+#define RCC_BDCR_LSERDY_Pos              (1U)
+#define RCC_BDCR_LSERDY_Msk              (0x1UL << RCC_BDCR_LSERDY_Pos)         /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                  RCC_BDCR_LSERDY_Msk
+#define RCC_BDCR_LSEBYP_Pos              (2U)
+#define RCC_BDCR_LSEBYP_Msk              (0x1UL << RCC_BDCR_LSEBYP_Pos)         /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                  RCC_BDCR_LSEBYP_Msk
+
+#define RCC_BDCR_LSEDRV_Pos              (3U)
+#define RCC_BDCR_LSEDRV_Msk              (0x3UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000018 */
+#define RCC_BDCR_LSEDRV                  RCC_BDCR_LSEDRV_Msk
+#define RCC_BDCR_LSEDRV_0                (0x1UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000008 */
+#define RCC_BDCR_LSEDRV_1                (0x2UL << RCC_BDCR_LSEDRV_Pos)         /*!< 0x00000010 */
+
+#define RCC_BDCR_LSECSSON_Pos            (5U)
+#define RCC_BDCR_LSECSSON_Msk            (0x1UL << RCC_BDCR_LSECSSON_Pos)       /*!< 0x00000020 */
+#define RCC_BDCR_LSECSSON                RCC_BDCR_LSECSSON_Msk
+#define RCC_BDCR_LSECSSD_Pos             (6U)
+#define RCC_BDCR_LSECSSD_Msk             (0x1UL << RCC_BDCR_LSECSSD_Pos)        /*!< 0x00000040 */
+#define RCC_BDCR_LSECSSD                 RCC_BDCR_LSECSSD_Msk
+
+#define RCC_BDCR_RTCSEL_Pos              (8U)
+#define RCC_BDCR_RTCSEL_Msk              (0x3UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                  RCC_BDCR_RTCSEL_Msk
+#define RCC_BDCR_RTCSEL_0                (0x1UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                (0x2UL << RCC_BDCR_RTCSEL_Pos)         /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos               (15U)
+#define RCC_BDCR_RTCEN_Msk               (0x1UL << RCC_BDCR_RTCEN_Pos)          /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                   RCC_BDCR_RTCEN_Msk
+#define RCC_BDCR_BDRST_Pos               (16U)
+#define RCC_BDCR_BDRST_Msk               (0x1UL << RCC_BDCR_BDRST_Pos)          /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                   RCC_BDCR_BDRST_Msk
+
+#define RCC_BDCR_LSCOEN_Pos              (24U)
+#define RCC_BDCR_LSCOEN_Msk              (0x1UL << RCC_BDCR_LSCOEN_Pos)         /*!< 0x01000000 */
+#define RCC_BDCR_LSCOEN                  RCC_BDCR_LSCOEN_Msk
+#define RCC_BDCR_LSCOSEL_Pos             (25U)
+#define RCC_BDCR_LSCOSEL_Msk             (0x1UL << RCC_BDCR_LSCOSEL_Pos)        /*!< 0x02000000 */
+#define RCC_BDCR_LSCOSEL                 RCC_BDCR_LSCOSEL_Msk
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSION_Pos                (0U)
+#define RCC_CSR_LSION_Msk                (0x1UL << RCC_CSR_LSION_Pos)           /*!< 0x00000001 */
+#define RCC_CSR_LSION                    RCC_CSR_LSION_Msk
+#define RCC_CSR_LSIRDY_Pos               (1U)
+#define RCC_CSR_LSIRDY_Msk               (0x1UL << RCC_CSR_LSIRDY_Pos)          /*!< 0x00000002 */
+#define RCC_CSR_LSIRDY                   RCC_CSR_LSIRDY_Msk
+
+#define RCC_CSR_RMVF_Pos                 (23U)
+#define RCC_CSR_RMVF_Msk                 (0x1UL << RCC_CSR_RMVF_Pos)            /*!< 0x00800000 */
+#define RCC_CSR_RMVF                     RCC_CSR_RMVF_Msk
+#define RCC_CSR_OBLRSTF_Pos              (25U)
+#define RCC_CSR_OBLRSTF_Msk              (0x1UL << RCC_CSR_OBLRSTF_Pos)         /*!< 0x02000000 */
+#define RCC_CSR_OBLRSTF                  RCC_CSR_OBLRSTF_Msk
+#define RCC_CSR_PINRSTF_Pos              (26U)
+#define RCC_CSR_PINRSTF_Msk              (0x1UL << RCC_CSR_PINRSTF_Pos)         /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                  RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_PWRRSTF_Pos              (27U)
+#define RCC_CSR_PWRRSTF_Msk              (0x1UL << RCC_CSR_PWRRSTF_Pos)         /*!< 0x08000000 */
+#define RCC_CSR_PWRRSTF                  RCC_CSR_PWRRSTF_Msk
+#define RCC_CSR_SFTRSTF_Pos              (28U)
+#define RCC_CSR_SFTRSTF_Msk              (0x1UL << RCC_CSR_SFTRSTF_Pos)         /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                  RCC_CSR_SFTRSTF_Msk
+#define RCC_CSR_IWDGRSTF_Pos             (29U)
+#define RCC_CSR_IWDGRSTF_Msk             (0x1UL << RCC_CSR_IWDGRSTF_Pos)        /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                 RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos             (30U)
+#define RCC_CSR_WWDGRSTF_Msk             (0x1UL << RCC_CSR_WWDGRSTF_Pos)        /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                 RCC_CSR_WWDGRSTF_Msk
+#define RCC_CSR_LPWRRSTF_Pos             (31U)
+#define RCC_CSR_LPWRRSTF_Msk             (0x1UL << RCC_CSR_LPWRRSTF_Pos)        /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                 RCC_CSR_LPWRRSTF_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RNG_CR register  *******************/
+#define RNG_CR_RNGEN_Pos    (2U)
+#define RNG_CR_RNGEN_Msk    (0x1UL << RNG_CR_RNGEN_Pos)                         /*!< 0x00000004 */
+#define RNG_CR_RNGEN        RNG_CR_RNGEN_Msk
+#define RNG_CR_IE_Pos       (3U)
+#define RNG_CR_IE_Msk       (0x1UL << RNG_CR_IE_Pos)                            /*!< 0x00000008 */
+#define RNG_CR_IE           RNG_CR_IE_Msk
+#define RNG_CR_CED_Pos      (5U)
+#define RNG_CR_CED_Msk      (0x1UL << RNG_CR_CED_Pos)                           /*!< 0x00000020 */
+#define RNG_CR_CED          RNG_CR_CED_Msk
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY_Pos     (0U)
+#define RNG_SR_DRDY_Msk     (0x1UL << RNG_SR_DRDY_Pos)                          /*!< 0x00000001 */
+#define RNG_SR_DRDY         RNG_SR_DRDY_Msk
+#define RNG_SR_CECS_Pos     (1U)
+#define RNG_SR_CECS_Msk     (0x1UL << RNG_SR_CECS_Pos)                          /*!< 0x00000002 */
+#define RNG_SR_CECS         RNG_SR_CECS_Msk
+#define RNG_SR_SECS_Pos     (2U)
+#define RNG_SR_SECS_Msk     (0x1UL << RNG_SR_SECS_Pos)                          /*!< 0x00000004 */
+#define RNG_SR_SECS         RNG_SR_SECS_Msk
+#define RNG_SR_CEIS_Pos     (5U)
+#define RNG_SR_CEIS_Msk     (0x1UL << RNG_SR_CEIS_Pos)                          /*!< 0x00000020 */
+#define RNG_SR_CEIS         RNG_SR_CEIS_Msk
+#define RNG_SR_SEIS_Pos     (6U)
+#define RNG_SR_SEIS_Msk     (0x1UL << RNG_SR_SEIS_Pos)                          /*!< 0x00000040 */
+#define RNG_SR_SEIS         RNG_SR_SEIS_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+* @brief Specific device feature definitions
+*/
+#define RTC_WAKEUP_SUPPORT
+#define RTC_BACKUP_SUPPORT
+
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                (22U)
+#define RTC_TR_PM_Msk                (0x1UL << RTC_TR_PM_Pos)                   /*!< 0x00400000 */
+#define RTC_TR_PM                    RTC_TR_PM_Msk
+#define RTC_TR_HT_Pos                (20U)
+#define RTC_TR_HT_Msk                (0x3UL << RTC_TR_HT_Pos)                   /*!< 0x00300000 */
+#define RTC_TR_HT                    RTC_TR_HT_Msk
+#define RTC_TR_HT_0                  (0x1UL << RTC_TR_HT_Pos)                   /*!< 0x00100000 */
+#define RTC_TR_HT_1                  (0x2UL << RTC_TR_HT_Pos)                   /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                (16U)
+#define RTC_TR_HU_Msk                (0xFUL << RTC_TR_HU_Pos)                   /*!< 0x000F0000 */
+#define RTC_TR_HU                    RTC_TR_HU_Msk
+#define RTC_TR_HU_0                  (0x1UL << RTC_TR_HU_Pos)                   /*!< 0x00010000 */
+#define RTC_TR_HU_1                  (0x2UL << RTC_TR_HU_Pos)                   /*!< 0x00020000 */
+#define RTC_TR_HU_2                  (0x4UL << RTC_TR_HU_Pos)                   /*!< 0x00040000 */
+#define RTC_TR_HU_3                  (0x8UL << RTC_TR_HU_Pos)                   /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos               (12U)
+#define RTC_TR_MNT_Msk               (0x7UL << RTC_TR_MNT_Pos)                  /*!< 0x00007000 */
+#define RTC_TR_MNT                   RTC_TR_MNT_Msk
+#define RTC_TR_MNT_0                 (0x1UL << RTC_TR_MNT_Pos)                  /*!< 0x00001000 */
+#define RTC_TR_MNT_1                 (0x2UL << RTC_TR_MNT_Pos)                  /*!< 0x00002000 */
+#define RTC_TR_MNT_2                 (0x4UL << RTC_TR_MNT_Pos)                  /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos               (8U)
+#define RTC_TR_MNU_Msk               (0xFUL << RTC_TR_MNU_Pos)                  /*!< 0x00000F00 */
+#define RTC_TR_MNU                   RTC_TR_MNU_Msk
+#define RTC_TR_MNU_0                 (0x1UL << RTC_TR_MNU_Pos)                  /*!< 0x00000100 */
+#define RTC_TR_MNU_1                 (0x2UL << RTC_TR_MNU_Pos)                  /*!< 0x00000200 */
+#define RTC_TR_MNU_2                 (0x4UL << RTC_TR_MNU_Pos)                  /*!< 0x00000400 */
+#define RTC_TR_MNU_3                 (0x8UL << RTC_TR_MNU_Pos)                  /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                (4U)
+#define RTC_TR_ST_Msk                (0x7UL << RTC_TR_ST_Pos)                   /*!< 0x00000070 */
+#define RTC_TR_ST                    RTC_TR_ST_Msk
+#define RTC_TR_ST_0                  (0x1UL << RTC_TR_ST_Pos)                   /*!< 0x00000010 */
+#define RTC_TR_ST_1                  (0x2UL << RTC_TR_ST_Pos)                   /*!< 0x00000020 */
+#define RTC_TR_ST_2                  (0x4UL << RTC_TR_ST_Pos)                   /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                (0U)
+#define RTC_TR_SU_Msk                (0xFUL << RTC_TR_SU_Pos)                   /*!< 0x0000000F */
+#define RTC_TR_SU                    RTC_TR_SU_Msk
+#define RTC_TR_SU_0                  (0x1UL << RTC_TR_SU_Pos)                   /*!< 0x00000001 */
+#define RTC_TR_SU_1                  (0x2UL << RTC_TR_SU_Pos)                   /*!< 0x00000002 */
+#define RTC_TR_SU_2                  (0x4UL << RTC_TR_SU_Pos)                   /*!< 0x00000004 */
+#define RTC_TR_SU_3                  (0x8UL << RTC_TR_SU_Pos)                   /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                (20U)
+#define RTC_DR_YT_Msk                (0xFUL << RTC_DR_YT_Pos)                   /*!< 0x00F00000 */
+#define RTC_DR_YT                    RTC_DR_YT_Msk
+#define RTC_DR_YT_0                  (0x1UL << RTC_DR_YT_Pos)                   /*!< 0x00100000 */
+#define RTC_DR_YT_1                  (0x2UL << RTC_DR_YT_Pos)                   /*!< 0x00200000 */
+#define RTC_DR_YT_2                  (0x4UL << RTC_DR_YT_Pos)                   /*!< 0x00400000 */
+#define RTC_DR_YT_3                  (0x8UL << RTC_DR_YT_Pos)                   /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                (16U)
+#define RTC_DR_YU_Msk                (0xFUL << RTC_DR_YU_Pos)                   /*!< 0x000F0000 */
+#define RTC_DR_YU                    RTC_DR_YU_Msk
+#define RTC_DR_YU_0                  (0x1UL << RTC_DR_YU_Pos)                   /*!< 0x00010000 */
+#define RTC_DR_YU_1                  (0x2UL << RTC_DR_YU_Pos)                   /*!< 0x00020000 */
+#define RTC_DR_YU_2                  (0x4UL << RTC_DR_YU_Pos)                   /*!< 0x00040000 */
+#define RTC_DR_YU_3                  (0x8UL << RTC_DR_YU_Pos)                   /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos               (13U)
+#define RTC_DR_WDU_Msk               (0x7UL << RTC_DR_WDU_Pos)                  /*!< 0x0000E000 */
+#define RTC_DR_WDU                   RTC_DR_WDU_Msk
+#define RTC_DR_WDU_0                 (0x1UL << RTC_DR_WDU_Pos)                  /*!< 0x00002000 */
+#define RTC_DR_WDU_1                 (0x2UL << RTC_DR_WDU_Pos)                  /*!< 0x00004000 */
+#define RTC_DR_WDU_2                 (0x4UL << RTC_DR_WDU_Pos)                  /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                (12U)
+#define RTC_DR_MT_Msk                (0x1UL << RTC_DR_MT_Pos)                   /*!< 0x00001000 */
+#define RTC_DR_MT                    RTC_DR_MT_Msk
+#define RTC_DR_MU_Pos                (8U)
+#define RTC_DR_MU_Msk                (0xFUL << RTC_DR_MU_Pos)                   /*!< 0x00000F00 */
+#define RTC_DR_MU                    RTC_DR_MU_Msk
+#define RTC_DR_MU_0                  (0x1UL << RTC_DR_MU_Pos)                   /*!< 0x00000100 */
+#define RTC_DR_MU_1                  (0x2UL << RTC_DR_MU_Pos)                   /*!< 0x00000200 */
+#define RTC_DR_MU_2                  (0x4UL << RTC_DR_MU_Pos)                   /*!< 0x00000400 */
+#define RTC_DR_MU_3                  (0x8UL << RTC_DR_MU_Pos)                   /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                (4U)
+#define RTC_DR_DT_Msk                (0x3UL << RTC_DR_DT_Pos)                   /*!< 0x00000030 */
+#define RTC_DR_DT                    RTC_DR_DT_Msk
+#define RTC_DR_DT_0                  (0x1UL << RTC_DR_DT_Pos)                   /*!< 0x00000010 */
+#define RTC_DR_DT_1                  (0x2UL << RTC_DR_DT_Pos)                   /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                (0U)
+#define RTC_DR_DU_Msk                (0xFUL << RTC_DR_DU_Pos)                   /*!< 0x0000000F */
+#define RTC_DR_DU                    RTC_DR_DU_Msk
+#define RTC_DR_DU_0                  (0x1UL << RTC_DR_DU_Pos)                   /*!< 0x00000001 */
+#define RTC_DR_DU_1                  (0x2UL << RTC_DR_DU_Pos)                   /*!< 0x00000002 */
+#define RTC_DR_DU_2                  (0x4UL << RTC_DR_DU_Pos)                   /*!< 0x00000004 */
+#define RTC_DR_DU_3                  (0x8UL << RTC_DR_DU_Pos)                   /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos               (0U)
+#define RTC_SSR_SS_Msk               (0xFFFFUL << RTC_SSR_SS_Pos)               /*!< 0x0000FFFF */
+#define RTC_SSR_SS                   RTC_SSR_SS_Msk
+
+/********************  Bits definition for RTC_ICSR register  ******************/
+#define RTC_ICSR_RECALPF_Pos         (16U)
+#define RTC_ICSR_RECALPF_Msk         (0x1UL << RTC_ICSR_RECALPF_Pos)            /*!< 0x00010000 */
+#define RTC_ICSR_RECALPF             RTC_ICSR_RECALPF_Msk
+#define RTC_ICSR_INIT_Pos            (7U)
+#define RTC_ICSR_INIT_Msk            (0x1UL << RTC_ICSR_INIT_Pos)               /*!< 0x00000080 */
+#define RTC_ICSR_INIT                RTC_ICSR_INIT_Msk
+#define RTC_ICSR_INITF_Pos           (6U)
+#define RTC_ICSR_INITF_Msk           (0x1UL << RTC_ICSR_INITF_Pos)              /*!< 0x00000040 */
+#define RTC_ICSR_INITF               RTC_ICSR_INITF_Msk
+#define RTC_ICSR_RSF_Pos             (5U)
+#define RTC_ICSR_RSF_Msk             (0x1UL << RTC_ICSR_RSF_Pos)                /*!< 0x00000020 */
+#define RTC_ICSR_RSF                 RTC_ICSR_RSF_Msk
+#define RTC_ICSR_INITS_Pos           (4U)
+#define RTC_ICSR_INITS_Msk           (0x1UL << RTC_ICSR_INITS_Pos)              /*!< 0x00000010 */
+#define RTC_ICSR_INITS               RTC_ICSR_INITS_Msk
+#define RTC_ICSR_SHPF_Pos            (3U)
+#define RTC_ICSR_SHPF_Msk            (0x1UL << RTC_ICSR_SHPF_Pos)               /*!< 0x00000008 */
+#define RTC_ICSR_SHPF                RTC_ICSR_SHPF_Msk
+#define RTC_ICSR_WUTWF_Pos           (2U)
+#define RTC_ICSR_WUTWF_Msk           (0x1UL << RTC_ICSR_WUTWF_Pos)              /*!< 0x00000004 */
+#define RTC_ICSR_WUTWF               RTC_ICSR_WUTWF_Msk                         /*!< Wakeup timer write flag > */
+#define RTC_ICSR_ALRBWF_Pos          (1U)
+#define RTC_ICSR_ALRBWF_Msk          (0x1UL << RTC_ICSR_ALRBWF_Pos)             /*!< 0x00000002 */
+#define RTC_ICSR_ALRBWF              RTC_ICSR_ALRBWF_Msk
+#define RTC_ICSR_ALRAWF_Pos          (0U)
+#define RTC_ICSR_ALRAWF_Msk          (0x1UL << RTC_ICSR_ALRAWF_Pos)             /*!< 0x00000001 */
+#define RTC_ICSR_ALRAWF              RTC_ICSR_ALRAWF_Msk
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos        (16U)
+#define RTC_PRER_PREDIV_A_Msk        (0x7FUL << RTC_PRER_PREDIV_A_Pos)          /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A            RTC_PRER_PREDIV_A_Msk
+#define RTC_PRER_PREDIV_S_Pos        (0U)
+#define RTC_PRER_PREDIV_S_Msk        (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)        /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S            RTC_PRER_PREDIV_S_Msk
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos             (0U)
+#define RTC_WUTR_WUT_Msk             (0xFFFFUL << RTC_WUTR_WUT_Pos)            /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                 RTC_WUTR_WUT_Msk                          /*!< Wakeup auto-reload value bits > */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_OUT2EN_Pos            (31U)
+#define RTC_CR_OUT2EN_Msk            (0x1UL << RTC_CR_OUT2EN_Pos)              /*!< 0x80000000 */
+#define RTC_CR_OUT2EN                RTC_CR_OUT2EN_Msk                         /*!< RTC_OUT2 output enable */
+#define RTC_CR_TAMPALRM_TYPE_Pos     (30U)
+#define RTC_CR_TAMPALRM_TYPE_Msk     (0x1UL << RTC_CR_TAMPALRM_TYPE_Pos)       /*!< 0x40000000 */
+#define RTC_CR_TAMPALRM_TYPE         RTC_CR_TAMPALRM_TYPE_Msk                  /*!< TAMPALARM output type  */
+#define RTC_CR_TAMPALRM_PU_Pos       (29U)
+#define RTC_CR_TAMPALRM_PU_Msk       (0x1UL << RTC_CR_TAMPALRM_PU_Pos)         /*!< 0x20000000 */
+#define RTC_CR_TAMPALRM_PU           RTC_CR_TAMPALRM_PU_Msk                    /*!< TAMPALARM output pull-up config */
+#define RTC_CR_TAMPOE_Pos            (26U)
+#define RTC_CR_TAMPOE_Msk            (0x1UL << RTC_CR_TAMPOE_Pos)              /*!< 0x04000000 */
+#define RTC_CR_TAMPOE                RTC_CR_TAMPOE_Msk                         /*!< Tamper detection output enable on TAMPALARM  */
+#define RTC_CR_TAMPTS_Pos            (25U)
+#define RTC_CR_TAMPTS_Msk            (0x1UL << RTC_CR_TAMPTS_Pos)              /*!< 0x02000000 */
+#define RTC_CR_TAMPTS                RTC_CR_TAMPTS_Msk                         /*!< Activate timestamp on tamper detection event  */
+#define RTC_CR_ITSE_Pos              (24U)
+#define RTC_CR_ITSE_Msk              (0x1UL << RTC_CR_ITSE_Pos)                /*!< 0x01000000 */
+#define RTC_CR_ITSE                  RTC_CR_ITSE_Msk                           /*!< Timestamp on internal event enable  */
+#define RTC_CR_COE_Pos               (23U)
+#define RTC_CR_COE_Msk               (0x1UL << RTC_CR_COE_Pos)                 /*!< 0x00800000 */
+#define RTC_CR_COE                   RTC_CR_COE_Msk
+#define RTC_CR_OSEL_Pos              (21U)
+#define RTC_CR_OSEL_Msk              (0x3UL << RTC_CR_OSEL_Pos)                 /*!< 0x00600000 */
+#define RTC_CR_OSEL                  RTC_CR_OSEL_Msk
+#define RTC_CR_OSEL_0                (0x1UL << RTC_CR_OSEL_Pos)                 /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                (0x2UL << RTC_CR_OSEL_Pos)                 /*!< 0x00400000 */
+#define RTC_CR_POL_Pos               (20U)
+#define RTC_CR_POL_Msk               (0x1UL << RTC_CR_POL_Pos)                  /*!< 0x00100000 */
+#define RTC_CR_POL                   RTC_CR_POL_Msk
+#define RTC_CR_COSEL_Pos             (19U)
+#define RTC_CR_COSEL_Msk             (0x1UL << RTC_CR_COSEL_Pos)                /*!< 0x00080000 */
+#define RTC_CR_COSEL                 RTC_CR_COSEL_Msk
+#define RTC_CR_BKP_Pos               (18U)
+#define RTC_CR_BKP_Msk               (0x1UL << RTC_CR_BKP_Pos)                  /*!< 0x00040000 */
+#define RTC_CR_BKP                   RTC_CR_BKP_Msk
+#define RTC_CR_SUB1H_Pos             (17U)
+#define RTC_CR_SUB1H_Msk             (0x1UL << RTC_CR_SUB1H_Pos)                /*!< 0x00020000 */
+#define RTC_CR_SUB1H                 RTC_CR_SUB1H_Msk
+#define RTC_CR_ADD1H_Pos             (16U)
+#define RTC_CR_ADD1H_Msk             (0x1UL << RTC_CR_ADD1H_Pos)                /*!< 0x00010000 */
+#define RTC_CR_ADD1H                 RTC_CR_ADD1H_Msk
+#define RTC_CR_TSIE_Pos              (15U)
+#define RTC_CR_TSIE_Msk              (0x1UL << RTC_CR_TSIE_Pos)                /*!< 0x00008000 */
+#define RTC_CR_TSIE                  RTC_CR_TSIE_Msk                           /*!< Timestamp interrupt enable > */
+#define RTC_CR_WUTIE_Pos             (14U)
+#define RTC_CR_WUTIE_Msk             (0x1UL << RTC_CR_WUTIE_Pos)               /*!< 0x00004000 */
+#define RTC_CR_WUTIE                 RTC_CR_WUTIE_Msk                          /*!< Wakeup timer interrupt enable > */
+#define RTC_CR_ALRBIE_Pos            (13U)
+#define RTC_CR_ALRBIE_Msk            (0x1UL << RTC_CR_ALRBIE_Pos)              /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                RTC_CR_ALRBIE_Msk
+#define RTC_CR_ALRAIE_Pos            (12U)
+#define RTC_CR_ALRAIE_Msk            (0x1UL << RTC_CR_ALRAIE_Pos)              /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                RTC_CR_ALRAIE_Msk
+#define RTC_CR_TSE_Pos               (11U)
+#define RTC_CR_TSE_Msk               (0x1UL << RTC_CR_TSE_Pos)                 /*!< 0x00000800 */
+#define RTC_CR_TSE                   RTC_CR_TSE_Msk                            /*!< timestamp enable > */
+#define RTC_CR_WUTE_Pos              (10U)
+#define RTC_CR_WUTE_Msk              (0x1UL << RTC_CR_WUTE_Pos)                /*!< 0x00000400 */
+#define RTC_CR_WUTE                  RTC_CR_WUTE_Msk                           /*!< Wakeup timer enable > */
+#define RTC_CR_ALRBE_Pos             (9U)
+#define RTC_CR_ALRBE_Msk             (0x1UL << RTC_CR_ALRBE_Pos)               /*!< 0x00000200 */
+#define RTC_CR_ALRBE                 RTC_CR_ALRBE_Msk
+#define RTC_CR_ALRAE_Pos             (8U)
+#define RTC_CR_ALRAE_Msk             (0x1UL << RTC_CR_ALRAE_Pos)                /*!< 0x00000100 */
+#define RTC_CR_ALRAE                 RTC_CR_ALRAE_Msk
+#define RTC_CR_FMT_Pos               (6U)
+#define RTC_CR_FMT_Msk               (0x1UL << RTC_CR_FMT_Pos)                  /*!< 0x00000040 */
+#define RTC_CR_FMT                   RTC_CR_FMT_Msk
+#define RTC_CR_BYPSHAD_Pos           (5U)
+#define RTC_CR_BYPSHAD_Msk           (0x1UL << RTC_CR_BYPSHAD_Pos)              /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD               RTC_CR_BYPSHAD_Msk
+#define RTC_CR_REFCKON_Pos           (4U)
+#define RTC_CR_REFCKON_Msk           (0x1UL << RTC_CR_REFCKON_Pos)              /*!< 0x00000010 */
+#define RTC_CR_REFCKON               RTC_CR_REFCKON_Msk
+#define RTC_CR_TSEDGE_Pos            (3U)
+#define RTC_CR_TSEDGE_Msk            (0x1UL << RTC_CR_TSEDGE_Pos)              /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                RTC_CR_TSEDGE_Msk                         /*!< Timestamp event active edge > */
+#define RTC_CR_WUCKSEL_Pos           (0U)
+#define RTC_CR_WUCKSEL_Msk           (0x7UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL               RTC_CR_WUCKSEL_Msk                        /*!< Wakeup clock selection > */
+#define RTC_CR_WUCKSEL_0             (0x1UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1             (0x2UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2             (0x4UL << RTC_CR_WUCKSEL_Pos)             /*!< 0x00000004 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos              (0U)
+#define RTC_WPR_KEY_Msk              (0xFFUL << RTC_WPR_KEY_Pos)                /*!< 0x000000FF */
+#define RTC_WPR_KEY                  RTC_WPR_KEY_Msk
+
+/********************  Bits definition for RTC_CALR register  *****************/
+#define RTC_CALR_CALP_Pos            (15U)
+#define RTC_CALR_CALP_Msk            (0x1UL << RTC_CALR_CALP_Pos)               /*!< 0x00008000 */
+#define RTC_CALR_CALP                RTC_CALR_CALP_Msk
+#define RTC_CALR_CALW8_Pos           (14U)
+#define RTC_CALR_CALW8_Msk           (0x1UL << RTC_CALR_CALW8_Pos)              /*!< 0x00004000 */
+#define RTC_CALR_CALW8               RTC_CALR_CALW8_Msk
+#define RTC_CALR_CALW16_Pos          (13U)
+#define RTC_CALR_CALW16_Msk          (0x1UL << RTC_CALR_CALW16_Pos)             /*!< 0x00002000 */
+#define RTC_CALR_CALW16              RTC_CALR_CALW16_Msk
+#define RTC_CALR_CALM_Pos            (0U)
+#define RTC_CALR_CALM_Msk            (0x1FFUL << RTC_CALR_CALM_Pos)             /*!< 0x000001FF */
+#define RTC_CALR_CALM                RTC_CALR_CALM_Msk
+#define RTC_CALR_CALM_0              (0x001UL << RTC_CALR_CALM_Pos)             /*!< 0x00000001 */
+#define RTC_CALR_CALM_1              (0x002UL << RTC_CALR_CALM_Pos)             /*!< 0x00000002 */
+#define RTC_CALR_CALM_2              (0x004UL << RTC_CALR_CALM_Pos)             /*!< 0x00000004 */
+#define RTC_CALR_CALM_3              (0x008UL << RTC_CALR_CALM_Pos)             /*!< 0x00000008 */
+#define RTC_CALR_CALM_4              (0x010UL << RTC_CALR_CALM_Pos)             /*!< 0x00000010 */
+#define RTC_CALR_CALM_5              (0x020UL << RTC_CALR_CALM_Pos)             /*!< 0x00000020 */
+#define RTC_CALR_CALM_6              (0x040UL << RTC_CALR_CALM_Pos)             /*!< 0x00000040 */
+#define RTC_CALR_CALM_7              (0x080UL << RTC_CALR_CALM_Pos)             /*!< 0x00000080 */
+#define RTC_CALR_CALM_8              (0x100UL << RTC_CALR_CALM_Pos)             /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos         (0U)
+#define RTC_SHIFTR_SUBFS_Msk         (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)         /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS             RTC_SHIFTR_SUBFS_Msk
+#define RTC_SHIFTR_ADD1S_Pos         (31U)
+#define RTC_SHIFTR_ADD1S_Msk         (0x1UL << RTC_SHIFTR_ADD1S_Pos)            /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S             RTC_SHIFTR_ADD1S_Msk
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos              (22U)
+#define RTC_TSTR_PM_Msk              (0x1UL << RTC_TSTR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TSTR_PM                  RTC_TSTR_PM_Msk                           /*!< AM-PM notation > */
+#define RTC_TSTR_HT_Pos              (20U)
+#define RTC_TSTR_HT_Msk              (0x3UL << RTC_TSTR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TSTR_HT                  RTC_TSTR_HT_Msk
+#define RTC_TSTR_HT_0                (0x1UL << RTC_TSTR_HT_Pos)                /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                (0x2UL << RTC_TSTR_HT_Pos)                /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos              (16U)
+#define RTC_TSTR_HU_Msk              (0xFUL << RTC_TSTR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TSTR_HU                  RTC_TSTR_HU_Msk
+#define RTC_TSTR_HU_0                (0x1UL << RTC_TSTR_HU_Pos)                /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                (0x2UL << RTC_TSTR_HU_Pos)                /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                (0x4UL << RTC_TSTR_HU_Pos)                /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                (0x8UL << RTC_TSTR_HU_Pos)                /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos             (12U)
+#define RTC_TSTR_MNT_Msk             (0x7UL << RTC_TSTR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TSTR_MNT                 RTC_TSTR_MNT_Msk
+#define RTC_TSTR_MNT_0               (0x1UL << RTC_TSTR_MNT_Pos)               /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1               (0x2UL << RTC_TSTR_MNT_Pos)               /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2               (0x4UL << RTC_TSTR_MNT_Pos)                /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos             (8U)
+#define RTC_TSTR_MNU_Msk             (0xFUL << RTC_TSTR_MNU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                 RTC_TSTR_MNU_Msk
+#define RTC_TSTR_MNU_0               (0x1UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1               (0x2UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2               (0x4UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3               (0x8UL << RTC_TSTR_MNU_Pos)                /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos              (4U)
+#define RTC_TSTR_ST_Msk              (0x7UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000070 */
+#define RTC_TSTR_ST                  RTC_TSTR_ST_Msk
+#define RTC_TSTR_ST_0                (0x1UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                (0x2UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                (0x4UL << RTC_TSTR_ST_Pos)                 /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos              (0U)
+#define RTC_TSTR_SU_Msk              (0xFUL << RTC_TSTR_SU_Pos)                 /*!< 0x0000000F */
+#define RTC_TSTR_SU                  RTC_TSTR_SU_Msk
+#define RTC_TSTR_SU_0                (0x1UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                (0x2UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                (0x4UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                (0x8UL << RTC_TSTR_SU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos             (13U)
+#define RTC_TSDR_WDU_Msk             (0x7UL << RTC_TSDR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                 RTC_TSDR_WDU_Msk                          /*!< Week day units > */
+#define RTC_TSDR_WDU_0               (0x1UL << RTC_TSDR_WDU_Pos)               /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1               (0x2UL << RTC_TSDR_WDU_Pos)               /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2               (0x4UL << RTC_TSDR_WDU_Pos)               /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos              (12U)
+#define RTC_TSDR_MT_Msk              (0x1UL << RTC_TSDR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_TSDR_MT                  RTC_TSDR_MT_Msk
+#define RTC_TSDR_MU_Pos              (8U)
+#define RTC_TSDR_MU_Msk              (0xFUL << RTC_TSDR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_TSDR_MU                  RTC_TSDR_MU_Msk
+#define RTC_TSDR_MU_0                (0x1UL << RTC_TSDR_MU_Pos)                /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                (0x2UL << RTC_TSDR_MU_Pos)                /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                (0x4UL << RTC_TSDR_MU_Pos)                /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                (0x8UL << RTC_TSDR_MU_Pos)                /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos              (4U)
+#define RTC_TSDR_DT_Msk              (0x3UL << RTC_TSDR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_TSDR_DT                  RTC_TSDR_DT_Msk
+#define RTC_TSDR_DT_0                (0x1UL << RTC_TSDR_DT_Pos)                /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                (0x2UL << RTC_TSDR_DT_Pos)                /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos              (0U)
+#define RTC_TSDR_DU_Msk              (0xFUL << RTC_TSDR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_TSDR_DU                  RTC_TSDR_DU_Msk
+#define RTC_TSDR_DU_0                (0x1UL << RTC_TSDR_DU_Pos)                /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                (0x2UL << RTC_TSDR_DU_Pos)                /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                (0x4UL << RTC_TSDR_DU_Pos)                /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                (0x8UL << RTC_TSDR_DU_Pos)                /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos             (0U)
+#define RTC_TSSSR_SS_Msk             (0xFFFFUL << RTC_TSSSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                 RTC_TSSSR_SS_Msk                          /*!< Sub second value > */
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos          (31U)
+#define RTC_ALRMAR_MSK4_Msk          (0x1UL << RTC_ALRMAR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4              RTC_ALRMAR_MSK4_Msk
+#define RTC_ALRMAR_WDSEL_Pos         (30U)
+#define RTC_ALRMAR_WDSEL_Msk         (0x1UL << RTC_ALRMAR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL             RTC_ALRMAR_WDSEL_Msk
+#define RTC_ALRMAR_DT_Pos            (28U)
+#define RTC_ALRMAR_DT_Msk            (0x3UL << RTC_ALRMAR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                RTC_ALRMAR_DT_Msk
+#define RTC_ALRMAR_DT_0              (0x1UL << RTC_ALRMAR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1              (0x2UL << RTC_ALRMAR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos            (24U)
+#define RTC_ALRMAR_DU_Msk            (0xFUL << RTC_ALRMAR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                RTC_ALRMAR_DU_Msk
+#define RTC_ALRMAR_DU_0              (0x1UL << RTC_ALRMAR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1              (0x2UL << RTC_ALRMAR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2              (0x4UL << RTC_ALRMAR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3              (0x8UL << RTC_ALRMAR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos          (23U)
+#define RTC_ALRMAR_MSK3_Msk          (0x1UL << RTC_ALRMAR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3              RTC_ALRMAR_MSK3_Msk
+#define RTC_ALRMAR_PM_Pos            (22U)
+#define RTC_ALRMAR_PM_Msk            (0x1UL << RTC_ALRMAR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                RTC_ALRMAR_PM_Msk
+#define RTC_ALRMAR_HT_Pos            (20U)
+#define RTC_ALRMAR_HT_Msk            (0x3UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                RTC_ALRMAR_HT_Msk
+#define RTC_ALRMAR_HT_0              (0x1UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1              (0x2UL << RTC_ALRMAR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos            (16U)
+#define RTC_ALRMAR_HU_Msk            (0xFUL << RTC_ALRMAR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                RTC_ALRMAR_HU_Msk
+#define RTC_ALRMAR_HU_0              (0x1UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1              (0x2UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2              (0x4UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3              (0x8UL << RTC_ALRMAR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos          (15U)
+#define RTC_ALRMAR_MSK2_Msk          (0x1UL << RTC_ALRMAR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2              RTC_ALRMAR_MSK2_Msk
+#define RTC_ALRMAR_MNT_Pos           (12U)
+#define RTC_ALRMAR_MNT_Msk           (0x7UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT               RTC_ALRMAR_MNT_Msk
+#define RTC_ALRMAR_MNT_0             (0x1UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1             (0x2UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2             (0x4UL << RTC_ALRMAR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos           (8U)
+#define RTC_ALRMAR_MNU_Msk           (0xFUL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU               RTC_ALRMAR_MNU_Msk
+#define RTC_ALRMAR_MNU_0             (0x1UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1             (0x2UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2             (0x4UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3             (0x8UL << RTC_ALRMAR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos          (7U)
+#define RTC_ALRMAR_MSK1_Msk          (0x1UL << RTC_ALRMAR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1              RTC_ALRMAR_MSK1_Msk
+#define RTC_ALRMAR_ST_Pos            (4U)
+#define RTC_ALRMAR_ST_Msk            (0x7UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                RTC_ALRMAR_ST_Msk
+#define RTC_ALRMAR_ST_0              (0x1UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1              (0x2UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2              (0x4UL << RTC_ALRMAR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos            (0U)
+#define RTC_ALRMAR_SU_Msk            (0xFUL << RTC_ALRMAR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                RTC_ALRMAR_SU_Msk
+#define RTC_ALRMAR_SU_0              (0x1UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1              (0x2UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2              (0x4UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3              (0x8UL << RTC_ALRMAR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos      (24U)
+#define RTC_ALRMASSR_MASKSS_Msk      (0xFUL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS          RTC_ALRMASSR_MASKSS_Msk
+#define RTC_ALRMASSR_MASKSS_0        (0x1UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1        (0x2UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2        (0x4UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3        (0x8UL << RTC_ALRMASSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos          (0U)
+#define RTC_ALRMASSR_SS_Msk          (0x7FFFUL << RTC_ALRMASSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS              RTC_ALRMASSR_SS_Msk
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos          (31U)
+#define RTC_ALRMBR_MSK4_Msk          (0x1UL << RTC_ALRMBR_MSK4_Pos)            /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4              RTC_ALRMBR_MSK4_Msk
+#define RTC_ALRMBR_WDSEL_Pos         (30U)
+#define RTC_ALRMBR_WDSEL_Msk         (0x1UL << RTC_ALRMBR_WDSEL_Pos)           /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL             RTC_ALRMBR_WDSEL_Msk
+#define RTC_ALRMBR_DT_Pos            (28U)
+#define RTC_ALRMBR_DT_Msk            (0x3UL << RTC_ALRMBR_DT_Pos)              /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                RTC_ALRMBR_DT_Msk
+#define RTC_ALRMBR_DT_0              (0x1UL << RTC_ALRMBR_DT_Pos)              /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1              (0x2UL << RTC_ALRMBR_DT_Pos)              /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos            (24U)
+#define RTC_ALRMBR_DU_Msk            (0xFUL << RTC_ALRMBR_DU_Pos)              /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                RTC_ALRMBR_DU_Msk
+#define RTC_ALRMBR_DU_0              (0x1UL << RTC_ALRMBR_DU_Pos)              /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1              (0x2UL << RTC_ALRMBR_DU_Pos)              /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2              (0x4UL << RTC_ALRMBR_DU_Pos)              /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3              (0x8UL << RTC_ALRMBR_DU_Pos)              /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos          (23U)
+#define RTC_ALRMBR_MSK3_Msk          (0x1UL << RTC_ALRMBR_MSK3_Pos)            /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3              RTC_ALRMBR_MSK3_Msk
+#define RTC_ALRMBR_PM_Pos            (22U)
+#define RTC_ALRMBR_PM_Msk            (0x1UL << RTC_ALRMBR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                RTC_ALRMBR_PM_Msk
+#define RTC_ALRMBR_HT_Pos            (20U)
+#define RTC_ALRMBR_HT_Msk            (0x3UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                RTC_ALRMBR_HT_Msk
+#define RTC_ALRMBR_HT_0              (0x1UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1              (0x2UL << RTC_ALRMBR_HT_Pos)              /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos            (16U)
+#define RTC_ALRMBR_HU_Msk            (0xFUL << RTC_ALRMBR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                RTC_ALRMBR_HU_Msk
+#define RTC_ALRMBR_HU_0              (0x1UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1              (0x2UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2              (0x4UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3              (0x8UL << RTC_ALRMBR_HU_Pos)              /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos          (15U)
+#define RTC_ALRMBR_MSK2_Msk          (0x1UL << RTC_ALRMBR_MSK2_Pos)            /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2              RTC_ALRMBR_MSK2_Msk
+#define RTC_ALRMBR_MNT_Pos           (12U)
+#define RTC_ALRMBR_MNT_Msk           (0x7UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT               RTC_ALRMBR_MNT_Msk
+#define RTC_ALRMBR_MNT_0             (0x1UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1             (0x2UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2             (0x4UL << RTC_ALRMBR_MNT_Pos)             /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos           (8U)
+#define RTC_ALRMBR_MNU_Msk           (0xFUL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU               RTC_ALRMBR_MNU_Msk
+#define RTC_ALRMBR_MNU_0             (0x1UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1             (0x2UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2             (0x4UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3             (0x8UL << RTC_ALRMBR_MNU_Pos)             /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos          (7U)
+#define RTC_ALRMBR_MSK1_Msk          (0x1UL << RTC_ALRMBR_MSK1_Pos)            /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1              RTC_ALRMBR_MSK1_Msk
+#define RTC_ALRMBR_ST_Pos            (4U)
+#define RTC_ALRMBR_ST_Msk            (0x7UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                RTC_ALRMBR_ST_Msk
+#define RTC_ALRMBR_ST_0              (0x1UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1              (0x2UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2              (0x4UL << RTC_ALRMBR_ST_Pos)              /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos            (0U)
+#define RTC_ALRMBR_SU_Msk            (0xFUL << RTC_ALRMBR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                RTC_ALRMBR_SU_Msk
+#define RTC_ALRMBR_SU_0              (0x1UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1              (0x2UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2              (0x4UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3              (0x8UL << RTC_ALRMBR_SU_Pos)              /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos      (24U)
+#define RTC_ALRMBSSR_MASKSS_Msk      (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS          RTC_ALRMBSSR_MASKSS_Msk
+#define RTC_ALRMBSSR_MASKSS_0        (0x1UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1        (0x2UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2        (0x4UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3        (0x8UL << RTC_ALRMBSSR_MASKSS_Pos)        /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos          (0U)
+#define RTC_ALRMBSSR_SS_Msk          (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)         /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS              RTC_ALRMBSSR_SS_Msk
+
+/********************  Bits definition for RTC_SR register  *******************/
+#define RTC_SR_ITSF_Pos              (5U)
+#define RTC_SR_ITSF_Msk              (0x1UL << RTC_SR_ITSF_Pos)                /*!< 0x00000020 */
+#define RTC_SR_ITSF                  RTC_SR_ITSF_Msk
+#define RTC_SR_TSOVF_Pos             (4U)
+#define RTC_SR_TSOVF_Msk             (0x1UL << RTC_SR_TSOVF_Pos)               /*!< 0x00000010 */
+#define RTC_SR_TSOVF                 RTC_SR_TSOVF_Msk                          /*!< Timestamp overflow flag > */
+#define RTC_SR_TSF_Pos               (3U)
+#define RTC_SR_TSF_Msk               (0x1UL << RTC_SR_TSF_Pos)                 /*!< 0x00000008 */
+#define RTC_SR_TSF                   RTC_SR_TSF_Msk                            /*!< Timestamp flag > */
+#define RTC_SR_WUTF_Pos              (2U)
+#define RTC_SR_WUTF_Msk              (0x1UL << RTC_SR_WUTF_Pos)                /*!< 0x00000004 */
+#define RTC_SR_WUTF                  RTC_SR_WUTF_Msk                           /*!< Wakeup timer flag > */
+#define RTC_SR_ALRBF_Pos             (1U)
+#define RTC_SR_ALRBF_Msk             (0x1UL << RTC_SR_ALRBF_Pos)               /*!< 0x00000002 */
+#define RTC_SR_ALRBF                 RTC_SR_ALRBF_Msk
+#define RTC_SR_ALRAF_Pos             (0U)
+#define RTC_SR_ALRAF_Msk             (0x1UL << RTC_SR_ALRAF_Pos)               /*!< 0x00000001 */
+#define RTC_SR_ALRAF                 RTC_SR_ALRAF_Msk
+
+/********************  Bits definition for RTC_MISR register  *****************/
+#define RTC_MISR_ITSMF_Pos           (5U)
+#define RTC_MISR_ITSMF_Msk           (0x1UL << RTC_MISR_ITSMF_Pos)             /*!< 0x00000020 */
+#define RTC_MISR_ITSMF               RTC_MISR_ITSMF_Msk
+#define RTC_MISR_TSOVMF_Pos          (4U)
+#define RTC_MISR_TSOVMF_Msk          (0x1UL << RTC_MISR_TSOVMF_Pos)            /*!< 0x00000010 */
+#define RTC_MISR_TSOVMF              RTC_MISR_TSOVMF_Msk                       /*!< Timestamp overflow masked flag > */
+#define RTC_MISR_TSMF_Pos            (3U)
+#define RTC_MISR_TSMF_Msk            (0x1UL << RTC_MISR_TSMF_Pos)              /*!< 0x00000008 */
+#define RTC_MISR_TSMF                RTC_MISR_TSMF_Msk                         /*!< Timestamp masked flag > */
+#define RTC_MISR_WUTMF_Pos           (2U)
+#define RTC_MISR_WUTMF_Msk           (0x1UL << RTC_MISR_WUTMF_Pos)             /*!< 0x00000004 */
+#define RTC_MISR_WUTMF               RTC_MISR_WUTMF_Msk                        /*!< Wakeup timer masked flag > */
+#define RTC_MISR_ALRBMF_Pos          (1U)
+#define RTC_MISR_ALRBMF_Msk          (0x1UL << RTC_MISR_ALRBMF_Pos)            /*!< 0x00000002 */
+#define RTC_MISR_ALRBMF              RTC_MISR_ALRBMF_Msk
+#define RTC_MISR_ALRAMF_Pos          (0U)
+#define RTC_MISR_ALRAMF_Msk          (0x1UL << RTC_MISR_ALRAMF_Pos)            /*!< 0x00000001 */
+#define RTC_MISR_ALRAMF              RTC_MISR_ALRAMF_Msk
+
+/********************  Bits definition for RTC_SCR register  ******************/
+#define RTC_SCR_CITSF_Pos            (5U)
+#define RTC_SCR_CITSF_Msk            (0x1UL << RTC_SCR_CITSF_Pos)              /*!< 0x00000020 */
+#define RTC_SCR_CITSF                RTC_SCR_CITSF_Msk
+#define RTC_SCR_CTSOVF_Pos           (4U)
+#define RTC_SCR_CTSOVF_Msk           (0x1UL << RTC_SCR_CTSOVF_Pos)             /*!< 0x00000010 */
+#define RTC_SCR_CTSOVF               RTC_SCR_CTSOVF_Msk                        /*!< Clear timestamp overflow flag > */
+#define RTC_SCR_CTSF_Pos             (3U)
+#define RTC_SCR_CTSF_Msk             (0x1UL << RTC_SCR_CTSF_Pos)               /*!< 0x00000008 */
+#define RTC_SCR_CTSF                 RTC_SCR_CTSF_Msk                          /*!< Clear timestamp flag > */
+#define RTC_SCR_CWUTF_Pos            (2U)
+#define RTC_SCR_CWUTF_Msk            (0x1UL << RTC_SCR_CWUTF_Pos)              /*!< 0x00000004 */
+#define RTC_SCR_CWUTF                RTC_SCR_CWUTF_Msk                         /*!< Clear wakeup timer flag > */
+#define RTC_SCR_CALRBF_Pos           (1U)
+#define RTC_SCR_CALRBF_Msk           (0x1UL << RTC_SCR_CALRBF_Pos)             /*!< 0x00000002 */
+#define RTC_SCR_CALRBF               RTC_SCR_CALRBF_Msk
+#define RTC_SCR_CALRAF_Pos           (0U)
+#define RTC_SCR_CALRAF_Msk           (0x1UL << RTC_SCR_CALRAF_Pos)             /*!< 0x00000001 */
+#define RTC_SCR_CALRAF               RTC_SCR_CALRAF_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                     Tamper and backup register (TAMP)                      */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for TAMP_CR1 register  *****************/
+#define TAMP_CR1_TAMP1E_Pos          (0U)
+#define TAMP_CR1_TAMP1E_Msk          (0x1UL << TAMP_CR1_TAMP1E_Pos)             /*!< 0x00000001 */
+#define TAMP_CR1_TAMP1E              TAMP_CR1_TAMP1E_Msk
+#define TAMP_CR1_TAMP2E_Pos          (1U)
+#define TAMP_CR1_TAMP2E_Msk          (0x1UL << TAMP_CR1_TAMP2E_Pos)             /*!< 0x00000002 */
+#define TAMP_CR1_TAMP2E              TAMP_CR1_TAMP2E_Msk
+#define TAMP_CR1_ITAMP3E_Pos         (18U)
+#define TAMP_CR1_ITAMP3E_Msk         (0x1UL << TAMP_CR1_ITAMP3E_Pos)            /*!< 0x00040000 */
+#define TAMP_CR1_ITAMP3E             TAMP_CR1_ITAMP3E_Msk
+#define TAMP_CR1_ITAMP4E_Pos         (19U)
+#define TAMP_CR1_ITAMP4E_Msk         (0x1UL << TAMP_CR1_ITAMP4E_Pos)            /*!< 0x00080000 */
+#define TAMP_CR1_ITAMP4E             TAMP_CR1_ITAMP4E_Msk
+#define TAMP_CR1_ITAMP5E_Pos         (20U)
+#define TAMP_CR1_ITAMP5E_Msk         (0x1UL << TAMP_CR1_ITAMP5E_Pos)            /*!< 0x00100000 */
+#define TAMP_CR1_ITAMP5E             TAMP_CR1_ITAMP5E_Msk
+#define TAMP_CR1_ITAMP6E_Pos         (21U)
+#define TAMP_CR1_ITAMP6E_Msk         (0x1UL << TAMP_CR1_ITAMP6E_Pos)            /*!< 0x00200000 */
+#define TAMP_CR1_ITAMP6E             TAMP_CR1_ITAMP6E_Msk
+
+/********************  Bits definition for TAMP_CR2 register  *****************/
+#define TAMP_CR2_TAMP1NOERASE_Pos    (0U)
+#define TAMP_CR2_TAMP1NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP1NOERASE_Pos)       /*!< 0x00000001 */
+#define TAMP_CR2_TAMP1NOERASE        TAMP_CR2_TAMP1NOERASE_Msk
+#define TAMP_CR2_TAMP2NOERASE_Pos    (1U)
+#define TAMP_CR2_TAMP2NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP2NOERASE_Pos)       /*!< 0x00000002 */
+#define TAMP_CR2_TAMP2NOERASE        TAMP_CR2_TAMP2NOERASE_Msk
+#define TAMP_CR2_TAMP1MSK_Pos        (16U)
+#define TAMP_CR2_TAMP1MSK_Msk        (0x1UL << TAMP_CR2_TAMP1MSK_Pos)           /*!< 0x00010000 */
+#define TAMP_CR2_TAMP1MSK            TAMP_CR2_TAMP1MSK_Msk
+#define TAMP_CR2_TAMP2MSK_Pos        (17U)
+#define TAMP_CR2_TAMP2MSK_Msk        (0x1UL << TAMP_CR2_TAMP2MSK_Pos)           /*!< 0x00020000 */
+#define TAMP_CR2_TAMP2MSK            TAMP_CR2_TAMP2MSK_Msk
+#define TAMP_CR2_TAMP1TRG_Pos        (24U)
+#define TAMP_CR2_TAMP1TRG_Msk        (0x1UL << TAMP_CR2_TAMP1TRG_Pos)           /*!< 0x01000000 */
+#define TAMP_CR2_TAMP1TRG            TAMP_CR2_TAMP1TRG_Msk
+#define TAMP_CR2_TAMP2TRG_Pos        (25U)
+#define TAMP_CR2_TAMP2TRG_Msk        (0x1UL << TAMP_CR2_TAMP2TRG_Pos)           /*!< 0x02000000 */
+#define TAMP_CR2_TAMP2TRG            TAMP_CR2_TAMP2TRG_Msk
+
+/********************  Bits definition for TAMP_FLTCR register  ***************/
+#define TAMP_FLTCR_TAMPFREQ_0        0x00000001U
+#define TAMP_FLTCR_TAMPFREQ_1        0x00000002U
+#define TAMP_FLTCR_TAMPFREQ_2        0x00000004U
+#define TAMP_FLTCR_TAMPFREQ_Pos      (0U)
+#define TAMP_FLTCR_TAMPFREQ_Msk      (0x7UL << TAMP_FLTCR_TAMPFREQ_Pos)         /*!< 0x00000007 */
+#define TAMP_FLTCR_TAMPFREQ          TAMP_FLTCR_TAMPFREQ_Msk
+#define TAMP_FLTCR_TAMPFLT_0         0x00000008U
+#define TAMP_FLTCR_TAMPFLT_1         0x00000010U
+#define TAMP_FLTCR_TAMPFLT_Pos       (3U)
+#define TAMP_FLTCR_TAMPFLT_Msk       (0x3UL << TAMP_FLTCR_TAMPFLT_Pos)          /*!< 0x00000018 */
+#define TAMP_FLTCR_TAMPFLT           TAMP_FLTCR_TAMPFLT_Msk
+#define TAMP_FLTCR_TAMPPRCH_0        0x00000020U
+#define TAMP_FLTCR_TAMPPRCH_1        0x00000040U
+#define TAMP_FLTCR_TAMPPRCH_Pos      (5U)
+#define TAMP_FLTCR_TAMPPRCH_Msk      (0x3UL << TAMP_FLTCR_TAMPPRCH_Pos)         /*!< 0x00000060 */
+#define TAMP_FLTCR_TAMPPRCH          TAMP_FLTCR_TAMPPRCH_Msk
+#define TAMP_FLTCR_TAMPPUDIS_Pos     (7U)
+#define TAMP_FLTCR_TAMPPUDIS_Msk     (0x1UL << TAMP_FLTCR_TAMPPUDIS_Pos)        /*!< 0x00000080 */
+#define TAMP_FLTCR_TAMPPUDIS         TAMP_FLTCR_TAMPPUDIS_Msk
+
+/********************  Bits definition for TAMP_IER register  *****************/
+#define TAMP_IER_TAMP1IE_Pos         (0U)
+#define TAMP_IER_TAMP1IE_Msk         (0x1UL << TAMP_IER_TAMP1IE_Pos)            /*!< 0x00000001 */
+#define TAMP_IER_TAMP1IE             TAMP_IER_TAMP1IE_Msk
+#define TAMP_IER_TAMP2IE_Pos         (1U)
+#define TAMP_IER_TAMP2IE_Msk         (0x1UL << TAMP_IER_TAMP2IE_Pos)            /*!< 0x00000002 */
+#define TAMP_IER_TAMP2IE             TAMP_IER_TAMP2IE_Msk
+#define TAMP_IER_ITAMP3IE_Pos        (18U)
+#define TAMP_IER_ITAMP3IE_Msk        (0x1UL << TAMP_IER_ITAMP3IE_Pos)           /*!< 0x00040000 */
+#define TAMP_IER_ITAMP3IE            TAMP_IER_ITAMP3IE_Msk
+#define TAMP_IER_ITAMP4IE_Pos        (19U)
+#define TAMP_IER_ITAMP4IE_Msk        (0x1UL << TAMP_IER_ITAMP4IE_Pos)           /*!< 0x00080000 */
+#define TAMP_IER_ITAMP4IE            TAMP_IER_ITAMP4IE_Msk
+#define TAMP_IER_ITAMP5IE_Pos        (20U)
+#define TAMP_IER_ITAMP5IE_Msk        (0x1UL << TAMP_IER_ITAMP5IE_Pos)           /*!< 0x00100000 */
+#define TAMP_IER_ITAMP5IE            TAMP_IER_ITAMP5IE_Msk
+#define TAMP_IER_ITAMP6IE_Pos        (21U)
+#define TAMP_IER_ITAMP6IE_Msk        (0x1UL << TAMP_IER_ITAMP6IE_Pos)           /*!< 0x00200000 */
+#define TAMP_IER_ITAMP6IE            TAMP_IER_ITAMP6IE_Msk
+
+/********************  Bits definition for TAMP_SR register  ******************/
+#define TAMP_SR_TAMP1F_Pos           (0U)
+#define TAMP_SR_TAMP1F_Msk           (0x1UL << TAMP_SR_TAMP1F_Pos)              /*!< 0x00000001 */
+#define TAMP_SR_TAMP1F               TAMP_SR_TAMP1F_Msk
+#define TAMP_SR_TAMP2F_Pos           (1U)
+#define TAMP_SR_TAMP2F_Msk           (0x1UL << TAMP_SR_TAMP2F_Pos)              /*!< 0x00000002 */
+#define TAMP_SR_TAMP2F               TAMP_SR_TAMP2F_Msk
+#define TAMP_SR_ITAMP3F_Pos          (18U)
+#define TAMP_SR_ITAMP3F_Msk          (0x1UL << TAMP_SR_ITAMP3F_Pos)             /*!< 0x00040000 */
+#define TAMP_SR_ITAMP3F              TAMP_SR_ITAMP3F_Msk
+#define TAMP_SR_ITAMP4F_Pos          (19U)
+#define TAMP_SR_ITAMP4F_Msk          (0x1UL << TAMP_SR_ITAMP4F_Pos)             /*!< 0x00080000 */
+#define TAMP_SR_ITAMP4F              TAMP_SR_ITAMP4F_Msk
+#define TAMP_SR_ITAMP5F_Pos          (20U)
+#define TAMP_SR_ITAMP5F_Msk          (0x1UL << TAMP_SR_ITAMP5F_Pos)             /*!< 0x00100000 */
+#define TAMP_SR_ITAMP5F              TAMP_SR_ITAMP5F_Msk
+#define TAMP_SR_ITAMP6F_Pos          (21U)
+#define TAMP_SR_ITAMP6F_Msk          (0x1UL << TAMP_SR_ITAMP6F_Pos)             /*!< 0x00200000 */
+#define TAMP_SR_ITAMP6F              TAMP_SR_ITAMP6F_Msk
+
+/********************  Bits definition for TAMP_MISR register  ****************/
+#define TAMP_MISR_TAMP1MF_Pos        (0U)
+#define TAMP_MISR_TAMP1MF_Msk        (0x1UL << TAMP_MISR_TAMP1MF_Pos)           /*!< 0x00000001 */
+#define TAMP_MISR_TAMP1MF            TAMP_MISR_TAMP1MF_Msk
+#define TAMP_MISR_TAMP2MF_Pos        (1U)
+#define TAMP_MISR_TAMP2MF_Msk        (0x1UL << TAMP_MISR_TAMP2MF_Pos)           /*!< 0x00000002 */
+#define TAMP_MISR_TAMP2MF            TAMP_MISR_TAMP2MF_Msk
+#define TAMP_MISR_ITAMP3MF_Pos       (18U)
+#define TAMP_MISR_ITAMP3MF_Msk       (0x1UL << TAMP_MISR_ITAMP3MF_Pos)          /*!< 0x00040000 */
+#define TAMP_MISR_ITAMP3MF           TAMP_MISR_ITAMP3MF_Msk
+#define TAMP_MISR_ITAMP4MF_Pos       (19U)
+#define TAMP_MISR_ITAMP4MF_Msk       (0x1UL << TAMP_MISR_ITAMP4MF_Pos)          /*!< 0x00080000 */
+#define TAMP_MISR_ITAMP4MF           TAMP_MISR_ITAMP4MF_Msk
+#define TAMP_MISR_ITAMP5MF_Pos       (20U)
+#define TAMP_MISR_ITAMP5MF_Msk       (0x1UL << TAMP_MISR_ITAMP5MF_Pos)          /*!< 0x00100000 */
+#define TAMP_MISR_ITAMP5MF           TAMP_MISR_ITAMP5MF_Msk
+#define TAMP_MISR_ITAMP6MF_Pos       (21U)
+#define TAMP_MISR_ITAMP6MF_Msk       (0x1UL << TAMP_MISR_ITAMP6MF_Pos)          /*!< 0x00200000 */
+#define TAMP_MISR_ITAMP6MF           TAMP_MISR_ITAMP6MF_Msk
+
+/********************  Bits definition for TAMP_SCR register  *****************/
+#define TAMP_SCR_CTAMP1F_Pos         (0U)
+#define TAMP_SCR_CTAMP1F_Msk         (0x1UL << TAMP_SCR_CTAMP1F_Pos)            /*!< 0x00000001 */
+#define TAMP_SCR_CTAMP1F             TAMP_SCR_CTAMP1F_Msk
+#define TAMP_SCR_CTAMP2F_Pos         (1U)
+#define TAMP_SCR_CTAMP2F_Msk         (0x1UL << TAMP_SCR_CTAMP2F_Pos)            /*!< 0x00000002 */
+#define TAMP_SCR_CTAMP2F             TAMP_SCR_CTAMP2F_Msk
+#define TAMP_SCR_CITAMP3F_Pos        (18U)
+#define TAMP_SCR_CITAMP3F_Msk        (0x1UL << TAMP_SCR_CITAMP3F_Pos)           /*!< 0x00040000 */
+#define TAMP_SCR_CITAMP3F            TAMP_SCR_CITAMP3F_Msk
+#define TAMP_SCR_CITAMP4F_Pos        (19U)
+#define TAMP_SCR_CITAMP4F_Msk        (0x1UL << TAMP_SCR_CITAMP4F_Pos)           /*!< 0x00080000 */
+#define TAMP_SCR_CITAMP4F            TAMP_SCR_CITAMP4F_Msk
+#define TAMP_SCR_CITAMP5F_Pos        (20U)
+#define TAMP_SCR_CITAMP5F_Msk        (0x1UL << TAMP_SCR_CITAMP5F_Pos)           /*!< 0x00100000 */
+#define TAMP_SCR_CITAMP5F            TAMP_SCR_CITAMP5F_Msk
+#define TAMP_SCR_CITAMP6F_Pos        (21U)
+#define TAMP_SCR_CITAMP6F_Msk        (0x1UL << TAMP_SCR_CITAMP6F_Pos)           /*!< 0x00200000 */
+#define TAMP_SCR_CITAMP6F            TAMP_SCR_CITAMP6F_Msk
+
+/********************  Bits definition for TAMP_BKP0R register  ***************/
+#define TAMP_BKP0R_Pos               (0U)
+#define TAMP_BKP0R_Msk               (0xFFFFFFFFUL << TAMP_BKP0R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP0R                   TAMP_BKP0R_Msk
+
+/********************  Bits definition for TAMP_BKP1R register  ***************/
+#define TAMP_BKP1R_Pos               (0U)
+#define TAMP_BKP1R_Msk               (0xFFFFFFFFUL << TAMP_BKP1R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP1R                   TAMP_BKP1R_Msk
+
+/********************  Bits definition for TAMP_BKP2R register  ***************/
+#define TAMP_BKP2R_Pos               (0U)
+#define TAMP_BKP2R_Msk               (0xFFFFFFFFUL << TAMP_BKP2R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP2R                   TAMP_BKP2R_Msk
+
+/********************  Bits definition for TAMP_BKP3R register  ***************/
+#define TAMP_BKP3R_Pos               (0U)
+#define TAMP_BKP3R_Msk               (0xFFFFFFFFUL << TAMP_BKP3R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP3R                   TAMP_BKP3R_Msk
+
+/********************  Bits definition for TAMP_BKP4R register  ***************/
+#define TAMP_BKP4R_Pos               (0U)
+#define TAMP_BKP4R_Msk               (0xFFFFFFFFUL << TAMP_BKP4R_Pos)           /*!< 0xFFFFFFFF */
+#define TAMP_BKP4R                   TAMP_BKP4R_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
+ */
+#define SPI_I2S_SUPPORT                       /*!< I2S support */
+
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                  /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                  /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                  /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                  /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                 /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)            /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                 /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                 /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)              /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_CRCL_Pos            (11U)
+#define SPI_CR1_CRCL_Msk            (0x1UL << SPI_CR1_CRCL_Pos)                /*!< 0x00000800 */
+#define SPI_CR1_CRCL                SPI_CR1_CRCL_Msk                           /*!< CRC Length */
+#define SPI_CR1_CRCNEXT_Pos         (12U)
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)             /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)               /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)              /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)            /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)             /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!< Rx Buffer DMA Enable */
+#define SPI_CR2_TXDMAEN_Pos         (1U)
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)             /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!< Tx Buffer DMA Enable */
+#define SPI_CR2_SSOE_Pos            (2U)
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!< SS Output Enable */
+#define SPI_CR2_NSSP_Pos            (3U)
+#define SPI_CR2_NSSP_Msk            (0x1UL << SPI_CR2_NSSP_Pos)                /*!< 0x00000008 */
+#define SPI_CR2_NSSP                SPI_CR2_NSSP_Msk                           /*!< NSS pulse management Enable */
+#define SPI_CR2_FRF_Pos             (4U)
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                 /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!< Frame Format Enable */
+#define SPI_CR2_ERRIE_Pos           (5U)
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)               /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!< Error Interrupt Enable */
+#define SPI_CR2_RXNEIE_Pos          (6U)
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)              /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!< RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)               /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!< Tx buffer Empty Interrupt Enable */
+#define SPI_CR2_DS_Pos              (8U)
+#define SPI_CR2_DS_Msk              (0xFUL << SPI_CR2_DS_Pos)                  /*!< 0x00000F00 */
+#define SPI_CR2_DS                  SPI_CR2_DS_Msk                             /*!< DS[3:0] Data Size */
+#define SPI_CR2_DS_0                (0x1UL << SPI_CR2_DS_Pos)                  /*!< 0x00000100 */
+#define SPI_CR2_DS_1                (0x2UL << SPI_CR2_DS_Pos)                  /*!< 0x00000200 */
+#define SPI_CR2_DS_2                (0x4UL << SPI_CR2_DS_Pos)                  /*!< 0x00000400 */
+#define SPI_CR2_DS_3                (0x8UL << SPI_CR2_DS_Pos)                  /*!< 0x00000800 */
+#define SPI_CR2_FRXTH_Pos           (12U)
+#define SPI_CR2_FRXTH_Msk           (0x1UL << SPI_CR2_FRXTH_Pos)               /*!< 0x00001000 */
+#define SPI_CR2_FRXTH               SPI_CR2_FRXTH_Msk                          /*!< FIFO reception Threshold */
+#define SPI_CR2_LDMARX_Pos          (13U)
+#define SPI_CR2_LDMARX_Msk          (0x1UL << SPI_CR2_LDMARX_Pos)              /*!< 0x00002000 */
+#define SPI_CR2_LDMARX              SPI_CR2_LDMARX_Msk                         /*!< Last DMA transfer for reception */
+#define SPI_CR2_LDMATX_Pos          (14U)
+#define SPI_CR2_LDMATX_Msk          (0x1UL << SPI_CR2_LDMATX_Pos)              /*!< 0x00004000 */
+#define SPI_CR2_LDMATX              SPI_CR2_LDMATX_Msk                         /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                 /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!< Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                  /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!< Transmit buffer Empty */
+#define SPI_SR_CHSIDE_Pos           (2U)
+#define SPI_SR_CHSIDE_Msk           (0x1UL << SPI_SR_CHSIDE_Pos)               /*!< 0x00000004 */
+#define SPI_SR_CHSIDE               SPI_SR_CHSIDE_Msk                          /*!< Channel side */
+#define SPI_SR_UDR_Pos              (3U)
+#define SPI_SR_UDR_Msk              (0x1UL << SPI_SR_UDR_Pos)                  /*!< 0x00000008 */
+#define SPI_SR_UDR                  SPI_SR_UDR_Msk                             /*!< Underrun flag */
+#define SPI_SR_CRCERR_Pos           (4U)
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)               /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!< CRC Error flag */
+#define SPI_SR_MODF_Pos             (5U)
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                 /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!< Mode fault */
+#define SPI_SR_OVR_Pos              (6U)
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                  /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!< Overrun flag */
+#define SPI_SR_BSY_Pos              (7U)
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                  /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!< Busy flag */
+#define SPI_SR_FRE_Pos              (8U)
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                  /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!< TI frame format error */
+#define SPI_SR_FRLVL_Pos            (9U)
+#define SPI_SR_FRLVL_Msk            (0x3UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000600 */
+#define SPI_SR_FRLVL                SPI_SR_FRLVL_Msk                           /*!< FIFO Reception Level */
+#define SPI_SR_FRLVL_0              (0x1UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000200 */
+#define SPI_SR_FRLVL_1              (0x2UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000400 */
+#define SPI_SR_FTLVL_Pos            (11U)
+#define SPI_SR_FTLVL_Msk            (0x3UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001800 */
+#define SPI_SR_FTLVL                SPI_SR_FTLVL_Msk                           /*!< FIFO Transmission Level */
+#define SPI_SR_FTLVL_0              (0x1UL << SPI_SR_FTLVL_Pos)                /*!< 0x00000800 */
+#define SPI_SR_FTLVL_1              (0x2UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001000 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)        /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define SPI_I2SCFGR_CHLEN_Pos       (0U)
+#define SPI_I2SCFGR_CHLEN_Msk       (0x1UL << SPI_I2SCFGR_CHLEN_Pos)           /*!< 0x00000001 */
+#define SPI_I2SCFGR_CHLEN           SPI_I2SCFGR_CHLEN_Msk                      /*!<Channel length (number of bits per audio channel) */
+#define SPI_I2SCFGR_DATLEN_Pos      (1U)
+#define SPI_I2SCFGR_DATLEN_Msk      (0x3UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000006 */
+#define SPI_I2SCFGR_DATLEN          SPI_I2SCFGR_DATLEN_Msk                     /*!<DATLEN[1:0] bits (Data length to be transferred) */
+#define SPI_I2SCFGR_DATLEN_0        (0x1UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000002 */
+#define SPI_I2SCFGR_DATLEN_1        (0x2UL << SPI_I2SCFGR_DATLEN_Pos)          /*!< 0x00000004 */
+#define SPI_I2SCFGR_CKPOL_Pos       (3U)
+#define SPI_I2SCFGR_CKPOL_Msk       (0x1UL << SPI_I2SCFGR_CKPOL_Pos)           /*!< 0x00000008 */
+#define SPI_I2SCFGR_CKPOL           SPI_I2SCFGR_CKPOL_Msk                      /*!<steady state clock polarity */
+#define SPI_I2SCFGR_I2SSTD_Pos      (4U)
+#define SPI_I2SCFGR_I2SSTD_Msk      (0x3UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000030 */
+#define SPI_I2SCFGR_I2SSTD          SPI_I2SCFGR_I2SSTD_Msk                     /*!<I2SSTD[1:0] bits (I2S standard selection) */
+#define SPI_I2SCFGR_I2SSTD_0        (0x1UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000010 */
+#define SPI_I2SCFGR_I2SSTD_1        (0x2UL << SPI_I2SCFGR_I2SSTD_Pos)          /*!< 0x00000020 */
+#define SPI_I2SCFGR_PCMSYNC_Pos     (7U)
+#define SPI_I2SCFGR_PCMSYNC_Msk     (0x1UL << SPI_I2SCFGR_PCMSYNC_Pos)         /*!< 0x00000080 */
+#define SPI_I2SCFGR_PCMSYNC         SPI_I2SCFGR_PCMSYNC_Msk                    /*!<PCM frame synchronization */
+#define SPI_I2SCFGR_I2SCFG_Pos      (8U)
+#define SPI_I2SCFGR_I2SCFG_Msk      (0x3UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000300 */
+#define SPI_I2SCFGR_I2SCFG          SPI_I2SCFGR_I2SCFG_Msk                     /*!<I2SCFG[1:0] bits (I2S configuration mode) */
+#define SPI_I2SCFGR_I2SCFG_0        (0x1UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000100 */
+#define SPI_I2SCFGR_I2SCFG_1        (0x2UL << SPI_I2SCFGR_I2SCFG_Pos)          /*!< 0x00000200 */
+#define SPI_I2SCFGR_I2SE_Pos        (10U)
+#define SPI_I2SCFGR_I2SE_Msk        (0x1UL << SPI_I2SCFGR_I2SE_Pos)            /*!< 0x00000400 */
+#define SPI_I2SCFGR_I2SE            SPI_I2SCFGR_I2SE_Msk                       /*!<I2S Enable */
+#define SPI_I2SCFGR_I2SMOD_Pos      (11U)
+#define SPI_I2SCFGR_I2SMOD_Msk      (0x1UL << SPI_I2SCFGR_I2SMOD_Pos)          /*!< 0x00000800 */
+#define SPI_I2SCFGR_I2SMOD          SPI_I2SCFGR_I2SMOD_Msk                     /*!<I2S mode selection */
+#define SPI_I2SCFGR_ASTRTEN_Pos     (12U)
+#define SPI_I2SCFGR_ASTRTEN_Msk     (0x1UL << SPI_I2SCFGR_ASTRTEN_Pos)         /*!< 0x00001000 */
+#define SPI_I2SCFGR_ASTRTEN         SPI_I2SCFGR_ASTRTEN_Msk                    /*!<Asynchronous start enable */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define SPI_I2SPR_I2SDIV_Pos        (0U)
+#define SPI_I2SPR_I2SDIV_Msk        (0xFFUL << SPI_I2SPR_I2SDIV_Pos)           /*!< 0x000000FF */
+#define SPI_I2SPR_I2SDIV            SPI_I2SPR_I2SDIV_Msk                       /*!<I2S Linear prescaler */
+#define SPI_I2SPR_ODD_Pos           (8U)
+#define SPI_I2SPR_ODD_Msk           (0x1UL << SPI_I2SPR_ODD_Pos)               /*!< 0x00000100 */
+#define SPI_I2SPR_ODD               SPI_I2SPR_ODD_Msk                          /*!<Odd factor for the prescaler */
+#define SPI_I2SPR_MCKOE_Pos         (9U)
+#define SPI_I2SPR_MCKOE_Msk         (0x1UL << SPI_I2SPR_MCKOE_Pos)             /*!< 0x00000200 */
+#define SPI_I2SPR_MCKOE             SPI_I2SPR_MCKOE_Msk                        /*!<Master Clock Output Enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
+/*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
+#define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
+#define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
+#define SYSCFG_CFGR1_MEM_MODE                 SYSCFG_CFGR1_MEM_MODE_Msk            /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_CFGR1_MEM_MODE_0               (0x1UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000001 */
+#define SYSCFG_CFGR1_MEM_MODE_1               (0x2UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000002 */
+#define SYSCFG_CFGR1_PA11_RMP_Pos             (3U)
+#define SYSCFG_CFGR1_PA11_RMP_Msk             (0x1UL << SYSCFG_CFGR1_PA11_RMP_Pos) /*!< 0x00000008 */
+#define SYSCFG_CFGR1_PA11_RMP                 SYSCFG_CFGR1_PA11_RMP_Msk            /*!< PA11 Remap */
+#define SYSCFG_CFGR1_PA12_RMP_Pos             (4U)
+#define SYSCFG_CFGR1_PA12_RMP_Msk             (0x1UL << SYSCFG_CFGR1_PA12_RMP_Pos) /*!< 0x00000010 */
+#define SYSCFG_CFGR1_PA12_RMP                 SYSCFG_CFGR1_PA12_RMP_Msk            /*!< PA12 Remap */
+#define SYSCFG_CFGR1_IR_POL_Pos               (5U)
+#define SYSCFG_CFGR1_IR_POL_Msk               (0x1UL << SYSCFG_CFGR1_IR_POL_Pos) /*!< 0x00000020 */
+#define SYSCFG_CFGR1_IR_POL                   SYSCFG_CFGR1_IR_POL_Msk            /*!< IROut Polarity Selection */
+#define SYSCFG_CFGR1_IR_MOD_Pos               (6U)
+#define SYSCFG_CFGR1_IR_MOD_Msk               (0x3UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x000000C0 */
+#define SYSCFG_CFGR1_IR_MOD                   SYSCFG_CFGR1_IR_MOD_Msk            /*!< IRDA Modulation Envelope signal source selection */
+#define SYSCFG_CFGR1_IR_MOD_0                 (0x1UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x00000040 */
+#define SYSCFG_CFGR1_IR_MOD_1                 (0x2UL << SYSCFG_CFGR1_IR_MOD_Pos) /*!< 0x00000080 */
+#define SYSCFG_CFGR1_BOOSTEN_Pos              (8U)
+#define SYSCFG_CFGR1_BOOSTEN_Msk              (0x1UL << SYSCFG_CFGR1_BOOSTEN_Pos) /*!< 0x00000100 */
+#define SYSCFG_CFGR1_BOOSTEN                  SYSCFG_CFGR1_BOOSTEN_Msk            /*!< I/O analog switch voltage booster enable */
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Pos          (16U)
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB6_FMP_Pos)  /*!< 0x00010000 */
+#define SYSCFG_CFGR1_I2C_PB6_FMP              SYSCFG_CFGR1_I2C_PB6_FMP_Msk             /*!< I2C PB6 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Pos          (17U)
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB7_FMP_Pos)  /*!< 0x00020000 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP              SYSCFG_CFGR1_I2C_PB7_FMP_Msk             /*!< I2C PB7 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Pos          (18U)
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB8_FMP_Pos)  /*!< 0x00040000 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP              SYSCFG_CFGR1_I2C_PB8_FMP_Msk             /*!< I2C PB8 Fast mode plus */
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Pos          (19U)
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PB9_FMP_Pos)  /*!< 0x00080000 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP              SYSCFG_CFGR1_I2C_PB9_FMP_Msk             /*!< I2C PB9 Fast mode plus */
+#define SYSCFG_CFGR1_I2C1_FMP_Pos             (20U)
+#define SYSCFG_CFGR1_I2C1_FMP_Msk             (0x1UL << SYSCFG_CFGR1_I2C1_FMP_Pos)     /*!< 0x00100000 */
+#define SYSCFG_CFGR1_I2C1_FMP                 SYSCFG_CFGR1_I2C1_FMP_Msk                /*!< Enable Fast Mode Plus on PB10, PB11, PF6 and PF7  */
+#define SYSCFG_CFGR1_I2C2_FMP_Pos             (21U)
+#define SYSCFG_CFGR1_I2C2_FMP_Msk             (0x1UL << SYSCFG_CFGR1_I2C2_FMP_Pos)     /*!< 0x00200000 */
+#define SYSCFG_CFGR1_I2C2_FMP                 SYSCFG_CFGR1_I2C2_FMP_Msk                /*!< Enable I2C2 Fast mode plus  */
+#define SYSCFG_CFGR1_I2C_PA9_FMP_Pos          (22U)
+#define SYSCFG_CFGR1_I2C_PA9_FMP_Msk          (0x1UL << SYSCFG_CFGR1_I2C_PA9_FMP_Pos)  /*!< 0x00400000 */
+#define SYSCFG_CFGR1_I2C_PA9_FMP              SYSCFG_CFGR1_I2C_PA9_FMP_Msk             /*!< Enable Fast Mode Plus on PA9  */
+#define SYSCFG_CFGR1_I2C_PA10_FMP_Pos         (23U)
+#define SYSCFG_CFGR1_I2C_PA10_FMP_Msk         (0x1UL << SYSCFG_CFGR1_I2C_PA10_FMP_Pos) /*!< 0x00800000 */
+#define SYSCFG_CFGR1_I2C_PA10_FMP             SYSCFG_CFGR1_I2C_PA10_FMP_Msk            /*!< Enable Fast Mode Plus on PA10 */
+
+/******************  Bit definition for SYSCFG_CFGR2 register  ****************/
+#define SYSCFG_CFGR2_CLL_Pos                  (0U)
+#define SYSCFG_CFGR2_CLL_Msk                  (0x1UL << SYSCFG_CFGR2_CLL_Pos)   /*!< 0x00000001 */
+#define SYSCFG_CFGR2_CLL                      SYSCFG_CFGR2_CLL_Msk              /*!< Enables and locks the LOCKUP (Hardfault) output of CortexM0 with Break Input of TIMER1 */
+#define SYSCFG_CFGR2_SPL_Pos                  (1U)
+#define SYSCFG_CFGR2_SPL_Msk                  (0x1UL << SYSCFG_CFGR2_SPL_Pos)   /*!< 0x00000002 */
+#define SYSCFG_CFGR2_SPL                      SYSCFG_CFGR2_SPL_Msk              /*!< Enables and locks the SRAM_PARITY error signal with Break Input of TIMER1 */
+#define SYSCFG_CFGR2_PVDL_Pos                 (2U)
+#define SYSCFG_CFGR2_PVDL_Msk                 (0x1UL << SYSCFG_CFGR2_PVDL_Pos)  /*!< 0x00000004 */
+#define SYSCFG_CFGR2_PVDL                     SYSCFG_CFGR2_PVDL_Msk             /*!< Enables and locks the PVD connection with Timer1 Break Input and also the PVD_EN and PVDSEL[2:0] bits of the Power Control Interface */
+#define SYSCFG_CFGR2_ECCL_Pos                 (3U)
+#define SYSCFG_CFGR2_ECCL_Msk                 (0x1UL << SYSCFG_CFGR2_ECCL_Pos)  /*!< 0x00000008 */
+#define SYSCFG_CFGR2_ECCL                     SYSCFG_CFGR2_ECCL_Msk             /*!< ECCL */
+#define SYSCFG_CFGR2_SPF_Pos                  (8U)
+#define SYSCFG_CFGR2_SPF_Msk                  (0x1UL << SYSCFG_CFGR2_SPF_Pos)   /*!< 0x00000100 */
+#define SYSCFG_CFGR2_SPF                      SYSCFG_CFGR2_SPF_Msk              /*!< SRAM Parity error flag */
+#define SYSCFG_CFGR2_SRAM_PE                  SYSCFG_CFGR2_SPF                  /*!< SRAM Parity error flag (define maintained for legacy purpose) */
+
+#define SYSCFG_CFGR2_PA1_CDEN_Pos             (16U)
+#define SYSCFG_CFGR2_PA1_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA1_CDEN_Pos)   /* 0x00010000 */
+#define SYSCFG_CFGR2_PA1_CDEN                 SYSCFG_CFGR2_PA1_CDEN_Msk              /*!< PA[1] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA3_CDEN_Pos             (17U)
+#define SYSCFG_CFGR2_PA3_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA3_CDEN_Pos)   /* 0x00020000 */
+#define SYSCFG_CFGR2_PA3_CDEN                 SYSCFG_CFGR2_PA3_CDEN_Msk              /*!< PA[3] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA5_CDEN_Pos             (18U)
+#define SYSCFG_CFGR2_PA5_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA5_CDEN_Pos)   /* 0x00040000 */
+#define SYSCFG_CFGR2_PA5_CDEN                 SYSCFG_CFGR2_PA5_CDEN_Msk              /*!< PA[5] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA6_CDEN_Pos             (19U)
+#define SYSCFG_CFGR2_PA6_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PA6_CDEN_Pos)   /* 0x00080000 */
+#define SYSCFG_CFGR2_PA6_CDEN                 SYSCFG_CFGR2_PA6_CDEN_Msk              /*!< PA[6] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PA13_CDEN_Pos            (20U)
+#define SYSCFG_CFGR2_PA13_CDEN_Msk            (0x1UL << SYSCFG_CFGR2_PA13_CDEN_Pos)  /* 0x00100000 */
+#define SYSCFG_CFGR2_PA13_CDEN                 SYSCFG_CFGR2_PA13_CDEN_Msk            /*!< PA[13] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB0_CDEN_Pos             (21U)
+#define SYSCFG_CFGR2_PB0_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB0_CDEN_Pos)   /* 0x00200000 */
+#define SYSCFG_CFGR2_PB0_CDEN                 SYSCFG_CFGR2_PB0_CDEN_Msk              /*!< PB[0] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB1_CDEN_Pos             (22U)
+#define SYSCFG_CFGR2_PB1_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB1_CDEN_Pos)   /* 0x00400000 */
+#define SYSCFG_CFGR2_PB1_CDEN                 SYSCFG_CFGR2_PB1_CDEN_Msk              /*!< PB[1] Clamping Diode Enable */
+#define SYSCFG_CFGR2_PB2_CDEN_Pos             (23U)
+#define SYSCFG_CFGR2_PB2_CDEN_Msk             (0x1UL << SYSCFG_CFGR2_PB2_CDEN_Pos)   /* 0x00800000 */
+#define SYSCFG_CFGR2_PB2_CDEN                 SYSCFG_CFGR2_PB2_CDEN_Msk              /*!< PB[2] Clamping Diode Enable */
+/*****************  Bit definition for SYSCFG_ITLINEx ISR Wrapper register  ****************/
+#define SYSCFG_ITLINE0_SR_EWDG_Pos            (0U)
+#define SYSCFG_ITLINE0_SR_EWDG_Msk            (0x1UL << SYSCFG_ITLINE0_SR_EWDG_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE0_SR_EWDG                SYSCFG_ITLINE0_SR_EWDG_Msk       /*!< EWDG interrupt */
+#define SYSCFG_ITLINE1_SR_PVDOUT_Pos          (0U)
+#define SYSCFG_ITLINE1_SR_PVDOUT_Msk          (0x1UL << SYSCFG_ITLINE1_SR_PVDOUT_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE1_SR_PVDOUT              SYSCFG_ITLINE1_SR_PVDOUT_Msk     /*!< Power voltage detection -> exti[16] Interrupt */
+#define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
+#define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
+#define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
+#define SYSCFG_ITLINE3_SR_FLASH_ITF_Pos       (1U)
+#define SYSCFG_ITLINE3_SR_FLASH_ITF_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ITF_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE3_SR_FLASH_ITF           SYSCFG_ITLINE3_SR_FLASH_ITF_Msk  /*!< FLASH ITF interrupt */
+#define SYSCFG_ITLINE4_SR_CLK_CTRL_Pos        (0U)
+#define SYSCFG_ITLINE4_SR_CLK_CTRL_Msk        (0x1UL << SYSCFG_ITLINE4_SR_CLK_CTRL_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE4_SR_CLK_CTRL            SYSCFG_ITLINE4_SR_CLK_CTRL_Msk   /*!< RCC interrupt */
+#define SYSCFG_ITLINE5_SR_EXTI0_Pos           (0U)
+#define SYSCFG_ITLINE5_SR_EXTI0_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI0_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE5_SR_EXTI0               SYSCFG_ITLINE5_SR_EXTI0_Msk      /*!< External Interrupt 0 */
+#define SYSCFG_ITLINE5_SR_EXTI1_Pos           (1U)
+#define SYSCFG_ITLINE5_SR_EXTI1_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE5_SR_EXTI1               SYSCFG_ITLINE5_SR_EXTI1_Msk      /*!< External Interrupt 1 */
+#define SYSCFG_ITLINE6_SR_EXTI2_Pos           (0U)
+#define SYSCFG_ITLINE6_SR_EXTI2_Msk           (0x1UL << SYSCFG_ITLINE6_SR_EXTI2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE6_SR_EXTI2               SYSCFG_ITLINE6_SR_EXTI2_Msk      /*!< External Interrupt 2 */
+#define SYSCFG_ITLINE6_SR_EXTI3_Pos           (1U)
+#define SYSCFG_ITLINE6_SR_EXTI3_Msk           (0x1UL << SYSCFG_ITLINE6_SR_EXTI3_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE6_SR_EXTI3               SYSCFG_ITLINE6_SR_EXTI3_Msk      /*!< External Interrupt 3 */
+#define SYSCFG_ITLINE7_SR_EXTI4_Pos           (0U)
+#define SYSCFG_ITLINE7_SR_EXTI4_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI4_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE7_SR_EXTI4               SYSCFG_ITLINE7_SR_EXTI4_Msk      /*!< External Interrupt 4 */
+#define SYSCFG_ITLINE7_SR_EXTI5_Pos           (1U)
+#define SYSCFG_ITLINE7_SR_EXTI5_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI5_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE7_SR_EXTI5               SYSCFG_ITLINE7_SR_EXTI5_Msk      /*!< External Interrupt 5 */
+#define SYSCFG_ITLINE7_SR_EXTI6_Pos           (2U)
+#define SYSCFG_ITLINE7_SR_EXTI6_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI6_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE7_SR_EXTI6               SYSCFG_ITLINE7_SR_EXTI6_Msk      /*!< External Interrupt 6 */
+#define SYSCFG_ITLINE7_SR_EXTI7_Pos           (3U)
+#define SYSCFG_ITLINE7_SR_EXTI7_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI7_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE7_SR_EXTI7               SYSCFG_ITLINE7_SR_EXTI7_Msk      /*!< External Interrupt 7 */
+#define SYSCFG_ITLINE7_SR_EXTI8_Pos           (4U)
+#define SYSCFG_ITLINE7_SR_EXTI8_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI8_Pos) /*!< 0x00000010 */
+#define SYSCFG_ITLINE7_SR_EXTI8               SYSCFG_ITLINE7_SR_EXTI8_Msk      /*!< External Interrupt 8 */
+#define SYSCFG_ITLINE7_SR_EXTI9_Pos           (5U)
+#define SYSCFG_ITLINE7_SR_EXTI9_Msk           (0x1UL << SYSCFG_ITLINE7_SR_EXTI9_Pos) /*!< 0x00000020 */
+#define SYSCFG_ITLINE7_SR_EXTI9               SYSCFG_ITLINE7_SR_EXTI9_Msk      /*!< External Interrupt 9 */
+#define SYSCFG_ITLINE7_SR_EXTI10_Pos          (6U)
+#define SYSCFG_ITLINE7_SR_EXTI10_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI10_Pos) /*!< 0x00000040 */
+#define SYSCFG_ITLINE7_SR_EXTI10              SYSCFG_ITLINE7_SR_EXTI10_Msk     /*!< External Interrupt 10 */
+#define SYSCFG_ITLINE7_SR_EXTI11_Pos          (7U)
+#define SYSCFG_ITLINE7_SR_EXTI11_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI11_Pos) /*!< 0x00000080 */
+#define SYSCFG_ITLINE7_SR_EXTI11              SYSCFG_ITLINE7_SR_EXTI11_Msk     /*!< External Interrupt 11 */
+#define SYSCFG_ITLINE7_SR_EXTI12_Pos          (8U)
+#define SYSCFG_ITLINE7_SR_EXTI12_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI12_Pos) /*!< 0x00000100 */
+#define SYSCFG_ITLINE7_SR_EXTI12              SYSCFG_ITLINE7_SR_EXTI12_Msk     /*!< External Interrupt 12 */
+#define SYSCFG_ITLINE7_SR_EXTI13_Pos          (9U)
+#define SYSCFG_ITLINE7_SR_EXTI13_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI13_Pos) /*!< 0x00000200 */
+#define SYSCFG_ITLINE7_SR_EXTI13              SYSCFG_ITLINE7_SR_EXTI13_Msk     /*!< External Interrupt 13 */
+#define SYSCFG_ITLINE7_SR_EXTI14_Pos          (10U)
+#define SYSCFG_ITLINE7_SR_EXTI14_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI14_Pos) /*!< 0x00000400 */
+#define SYSCFG_ITLINE7_SR_EXTI14              SYSCFG_ITLINE7_SR_EXTI14_Msk     /*!< External Interrupt 14 */
+#define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
+#define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
+#define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
+#define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
+#define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
+#define SYSCFG_ITLINE10_SR_DMA1_CH2_Pos       (0U)
+#define SYSCFG_ITLINE10_SR_DMA1_CH2_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE10_SR_DMA1_CH2           SYSCFG_ITLINE10_SR_DMA1_CH2_Msk  /*!< DMA1 Channel 2 Interrupt */
+#define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
+#define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH5_Pos       (2U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH5_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH5_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH5           SYSCFG_ITLINE11_SR_DMA1_CH5_Msk  /*!< DMA1 Channel 5 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH6_Pos       (3U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH6_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH6_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH6           SYSCFG_ITLINE11_SR_DMA1_CH6_Msk  /*!< DMA1 Channel 6 Interrupt */
+#define SYSCFG_ITLINE11_SR_DMA1_CH7_Pos       (4U)
+#define SYSCFG_ITLINE11_SR_DMA1_CH7_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH7_Pos) /*!< 0x00000010 */
+#define SYSCFG_ITLINE11_SR_DMA1_CH7           SYSCFG_ITLINE11_SR_DMA1_CH7_Msk  /*!< DMA1 Channel 7 Interrupt */
+#define SYSCFG_ITLINE12_SR_ADC_Pos            (0U)
+#define SYSCFG_ITLINE12_SR_ADC_Msk            (0x1UL << SYSCFG_ITLINE12_SR_ADC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE12_SR_ADC                SYSCFG_ITLINE12_SR_ADC_Msk       /*!< ADC Interrupt */
+#define SYSCFG_ITLINE12_SR_COMP1_Pos          (1U)
+#define SYSCFG_ITLINE12_SR_COMP1_Msk          (0x1UL << SYSCFG_ITLINE12_SR_COMP1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE12_SR_COMP1              SYSCFG_ITLINE12_SR_COMP1_Msk     /*!< COMP1 Interrupt -> exti[17] */
+#define SYSCFG_ITLINE12_SR_COMP2_Pos          (2U)
+#define SYSCFG_ITLINE12_SR_COMP2_Msk          (0x1UL << SYSCFG_ITLINE12_SR_COMP2_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE12_SR_COMP2              SYSCFG_ITLINE12_SR_COMP2_Msk     /*!< COMP2 Interrupt -> exti[18] */
+#define SYSCFG_ITLINE13_SR_TIM1_CCU_Pos       (0U)
+#define SYSCFG_ITLINE13_SR_TIM1_CCU_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_CCU_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE13_SR_TIM1_CCU           SYSCFG_ITLINE13_SR_TIM1_CCU_Msk  /*!< TIM1 CCU Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_TRG_Pos       (1U)
+#define SYSCFG_ITLINE13_SR_TIM1_TRG_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_TRG_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE13_SR_TIM1_TRG           SYSCFG_ITLINE13_SR_TIM1_TRG_Msk  /*!< TIM1 TRG Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_UPD_Pos       (2U)
+#define SYSCFG_ITLINE13_SR_TIM1_UPD_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_UPD_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE13_SR_TIM1_UPD           SYSCFG_ITLINE13_SR_TIM1_UPD_Msk  /*!< TIM1 UPD Interrupt */
+#define SYSCFG_ITLINE13_SR_TIM1_BRK_Pos       (3U)
+#define SYSCFG_ITLINE13_SR_TIM1_BRK_Msk       (0x1UL << SYSCFG_ITLINE13_SR_TIM1_BRK_Pos) /*!< 0x00000008 */
+#define SYSCFG_ITLINE13_SR_TIM1_BRK           SYSCFG_ITLINE13_SR_TIM1_BRK_Msk  /*!< TIM1 BRK Interrupt */
+#define SYSCFG_ITLINE14_SR_TIM1_CC_Pos        (0U)
+#define SYSCFG_ITLINE14_SR_TIM1_CC_Msk        (0x1UL << SYSCFG_ITLINE14_SR_TIM1_CC_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE14_SR_TIM1_CC            SYSCFG_ITLINE14_SR_TIM1_CC_Msk   /*!< TIM1 CC Interrupt */
+#define SYSCFG_ITLINE15_SR_TIM2_GLB_Pos       (0U)
+#define SYSCFG_ITLINE15_SR_TIM2_GLB_Msk       (0x1UL << SYSCFG_ITLINE15_SR_TIM2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE15_SR_TIM2_GLB           SYSCFG_ITLINE15_SR_TIM2_GLB_Msk  /*!< TIM2 GLB Interrupt */
+#define SYSCFG_ITLINE16_SR_TIM3_GLB_Pos       (0U)
+#define SYSCFG_ITLINE16_SR_TIM3_GLB_Msk       (0x1UL << SYSCFG_ITLINE16_SR_TIM3_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE16_SR_TIM3_GLB           SYSCFG_ITLINE16_SR_TIM3_GLB_Msk  /*!< TIM3 GLB Interrupt */
+#define SYSCFG_ITLINE17_SR_TIM6_GLB_Pos       (0U)
+#define SYSCFG_ITLINE17_SR_TIM6_GLB_Msk       (0x1UL << SYSCFG_ITLINE17_SR_TIM6_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE17_SR_TIM6_GLB           SYSCFG_ITLINE17_SR_TIM6_GLB_Msk  /*!< TIM6 GLB Interrupt */
+#define SYSCFG_ITLINE17_SR_DAC_Pos            (1U)
+#define SYSCFG_ITLINE17_SR_DAC_Msk            (0x1UL << SYSCFG_ITLINE17_SR_DAC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE17_SR_DAC                SYSCFG_ITLINE17_SR_DAC_Msk       /*!< DAC Interrupt */
+#define SYSCFG_ITLINE17_SR_LPTIM1_GLB_Pos     (2U)
+#define SYSCFG_ITLINE17_SR_LPTIM1_GLB_Msk     (0x1UL << SYSCFG_ITLINE17_SR_LPTIM1_GLB_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE17_SR_LPTIM1_GLB         SYSCFG_ITLINE17_SR_LPTIM1_GLB_Msk /*!< LPTIM1 -> exti[29] Interrupt */
+#define SYSCFG_ITLINE18_SR_TIM7_GLB_Pos       (0U)
+#define SYSCFG_ITLINE18_SR_TIM7_GLB_Msk       (0x1UL << SYSCFG_ITLINE18_SR_TIM7_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE18_SR_TIM7_GLB           SYSCFG_ITLINE18_SR_TIM7_GLB_Msk  /*!< TIM7 GLB Interrupt */
+#define SYSCFG_ITLINE18_SR_LPTIM2_GLB_Pos     (1U)
+#define SYSCFG_ITLINE18_SR_LPTIM2_GLB_Msk     (0x1UL << SYSCFG_ITLINE18_SR_LPTIM2_GLB_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE18_SR_LPTIM2_GLB         SYSCFG_ITLINE18_SR_LPTIM2_GLB_Msk /*!< LPTIM2 -> exti[30] Interrupt */
+#define SYSCFG_ITLINE19_SR_TIM14_GLB_Pos      (0U)
+#define SYSCFG_ITLINE19_SR_TIM14_GLB_Msk      (0x1UL << SYSCFG_ITLINE19_SR_TIM14_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE19_SR_TIM14_GLB          SYSCFG_ITLINE19_SR_TIM14_GLB_Msk /*!< TIM14 GLB Interrupt */
+#define SYSCFG_ITLINE20_SR_TIM15_GLB_Pos      (0U)
+#define SYSCFG_ITLINE20_SR_TIM15_GLB_Msk      (0x1UL << SYSCFG_ITLINE20_SR_TIM15_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE20_SR_TIM15_GLB          SYSCFG_ITLINE20_SR_TIM15_GLB_Msk /*!< TIM15 GLB Interrupt */
+#define SYSCFG_ITLINE21_SR_TIM16_GLB_Pos      (0U)
+#define SYSCFG_ITLINE21_SR_TIM16_GLB_Msk      (0x1UL << SYSCFG_ITLINE21_SR_TIM16_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE21_SR_TIM16_GLB          SYSCFG_ITLINE21_SR_TIM16_GLB_Msk /*!< TIM16 GLB Interrupt */
+#define SYSCFG_ITLINE22_SR_TIM17_GLB_Pos      (0U)
+#define SYSCFG_ITLINE22_SR_TIM17_GLB_Msk      (0x1UL << SYSCFG_ITLINE22_SR_TIM17_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE22_SR_TIM17_GLB          SYSCFG_ITLINE22_SR_TIM17_GLB_Msk /*!< TIM17 GLB Interrupt */
+#define SYSCFG_ITLINE23_SR_I2C1_GLB_Pos       (0U)
+#define SYSCFG_ITLINE23_SR_I2C1_GLB_Msk       (0x1UL << SYSCFG_ITLINE23_SR_I2C1_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
+#define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
+#define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
+#define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
+#define SYSCFG_ITLINE26_SR_SPI2_Pos           (0U)
+#define SYSCFG_ITLINE26_SR_SPI2_Msk           (0x1UL << SYSCFG_ITLINE26_SR_SPI2_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE26_SR_SPI2               SYSCFG_ITLINE26_SR_SPI2_Msk      /*!< SPI2  Interrupt */
+#define SYSCFG_ITLINE27_SR_USART1_GLB_Pos     (0U)
+#define SYSCFG_ITLINE27_SR_USART1_GLB_Msk     (0x1UL << SYSCFG_ITLINE27_SR_USART1_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE27_SR_USART1_GLB         SYSCFG_ITLINE27_SR_USART1_GLB_Msk /*!< USART1 GLB Interrupt -> exti[25] */
+#define SYSCFG_ITLINE28_SR_USART2_GLB_Pos     (0U)
+#define SYSCFG_ITLINE28_SR_USART2_GLB_Msk     (0x1UL << SYSCFG_ITLINE28_SR_USART2_GLB_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE28_SR_USART2_GLB         SYSCFG_ITLINE28_SR_USART2_GLB_Msk /*!< USART2 GLB Interrupt -> exti[26] */
+#define SYSCFG_ITLINE29_SR_LPUART1_GLB_Pos    (2U)
+#define SYSCFG_ITLINE29_SR_LPUART1_GLB_Msk    (0x1UL << SYSCFG_ITLINE29_SR_LPUART1_GLB_Pos) /*!< 0x00000004 */
+#define SYSCFG_ITLINE29_SR_LPUART1_GLB        SYSCFG_ITLINE29_SR_LPUART1_GLB_Msk /*!< LPUART1 GLB Interrupt -> exti[28] */
+#define SYSCFG_ITLINE31_SR_RNG_Pos            (0U)
+#define SYSCFG_ITLINE31_SR_RNG_Msk            (0x1UL << SYSCFG_ITLINE31_SR_RNG_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE31_SR_RNG                SYSCFG_ITLINE31_SR_RNG_Msk       /*!< RNG Interrupt */
+#define SYSCFG_ITLINE31_SR_AES_Pos            (1U)
+#define SYSCFG_ITLINE31_SR_AES_Msk            (0x1UL << SYSCFG_ITLINE31_SR_AES_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE31_SR_AES                SYSCFG_ITLINE31_SR_AES_Msk       /*!< AES Interrupt */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                   /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable */
+#define TIM_CR1_UDIS_Pos          (1U)
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                  /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable */
+#define TIM_CR1_URS_Pos           (2U)
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                   /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode */
+#define TIM_CR1_DIR_Pos           (4U)
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                   /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction */
+
+#define TIM_CR1_CMS_Pos           (5U)
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000020 */
+#define TIM_CR1_CMS_1             (0x2UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                  /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable */
+
+#define TIM_CR1_CKD_Pos           (8U)
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000100 */
+#define TIM_CR1_CKD_1             (0x2UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000200 */
+
+#define TIM_CR1_UIFREMAP_Pos      (11U)
+#define TIM_CR1_UIFREMAP_Msk      (0x1UL << TIM_CR1_UIFREMAP_Pos)              /*!< 0x00000800 */
+#define TIM_CR1_UIFREMAP          TIM_CR1_UIFREMAP_Msk                         /*!<Update interrupt flag remap */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                  /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control */
+#define TIM_CR2_CCUS_Pos          (2U)
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                  /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                  /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection */
+
+#define TIM_CR2_MMS_Pos           (4U)
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000010 */
+#define TIM_CR2_MMS_1             (0x2UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000020 */
+#define TIM_CR2_MMS_2             (0x4UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                  /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                  /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output) */
+#define TIM_CR2_OIS1N_Pos         (9U)
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                 /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                  /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output) */
+#define TIM_CR2_OIS2N_Pos         (11U)
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                 /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                  /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output) */
+#define TIM_CR2_OIS3N_Pos         (13U)
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                 /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                  /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output) */
+#define TIM_CR2_OIS5_Pos          (16U)
+#define TIM_CR2_OIS5_Msk          (0x1UL << TIM_CR2_OIS5_Pos)                  /*!< 0x00010000 */
+#define TIM_CR2_OIS5              TIM_CR2_OIS5_Msk                             /*!<Output Idle state 5 (OC5 output) */
+#define TIM_CR2_OIS6_Pos          (18U)
+#define TIM_CR2_OIS6_Msk          (0x1UL << TIM_CR2_OIS6_Pos)                  /*!< 0x00040000 */
+#define TIM_CR2_OIS6              TIM_CR2_OIS6_Msk                             /*!<Output Idle state 6 (OC6 output) */
+
+#define TIM_CR2_MMS2_Pos          (20U)
+#define TIM_CR2_MMS2_Msk          (0xFUL << TIM_CR2_MMS2_Pos)                  /*!< 0x00F00000 */
+#define TIM_CR2_MMS2              TIM_CR2_MMS2_Msk                             /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS2_0            (0x1UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00100000 */
+#define TIM_CR2_MMS2_1            (0x2UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00200000 */
+#define TIM_CR2_MMS2_2            (0x4UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00400000 */
+#define TIM_CR2_MMS2_3            (0x8UL << TIM_CR2_MMS2_Pos)                  /*!< 0x00800000 */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)
+#define TIM_SMCR_SMS_Msk          (0x10007UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMCR_SMS_0            (0x00001UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000001 */
+#define TIM_SMCR_SMS_1            (0x00002UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000002 */
+#define TIM_SMCR_SMS_2            (0x00004UL << TIM_SMCR_SMS_Pos)              /*!< 0x00000004 */
+#define TIM_SMCR_SMS_3            (0x10000UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010000 */
+
+#define TIM_SMCR_OCCS_Pos         (3U)
+#define TIM_SMCR_OCCS_Msk         (0x1UL << TIM_SMCR_OCCS_Pos)                 /*!< 0x00000008 */
+#define TIM_SMCR_OCCS             TIM_SMCR_OCCS_Msk                            /*!< OCREF clear selection */
+
+#define TIM_SMCR_TS_Pos           (4U)
+#define TIM_SMCR_TS_Msk           (0x30007UL << TIM_SMCR_TS_Pos)               /*!< 0x00300070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection) */
+#define TIM_SMCR_TS_0             (0x00001UL << TIM_SMCR_TS_Pos)               /*!< 0x00000010 */
+#define TIM_SMCR_TS_1             (0x00002UL << TIM_SMCR_TS_Pos)               /*!< 0x00000020 */
+#define TIM_SMCR_TS_2             (0x00004UL << TIM_SMCR_TS_Pos)               /*!< 0x00000040 */
+#define TIM_SMCR_TS_3             (0x10000UL << TIM_SMCR_TS_Pos)               /*!< 0x00100000 */
+#define TIM_SMCR_TS_4             (0x20000UL << TIM_SMCR_TS_Pos)               /*!< 0x00200000 */
+
+#define TIM_SMCR_MSM_Pos          (7U)
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                  /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode */
+
+#define TIM_SMCR_ETF_Pos          (8U)
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000100 */
+#define TIM_SMCR_ETF_1            (0x2UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000200 */
+#define TIM_SMCR_ETF_2            (0x4UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000400 */
+#define TIM_SMCR_ETF_3            (0x8UL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00001000 */
+#define TIM_SMCR_ETPS_1           (0x2UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00002000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                  /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable */
+#define TIM_SMCR_ETP_Pos          (15U)
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                  /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                  /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable */
+#define TIM_DIER_CC2IE_Pos        (2U)
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable */
+#define TIM_DIER_CC3IE_Pos        (3U)
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable */
+#define TIM_DIER_CC4IE_Pos        (4U)
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable */
+#define TIM_DIER_COMIE_Pos        (5U)
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable */
+#define TIM_DIER_TIE_Pos          (6U)
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                  /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable */
+#define TIM_DIER_BIE_Pos          (7U)
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                  /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable */
+#define TIM_DIER_UDE_Pos          (8U)
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                  /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable */
+#define TIM_DIER_CC1DE_Pos        (9U)
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable */
+#define TIM_DIER_TDE_Pos          (14U)
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                  /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                    /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag */
+#define TIM_SR_CC1IF_Pos          (1U)
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                  /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag */
+#define TIM_SR_CC2IF_Pos          (2U)
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                  /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag */
+#define TIM_SR_CC3IF_Pos          (3U)
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                  /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag */
+#define TIM_SR_CC4IF_Pos          (4U)
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                  /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag */
+#define TIM_SR_COMIF_Pos          (5U)
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                  /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag */
+#define TIM_SR_TIF_Pos            (6U)
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                    /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag */
+#define TIM_SR_BIF_Pos            (7U)
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                    /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag */
+#define TIM_SR_B2IF_Pos           (8U)
+#define TIM_SR_B2IF_Msk           (0x1UL << TIM_SR_B2IF_Pos)                   /*!< 0x00000100 */
+#define TIM_SR_B2IF               TIM_SR_B2IF_Msk                              /*!<Break 2 interrupt Flag */
+#define TIM_SR_CC1OF_Pos          (9U)
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                  /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                  /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                  /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                  /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+#define TIM_SR_SBIF_Pos           (13U)
+#define TIM_SR_SBIF_Msk           (0x1UL << TIM_SR_SBIF_Pos)                   /*!< 0x00002000 */
+#define TIM_SR_SBIF               TIM_SR_SBIF_Msk                              /*!<System Break interrupt Flag */
+#define TIM_SR_CC5IF_Pos          (16U)
+#define TIM_SR_CC5IF_Msk          (0x1UL << TIM_SR_CC5IF_Pos)                  /*!< 0x00010000 */
+#define TIM_SR_CC5IF              TIM_SR_CC5IF_Msk                             /*!<Capture/Compare 5 interrupt Flag */
+#define TIM_SR_CC6IF_Pos          (17U)
+#define TIM_SR_CC6IF_Msk          (0x1UL << TIM_SR_CC6IF_Pos)                  /*!< 0x00020000 */
+#define TIM_SR_CC6IF              TIM_SR_CC6IF_Msk                             /*!<Capture/Compare 6 interrupt Flag */
+
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                    /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation */
+#define TIM_EGR_CC1G_Pos          (1U)
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                  /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation */
+#define TIM_EGR_CC2G_Pos          (2U)
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                  /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation */
+#define TIM_EGR_CC3G_Pos          (3U)
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                  /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation */
+#define TIM_EGR_CC4G_Pos          (4U)
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                  /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation */
+#define TIM_EGR_COMG_Pos          (5U)
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                  /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                    /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation */
+#define TIM_EGR_BG_Pos            (7U)
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                    /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation */
+#define TIM_EGR_B2G_Pos           (8U)
+#define TIM_EGR_B2G_Msk           (0x1UL << TIM_EGR_B2G_Pos)                   /*!< 0x00000100 */
+#define TIM_EGR_B2G               TIM_EGR_B2G_Msk                              /*!<Break 2 Generation */
+
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000001 */
+#define TIM_CCMR1_CC1S_1          (0x2UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable */
+#define TIM_CCMR1_OC1PE_Pos       (3U)
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)
+#define TIM_CCMR1_OC1M_Msk        (0x1007UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_CCMR1_OC1M_0          (0x0001UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR1_OC1M_1          (0x0002UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR1_OC1M_2          (0x0004UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR1_OC1M_3          (0x1000UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1 Clear Enable */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000100 */
+#define TIM_CCMR1_CC2S_1          (0x2UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable */
+#define TIM_CCMR1_OC2PE_Pos       (11U)
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)
+#define TIM_CCMR1_OC2M_Msk        (0x1007UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_CCMR1_OC2M_0          (0x0001UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR1_OC2M_1          (0x0002UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR1_OC2M_2          (0x0004UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR1_OC2M_3          (0x1000UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR1_IC1PSC_Pos      (2U)
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x00000004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x00000008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_CCMR1_IC1F_0          (0x1UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000010 */
+#define TIM_CCMR1_IC1F_1          (0x2UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000020 */
+#define TIM_CCMR1_IC1F_2          (0x4UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000040 */
+#define TIM_CCMR1_IC1F_3          (0x8UL << TIM_CCMR1_IC1F_Pos)                /*!< 0x00000080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_CCMR1_IC2PSC_0        (0x1UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_CCMR1_IC2F_0          (0x1UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00001000 */
+#define TIM_CCMR1_IC2F_1          (0x2UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00002000 */
+#define TIM_CCMR1_IC2F_2          (0x4UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00004000 */
+#define TIM_CCMR1_IC2F_3          (0x8UL << TIM_CCMR1_IC2F_Pos)                /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CCMR2_CC3S_0          (0x1UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000001 */
+#define TIM_CCMR2_CC3S_1          (0x2UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable */
+#define TIM_CCMR2_OC3PE_Pos       (3U)
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)
+#define TIM_CCMR2_OC3M_Msk        (0x1007UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x0001UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR2_OC3M_1          (0x0002UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR2_OC3M_2          (0x0004UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR2_OC3M_3          (0x1000UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000100 */
+#define TIM_CCMR2_CC4S_1          (0x2UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable */
+#define TIM_CCMR2_OC4PE_Pos       (11U)
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)
+#define TIM_CCMR2_OC4M_Msk        (0x1007UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x0001UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR2_OC4M_1          (0x0002UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR2_OC4M_2          (0x0004UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR2_OC4M_3          (0x1000UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR2_IC3PSC_Pos      (2U)
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x00000004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x00000008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000010 */
+#define TIM_CCMR2_IC3F_1          (0x2UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000020 */
+#define TIM_CCMR2_IC3F_2          (0x4UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000040 */
+#define TIM_CCMR2_IC3F_3          (0x8UL << TIM_CCMR2_IC3F_Pos)                /*!< 0x00000080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00001000 */
+#define TIM_CCMR2_IC4F_1          (0x2UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00002000 */
+#define TIM_CCMR2_IC4F_2          (0x4UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00004000 */
+#define TIM_CCMR2_IC4F_3          (0x8UL << TIM_CCMR2_IC4F_Pos)                /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define TIM_CCMR3_OC5FE_Pos       (2U)
+#define TIM_CCMR3_OC5FE_Msk       (0x1UL << TIM_CCMR3_OC5FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR3_OC5FE           TIM_CCMR3_OC5FE_Msk                          /*!<Output Compare 5 Fast enable */
+#define TIM_CCMR3_OC5PE_Pos       (3U)
+#define TIM_CCMR3_OC5PE_Msk       (0x1UL << TIM_CCMR3_OC5PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR3_OC5PE           TIM_CCMR3_OC5PE_Msk                          /*!<Output Compare 5 Preload enable */
+
+#define TIM_CCMR3_OC5M_Pos        (4U)
+#define TIM_CCMR3_OC5M_Msk        (0x1007UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR3_OC5M            TIM_CCMR3_OC5M_Msk                           /*!<OC5M[3:0] bits (Output Compare 5 Mode) */
+#define TIM_CCMR3_OC5M_0          (0x0001UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000010 */
+#define TIM_CCMR3_OC5M_1          (0x0002UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000020 */
+#define TIM_CCMR3_OC5M_2          (0x0004UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00000040 */
+#define TIM_CCMR3_OC5M_3          (0x1000UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010000 */
+
+#define TIM_CCMR3_OC5CE_Pos       (7U)
+#define TIM_CCMR3_OC5CE_Msk       (0x1UL << TIM_CCMR3_OC5CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR3_OC5CE           TIM_CCMR3_OC5CE_Msk                          /*!<Output Compare 5 Clear Enable */
+
+#define TIM_CCMR3_OC6FE_Pos       (10U)
+#define TIM_CCMR3_OC6FE_Msk       (0x1UL << TIM_CCMR3_OC6FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR3_OC6FE           TIM_CCMR3_OC6FE_Msk                          /*!<Output Compare 6 Fast enable */
+#define TIM_CCMR3_OC6PE_Pos       (11U)
+#define TIM_CCMR3_OC6PE_Msk       (0x1UL << TIM_CCMR3_OC6PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR3_OC6PE           TIM_CCMR3_OC6PE_Msk                          /*!<Output Compare 6 Preload enable */
+
+#define TIM_CCMR3_OC6M_Pos        (12U)
+#define TIM_CCMR3_OC6M_Msk        (0x1007UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR3_OC6M            TIM_CCMR3_OC6M_Msk                           /*!<OC6M[3:0] bits (Output Compare 6 Mode) */
+#define TIM_CCMR3_OC6M_0          (0x0001UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00001000 */
+#define TIM_CCMR3_OC6M_1          (0x0002UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00002000 */
+#define TIM_CCMR3_OC6M_2          (0x0004UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x00004000 */
+#define TIM_CCMR3_OC6M_3          (0x1000UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01000000 */
+
+#define TIM_CCMR3_OC6CE_Pos       (15U)
+#define TIM_CCMR3_OC6CE_Msk       (0x1UL << TIM_CCMR3_OC6CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR3_OC6CE           TIM_CCMR3_OC6CE_Msk                          /*!<Output Compare 6 Clear Enable */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                 /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable */
+#define TIM_CCER_CC1P_Pos         (1U)
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                 /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity */
+#define TIM_CCER_CC1NE_Pos        (2U)
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable */
+#define TIM_CCER_CC1NP_Pos        (3U)
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                 /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable */
+#define TIM_CCER_CC2P_Pos         (5U)
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                 /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity */
+#define TIM_CCER_CC2NE_Pos        (6U)
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable */
+#define TIM_CCER_CC2NP_Pos        (7U)
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                 /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable */
+#define TIM_CCER_CC3P_Pos         (9U)
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                 /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity */
+#define TIM_CCER_CC3NE_Pos        (10U)
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable */
+#define TIM_CCER_CC3NP_Pos        (11U)
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                 /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable */
+#define TIM_CCER_CC4P_Pos         (13U)
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                 /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity */
+#define TIM_CCER_CC4NP_Pos        (15U)
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+#define TIM_CCER_CC5E_Pos         (16U)
+#define TIM_CCER_CC5E_Msk         (0x1UL << TIM_CCER_CC5E_Pos)                 /*!< 0x00010000 */
+#define TIM_CCER_CC5E             TIM_CCER_CC5E_Msk                            /*!<Capture/Compare 5 output enable */
+#define TIM_CCER_CC5P_Pos         (17U)
+#define TIM_CCER_CC5P_Msk         (0x1UL << TIM_CCER_CC5P_Pos)                 /*!< 0x00020000 */
+#define TIM_CCER_CC5P             TIM_CCER_CC5P_Msk                            /*!<Capture/Compare 5 output Polarity */
+#define TIM_CCER_CC6E_Pos         (20U)
+#define TIM_CCER_CC6E_Msk         (0x1UL << TIM_CCER_CC6E_Pos)                 /*!< 0x00100000 */
+#define TIM_CCER_CC6E             TIM_CCER_CC6E_Msk                            /*!<Capture/Compare 6 output enable */
+#define TIM_CCER_CC6P_Pos         (21U)
+#define TIM_CCER_CC6P_Msk         (0x1UL << TIM_CCER_CC6P_Pos)                 /*!< 0x00200000 */
+#define TIM_CCER_CC6P             TIM_CCER_CC6P_Msk                            /*!<Capture/Compare 6 output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                              /*!<Counter Value */
+#define TIM_CNT_UIFCPY_Pos        (31U)
+#define TIM_CNT_UIFCPY_Msk        (0x1UL << TIM_CNT_UIFCPY_Pos)                /*!< 0x80000000 */
+#define TIM_CNT_UIFCPY            TIM_CNT_UIFCPY_Msk                           /*!<Update interrupt flag copy (if UIFREMAP=1) */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<Actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)
+#define TIM_RCR_REP_Msk           (0xFFFFUL << TIM_RCR_REP_Pos)                /*!< 0x0000FFFF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define TIM_CCR5_CCR5_Pos         (0U)
+#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
+#define TIM_CCR5_GC5C1_Pos        (29U)
+#define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
+#define TIM_CCR5_GC5C1            TIM_CCR5_GC5C1_Msk                           /*!<Group Channel 5 and Channel 1 */
+#define TIM_CCR5_GC5C2_Pos        (30U)
+#define TIM_CCR5_GC5C2_Msk        (0x1UL << TIM_CCR5_GC5C2_Pos)                /*!< 0x40000000 */
+#define TIM_CCR5_GC5C2            TIM_CCR5_GC5C2_Msk                           /*!<Group Channel 5 and Channel 2 */
+#define TIM_CCR5_GC5C3_Pos        (31U)
+#define TIM_CCR5_GC5C3_Msk        (0x1UL << TIM_CCR5_GC5C3_Pos)                /*!< 0x80000000 */
+#define TIM_CCR5_GC5C3            TIM_CCR5_GC5C3_Msk                           /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define TIM_CCR6_CCR6_Pos         (0U)
+#define TIM_CCR6_CCR6_Msk         (0xFFFFUL << TIM_CCR6_CCR6_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6             TIM_CCR6_CCR6_Msk                            /*!<Capture/Compare 6 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                 /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000001 */
+#define TIM_BDTR_DTG_1            (0x02UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000002 */
+#define TIM_BDTR_DTG_2            (0x04UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000004 */
+#define TIM_BDTR_DTG_3            (0x08UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000008 */
+#define TIM_BDTR_DTG_4            (0x10UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000010 */
+#define TIM_BDTR_DTG_5            (0x20UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000020 */
+#define TIM_BDTR_DTG_6            (0x40UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000040 */
+#define TIM_BDTR_DTG_7            (0x80UL << TIM_BDTR_DTG_Pos)                 /*!< 0x00000080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000100 */
+#define TIM_BDTR_LOCK_1           (0x2UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                 /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                 /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode */
+#define TIM_BDTR_BKE_Pos          (12U)
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                  /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable for Break 1 */
+#define TIM_BDTR_BKP_Pos          (13U)
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                  /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity for Break 1 */
+#define TIM_BDTR_AOE_Pos          (14U)
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                  /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable */
+#define TIM_BDTR_MOE_Pos          (15U)
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                  /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable */
+
+#define TIM_BDTR_BKF_Pos          (16U)
+#define TIM_BDTR_BKF_Msk          (0xFUL << TIM_BDTR_BKF_Pos)                  /*!< 0x000F0000 */
+#define TIM_BDTR_BKF              TIM_BDTR_BKF_Msk                             /*!<Break Filter for Break 1 */
+#define TIM_BDTR_BK2F_Pos         (20U)
+#define TIM_BDTR_BK2F_Msk         (0xFUL << TIM_BDTR_BK2F_Pos)                 /*!< 0x00F00000 */
+#define TIM_BDTR_BK2F             TIM_BDTR_BK2F_Msk                            /*!<Break Filter for Break 2 */
+
+#define TIM_BDTR_BK2E_Pos         (24U)
+#define TIM_BDTR_BK2E_Msk         (0x1UL << TIM_BDTR_BK2E_Pos)                 /*!< 0x01000000 */
+#define TIM_BDTR_BK2E             TIM_BDTR_BK2E_Msk                            /*!<Break enable for Break 2 */
+#define TIM_BDTR_BK2P_Pos         (25U)
+#define TIM_BDTR_BK2P_Msk         (0x1UL << TIM_BDTR_BK2P_Pos)                 /*!< 0x02000000 */
+#define TIM_BDTR_BK2P             TIM_BDTR_BK2P_Msk                            /*!<Break Polarity for Break 2 */
+
+#define TIM_BDTR_BKDSRM_Pos       (26U)
+#define TIM_BDTR_BKDSRM_Msk       (0x1UL << TIM_BDTR_BKDSRM_Pos)               /*!< 0x04000000 */
+#define TIM_BDTR_BKDSRM           TIM_BDTR_BKDSRM_Msk                          /*!<Break disarming/re-arming */
+#define TIM_BDTR_BK2DSRM_Pos      (27U)
+#define TIM_BDTR_BK2DSRM_Msk      (0x1UL << TIM_BDTR_BK2DSRM_Pos)              /*!< 0x08000000 */
+#define TIM_BDTR_BK2DSRM          TIM_BDTR_BK2DSRM_Msk                         /*!<Break2 disarming/re-arming */
+
+#define TIM_BDTR_BKBID_Pos        (28U)
+#define TIM_BDTR_BKBID_Msk        (0x1UL << TIM_BDTR_BKBID_Pos)                /*!< 0x10000000 */
+#define TIM_BDTR_BKBID            TIM_BDTR_BKBID_Msk                           /*!<Break BIDirectional */
+#define TIM_BDTR_BK2BID_Pos       (29U)
+#define TIM_BDTR_BK2BID_Msk       (0x1UL << TIM_BDTR_BK2BID_Pos)               /*!< 0x20000000 */
+#define TIM_BDTR_BK2BID           TIM_BDTR_BK2BID_Msk                          /*!<Break2 BIDirectional */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                  /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000001 */
+#define TIM_DCR_DBA_1             (0x02UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000002 */
+#define TIM_DCR_DBA_2             (0x04UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000004 */
+#define TIM_DCR_DBA_3             (0x08UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000008 */
+#define TIM_DCR_DBA_4             (0x10UL << TIM_DCR_DBA_Pos)                  /*!< 0x00000010 */
+
+#define TIM_DCR_DBL_Pos           (8U)
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                  /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000100 */
+#define TIM_DCR_DBL_1             (0x02UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000200 */
+#define TIM_DCR_DBL_2             (0x04UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000400 */
+#define TIM_DCR_DBL_3             (0x08UL << TIM_DCR_DBL_Pos)                  /*!< 0x00000800 */
+#define TIM_DCR_DBL_4             (0x10UL << TIM_DCR_DBL_Pos)                  /*!< 0x00001000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)              /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM1_OR1 register  *******************/
+#define TIM1_OR1_OCREF_CLR_Pos     (0U)
+#define TIM1_OR1_OCREF_CLR_Msk     (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM1_AF1 register  *******************/
+#define TIM1_AF1_BKINE_Pos        (0U)
+#define TIM1_AF1_BKINE_Msk        (0x1UL << TIM1_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM1_AF1_BKINE            TIM1_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM1_AF1_BKCMP1E_Pos      (1U)
+#define TIM1_AF1_BKCMP1E_Msk      (0x1UL << TIM1_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM1_AF1_BKCMP1E          TIM1_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM1_AF1_BKCMP2E_Pos      (2U)
+#define TIM1_AF1_BKCMP2E_Msk      (0x1UL << TIM1_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM1_AF1_BKCMP2E          TIM1_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM1_AF1_BKINP_Pos        (9U)
+#define TIM1_AF1_BKINP_Msk        (0x1UL << TIM1_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM1_AF1_BKINP            TIM1_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM1_AF1_BKCMP1P_Pos      (10U)
+#define TIM1_AF1_BKCMP1P_Msk      (0x1UL << TIM1_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM1_AF1_BKCMP1P          TIM1_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM1_AF1_BKCMP2P_Pos      (11U)
+#define TIM1_AF1_BKCMP2P_Msk      (0x1UL << TIM1_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM1_AF1_BKCMP2P          TIM1_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+#define TIM1_AF1_ETRSEL_Pos       (14U)
+#define TIM1_AF1_ETRSEL_Msk       (0xFUL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM1_AF1_ETRSEL           TIM1_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM1 ETR source selection) */
+#define TIM1_AF1_ETRSEL_0         (0x1UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM1_AF1_ETRSEL_1         (0x2UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM1_AF1_ETRSEL_2         (0x4UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM1_AF1_ETRSEL_3         (0x8UL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM1_AF2 register  *******************/
+#define TIM1_AF2_BK2INE_Pos       (0U)
+#define TIM1_AF2_BK2INE_Msk       (0x1UL << TIM1_AF2_BK2INE_Pos)               /*!< 0x00000001 */
+#define TIM1_AF2_BK2INE           TIM1_AF2_BK2INE_Msk                          /*!<BRK2 BKIN2 input enable */
+#define TIM1_AF2_BK2CMP1E_Pos     (1U)
+#define TIM1_AF2_BK2CMP1E_Msk     (0x1UL << TIM1_AF2_BK2CMP1E_Pos)             /*!< 0x00000002 */
+#define TIM1_AF2_BK2CMP1E         TIM1_AF2_BK2CMP1E_Msk                        /*!<BRK2 COMP1 enable */
+#define TIM1_AF2_BK2CMP2E_Pos     (2U)
+#define TIM1_AF2_BK2CMP2E_Msk     (0x1UL << TIM1_AF2_BK2CMP2E_Pos)             /*!< 0x00000004 */
+#define TIM1_AF2_BK2CMP2E         TIM1_AF2_BK2CMP2E_Msk                        /*!<BRK2 COMP2 enable */
+#define TIM1_AF2_BK2INP_Pos       (9U)
+#define TIM1_AF2_BK2INP_Msk       (0x1UL << TIM1_AF2_BK2INP_Pos)               /*!< 0x00000200 */
+#define TIM1_AF2_BK2INP           TIM1_AF2_BK2INP_Msk                          /*!<BRK2 BKIN2 input polarity */
+#define TIM1_AF2_BK2CMP1P_Pos     (10U)
+#define TIM1_AF2_BK2CMP1P_Msk     (0x1UL << TIM1_AF2_BK2CMP1P_Pos)             /*!< 0x00000400 */
+#define TIM1_AF2_BK2CMP1P         TIM1_AF2_BK2CMP1P_Msk                        /*!<BRK2 COMP1 input polarity */
+#define TIM1_AF2_BK2CMP2P_Pos     (11U)
+#define TIM1_AF2_BK2CMP2P_Msk     (0x1UL << TIM1_AF2_BK2CMP2P_Pos)             /*!< 0x00000800 */
+#define TIM1_AF2_BK2CMP2P         TIM1_AF2_BK2CMP2P_Msk                        /*!<BRK2 COMP2 input polarity */
+
+/*******************  Bit definition for TIM2_OR1 register  *******************/
+#define TIM2_OR1_OCREF_CLR_Pos     (0U)
+#define TIM2_OR1_OCREF_CLR_Msk     (0x1UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM2_OR1_OCREF_CLR         TIM2_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM2_AF1 register  *******************/
+#define TIM2_AF1_ETRSEL_Pos       (14U)
+#define TIM2_AF1_ETRSEL_Msk       (0xFUL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM2_AF1_ETRSEL           TIM2_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM2 ETR source selection) */
+#define TIM2_AF1_ETRSEL_0         (0x1UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM2_AF1_ETRSEL_1         (0x2UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM2_AF1_ETRSEL_2         (0x4UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM2_AF1_ETRSEL_3         (0x8UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM3_OR1 register  *******************/
+#define TIM3_OR1_OCREF_CLR_Pos     (0U)
+#define TIM3_OR1_OCREF_CLR_Msk     (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+
+/*******************  Bit definition for TIM3_AF1 register  *******************/
+#define TIM3_AF1_ETRSEL_Pos       (14U)
+#define TIM3_AF1_ETRSEL_Msk       (0xFUL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM3_AF1_ETRSEL           TIM3_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM3_AF1_ETRSEL_0         (0x1UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM3_AF1_ETRSEL_1         (0x2UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM3_AF1_ETRSEL_2         (0x4UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM3_AF1_ETRSEL_3         (0x8UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM14_AF1 register  *******************/
+#define TIM14_AF1_ETRSEL_Pos      (14U)
+#define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
+#define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
+#define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
+#define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
+#define TIM14_AF1_ETRSEL_3        (0x8UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00020000 */
+
+/*******************  Bit definition for TIM15_AF1 register  ******************/
+#define TIM15_AF1_BKINE_Pos      (0U)
+#define TIM15_AF1_BKINE_Msk      (0x1UL << TIM15_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM15_AF1_BKINE          TIM15_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM15_AF1_BKCMP1E_Pos    (1U)
+#define TIM15_AF1_BKCMP1E_Msk    (0x1UL << TIM15_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM15_AF1_BKCMP1E        TIM15_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM15_AF1_BKCMP2E_Pos    (2U)
+#define TIM15_AF1_BKCMP2E_Msk    (0x1UL << TIM15_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM15_AF1_BKCMP2E        TIM15_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM15_AF1_BKINP_Pos      (9U)
+#define TIM15_AF1_BKINP_Msk      (0x1UL << TIM15_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM15_AF1_BKINP          TIM15_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM15_AF1_BKCMP1P_Pos    (10U)
+#define TIM15_AF1_BKCMP1P_Msk    (0x1UL << TIM15_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM15_AF1_BKCMP1P        TIM15_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM15_AF1_BKCMP2P_Pos    (11U)
+#define TIM15_AF1_BKCMP2P_Msk    (0x1UL << TIM15_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM15_AF1_BKCMP2P        TIM15_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM16_AF1 register  ******************/
+#define TIM16_AF1_BKINE_Pos      (0U)
+#define TIM16_AF1_BKINE_Msk      (0x1UL << TIM16_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM16_AF1_BKINE          TIM16_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM16_AF1_BKCMP1E_Pos    (1U)
+#define TIM16_AF1_BKCMP1E_Msk    (0x1UL << TIM16_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM16_AF1_BKCMP1E        TIM16_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM16_AF1_BKCMP2E_Pos    (2U)
+#define TIM16_AF1_BKCMP2E_Msk    (0x1UL << TIM16_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM16_AF1_BKCMP2E        TIM16_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM16_AF1_BKINP_Pos      (9U)
+#define TIM16_AF1_BKINP_Msk      (0x1UL << TIM16_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM16_AF1_BKINP          TIM16_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM16_AF1_BKCMP1P_Pos    (10U)
+#define TIM16_AF1_BKCMP1P_Msk    (0x1UL << TIM16_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM16_AF1_BKCMP1P        TIM16_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM16_AF1_BKCMP2P_Pos    (11U)
+#define TIM16_AF1_BKCMP2P_Msk    (0x1UL << TIM16_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM16_AF1_BKCMP2P        TIM16_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM17_AF1 register  ******************/
+#define TIM17_AF1_BKINE_Pos      (0U)
+#define TIM17_AF1_BKINE_Msk      (0x1UL << TIM17_AF1_BKINE_Pos)                /*!< 0x00000001 */
+#define TIM17_AF1_BKINE          TIM17_AF1_BKINE_Msk                           /*!<BRK BKIN input enable */
+#define TIM17_AF1_BKCMP1E_Pos    (1U)
+#define TIM17_AF1_BKCMP1E_Msk    (0x1UL << TIM17_AF1_BKCMP1E_Pos)              /*!< 0x00000002 */
+#define TIM17_AF1_BKCMP1E        TIM17_AF1_BKCMP1E_Msk                         /*!<BRK COMP1 enable */
+#define TIM17_AF1_BKCMP2E_Pos    (2U)
+#define TIM17_AF1_BKCMP2E_Msk    (0x1UL << TIM17_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
+#define TIM17_AF1_BKCMP2E        TIM17_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM17_AF1_BKINP_Pos      (9U)
+#define TIM17_AF1_BKINP_Msk      (0x1UL << TIM17_AF1_BKINP_Pos)                /*!< 0x00000200 */
+#define TIM17_AF1_BKINP          TIM17_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
+#define TIM17_AF1_BKCMP1P_Pos    (10U)
+#define TIM17_AF1_BKCMP1P_Msk    (0x1UL << TIM17_AF1_BKCMP1P_Pos)              /*!< 0x00000400 */
+#define TIM17_AF1_BKCMP1P        TIM17_AF1_BKCMP1P_Msk                         /*!<BRK COMP1 input polarity */
+#define TIM17_AF1_BKCMP2P_Pos    (11U)
+#define TIM17_AF1_BKCMP2P_Msk    (0x1UL << TIM17_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
+#define TIM17_AF1_BKCMP2P        TIM17_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+
+/*******************  Bit definition for TIM_TISEL register  *********************/
+#define TIM_TISEL_TI1SEL_Pos      (0U)
+#define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
+#define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
+#define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
+#define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
+#define TIM_TISEL_TI1SEL_3        (0x8UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000008 */
+
+#define TIM_TISEL_TI2SEL_Pos      (8U)
+#define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
+#define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
+#define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
+#define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
+#define TIM_TISEL_TI2SEL_3        (0x8UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000800 */
+
+#define TIM_TISEL_TI3SEL_Pos      (16U)
+#define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
+#define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
+#define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
+#define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
+#define TIM_TISEL_TI3SEL_3        (0x8UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00080000 */
+
+#define TIM_TISEL_TI4SEL_Pos      (24U)
+#define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
+#define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
+#define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
+#define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
+#define TIM_TISEL_TI4SEL_3        (0x8UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x08000000 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define LPTIM_ISR_CMPM_Pos          (0U)
+#define LPTIM_ISR_CMPM_Msk          (0x1UL << LPTIM_ISR_CMPM_Pos)              /*!< 0x00000001 */
+#define LPTIM_ISR_CMPM              LPTIM_ISR_CMPM_Msk                         /*!< Compare match */
+#define LPTIM_ISR_ARRM_Pos          (1U)
+#define LPTIM_ISR_ARRM_Msk          (0x1UL << LPTIM_ISR_ARRM_Pos)              /*!< 0x00000002 */
+#define LPTIM_ISR_ARRM              LPTIM_ISR_ARRM_Msk                         /*!< Autoreload match */
+#define LPTIM_ISR_EXTTRIG_Pos       (2U)
+#define LPTIM_ISR_EXTTRIG_Msk       (0x1UL << LPTIM_ISR_EXTTRIG_Pos)           /*!< 0x00000004 */
+#define LPTIM_ISR_EXTTRIG           LPTIM_ISR_EXTTRIG_Msk                      /*!< External trigger edge event */
+#define LPTIM_ISR_CMPOK_Pos         (3U)
+#define LPTIM_ISR_CMPOK_Msk         (0x1UL << LPTIM_ISR_CMPOK_Pos)             /*!< 0x00000008 */
+#define LPTIM_ISR_CMPOK             LPTIM_ISR_CMPOK_Msk                        /*!< Compare register update OK */
+#define LPTIM_ISR_ARROK_Pos         (4U)
+#define LPTIM_ISR_ARROK_Msk         (0x1UL << LPTIM_ISR_ARROK_Pos)             /*!< 0x00000010 */
+#define LPTIM_ISR_ARROK             LPTIM_ISR_ARROK_Msk                        /*!< Autoreload register update OK */
+#define LPTIM_ISR_UP_Pos            (5U)
+#define LPTIM_ISR_UP_Msk            (0x1UL << LPTIM_ISR_UP_Pos)                /*!< 0x00000020 */
+#define LPTIM_ISR_UP                LPTIM_ISR_UP_Msk                           /*!< Counter direction change down to up */
+#define LPTIM_ISR_DOWN_Pos          (6U)
+#define LPTIM_ISR_DOWN_Msk          (0x1UL << LPTIM_ISR_DOWN_Pos)              /*!< 0x00000040 */
+#define LPTIM_ISR_DOWN              LPTIM_ISR_DOWN_Msk                         /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define LPTIM_ICR_CMPMCF_Pos        (0U)
+#define LPTIM_ICR_CMPMCF_Msk        (0x1UL << LPTIM_ICR_CMPMCF_Pos)            /*!< 0x00000001 */
+#define LPTIM_ICR_CMPMCF            LPTIM_ICR_CMPMCF_Msk                       /*!< Compare match Clear Flag */
+#define LPTIM_ICR_ARRMCF_Pos        (1U)
+#define LPTIM_ICR_ARRMCF_Msk        (0x1UL << LPTIM_ICR_ARRMCF_Pos)            /*!< 0x00000002 */
+#define LPTIM_ICR_ARRMCF            LPTIM_ICR_ARRMCF_Msk                       /*!< Autoreload match Clear Flag */
+#define LPTIM_ICR_EXTTRIGCF_Pos     (2U)
+#define LPTIM_ICR_EXTTRIGCF_Msk     (0x1UL << LPTIM_ICR_EXTTRIGCF_Pos)         /*!< 0x00000004 */
+#define LPTIM_ICR_EXTTRIGCF         LPTIM_ICR_EXTTRIGCF_Msk                    /*!< External trigger edge event Clear Flag */
+#define LPTIM_ICR_CMPOKCF_Pos       (3U)
+#define LPTIM_ICR_CMPOKCF_Msk       (0x1UL << LPTIM_ICR_CMPOKCF_Pos)           /*!< 0x00000008 */
+#define LPTIM_ICR_CMPOKCF           LPTIM_ICR_CMPOKCF_Msk                      /*!< Compare register update OK Clear Flag */
+#define LPTIM_ICR_ARROKCF_Pos       (4U)
+#define LPTIM_ICR_ARROKCF_Msk       (0x1UL << LPTIM_ICR_ARROKCF_Pos)           /*!< 0x00000010 */
+#define LPTIM_ICR_ARROKCF           LPTIM_ICR_ARROKCF_Msk                      /*!< Autoreload register update OK Clear Flag */
+#define LPTIM_ICR_UPCF_Pos          (5U)
+#define LPTIM_ICR_UPCF_Msk          (0x1UL << LPTIM_ICR_UPCF_Pos)              /*!< 0x00000020 */
+#define LPTIM_ICR_UPCF              LPTIM_ICR_UPCF_Msk                         /*!< Counter direction change down to up Clear Flag */
+#define LPTIM_ICR_DOWNCF_Pos        (6U)
+#define LPTIM_ICR_DOWNCF_Msk        (0x1UL << LPTIM_ICR_DOWNCF_Pos)            /*!< 0x00000040 */
+#define LPTIM_ICR_DOWNCF            LPTIM_ICR_DOWNCF_Msk                       /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define LPTIM_IER_CMPMIE_Pos        (0U)
+#define LPTIM_IER_CMPMIE_Msk        (0x1UL << LPTIM_IER_CMPMIE_Pos)            /*!< 0x00000001 */
+#define LPTIM_IER_CMPMIE            LPTIM_IER_CMPMIE_Msk                       /*!< Compare match Interrupt Enable */
+#define LPTIM_IER_ARRMIE_Pos        (1U)
+#define LPTIM_IER_ARRMIE_Msk        (0x1UL << LPTIM_IER_ARRMIE_Pos)            /*!< 0x00000002 */
+#define LPTIM_IER_ARRMIE            LPTIM_IER_ARRMIE_Msk                       /*!< Autoreload match Interrupt Enable */
+#define LPTIM_IER_EXTTRIGIE_Pos     (2U)
+#define LPTIM_IER_EXTTRIGIE_Msk     (0x1UL << LPTIM_IER_EXTTRIGIE_Pos)         /*!< 0x00000004 */
+#define LPTIM_IER_EXTTRIGIE         LPTIM_IER_EXTTRIGIE_Msk                    /*!< External trigger edge event Interrupt Enable */
+#define LPTIM_IER_CMPOKIE_Pos       (3U)
+#define LPTIM_IER_CMPOKIE_Msk       (0x1UL << LPTIM_IER_CMPOKIE_Pos)           /*!< 0x00000008 */
+#define LPTIM_IER_CMPOKIE           LPTIM_IER_CMPOKIE_Msk                      /*!< Compare register update OK Interrupt Enable */
+#define LPTIM_IER_ARROKIE_Pos       (4U)
+#define LPTIM_IER_ARROKIE_Msk       (0x1UL << LPTIM_IER_ARROKIE_Pos)           /*!< 0x00000010 */
+#define LPTIM_IER_ARROKIE           LPTIM_IER_ARROKIE_Msk                      /*!< Autoreload register update OK Interrupt Enable */
+#define LPTIM_IER_UPIE_Pos          (5U)
+#define LPTIM_IER_UPIE_Msk          (0x1UL << LPTIM_IER_UPIE_Pos)              /*!< 0x00000020 */
+#define LPTIM_IER_UPIE              LPTIM_IER_UPIE_Msk                         /*!< Counter direction change down to up Interrupt Enable */
+#define LPTIM_IER_DOWNIE_Pos        (6U)
+#define LPTIM_IER_DOWNIE_Msk        (0x1UL << LPTIM_IER_DOWNIE_Pos)            /*!< 0x00000040 */
+#define LPTIM_IER_DOWNIE            LPTIM_IER_DOWNIE_Msk                       /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define LPTIM_CFGR_CKSEL_Pos        (0U)
+#define LPTIM_CFGR_CKSEL_Msk        (0x1UL << LPTIM_CFGR_CKSEL_Pos)            /*!< 0x00000001 */
+#define LPTIM_CFGR_CKSEL            LPTIM_CFGR_CKSEL_Msk                       /*!< Clock selector */
+
+#define LPTIM_CFGR_CKPOL_Pos        (1U)
+#define LPTIM_CFGR_CKPOL_Msk        (0x3UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000006 */
+#define LPTIM_CFGR_CKPOL            LPTIM_CFGR_CKPOL_Msk                       /*!< CKPOL[1:0] bits (Clock polarity) */
+#define LPTIM_CFGR_CKPOL_0          (0x1UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000002 */
+#define LPTIM_CFGR_CKPOL_1          (0x2UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000004 */
+
+#define LPTIM_CFGR_CKFLT_Pos        (3U)
+#define LPTIM_CFGR_CKFLT_Msk        (0x3UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000018 */
+#define LPTIM_CFGR_CKFLT            LPTIM_CFGR_CKFLT_Msk                       /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define LPTIM_CFGR_CKFLT_0          (0x1UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000008 */
+#define LPTIM_CFGR_CKFLT_1          (0x2UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000010 */
+
+#define LPTIM_CFGR_TRGFLT_Pos       (6U)
+#define LPTIM_CFGR_TRGFLT_Msk       (0x3UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x000000C0 */
+#define LPTIM_CFGR_TRGFLT           LPTIM_CFGR_TRGFLT_Msk                      /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define LPTIM_CFGR_TRGFLT_0         (0x1UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x00000040 */
+#define LPTIM_CFGR_TRGFLT_1         (0x2UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x00000080 */
+
+#define LPTIM_CFGR_PRESC_Pos        (9U)
+#define LPTIM_CFGR_PRESC_Msk        (0x7UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000E00 */
+#define LPTIM_CFGR_PRESC            LPTIM_CFGR_PRESC_Msk                       /*!< PRESC[2:0] bits (Clock prescaler) */
+#define LPTIM_CFGR_PRESC_0          (0x1UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000200 */
+#define LPTIM_CFGR_PRESC_1          (0x2UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000400 */
+#define LPTIM_CFGR_PRESC_2          (0x4UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000800 */
+
+#define LPTIM_CFGR_TRIGSEL_Pos      (13U)
+#define LPTIM_CFGR_TRIGSEL_Msk      (0x7UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x0000E000 */
+#define LPTIM_CFGR_TRIGSEL          LPTIM_CFGR_TRIGSEL_Msk                     /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define LPTIM_CFGR_TRIGSEL_0        (0x1UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x00002000 */
+#define LPTIM_CFGR_TRIGSEL_1        (0x2UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x00004000 */
+#define LPTIM_CFGR_TRIGSEL_2        (0x4UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x00008000 */
+
+#define LPTIM_CFGR_TRIGEN_Pos       (17U)
+#define LPTIM_CFGR_TRIGEN_Msk       (0x3UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00060000 */
+#define LPTIM_CFGR_TRIGEN           LPTIM_CFGR_TRIGEN_Msk                      /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define LPTIM_CFGR_TRIGEN_0         (0x1UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00020000 */
+#define LPTIM_CFGR_TRIGEN_1         (0x2UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00040000 */
+
+#define LPTIM_CFGR_TIMOUT_Pos       (19U)
+#define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
+#define LPTIM_CFGR_WAVE_Pos         (20U)
+#define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
+#define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
+#define LPTIM_CFGR_WAVPOL_Pos       (21U)
+#define LPTIM_CFGR_WAVPOL_Msk       (0x1UL << LPTIM_CFGR_WAVPOL_Pos)           /*!< 0x00200000 */
+#define LPTIM_CFGR_WAVPOL           LPTIM_CFGR_WAVPOL_Msk                      /*!< Waveform shape polarity */
+#define LPTIM_CFGR_PRELOAD_Pos      (22U)
+#define LPTIM_CFGR_PRELOAD_Msk      (0x1UL << LPTIM_CFGR_PRELOAD_Pos)          /*!< 0x00400000 */
+#define LPTIM_CFGR_PRELOAD          LPTIM_CFGR_PRELOAD_Msk                     /*!< Reg update mode */
+#define LPTIM_CFGR_COUNTMODE_Pos    (23U)
+#define LPTIM_CFGR_COUNTMODE_Msk    (0x1UL << LPTIM_CFGR_COUNTMODE_Pos)        /*!< 0x00800000 */
+#define LPTIM_CFGR_COUNTMODE        LPTIM_CFGR_COUNTMODE_Msk                   /*!< Counter mode enable */
+#define LPTIM_CFGR_ENC_Pos          (24U)
+#define LPTIM_CFGR_ENC_Msk          (0x1UL << LPTIM_CFGR_ENC_Pos)              /*!< 0x01000000 */
+#define LPTIM_CFGR_ENC              LPTIM_CFGR_ENC_Msk                         /*!< Encoder mode enable */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define LPTIM_CR_ENABLE_Pos         (0U)
+#define LPTIM_CR_ENABLE_Msk         (0x1UL << LPTIM_CR_ENABLE_Pos)             /*!< 0x00000001 */
+#define LPTIM_CR_ENABLE             LPTIM_CR_ENABLE_Msk                        /*!< LPTIMer enable */
+#define LPTIM_CR_SNGSTRT_Pos        (1U)
+#define LPTIM_CR_SNGSTRT_Msk        (0x1UL << LPTIM_CR_SNGSTRT_Pos)            /*!< 0x00000002 */
+#define LPTIM_CR_SNGSTRT            LPTIM_CR_SNGSTRT_Msk                       /*!< Timer start in single mode */
+#define LPTIM_CR_CNTSTRT_Pos        (2U)
+#define LPTIM_CR_CNTSTRT_Msk        (0x1UL << LPTIM_CR_CNTSTRT_Pos)            /*!< 0x00000004 */
+#define LPTIM_CR_CNTSTRT            LPTIM_CR_CNTSTRT_Msk                       /*!< Timer start in continuous mode */
+#define LPTIM_CR_COUNTRST_Pos       (3U)
+#define LPTIM_CR_COUNTRST_Msk       (0x1UL << LPTIM_CR_COUNTRST_Pos)           /*!< 0x00000008 */
+#define LPTIM_CR_COUNTRST           LPTIM_CR_COUNTRST_Msk                      /*!< Counter reset */
+#define LPTIM_CR_RSTARE_Pos         (4U)
+#define LPTIM_CR_RSTARE_Msk         (0x1UL << LPTIM_CR_RSTARE_Pos)             /*!< 0x00000010 */
+#define LPTIM_CR_RSTARE             LPTIM_CR_RSTARE_Msk                        /*!< Reset after read enable */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define LPTIM_CMP_CMP_Pos           (0U)
+#define LPTIM_CMP_CMP_Msk           (0xFFFFUL << LPTIM_CMP_CMP_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CMP_CMP               LPTIM_CMP_CMP_Msk                          /*!< Compare register */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define LPTIM_ARR_ARR_Pos           (0U)
+#define LPTIM_ARR_ARR_Msk           (0xFFFFUL << LPTIM_ARR_ARR_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_ARR_ARR               LPTIM_ARR_ARR_Msk                          /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define LPTIM_CNT_CNT_Pos           (0U)
+#define LPTIM_CNT_CNT_Msk           (0xFFFFUL << LPTIM_CNT_CNT_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CNT_CNT               LPTIM_CNT_CNT_Msk                          /*!< Counter register */
+
+/******************  Bit definition for LPTIM_CFGR2 register  *******************/
+#define LPTIM_CFGR2_IN1SEL_Pos      (0U)
+#define LPTIM_CFGR2_IN1SEL_Msk      (0xFUL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x0000000F */
+#define LPTIM_CFGR2_IN1SEL          LPTIM_CFGR2_IN1SEL_Msk                     /*!< CFGR2[3:0] bits (INPUT1 selection) */
+#define LPTIM_CFGR2_IN1SEL_0        (0x1UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000001 */
+#define LPTIM_CFGR2_IN1SEL_1        (0x2UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000002 */
+#define LPTIM_CFGR2_IN1SEL_2        (0x4UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000004 */
+#define LPTIM_CFGR2_IN1SEL_3        (0x8UL << LPTIM_CFGR2_IN1SEL_Pos)          /*!< 0x00000008 */
+
+#define LPTIM_CFGR2_IN2SEL_Pos      (4U)
+#define LPTIM_CFGR2_IN2SEL_Msk      (0xFUL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x000000F0 */
+#define LPTIM_CFGR2_IN2SEL          LPTIM_CFGR2_IN2SEL_Msk                     /*!< CFGR2[7:4] bits (INPUT2 selection) */
+#define LPTIM_CFGR2_IN2SEL_0        (0x1UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000010 */
+#define LPTIM_CFGR2_IN2SEL_1        (0x2UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000020 */
+#define LPTIM_CFGR2_IN2SEL_2        (0x4UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000040 */
+#define LPTIM_CFGR2_IN2SEL_3        (0x8UL << LPTIM_CFGR2_IN2SEL_Pos)          /*!< 0x00000080 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog Comparators (COMP)                             */
+/*                                                                            */
+/******************************************************************************/
+/**********************  Bit definition for COMP_CSR register  ****************/
+#define COMP_CSR_EN_Pos            (0U)
+#define COMP_CSR_EN_Msk            (0x1UL << COMP_CSR_EN_Pos)                  /*!< 0x00000001 */
+#define COMP_CSR_EN                COMP_CSR_EN_Msk                             /*!< Comparator enable */
+
+#define COMP_CSR_INMSEL_Pos        (4U)
+#define COMP_CSR_INMSEL_Msk        (0xFUL << COMP_CSR_INMSEL_Pos)              /*!< 0x000000F0 */
+#define COMP_CSR_INMSEL            COMP_CSR_INMSEL_Msk                         /*!< Comparator input minus selection */
+#define COMP_CSR_INMSEL_0          (0x1UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000010 */
+#define COMP_CSR_INMSEL_1          (0x2UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000020 */
+#define COMP_CSR_INMSEL_2          (0x4UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000040 */
+#define COMP_CSR_INMSEL_3          (0x8UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000080 */
+
+#define COMP_CSR_INPSEL_Pos        (8U)
+#define COMP_CSR_INPSEL_Msk        (0x3UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000300 */
+#define COMP_CSR_INPSEL            COMP_CSR_INPSEL_Msk                         /*!< Comparator plus minus selection */
+#define COMP_CSR_INPSEL_0          (0x1UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000100 */
+#define COMP_CSR_INPSEL_1          (0x2UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000200 */
+
+#define COMP_CSR_WINMODE_Pos       (11U)
+#define COMP_CSR_WINMODE_Msk       (0x1UL << COMP_CSR_WINMODE_Pos)             /*!< 0x00000800 */
+#define COMP_CSR_WINMODE           COMP_CSR_WINMODE_Msk                        /*!< Pair of comparators window mode. Bit intended to be used with COMP common instance (COMP_Common_TypeDef) */
+#define COMP_CSR_WINOUT_Pos        (14U)
+#define COMP_CSR_WINOUT_Msk        (0x1UL << COMP_CSR_WINOUT_Pos)              /*!< 0x00004000 */
+#define COMP_CSR_WINOUT            COMP_CSR_WINOUT_Msk                         /*!< Pair of comparators window output level. Bit intended to be used with COMP common instance (COMP_Common_TypeDef) */
+
+#define COMP_CSR_POLARITY_Pos      (15U)
+#define COMP_CSR_POLARITY_Msk      (0x1UL << COMP_CSR_POLARITY_Pos)            /*!< 0x00008000 */
+#define COMP_CSR_POLARITY          COMP_CSR_POLARITY_Msk                       /*!< Comparator output polarity */
+
+#define COMP_CSR_HYST_Pos          (16U)
+#define COMP_CSR_HYST_Msk          (0x3UL << COMP_CSR_HYST_Pos)                /*!< 0x00030000 */
+#define COMP_CSR_HYST              COMP_CSR_HYST_Msk                           /*!< Comparator input hysteresis */
+#define COMP_CSR_HYST_0            (0x1UL << COMP_CSR_HYST_Pos)                /*!< 0x00010000 */
+#define COMP_CSR_HYST_1            (0x2UL << COMP_CSR_HYST_Pos)                /*!< 0x00020000 */
+
+#define COMP_CSR_PWRMODE_Pos       (18U)
+#define COMP_CSR_PWRMODE_Msk       (0x3UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x000C0000 */
+#define COMP_CSR_PWRMODE           COMP_CSR_PWRMODE_Msk                        /*!< Comparator power mode */
+#define COMP_CSR_PWRMODE_0         (0x1UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00040000 */
+#define COMP_CSR_PWRMODE_1         (0x2UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00080000 */
+
+#define COMP_CSR_BLANKING_Pos      (20U)
+#define COMP_CSR_BLANKING_Msk      (0x1FUL << COMP_CSR_BLANKING_Pos)           /*!< 0x01F00000 */
+#define COMP_CSR_BLANKING          COMP_CSR_BLANKING_Msk                       /*!< Comparator blanking source */
+#define COMP_CSR_BLANKING_0        (0x01UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00100000 */
+#define COMP_CSR_BLANKING_1        (0x02UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00200000 */
+#define COMP_CSR_BLANKING_2        (0x04UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00400000 */
+#define COMP_CSR_BLANKING_3        (0x08UL << COMP_CSR_BLANKING_Pos)           /*!< 0x00800000 */
+#define COMP_CSR_BLANKING_4        (0x10UL << COMP_CSR_BLANKING_Pos)           /*!< 0x01000000 */
+
+#define COMP_CSR_VALUE_Pos         (30U)
+#define COMP_CSR_VALUE_Msk         (0x1UL << COMP_CSR_VALUE_Pos)               /*!< 0x40000000 */
+#define COMP_CSR_VALUE             COMP_CSR_VALUE_Msk                          /*!< Comparator output level */
+
+#define COMP_CSR_LOCK_Pos          (31U)
+#define COMP_CSR_LOCK_Msk          (0x1UL << COMP_CSR_LOCK_Pos)                /*!< 0x80000000 */
+#define COMP_CSR_LOCK              COMP_CSR_LOCK_Msk                           /*!< Comparator lock */
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_UE_Pos             (0U)
+#define USART_CR1_UE_Msk             (0x1UL << USART_CR1_UE_Pos)               /*!< 0x00000001 */
+#define USART_CR1_UE                 USART_CR1_UE_Msk                          /*!< USART Enable */
+#define USART_CR1_UESM_Pos           (1U)
+#define USART_CR1_UESM_Msk           (0x1UL << USART_CR1_UESM_Pos)             /*!< 0x00000002 */
+#define USART_CR1_UESM               USART_CR1_UESM_Msk                        /*!< USART Enable in STOP Mode */
+#define USART_CR1_RE_Pos             (2U)
+#define USART_CR1_RE_Msk             (0x1UL << USART_CR1_RE_Pos)               /*!< 0x00000004 */
+#define USART_CR1_RE                 USART_CR1_RE_Msk                          /*!< Receiver Enable */
+#define USART_CR1_TE_Pos             (3U)
+#define USART_CR1_TE_Msk             (0x1UL << USART_CR1_TE_Pos)               /*!< 0x00000008 */
+#define USART_CR1_TE                 USART_CR1_TE_Msk                          /*!< Transmitter Enable */
+#define USART_CR1_IDLEIE_Pos         (4U)
+#define USART_CR1_IDLEIE_Msk         (0x1UL << USART_CR1_IDLEIE_Pos)           /*!< 0x00000010 */
+#define USART_CR1_IDLEIE             USART_CR1_IDLEIE_Msk                      /*!< IDLE Interrupt Enable */
+#define USART_CR1_RXNEIE_RXFNEIE_Pos   (5U)
+#define USART_CR1_RXNEIE_RXFNEIE_Msk   (0x1UL << USART_CR1_RXNEIE_RXFNEIE_Pos) /*!< 0x00000020 */
+#define USART_CR1_RXNEIE_RXFNEIE       USART_CR1_RXNEIE_RXFNEIE_Msk            /*!< RXNE/RXFIFO not empty Interrupt Enable */
+#define USART_CR1_TCIE_Pos           (6U)
+#define USART_CR1_TCIE_Msk           (0x1UL << USART_CR1_TCIE_Pos)             /*!< 0x00000040 */
+#define USART_CR1_TCIE               USART_CR1_TCIE_Msk                        /*!< Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_TXFNFIE_Pos  (7U)
+#define USART_CR1_TXEIE_TXFNFIE_Msk   (0x1UL << USART_CR1_TXEIE_TXFNFIE_Pos)   /*!< 0x00000080 */
+#define USART_CR1_TXEIE_TXFNFIE       USART_CR1_TXEIE_TXFNFIE_Msk              /*!< TXE/TXFIFO not full Interrupt Enable */
+#define USART_CR1_PEIE_Pos           (8U)
+#define USART_CR1_PEIE_Msk           (0x1UL << USART_CR1_PEIE_Pos)             /*!< 0x00000100 */
+#define USART_CR1_PEIE               USART_CR1_PEIE_Msk                        /*!< PE Interrupt Enable */
+#define USART_CR1_PS_Pos             (9U)
+#define USART_CR1_PS_Msk             (0x1UL << USART_CR1_PS_Pos)               /*!< 0x00000200 */
+#define USART_CR1_PS                 USART_CR1_PS_Msk                          /*!< Parity Selection */
+#define USART_CR1_PCE_Pos            (10U)
+#define USART_CR1_PCE_Msk            (0x1UL << USART_CR1_PCE_Pos)              /*!< 0x00000400 */
+#define USART_CR1_PCE                USART_CR1_PCE_Msk                         /*!< Parity Control Enable */
+#define USART_CR1_WAKE_Pos           (11U)
+#define USART_CR1_WAKE_Msk           (0x1UL << USART_CR1_WAKE_Pos)             /*!< 0x00000800 */
+#define USART_CR1_WAKE               USART_CR1_WAKE_Msk                        /*!< Receiver Wakeup method */
+#define USART_CR1_M_Pos              (12U)
+#define USART_CR1_M_Msk              (0x10001UL << USART_CR1_M_Pos)            /*!< 0x10001000 */
+#define USART_CR1_M                  USART_CR1_M_Msk                           /*!< Word length */
+#define USART_CR1_M0_Pos             (12U)
+#define USART_CR1_M0_Msk             (0x1UL << USART_CR1_M0_Pos)               /*!< 0x00001000 */
+#define USART_CR1_M0                 USART_CR1_M0_Msk                          /*!< Word length - Bit 0 */
+#define USART_CR1_MME_Pos            (13U)
+#define USART_CR1_MME_Msk            (0x1UL << USART_CR1_MME_Pos)              /*!< 0x00002000 */
+#define USART_CR1_MME                USART_CR1_MME_Msk                         /*!< Mute Mode Enable */
+#define USART_CR1_CMIE_Pos           (14U)
+#define USART_CR1_CMIE_Msk           (0x1UL << USART_CR1_CMIE_Pos)             /*!< 0x00004000 */
+#define USART_CR1_CMIE               USART_CR1_CMIE_Msk                        /*!< Character match interrupt enable */
+#define USART_CR1_OVER8_Pos          (15U)
+#define USART_CR1_OVER8_Msk          (0x1UL << USART_CR1_OVER8_Pos)            /*!< 0x00008000 */
+#define USART_CR1_OVER8              USART_CR1_OVER8_Msk                       /*!< Oversampling by 8-bit or 16-bit mode */
+#define USART_CR1_DEDT_Pos           (16U)
+#define USART_CR1_DEDT_Msk           (0x1FUL << USART_CR1_DEDT_Pos)            /*!< 0x001F0000 */
+#define USART_CR1_DEDT               USART_CR1_DEDT_Msk                        /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define USART_CR1_DEDT_0             (0x01UL << USART_CR1_DEDT_Pos)            /*!< 0x00010000 */
+#define USART_CR1_DEDT_1             (0x02UL << USART_CR1_DEDT_Pos)            /*!< 0x00020000 */
+#define USART_CR1_DEDT_2             (0x04UL << USART_CR1_DEDT_Pos)            /*!< 0x00040000 */
+#define USART_CR1_DEDT_3             (0x08UL << USART_CR1_DEDT_Pos)            /*!< 0x00080000 */
+#define USART_CR1_DEDT_4             (0x10UL << USART_CR1_DEDT_Pos)            /*!< 0x00100000 */
+#define USART_CR1_DEAT_Pos           (21U)
+#define USART_CR1_DEAT_Msk           (0x1FUL << USART_CR1_DEAT_Pos)            /*!< 0x03E00000 */
+#define USART_CR1_DEAT               USART_CR1_DEAT_Msk                        /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define USART_CR1_DEAT_0             (0x01UL << USART_CR1_DEAT_Pos)            /*!< 0x00200000 */
+#define USART_CR1_DEAT_1             (0x02UL << USART_CR1_DEAT_Pos)            /*!< 0x00400000 */
+#define USART_CR1_DEAT_2             (0x04UL << USART_CR1_DEAT_Pos)            /*!< 0x00800000 */
+#define USART_CR1_DEAT_3             (0x08UL << USART_CR1_DEAT_Pos)            /*!< 0x01000000 */
+#define USART_CR1_DEAT_4             (0x10UL << USART_CR1_DEAT_Pos)            /*!< 0x02000000 */
+#define USART_CR1_RTOIE_Pos          (26U)
+#define USART_CR1_RTOIE_Msk          (0x1UL << USART_CR1_RTOIE_Pos)            /*!< 0x04000000 */
+#define USART_CR1_RTOIE              USART_CR1_RTOIE_Msk                       /*!< Receive Time Out interrupt enable */
+#define USART_CR1_EOBIE_Pos          (27U)
+#define USART_CR1_EOBIE_Msk          (0x1UL << USART_CR1_EOBIE_Pos)            /*!< 0x08000000 */
+#define USART_CR1_EOBIE              USART_CR1_EOBIE_Msk                       /*!< End of Block interrupt enable */
+#define USART_CR1_M1_Pos             (28U)
+#define USART_CR1_M1_Msk             (0x1UL << USART_CR1_M1_Pos)               /*!< 0x10000000 */
+#define USART_CR1_M1                 USART_CR1_M1_Msk                          /*!< Word length - Bit 1 */
+#define USART_CR1_FIFOEN_Pos         (29U)
+#define USART_CR1_FIFOEN_Msk         (0x1UL << USART_CR1_FIFOEN_Pos)           /*!< 0x20000000 */
+#define USART_CR1_FIFOEN             USART_CR1_FIFOEN_Msk                      /*!< FIFO mode enable */
+#define USART_CR1_TXFEIE_Pos         (30U)
+#define USART_CR1_TXFEIE_Msk         (0x1UL << USART_CR1_TXFEIE_Pos)           /*!< 0x40000000 */
+#define USART_CR1_TXFEIE             USART_CR1_TXFEIE_Msk                      /*!< TXFIFO empty interrupt enable */
+#define USART_CR1_RXFFIE_Pos         (31U)
+#define USART_CR1_RXFFIE_Msk         (0x1UL << USART_CR1_RXFFIE_Pos)           /*!< 0x80000000 */
+#define USART_CR1_RXFFIE             USART_CR1_RXFFIE_Msk                      /*!< RXFIFO Full interrupt enable */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_SLVEN_Pos          (0U)
+#define USART_CR2_SLVEN_Msk          (0x1UL << USART_CR2_SLVEN_Pos)            /*!< 0x00000001 */
+#define USART_CR2_SLVEN              USART_CR2_SLVEN_Msk                       /*!< Synchronous Slave mode enable */
+#define USART_CR2_DIS_NSS_Pos        (3U)
+#define USART_CR2_DIS_NSS_Msk        (0x1UL << USART_CR2_DIS_NSS_Pos)          /*!< 0x00000008 */
+#define USART_CR2_DIS_NSS            USART_CR2_DIS_NSS_Msk                     /*!< NSS input pin disable for SPI slave selection */
+#define USART_CR2_ADDM7_Pos          (4U)
+#define USART_CR2_ADDM7_Msk          (0x1UL << USART_CR2_ADDM7_Pos)            /*!< 0x00000010 */
+#define USART_CR2_ADDM7              USART_CR2_ADDM7_Msk                       /*!< 7-bit or 4-bit Address Detection */
+#define USART_CR2_LBDL_Pos           (5U)
+#define USART_CR2_LBDL_Msk           (0x1UL << USART_CR2_LBDL_Pos)             /*!< 0x00000020 */
+#define USART_CR2_LBDL               USART_CR2_LBDL_Msk                        /*!< LIN Break Detection Length */
+#define USART_CR2_LBDIE_Pos          (6U)
+#define USART_CR2_LBDIE_Msk          (0x1UL << USART_CR2_LBDIE_Pos)            /*!< 0x00000040 */
+#define USART_CR2_LBDIE              USART_CR2_LBDIE_Msk                       /*!< LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos           (8U)
+#define USART_CR2_LBCL_Msk           (0x1UL << USART_CR2_LBCL_Pos)             /*!< 0x00000100 */
+#define USART_CR2_LBCL               USART_CR2_LBCL_Msk                        /*!< Last Bit Clock pulse */
+#define USART_CR2_CPHA_Pos           (9U)
+#define USART_CR2_CPHA_Msk           (0x1UL << USART_CR2_CPHA_Pos)             /*!< 0x00000200 */
+#define USART_CR2_CPHA               USART_CR2_CPHA_Msk                        /*!< Clock Phase */
+#define USART_CR2_CPOL_Pos           (10U)
+#define USART_CR2_CPOL_Msk           (0x1UL << USART_CR2_CPOL_Pos)             /*!< 0x00000400 */
+#define USART_CR2_CPOL               USART_CR2_CPOL_Msk                        /*!< Clock Polarity */
+#define USART_CR2_CLKEN_Pos          (11U)
+#define USART_CR2_CLKEN_Msk          (0x1UL << USART_CR2_CLKEN_Pos)            /*!< 0x00000800 */
+#define USART_CR2_CLKEN              USART_CR2_CLKEN_Msk                       /*!< Clock Enable */
+#define USART_CR2_STOP_Pos           (12U)
+#define USART_CR2_STOP_Msk           (0x3UL << USART_CR2_STOP_Pos)             /*!< 0x00003000 */
+#define USART_CR2_STOP               USART_CR2_STOP_Msk                        /*!< STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0             (0x1UL << USART_CR2_STOP_Pos)             /*!< 0x00001000 */
+#define USART_CR2_STOP_1             (0x2UL << USART_CR2_STOP_Pos)             /*!< 0x00002000 */
+#define USART_CR2_LINEN_Pos          (14U)
+#define USART_CR2_LINEN_Msk          (0x1UL << USART_CR2_LINEN_Pos)            /*!< 0x00004000 */
+#define USART_CR2_LINEN              USART_CR2_LINEN_Msk                       /*!< LIN mode enable */
+#define USART_CR2_SWAP_Pos           (15U)
+#define USART_CR2_SWAP_Msk           (0x1UL << USART_CR2_SWAP_Pos)             /*!< 0x00008000 */
+#define USART_CR2_SWAP               USART_CR2_SWAP_Msk                        /*!< SWAP TX/RX pins */
+#define USART_CR2_RXINV_Pos          (16U)
+#define USART_CR2_RXINV_Msk          (0x1UL << USART_CR2_RXINV_Pos)            /*!< 0x00010000 */
+#define USART_CR2_RXINV              USART_CR2_RXINV_Msk                       /*!< RX pin active level inversion */
+#define USART_CR2_TXINV_Pos          (17U)
+#define USART_CR2_TXINV_Msk          (0x1UL << USART_CR2_TXINV_Pos)            /*!< 0x00020000 */
+#define USART_CR2_TXINV              USART_CR2_TXINV_Msk                       /*!< TX pin active level inversion */
+#define USART_CR2_DATAINV_Pos        (18U)
+#define USART_CR2_DATAINV_Msk        (0x1UL << USART_CR2_DATAINV_Pos)          /*!< 0x00040000 */
+#define USART_CR2_DATAINV            USART_CR2_DATAINV_Msk                     /*!< Binary data inversion */
+#define USART_CR2_MSBFIRST_Pos       (19U)
+#define USART_CR2_MSBFIRST_Msk       (0x1UL << USART_CR2_MSBFIRST_Pos)         /*!< 0x00080000 */
+#define USART_CR2_MSBFIRST           USART_CR2_MSBFIRST_Msk                    /*!< Most Significant Bit First */
+#define USART_CR2_ABREN_Pos          (20U)
+#define USART_CR2_ABREN_Msk          (0x1UL << USART_CR2_ABREN_Pos)            /*!< 0x00100000 */
+#define USART_CR2_ABREN              USART_CR2_ABREN_Msk                       /*!< Auto Baud-Rate Enable*/
+#define USART_CR2_ABRMODE_Pos        (21U)
+#define USART_CR2_ABRMODE_Msk        (0x3UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00600000 */
+#define USART_CR2_ABRMODE            USART_CR2_ABRMODE_Msk                     /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define USART_CR2_ABRMODE_0          (0x1UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00200000 */
+#define USART_CR2_ABRMODE_1          (0x2UL << USART_CR2_ABRMODE_Pos)          /*!< 0x00400000 */
+#define USART_CR2_RTOEN_Pos          (23U)
+#define USART_CR2_RTOEN_Msk          (0x1UL << USART_CR2_RTOEN_Pos)            /*!< 0x00800000 */
+#define USART_CR2_RTOEN              USART_CR2_RTOEN_Msk                       /*!< Receiver Time-Out enable */
+#define USART_CR2_ADD_Pos            (24U)
+#define USART_CR2_ADD_Msk            (0xFFUL << USART_CR2_ADD_Pos)             /*!< 0xFF000000 */
+#define USART_CR2_ADD                USART_CR2_ADD_Msk                         /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos            (0U)
+#define USART_CR3_EIE_Msk            (0x1UL << USART_CR3_EIE_Pos)              /*!< 0x00000001 */
+#define USART_CR3_EIE                USART_CR3_EIE_Msk                         /*!< Error Interrupt Enable */
+#define USART_CR3_IREN_Pos           (1U)
+#define USART_CR3_IREN_Msk           (0x1UL << USART_CR3_IREN_Pos)             /*!< 0x00000002 */
+#define USART_CR3_IREN               USART_CR3_IREN_Msk                        /*!< IrDA mode Enable */
+#define USART_CR3_IRLP_Pos           (2U)
+#define USART_CR3_IRLP_Msk           (0x1UL << USART_CR3_IRLP_Pos)             /*!< 0x00000004 */
+#define USART_CR3_IRLP               USART_CR3_IRLP_Msk                        /*!< IrDA Low-Power */
+#define USART_CR3_HDSEL_Pos          (3U)
+#define USART_CR3_HDSEL_Msk          (0x1UL << USART_CR3_HDSEL_Pos)            /*!< 0x00000008 */
+#define USART_CR3_HDSEL              USART_CR3_HDSEL_Msk                       /*!< Half-Duplex Selection */
+#define USART_CR3_NACK_Pos           (4U)
+#define USART_CR3_NACK_Msk           (0x1UL << USART_CR3_NACK_Pos)             /*!< 0x00000010 */
+#define USART_CR3_NACK               USART_CR3_NACK_Msk                        /*!< SmartCard NACK enable */
+#define USART_CR3_SCEN_Pos           (5U)
+#define USART_CR3_SCEN_Msk           (0x1UL << USART_CR3_SCEN_Pos)             /*!< 0x00000020 */
+#define USART_CR3_SCEN               USART_CR3_SCEN_Msk                        /*!< SmartCard mode enable */
+#define USART_CR3_DMAR_Pos           (6U)
+#define USART_CR3_DMAR_Msk           (0x1UL << USART_CR3_DMAR_Pos)             /*!< 0x00000040 */
+#define USART_CR3_DMAR               USART_CR3_DMAR_Msk                        /*!< DMA Enable Receiver */
+#define USART_CR3_DMAT_Pos           (7U)
+#define USART_CR3_DMAT_Msk           (0x1UL << USART_CR3_DMAT_Pos)             /*!< 0x00000080 */
+#define USART_CR3_DMAT               USART_CR3_DMAT_Msk                        /*!< DMA Enable Transmitter */
+#define USART_CR3_RTSE_Pos           (8U)
+#define USART_CR3_RTSE_Msk           (0x1UL << USART_CR3_RTSE_Pos)             /*!< 0x00000100 */
+#define USART_CR3_RTSE               USART_CR3_RTSE_Msk                        /*!< RTS Enable */
+#define USART_CR3_CTSE_Pos           (9U)
+#define USART_CR3_CTSE_Msk           (0x1UL << USART_CR3_CTSE_Pos)             /*!< 0x00000200 */
+#define USART_CR3_CTSE               USART_CR3_CTSE_Msk                        /*!< CTS Enable */
+#define USART_CR3_CTSIE_Pos          (10U)
+#define USART_CR3_CTSIE_Msk          (0x1UL << USART_CR3_CTSIE_Pos)            /*!< 0x00000400 */
+#define USART_CR3_CTSIE              USART_CR3_CTSIE_Msk                       /*!< CTS Interrupt Enable */
+#define USART_CR3_ONEBIT_Pos         (11U)
+#define USART_CR3_ONEBIT_Msk         (0x1UL << USART_CR3_ONEBIT_Pos)           /*!< 0x00000800 */
+#define USART_CR3_ONEBIT             USART_CR3_ONEBIT_Msk                      /*!< One sample bit method enable */
+#define USART_CR3_OVRDIS_Pos         (12U)
+#define USART_CR3_OVRDIS_Msk         (0x1UL << USART_CR3_OVRDIS_Pos)           /*!< 0x00001000 */
+#define USART_CR3_OVRDIS             USART_CR3_OVRDIS_Msk                      /*!< Overrun Disable */
+#define USART_CR3_DDRE_Pos           (13U)
+#define USART_CR3_DDRE_Msk           (0x1UL << USART_CR3_DDRE_Pos)             /*!< 0x00002000 */
+#define USART_CR3_DDRE               USART_CR3_DDRE_Msk                        /*!< DMA Disable on Reception Error */
+#define USART_CR3_DEM_Pos            (14U)
+#define USART_CR3_DEM_Msk            (0x1UL << USART_CR3_DEM_Pos)              /*!< 0x00004000 */
+#define USART_CR3_DEM                USART_CR3_DEM_Msk                         /*!< Driver Enable Mode */
+#define USART_CR3_DEP_Pos            (15U)
+#define USART_CR3_DEP_Msk            (0x1UL << USART_CR3_DEP_Pos)              /*!< 0x00008000 */
+#define USART_CR3_DEP                USART_CR3_DEP_Msk                         /*!< Driver Enable Polarity Selection */
+#define USART_CR3_SCARCNT_Pos        (17U)
+#define USART_CR3_SCARCNT_Msk        (0x7UL << USART_CR3_SCARCNT_Pos)          /*!< 0x000E0000 */
+#define USART_CR3_SCARCNT            USART_CR3_SCARCNT_Msk                     /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define USART_CR3_SCARCNT_0          (0x1UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00020000 */
+#define USART_CR3_SCARCNT_1          (0x2UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00040000 */
+#define USART_CR3_SCARCNT_2          (0x4UL << USART_CR3_SCARCNT_Pos)          /*!< 0x00080000 */
+#define USART_CR3_WUS_Pos            (20U)
+#define USART_CR3_WUS_Msk            (0x3UL << USART_CR3_WUS_Pos)              /*!< 0x00300000 */
+#define USART_CR3_WUS                USART_CR3_WUS_Msk                         /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define USART_CR3_WUS_0              (0x1UL << USART_CR3_WUS_Pos)              /*!< 0x00100000 */
+#define USART_CR3_WUS_1              (0x2UL << USART_CR3_WUS_Pos)              /*!< 0x00200000 */
+#define USART_CR3_WUFIE_Pos          (22U)
+#define USART_CR3_WUFIE_Msk          (0x1UL << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
+#define USART_CR3_WUFIE              USART_CR3_WUFIE_Msk                       /*!< Wake Up Interrupt Enable */
+#define USART_CR3_TXFTIE_Pos         (23U)
+#define USART_CR3_TXFTIE_Msk         (0x1UL << USART_CR3_TXFTIE_Pos)           /*!< 0x00800000 */
+#define USART_CR3_TXFTIE             USART_CR3_TXFTIE_Msk                      /*!< TXFIFO threshold interrupt enable */
+#define USART_CR3_TCBGTIE_Pos        (24U)
+#define USART_CR3_TCBGTIE_Msk        (0x1UL << USART_CR3_TCBGTIE_Pos)          /*!< 0x01000000 */
+#define USART_CR3_TCBGTIE            USART_CR3_TCBGTIE_Msk                     /*!< Transmission Complete Before Guard Time Interrupt Enable */
+#define USART_CR3_RXFTCFG_Pos        (25U)
+#define USART_CR3_RXFTCFG_Msk        (0x7UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x0E000000 */
+#define USART_CR3_RXFTCFG            USART_CR3_RXFTCFG_Msk                     /*!< RXFIFO FIFO threshold configuration */
+#define USART_CR3_RXFTCFG_0          (0x1UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x02000000 */
+#define USART_CR3_RXFTCFG_1          (0x2UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x04000000 */
+#define USART_CR3_RXFTCFG_2          (0x4UL << USART_CR3_RXFTCFG_Pos)          /*!< 0x08000000 */
+#define USART_CR3_RXFTIE_Pos         (28U)
+#define USART_CR3_RXFTIE_Msk         (0x1UL << USART_CR3_RXFTIE_Pos)           /*!< 0x10000000 */
+#define USART_CR3_RXFTIE             USART_CR3_RXFTIE_Msk                      /*!< RXFIFO threshold interrupt enable */
+#define USART_CR3_TXFTCFG_Pos        (29U)
+#define USART_CR3_TXFTCFG_Msk        (0x7UL << USART_CR3_TXFTCFG_Pos)          /*!< 0xE0000000 */
+#define USART_CR3_TXFTCFG            USART_CR3_TXFTCFG_Msk                     /*!< TXFIFO threshold configuration */
+#define USART_CR3_TXFTCFG_0          (0x1UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x20000000 */
+#define USART_CR3_TXFTCFG_1          (0x2UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x40000000 */
+#define USART_CR3_TXFTCFG_2          (0x4UL << USART_CR3_TXFTCFG_Pos)          /*!< 0x80000000 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_LPUART_Pos         (0U)
+#define USART_BRR_LPUART_Msk         (0xFFFFFUL << USART_BRR_LPUART_Pos)       /*!< 0x000FFFFF */
+#define USART_BRR_LPUART             USART_BRR_LPUART_Msk                      /*!< LPUART Baud rate register [19:0] */
+#define USART_BRR_BRR                ((uint16_t)0xFFFF)                        /*!< USART  Baud rate register [15:0] */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos           (0U)
+#define USART_GTPR_PSC_Msk           (0xFFUL << USART_GTPR_PSC_Pos)            /*!< 0x000000FF */
+#define USART_GTPR_PSC               USART_GTPR_PSC_Msk                        /*!< PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_GT_Pos            (8U)
+#define USART_GTPR_GT_Msk            (0xFFUL << USART_GTPR_GT_Pos)             /*!< 0x0000FF00 */
+#define USART_GTPR_GT                USART_GTPR_GT_Msk                         /*!< GT[7:0] bits (Guard time value) */
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define USART_RTOR_RTO_Pos           (0U)
+#define USART_RTOR_RTO_Msk           (0xFFFFFFUL << USART_RTOR_RTO_Pos)        /*!< 0x00FFFFFF */
+#define USART_RTOR_RTO               USART_RTOR_RTO_Msk                        /*!< Receiver Time Out Value */
+#define USART_RTOR_BLEN_Pos          (24U)
+#define USART_RTOR_BLEN_Msk          (0xFFUL << USART_RTOR_BLEN_Pos)           /*!< 0xFF000000 */
+#define USART_RTOR_BLEN              USART_RTOR_BLEN_Msk                       /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define USART_RQR_ABRRQ        ((uint16_t)0x0001)                              /*!< Auto-Baud Rate Request */
+#define USART_RQR_SBKRQ        ((uint16_t)0x0002)                              /*!< Send Break Request */
+#define USART_RQR_MMRQ         ((uint16_t)0x0004)                              /*!< Mute Mode Request */
+#define USART_RQR_RXFRQ        ((uint16_t)0x0008)                              /*!< Receive Data flush Request */
+#define USART_RQR_TXFRQ        ((uint16_t)0x0010)                              /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define USART_ISR_PE_Pos             (0U)
+#define USART_ISR_PE_Msk             (0x1UL << USART_ISR_PE_Pos)               /*!< 0x00000001 */
+#define USART_ISR_PE                 USART_ISR_PE_Msk                          /*!< Parity Error */
+#define USART_ISR_FE_Pos             (1U)
+#define USART_ISR_FE_Msk             (0x1UL << USART_ISR_FE_Pos)               /*!< 0x00000002 */
+#define USART_ISR_FE                 USART_ISR_FE_Msk                          /*!< Framing Error */
+#define USART_ISR_NE_Pos             (2U)
+#define USART_ISR_NE_Msk             (0x1UL << USART_ISR_NE_Pos)               /*!< 0x00000004 */
+#define USART_ISR_NE                 USART_ISR_NE_Msk                          /*!< Noise detected Flag */
+#define USART_ISR_ORE_Pos            (3U)
+#define USART_ISR_ORE_Msk            (0x1UL << USART_ISR_ORE_Pos)              /*!< 0x00000008 */
+#define USART_ISR_ORE                USART_ISR_ORE_Msk                         /*!< OverRun Error */
+#define USART_ISR_IDLE_Pos           (4U)
+#define USART_ISR_IDLE_Msk           (0x1UL << USART_ISR_IDLE_Pos)             /*!< 0x00000010 */
+#define USART_ISR_IDLE               USART_ISR_IDLE_Msk                        /*!< IDLE line detected */
+#define USART_ISR_RXNE_RXFNE_Pos     (5U)
+#define USART_ISR_RXNE_RXFNE_Msk     (0x1UL << USART_ISR_RXNE_RXFNE_Pos)       /*!< 0x00000020 */
+#define USART_ISR_RXNE_RXFNE         USART_ISR_RXNE_RXFNE_Msk                  /*!< Read Data Register Not Empty/RXFIFO Not Empty */
+#define USART_ISR_TC_Pos             (6U)
+#define USART_ISR_TC_Msk             (0x1UL << USART_ISR_TC_Pos)               /*!< 0x00000040 */
+#define USART_ISR_TC                 USART_ISR_TC_Msk                          /*!< Transmission Complete */
+#define USART_ISR_TXE_TXFNF_Pos      (7U)
+#define USART_ISR_TXE_TXFNF_Msk      (0x1UL << USART_ISR_TXE_TXFNF_Pos)        /*!< 0x00000080 */
+#define USART_ISR_TXE_TXFNF          USART_ISR_TXE_TXFNF_Msk                   /*!< Transmit Data Register Empty/TXFIFO Not Full */
+#define USART_ISR_LBDF_Pos           (8U)
+#define USART_ISR_LBDF_Msk           (0x1UL << USART_ISR_LBDF_Pos)             /*!< 0x00000100 */
+#define USART_ISR_LBDF               USART_ISR_LBDF_Msk                        /*!< LIN Break Detection Flag */
+#define USART_ISR_CTSIF_Pos          (9U)
+#define USART_ISR_CTSIF_Msk          (0x1UL << USART_ISR_CTSIF_Pos)            /*!< 0x00000200 */
+#define USART_ISR_CTSIF              USART_ISR_CTSIF_Msk                       /*!< CTS interrupt flag */
+#define USART_ISR_CTS_Pos            (10U)
+#define USART_ISR_CTS_Msk            (0x1UL << USART_ISR_CTS_Pos)              /*!< 0x00000400 */
+#define USART_ISR_CTS                USART_ISR_CTS_Msk                         /*!< CTS flag */
+#define USART_ISR_RTOF_Pos           (11U)
+#define USART_ISR_RTOF_Msk           (0x1UL << USART_ISR_RTOF_Pos)             /*!< 0x00000800 */
+#define USART_ISR_RTOF               USART_ISR_RTOF_Msk                        /*!< Receiver Time Out */
+#define USART_ISR_EOBF_Pos           (12U)
+#define USART_ISR_EOBF_Msk           (0x1UL << USART_ISR_EOBF_Pos)             /*!< 0x00001000 */
+#define USART_ISR_EOBF               USART_ISR_EOBF_Msk                        /*!< End Of Block Flag */
+#define USART_ISR_UDR_Pos            (13U)
+#define USART_ISR_UDR_Msk            (0x1UL << USART_ISR_UDR_Pos)              /*!< 0x00002000 */
+#define USART_ISR_UDR                 USART_ISR_UDR_Msk                        /*!< SPI Slave Underrun Error Flag */
+#define USART_ISR_ABRE_Pos           (14U)
+#define USART_ISR_ABRE_Msk           (0x1UL << USART_ISR_ABRE_Pos)             /*!< 0x00004000 */
+#define USART_ISR_ABRE               USART_ISR_ABRE_Msk                        /*!< Auto-Baud Rate Error */
+#define USART_ISR_ABRF_Pos           (15U)
+#define USART_ISR_ABRF_Msk           (0x1UL << USART_ISR_ABRF_Pos)             /*!< 0x00008000 */
+#define USART_ISR_ABRF               USART_ISR_ABRF_Msk                        /*!< Auto-Baud Rate Flag */
+#define USART_ISR_BUSY_Pos           (16U)
+#define USART_ISR_BUSY_Msk           (0x1UL << USART_ISR_BUSY_Pos)             /*!< 0x00010000 */
+#define USART_ISR_BUSY               USART_ISR_BUSY_Msk                        /*!< Busy Flag */
+#define USART_ISR_CMF_Pos            (17U)
+#define USART_ISR_CMF_Msk            (0x1UL << USART_ISR_CMF_Pos)              /*!< 0x00020000 */
+#define USART_ISR_CMF                USART_ISR_CMF_Msk                         /*!< Character Match Flag */
+#define USART_ISR_SBKF_Pos           (18U)
+#define USART_ISR_SBKF_Msk           (0x1UL << USART_ISR_SBKF_Pos)             /*!< 0x00040000 */
+#define USART_ISR_SBKF               USART_ISR_SBKF_Msk                        /*!< Send Break Flag */
+#define USART_ISR_RWU_Pos            (19U)
+#define USART_ISR_RWU_Msk            (0x1UL << USART_ISR_RWU_Pos)              /*!< 0x00080000 */
+#define USART_ISR_RWU                USART_ISR_RWU_Msk                         /*!< Receive Wake Up from mute mode Flag */
+#define USART_ISR_WUF_Pos            (20U)
+#define USART_ISR_WUF_Msk            (0x1UL << USART_ISR_WUF_Pos)              /*!< 0x00100000 */
+#define USART_ISR_WUF                USART_ISR_WUF_Msk                         /*!< Wake Up from stop mode Flag */
+#define USART_ISR_TEACK_Pos          (21U)
+#define USART_ISR_TEACK_Msk          (0x1UL << USART_ISR_TEACK_Pos)            /*!< 0x00200000 */
+#define USART_ISR_TEACK              USART_ISR_TEACK_Msk                       /*!< Transmit Enable Acknowledge Flag */
+#define USART_ISR_REACK_Pos          (22U)
+#define USART_ISR_REACK_Msk          (0x1UL << USART_ISR_REACK_Pos)            /*!< 0x00400000 */
+#define USART_ISR_REACK              USART_ISR_REACK_Msk                       /*!< Receive Enable Acknowledge Flag */
+#define USART_ISR_TXFE_Pos           (23U)
+#define USART_ISR_TXFE_Msk           (0x1UL << USART_ISR_TXFE_Pos)             /*!< 0x00800000 */
+#define USART_ISR_TXFE               USART_ISR_TXFE_Msk                        /*!< TXFIFO Empty Flag */
+#define USART_ISR_RXFF_Pos           (24U)
+#define USART_ISR_RXFF_Msk           (0x1UL << USART_ISR_RXFF_Pos)             /*!< 0x01000000 */
+#define USART_ISR_RXFF               USART_ISR_RXFF_Msk                        /*!< RXFIFO Full Flag */
+#define USART_ISR_TCBGT_Pos          (25U)
+#define USART_ISR_TCBGT_Msk          (0x1UL << USART_ISR_TCBGT_Pos)            /*!< 0x02000000 */
+#define USART_ISR_TCBGT              USART_ISR_TCBGT_Msk                       /*!< Transmission Complete Before Guard Time Completion Flag */
+#define USART_ISR_RXFT_Pos           (26U)
+#define USART_ISR_RXFT_Msk           (0x1UL << USART_ISR_RXFT_Pos)             /*!< 0x04000000 */
+#define USART_ISR_RXFT               USART_ISR_RXFT_Msk                        /*!< RXFIFO Threshold Flag */
+#define USART_ISR_TXFT_Pos           (27U)
+#define USART_ISR_TXFT_Msk           (0x1UL << USART_ISR_TXFT_Pos)             /*!< 0x08000000 */
+#define USART_ISR_TXFT               USART_ISR_TXFT_Msk                        /*!< TXFIFO Threshold Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define USART_ICR_PECF_Pos           (0U)
+#define USART_ICR_PECF_Msk           (0x1UL << USART_ICR_PECF_Pos)             /*!< 0x00000001 */
+#define USART_ICR_PECF               USART_ICR_PECF_Msk                        /*!< Parity Error Clear Flag */
+#define USART_ICR_FECF_Pos           (1U)
+#define USART_ICR_FECF_Msk           (0x1UL << USART_ICR_FECF_Pos)             /*!< 0x00000002 */
+#define USART_ICR_FECF               USART_ICR_FECF_Msk                        /*!< Framing Error Clear Flag */
+#define USART_ICR_NECF_Pos           (2U)
+#define USART_ICR_NECF_Msk           (0x1UL << USART_ICR_NECF_Pos)             /*!< 0x00000004 */
+#define USART_ICR_NECF               USART_ICR_NECF_Msk                        /*!< Noise Error detected Clear Flag */
+#define USART_ICR_ORECF_Pos          (3U)
+#define USART_ICR_ORECF_Msk          (0x1UL << USART_ICR_ORECF_Pos)            /*!< 0x00000008 */
+#define USART_ICR_ORECF              USART_ICR_ORECF_Msk                       /*!< OverRun Error Clear Flag */
+#define USART_ICR_IDLECF_Pos         (4U)
+#define USART_ICR_IDLECF_Msk         (0x1UL << USART_ICR_IDLECF_Pos)           /*!< 0x00000010 */
+#define USART_ICR_IDLECF             USART_ICR_IDLECF_Msk                      /*!< IDLE line detected Clear Flag */
+#define USART_ICR_TXFECF_Pos         (5U)
+#define USART_ICR_TXFECF_Msk         (0x1UL << USART_ICR_TXFECF_Pos)           /*!< 0x00000020 */
+#define USART_ICR_TXFECF             USART_ICR_TXFECF_Msk                      /*!< TXFIFO Empty Clear Flag */
+#define USART_ICR_TCCF_Pos           (6U)
+#define USART_ICR_TCCF_Msk           (0x1UL << USART_ICR_TCCF_Pos)             /*!< 0x00000040 */
+#define USART_ICR_TCCF               USART_ICR_TCCF_Msk                        /*!< Transmission Complete Clear Flag */
+#define USART_ICR_TCBGTCF_Pos        (7U)
+#define USART_ICR_TCBGTCF_Msk        (0x1UL << USART_ICR_TCBGTCF_Pos)          /*!< 0x00000080 */
+#define USART_ICR_TCBGTCF            USART_ICR_TCBGTCF_Msk                     /*!< Transmission Complete Before Guard Time Clear Flag */
+#define USART_ICR_LBDCF_Pos          (8U)
+#define USART_ICR_LBDCF_Msk          (0x1UL << USART_ICR_LBDCF_Pos)            /*!< 0x00000100 */
+#define USART_ICR_LBDCF              USART_ICR_LBDCF_Msk                       /*!< LIN Break Detection Clear Flag */
+#define USART_ICR_CTSCF_Pos          (9U)
+#define USART_ICR_CTSCF_Msk          (0x1UL << USART_ICR_CTSCF_Pos)            /*!< 0x00000200 */
+#define USART_ICR_CTSCF              USART_ICR_CTSCF_Msk                       /*!< CTS Interrupt Clear Flag */
+#define USART_ICR_RTOCF_Pos          (11U)
+#define USART_ICR_RTOCF_Msk          (0x1UL << USART_ICR_RTOCF_Pos)            /*!< 0x00000800 */
+#define USART_ICR_RTOCF              USART_ICR_RTOCF_Msk                       /*!< Receiver Time Out Clear Flag */
+#define USART_ICR_EOBCF_Pos          (12U)
+#define USART_ICR_EOBCF_Msk          (0x1UL << USART_ICR_EOBCF_Pos)            /*!< 0x00001000 */
+#define USART_ICR_EOBCF              USART_ICR_EOBCF_Msk                       /*!< End Of Block Clear Flag */
+#define USART_ICR_UDRCF_Pos          (13U)
+#define USART_ICR_UDRCF_Msk          (0x1UL << USART_ICR_UDRCF_Pos)            /*!< 0x00002000 */
+#define USART_ICR_UDRCF              USART_ICR_UDRCF_Msk                       /*!< SPI Slave Underrun Clear Flag */
+#define USART_ICR_CMCF_Pos           (17U)
+#define USART_ICR_CMCF_Msk           (0x1UL << USART_ICR_CMCF_Pos)             /*!< 0x00020000 */
+#define USART_ICR_CMCF               USART_ICR_CMCF_Msk                        /*!< Character Match Clear Flag */
+#define USART_ICR_WUCF_Pos           (20U)
+#define USART_ICR_WUCF_Msk           (0x1UL << USART_ICR_WUCF_Pos)             /*!< 0x00100000 */
+#define USART_ICR_WUCF               USART_ICR_WUCF_Msk                        /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define USART_RDR_RDR_Pos             (0U)
+#define USART_RDR_RDR_Msk             (0x1FFUL << USART_RDR_RDR_Pos)           /*!< 0x000001FF */
+#define USART_RDR_RDR                 USART_RDR_RDR_Msk                        /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define USART_TDR_TDR_Pos             (0U)
+#define USART_TDR_TDR_Msk             (0x1FFUL << USART_TDR_TDR_Pos)           /*!< 0x000001FF */
+#define USART_TDR_TDR                 USART_TDR_TDR_Msk                        /*!< TDR[8:0] bits (Transmit Data value) */
+
+/*******************  Bit definition for USART_PRESC register  ****************/
+#define USART_PRESC_PRESCALER_Pos    (0U)
+#define USART_PRESC_PRESCALER_Msk    (0xFUL << USART_PRESC_PRESCALER_Pos)      /*!< 0x0000000F */
+#define USART_PRESC_PRESCALER        USART_PRESC_PRESCALER_Msk                 /*!< PRESCALER[3:0] bits (Clock prescaler) */
+#define USART_PRESC_PRESCALER_0      (0x1UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000001 */
+#define USART_PRESC_PRESCALER_1      (0x2UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000002 */
+#define USART_PRESC_PRESCALER_2      (0x4UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000004 */
+#define USART_PRESC_PRESCALER_3      (0x8UL << USART_PRESC_PRESCALER_Pos)      /*!< 0x00000008 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 VREFBUF                                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for VREFBUF_CSR register  ****************/
+#define VREFBUF_CSR_ENVR_Pos    (0U)
+#define VREFBUF_CSR_ENVR_Msk    (0x1UL << VREFBUF_CSR_ENVR_Pos)                /*!< 0x00000001 */
+#define VREFBUF_CSR_ENVR        VREFBUF_CSR_ENVR_Msk                           /*!<Voltage reference buffer enable */
+#define VREFBUF_CSR_HIZ_Pos     (1U)
+#define VREFBUF_CSR_HIZ_Msk     (0x1UL << VREFBUF_CSR_HIZ_Pos)                 /*!< 0x00000002 */
+#define VREFBUF_CSR_HIZ         VREFBUF_CSR_HIZ_Msk                            /*!<High impedance mode             */
+#define VREFBUF_CSR_VRS_Pos     (2U)
+#define VREFBUF_CSR_VRS_Msk     (0x1UL << VREFBUF_CSR_VRS_Pos)                 /*!< 0x00000004 */
+#define VREFBUF_CSR_VRS         VREFBUF_CSR_VRS_Msk                            /*!<Voltage reference scale         */
+#define VREFBUF_CSR_VRR_Pos     (3U)
+#define VREFBUF_CSR_VRR_Msk     (0x1UL << VREFBUF_CSR_VRR_Pos)                 /*!< 0x00000008 */
+#define VREFBUF_CSR_VRR         VREFBUF_CSR_VRR_Msk                            /*!<Voltage reference buffer ready  */
+
+/*******************  Bit definition for VREFBUF_CCR register  ******************/
+#define VREFBUF_CCR_TRIM_Pos    (0U)
+#define VREFBUF_CCR_TRIM_Msk    (0x3FUL << VREFBUF_CCR_TRIM_Pos)               /*!< 0x0000003F */
+#define VREFBUF_CCR_TRIM        VREFBUF_CCR_TRIM_Msk                           /*!<TRIM[5:0] bits (Trimming code)  */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                      /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01UL << WWDG_CR_T_Pos)                      /*!< 0x00000001 */
+#define WWDG_CR_T_1             (0x02UL << WWDG_CR_T_Pos)                      /*!< 0x00000002 */
+#define WWDG_CR_T_2             (0x04UL << WWDG_CR_T_Pos)                      /*!< 0x00000004 */
+#define WWDG_CR_T_3             (0x08UL << WWDG_CR_T_Pos)                      /*!< 0x00000008 */
+#define WWDG_CR_T_4             (0x10UL << WWDG_CR_T_Pos)                      /*!< 0x00000010 */
+#define WWDG_CR_T_5             (0x20UL << WWDG_CR_T_Pos)                      /*!< 0x00000020 */
+#define WWDG_CR_T_6             (0x40UL << WWDG_CR_T_Pos)                      /*!< 0x00000040 */
+
+#define WWDG_CR_WDGA_Pos        (7U)
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                    /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                     /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01UL << WWDG_CFR_W_Pos)                     /*!< 0x00000001 */
+#define WWDG_CFR_W_1            (0x02UL << WWDG_CFR_W_Pos)                     /*!< 0x00000002 */
+#define WWDG_CFR_W_2            (0x04UL << WWDG_CFR_W_Pos)                     /*!< 0x00000004 */
+#define WWDG_CFR_W_3            (0x08UL << WWDG_CFR_W_Pos)                     /*!< 0x00000008 */
+#define WWDG_CFR_W_4            (0x10UL << WWDG_CFR_W_Pos)                     /*!< 0x00000010 */
+#define WWDG_CFR_W_5            (0x20UL << WWDG_CFR_W_Pos)                     /*!< 0x00000020 */
+#define WWDG_CFR_W_6            (0x40UL << WWDG_CFR_W_Pos)                     /*!< 0x00000040 */
+
+#define WWDG_CFR_WDGTB_Pos      (11U)
+#define WWDG_CFR_WDGTB_Msk      (0x7UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00003800 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[2:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00000800 */
+#define WWDG_CFR_WDGTB_1        (0x2UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00001000 */
+#define WWDG_CFR_WDGTB_2        (0x4UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00002000 */
+
+#define WWDG_CFR_EWI_Pos        (9U)
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                    /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                    /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                Debug MCU                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBG_IDCODE register  *************/
+#define DBG_IDCODE_DEV_ID_Pos                          (0U)
+#define DBG_IDCODE_DEV_ID_Msk                          (0xFFFUL << DBG_IDCODE_DEV_ID_Pos)  /*!< 0x00000FFF */
+#define DBG_IDCODE_DEV_ID                              DBG_IDCODE_DEV_ID_Msk
+#define DBG_IDCODE_REV_ID_Pos                          (16U)
+#define DBG_IDCODE_REV_ID_Msk                          (0xFFFFUL << DBG_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBG_IDCODE_REV_ID                              DBG_IDCODE_REV_ID_Msk
+
+/********************  Bit definition for DBG_CR register  *****************/
+#define DBG_CR_DBG_STOP_Pos                            (1U)
+#define DBG_CR_DBG_STOP_Msk                            (0x1UL << DBG_CR_DBG_STOP_Pos)      /*!< 0x00000002 */
+#define DBG_CR_DBG_STOP                                DBG_CR_DBG_STOP_Msk
+#define DBG_CR_DBG_STANDBY_Pos                         (2U)
+#define DBG_CR_DBG_STANDBY_Msk                         (0x1UL << DBG_CR_DBG_STANDBY_Pos)   /*!< 0x00000004 */
+#define DBG_CR_DBG_STANDBY                             DBG_CR_DBG_STANDBY_Msk
+
+
+/********************  Bit definition for DBG_APB_FZ1 register  ***********/
+#define DBG_APB_FZ1_DBG_TIM2_STOP_Pos                  (0U)
+#define DBG_APB_FZ1_DBG_TIM2_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM2_STOP_Pos) /*!< 0x00000001 */
+#define DBG_APB_FZ1_DBG_TIM2_STOP                      DBG_APB_FZ1_DBG_TIM2_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM3_STOP_Pos                  (1U)
+#define DBG_APB_FZ1_DBG_TIM3_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
+#define DBG_APB_FZ1_DBG_TIM3_STOP                      DBG_APB_FZ1_DBG_TIM3_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM6_STOP_Pos                  (4U)
+#define DBG_APB_FZ1_DBG_TIM6_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM6_STOP_Pos) /*!< 0x00000010 */
+#define DBG_APB_FZ1_DBG_TIM6_STOP                      DBG_APB_FZ1_DBG_TIM6_STOP_Msk
+#define DBG_APB_FZ1_DBG_TIM7_STOP_Pos                  (5U)
+#define DBG_APB_FZ1_DBG_TIM7_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM7_STOP_Pos) /*!< 0x00000020 */
+#define DBG_APB_FZ1_DBG_TIM7_STOP                      DBG_APB_FZ1_DBG_TIM7_STOP_Msk
+#define DBG_APB_FZ1_DBG_RTC_STOP_Pos                   (10U)
+#define DBG_APB_FZ1_DBG_RTC_STOP_Msk                   (0x1UL << DBG_APB_FZ1_DBG_RTC_STOP_Pos)  /*!< 0x00000400 */
+#define DBG_APB_FZ1_DBG_RTC_STOP                       DBG_APB_FZ1_DBG_RTC_STOP_Msk
+#define DBG_APB_FZ1_DBG_WWDG_STOP_Pos                  (11U)
+#define DBG_APB_FZ1_DBG_WWDG_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_WWDG_STOP_Pos) /*!< 0x00000800 */
+#define DBG_APB_FZ1_DBG_WWDG_STOP                      DBG_APB_FZ1_DBG_WWDG_STOP_Msk
+#define DBG_APB_FZ1_DBG_IWDG_STOP_Pos                  (12U)
+#define DBG_APB_FZ1_DBG_IWDG_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_IWDG_STOP_Pos) /*!< 0x00001000 */
+#define DBG_APB_FZ1_DBG_IWDG_STOP                      DBG_APB_FZ1_DBG_IWDG_STOP_Msk
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Pos    (21U)
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00200000 */
+#define DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C1_SMBUS_TIMEOUT_STOP_Msk
+#define DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos                (30U)
+#define DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk                (0x1UL << DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos) /*!< 0x40000000 */
+#define DBG_APB_FZ1_DBG_LPTIM2_STOP                    DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk
+#define DBG_APB_FZ1_DBG_LPTIM1_STOP_Pos                (31U)
+#define DBG_APB_FZ1_DBG_LPTIM1_STOP_Msk                (0x1UL << DBG_APB_FZ1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBG_APB_FZ1_DBG_LPTIM1_STOP                    DBG_APB_FZ1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBG_APB_FZ2 register  ************/
+#define DBG_APB_FZ2_DBG_TIM1_STOP_Pos                  (11U)
+#define DBG_APB_FZ2_DBG_TIM1_STOP_Msk                  (0x1UL << DBG_APB_FZ2_DBG_TIM1_STOP_Pos)  /*!< 0x00000800 */
+#define DBG_APB_FZ2_DBG_TIM1_STOP                      DBG_APB_FZ2_DBG_TIM1_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM14_STOP_Pos                 (15U)
+#define DBG_APB_FZ2_DBG_TIM14_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM14_STOP_Pos) /*!< 0x00008000 */
+#define DBG_APB_FZ2_DBG_TIM14_STOP                     DBG_APB_FZ2_DBG_TIM14_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM15_STOP_Pos                 (16U)
+#define DBG_APB_FZ2_DBG_TIM15_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM15_STOP_Pos) /*!< 0x00010000 */
+#define DBG_APB_FZ2_DBG_TIM15_STOP                     DBG_APB_FZ2_DBG_TIM15_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM16_STOP_Pos                 (17U)
+#define DBG_APB_FZ2_DBG_TIM16_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM16_STOP_Pos) /*!< 0x00020000 */
+#define DBG_APB_FZ2_DBG_TIM16_STOP                     DBG_APB_FZ2_DBG_TIM16_STOP_Msk
+#define DBG_APB_FZ2_DBG_TIM17_STOP_Pos                 (18U)
+#define DBG_APB_FZ2_DBG_TIM17_STOP_Msk                 (0x1UL << DBG_APB_FZ2_DBG_TIM17_STOP_Pos) /*!< 0x00040000 */
+#define DBG_APB_FZ2_DBG_TIM17_STOP                     DBG_APB_FZ2_DBG_TIM17_STOP_Msk
+
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+
+/******************************* AES Instances ********************************/
+#define IS_AES_ALL_INSTANCE(INSTANCE) ((INSTANCE) == AES)
+
+
+/******************************** COMP Instances ******************************/
+#define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                        ((INSTANCE) == COMP2))
+
+#define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) ((COMMON_INSTANCE) == COMP12_COMMON)
+
+/******************** COMP Instances with window mode capability **************/
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                               ((INSTANCE) == COMP2))
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+/******************************* DAC Instances ********************************/
+#define IS_DAC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DAC1)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Channel1) || \
+                                       ((INSTANCE) == DMA1_Channel2) || \
+                                       ((INSTANCE) == DMA1_Channel3) || \
+                                       ((INSTANCE) == DMA1_Channel4) || \
+                                       ((INSTANCE) == DMA1_Channel5) || \
+                                       ((INSTANCE) == DMA1_Channel6) || \
+                                       ((INSTANCE) == DMA1_Channel7))
+
+/******************************** DMAMUX Instances ****************************/
+#define IS_DMAMUX_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DMAMUX1)
+
+#define IS_DMAMUX_REQUEST_GEN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMAMUX1_RequestGenerator0) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator1) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator2) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator3))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOD) || \
+                                        ((INSTANCE) == GPIOF))
+/******************************* GPIO AF Instances ****************************/
+#define IS_GPIO_AF_INSTANCE(INSTANCE)   IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/**************************** GPIO Lock Instances *****************************/
+#define IS_GPIO_LOCK_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                         ((INSTANCE) == GPIOB) || \
+                                         ((INSTANCE) == GPIOC))
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1) || \
+                                       ((INSTANCE) == I2C2))
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/****************************** SMBUS Instances *******************************/
+#define IS_SMBUS_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1))
+
+/****************************** WAKEUP_FROMSTOP Instances *******************************/
+#define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) (((INSTANCE) == I2C1))
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
+                                       ((INSTANCE) == SPI2))
+
+/******************************** SPI Instances *******************************/
+#define IS_I2S_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == SPI1)
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
+                                         ((INSTANCE) == LPTIM2))
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) ((INSTANCE) == LPTIM1)
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM6)   || \
+                                         ((INSTANCE) == TIM7)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting 32 bits counter ****************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) ((INSTANCE) == TIM2)
+
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)    || \
+                                            ((INSTANCE) == TIM15)   || \
+                                            ((INSTANCE) == TIM16)   || \
+                                            ((INSTANCE) == TIM17))
+
+/************** TIM Instances : supporting Break source selection *************/
+#define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                               ((INSTANCE) == TIM15)  || \
+                                               ((INSTANCE) == TIM16)  || \
+                                               ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BKIN2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM15))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(INSTANCE)   ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(INSTANCE)   ((INSTANCE) == TIM1)
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.COMDE) *******/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : DMA requests generation (TIMx_DIER.UDE) ***/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM6)   || \
+                                            ((INSTANCE) == TIM7)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM14)  || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM15)  || \
+                                            ((INSTANCE) == TIM16)  || \
+                                            ((INSTANCE) == TIM17))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+    ((((INSTANCE) == TIM1) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4) ||          \
+      ((CHANNEL) == TIM_CHANNEL_5) ||          \
+      ((CHANNEL) == TIM_CHANNEL_6)))           \
+     ||                                        \
+     (((INSTANCE) == TIM2) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
+     (((INSTANCE) == TIM3) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
+     (((INSTANCE) == TIM14) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+     ||                                        \
+     (((INSTANCE) == TIM15) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2)))           \
+     ||                                        \
+     (((INSTANCE) == TIM16) &&                 \
+     (((CHANNEL) == TIM_CHANNEL_1)))           \
+     ||                                        \
+     (((INSTANCE) == TIM17) &&                 \
+      (((CHANNEL) == TIM_CHANNEL_1))))
+
+/****************** TIM Instances : supporting complementary output(s) ********/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+   ((((INSTANCE) == TIM1) &&                    \
+     (((CHANNEL) == TIM_CHANNEL_1) ||           \
+      ((CHANNEL) == TIM_CHANNEL_2) ||           \
+      ((CHANNEL) == TIM_CHANNEL_3)))            \
+    ||                                          \
+    (((INSTANCE) == TIM15) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1))              \
+    ||                                          \
+    (((INSTANCE) == TIM16) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1))              \
+    ||                                          \
+    (((INSTANCE) == TIM17) &&                   \
+     ((CHANNEL) == TIM_CHANNEL_1)))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
+                                                    ((INSTANCE) == TIM2)    || \
+                                                    ((INSTANCE) == TIM3)    || \
+                                                    ((INSTANCE) == TIM14)   || \
+                                                    ((INSTANCE) == TIM15)   || \
+                                                    ((INSTANCE) == TIM16)   || \
+                                                    ((INSTANCE) == TIM17))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3) || \
+                                                        ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting commutation event generation ***/
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                     ((INSTANCE) == TIM15)  || \
+                                                     ((INSTANCE) == TIM16)  || \
+                                                     ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2) || \
+                                                        ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                      ((INSTANCE) == TIM2)  || \
+                                                      ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                                         ((INSTANCE) == TIM2)   || \
+                                                         ((INSTANCE) == TIM3))
+
+/**************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3))
+
+/************* TIM Instances : supporting ETR source selection ***************/
+#define IS_TIM_ETRSEL_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                             ((INSTANCE) == TIM2)  || \
+                                             ((INSTANCE) == TIM3))
+
+/****** TIM Instances : Master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3)  || \
+                                            ((INSTANCE) == TIM6)  || \
+                                            ((INSTANCE) == TIM7)  || \
+                                            ((INSTANCE) == TIM15))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3)  || \
+                                            ((INSTANCE) == TIM15))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM2) || \
+                                                       ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM3))
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM15) || \
+                                                       ((INSTANCE) == TIM16) || \
+                                                       ((INSTANCE) == TIM17))
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2)   || \
+                                            ((INSTANCE) == TIM3)   || \
+                                            ((INSTANCE) == TIM15))
+
+/******************* TIM Instances : Timer input selection ********************/
+#define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM3)   || \
+                                         ((INSTANCE) == TIM14)  || \
+                                         ((INSTANCE) == TIM15)  || \
+                                         ((INSTANCE) == TIM16)  || \
+                                         ((INSTANCE) == TIM17))
+
+/************ TIM Instances : Advanced timers  ********************************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                    ((INSTANCE) == USART2))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                     ((INSTANCE) == USART2))
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == USART2) || \
+                                           ((INSTANCE) == LPUART1))
+
+/********************* USART Instances : Smard card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+/****************** UART Instances : Auto Baud Rate detection ****************/
+#define IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+/******************** UART Instances : Half-Duplex mode **********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                 ((INSTANCE) == USART2) || \
+                                                 ((INSTANCE) == LPUART1))
+
+/******************** UART Instances : LIN mode **********************/
+#define IS_UART_LIN_INSTANCE(INSTANCE)   ((INSTANCE) == USART1)
+/******************** UART Instances : Wake-up from Stop mode **********************/
+#define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == LPUART1))
+
+/****************** UART Instances : Driver Enable *****************/
+#define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE)     (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == USART2) || \
+                                                      ((INSTANCE) == LPUART1))
+
+/****************** UART Instances : SPI Slave selection mode ***************/
+#define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                              ((INSTANCE) == USART2))
+
+/****************** UART Instances : Driver Enable *****************/
+#define IS_UART_FIFO_INSTANCE(INSTANCE)     (((INSTANCE) == USART1) || \
+                                             ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/******************** LPUART Instance *****************************************/
+#define IS_LPUART_INSTANCE(INSTANCE)    ((INSTANCE) == LPUART1)
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+
+/**
+  * @}
+  */
+
+ /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* STM32G061xx_H */
+
+/**
+  * @}
+  */
+
+  /**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32g0xx/soc/stm32g070xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g070xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -251,10 +251,10 @@ typedef struct
   __IO uint32_t ECCR;         /*!< FLASH ECC register,                                Address offset: 0x18 */
        uint32_t RESERVED2;    /*!< Reserved2,                                         Address offset: 0x1C */
   __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
-       uint32_t RESERVED4[2]; /*!< Reserved4,                                         Address offset: 0x24--0x28 */
+       uint32_t RESERVED3[2]; /*!< Reserved3,                                         Address offset: 0x24--0x28 */
   __IO uint32_t WRP1AR;       /*!< FLASH Bank WRP area A address register,            Address offset: 0x2C */
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
-       uint32_t RESERVED5[2]; /*!< Reserved5,                                         Address offset: 0x34--0x38 */
+       uint32_t RESERVED4[2]; /*!< Reserved4,                                         Address offset: 0x34--0x38 */
 } FLASH_TypeDef;
 
 /**
@@ -523,6 +523,8 @@ typedef struct
 #define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
 #define SRAM_SIZE_MAX         (0x00008000UL)  /*!< maximum SRAM size (up to 32 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x00FFU)) << 10U)
 
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
@@ -805,7 +807,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -1603,7 +1605,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2158,21 +2160,12 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
-#define EXTI_IMR1_IM22_Pos           (22U)
-#define EXTI_IMR1_IM22_Msk           (0x1UL << EXTI_IMR1_IM22_Pos)             /*!< 0x00400000 */
-#define EXTI_IMR1_IM22               EXTI_IMR1_IM22_Msk                        /*!< Interrupt Mask on line 22 */
 #define EXTI_IMR1_IM23_Pos           (23U)
 #define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
 #define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
-#define EXTI_IMR1_IM24_Pos           (24U)
-#define EXTI_IMR1_IM24_Msk           (0x1UL << EXTI_IMR1_IM24_Pos)             /*!< 0x01000000 */
-#define EXTI_IMR1_IM24               EXTI_IMR1_IM24_Msk                        /*!< Interrupt Mask on line 24 */
 #define EXTI_IMR1_IM25_Pos           (25U)
 #define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
 #define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
@@ -2183,7 +2176,7 @@ typedef struct
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0x86A8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x86A8FFFFU */
+#define EXTI_IMR1_IM_Msk             (0x86A8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x86A8FFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
 
@@ -2236,12 +2229,6 @@ typedef struct
 #define EXTI_EMR1_EM15_Pos           (15U)
 #define EXTI_EMR1_EM15_Msk           (0x1UL << EXTI_EMR1_EM15_Pos)             /*!< 0x00008000 */
 #define EXTI_EMR1_EM15               EXTI_EMR1_EM15_Msk                        /*!< Event Mask on line 15 */
-#define EXTI_EMR1_EM17_Pos           (17U)
-#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
-#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
-#define EXTI_EMR1_EM18_Pos           (18U)
-#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
-#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
 #define EXTI_EMR1_EM19_Pos           (19U)
 #define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
 #define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
@@ -2329,94 +2316,93 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)       /*!< 0x000001F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
 /*******************  Bits definition for FLASH_ECCR register  ****************/
 #define FLASH_ECCR_ADDR_ECC_Pos                (0U)
-#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
 #define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
 #define FLASH_ECCR_SYSF_ECC_Pos                (20U)
-#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
 #define FLASH_ECCR_ECCCIE_Pos                  (24U)
-#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
 #define FLASH_ECCR_ECCC_Pos                    (30U)
-#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
 #define FLASH_ECCR_ECCD_Pos                    (31U)
-#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
-
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
 #define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
@@ -2433,7 +2419,6 @@ typedef struct
 #define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
 #define FLASH_WRP1BR_WRP1B_END_Msk             (0x3FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x003F0000 */
 #define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
-
 
 
 /******************************************************************************/
@@ -4024,7 +4009,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
 
 /********************  Bit definition for RCC_CR register  *****************/
@@ -4106,12 +4091,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -4129,9 +4108,10 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
@@ -5415,7 +5395,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -5696,9 +5676,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -5765,9 +5745,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -5824,7 +5804,7 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -6599,7 +6579,7 @@ typedef struct
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -6668,7 +6648,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -6676,7 +6656,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -6684,7 +6664,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -6692,7 +6672,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -7504,6 +7484,10 @@ typedef struct
 #define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
                                                        ((INSTANCE) == TIM3))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
 
@@ -7512,9 +7496,6 @@ typedef struct
                                                        ((INSTANCE) == TIM15) || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))

--- a/stm32cube/stm32g0xx/soc/stm32g071xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g071xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -77,7 +77,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
 /******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
-  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt(EXTI line 16)           */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI line 16                                          */
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
   RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
@@ -315,7 +315,7 @@ typedef struct
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
   __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
   __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
-       uint32_t RESERVED3[17];/*!< Reserved3,                                         Address offset: 0x3C */
+       uint32_t RESERVED8[17];/*!< Reserved8,                                         Address offset: 0x3C--0x7C */
   __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
 } FLASH_TypeDef;
 
@@ -636,6 +636,8 @@ typedef struct
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
 #define SRAM_SIZE_MAX         (0x00008000UL)  /*!< maximum SRAM size (up to 32 KBytes) */
 
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x00FFU)) << 10U)
+
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
 #define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
@@ -942,7 +944,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -2108,7 +2110,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2717,21 +2719,12 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
-#define EXTI_IMR1_IM22_Pos           (22U)
-#define EXTI_IMR1_IM22_Msk           (0x1UL << EXTI_IMR1_IM22_Pos)             /*!< 0x00400000 */
-#define EXTI_IMR1_IM22               EXTI_IMR1_IM22_Msk                        /*!< Interrupt Mask on line 22 */
 #define EXTI_IMR1_IM23_Pos           (23U)
 #define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
 #define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
-#define EXTI_IMR1_IM24_Pos           (24U)
-#define EXTI_IMR1_IM24_Msk           (0x1UL << EXTI_IMR1_IM24_Pos)             /*!< 0x01000000 */
-#define EXTI_IMR1_IM24               EXTI_IMR1_IM24_Msk                        /*!< Interrupt Mask on line 24 */
 #define EXTI_IMR1_IM25_Pos           (25U)
 #define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
 #define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
@@ -2940,135 +2933,135 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)       /*!< 0x000001F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_RDERRIE_Pos                   (26U)
-#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)  /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
 #define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_SEC_PROT_Pos                  (28U)
-#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos) /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
 #define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
 /*******************  Bits definition for FLASH_ECCR register  ****************/
 #define FLASH_ECCR_ADDR_ECC_Pos                (0U)
-#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
 #define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
 #define FLASH_ECCR_SYSF_ECC_Pos                (20U)
-#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
 #define FLASH_ECCR_ECCCIE_Pos                  (24U)
-#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
 #define FLASH_ECCR_ECCC_Pos                    (30U)
-#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
 #define FLASH_ECCR_ECCD_Pos                    (31U)
-#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_BOR_EN_Pos                  (8U)
-#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos) /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
 #define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
-#define FLASH_OPTR_BORF_LEV_Pos                (9U)
-#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000600 */
-#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
-#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000200 */
-#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000400 */
-#define FLASH_OPTR_BORR_LEV_Pos                (11U)
-#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001800 */
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
 #define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
-#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00000800 */
-#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_nRST_SHDW_Pos               (15U)
-#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
 #define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
 #define FLASH_OPTR_NRST_MODE_Pos               (27U)
-#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
 #define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
-#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x08000000 */
-#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x10000000 */
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
 #define FLASH_OPTR_IRHEN_Pos                   (29U)
-#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos) /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
 #define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
 
 /******************  Bits definition for FLASH_PCROP1ASR register  ************/
 #define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
-#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0xFFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0xFFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)   /*!< 0x000000FF */
 #define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1AER register  ************/
 #define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
-#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0xFFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0xFFUL << FLASH_PCROP1AER_PCROP1A_END_Pos)    /*!< 0x000000FF */
 #define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
 #define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
-#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
 #define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
@@ -3089,13 +3082,14 @@ typedef struct
 
 /******************  Bits definition for FLASH_PCROP1BSR register  ************/
 #define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
-#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0xFFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0xFFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)   /*!< 0x000000FF */
 #define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1BER register  ************/
 #define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
-#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0xFFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)  /*!< 0x000000FF */
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0xFFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)    /*!< 0x000000FF */
 #define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
 
 /******************  Bits definition for FLASH_SECR register  *****************/
 #define FLASH_SECR_SEC_SIZE_Pos                (0U)
@@ -3104,7 +3098,6 @@ typedef struct
 #define FLASH_SECR_BOOT_LOCK_Pos               (16U)
 #define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
 #define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -4722,7 +4715,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
 #define RCC_PLLQ_SUPPORT
 
@@ -4805,12 +4798,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -4828,9 +4815,10 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
@@ -6222,7 +6210,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -6509,9 +6497,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -6569,12 +6557,12 @@ typedef struct
 #define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
 #define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
 #define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
-#define SYSCFG_ITLINE8_SR_UCPD1_Pos          (0U)
-#define SYSCFG_ITLINE8_SR_UCPD1_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE8_SR_UCPD1              SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
-#define SYSCFG_ITLINE8_SR_UCPD2_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_UCPD2_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_UCPD2              SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD1_Pos           (0U)
+#define SYSCFG_ITLINE8_SR_UCPD1_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE8_SR_UCPD1               SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD2_Pos           (1U)
+#define SYSCFG_ITLINE8_SR_UCPD2_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE8_SR_UCPD2               SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
@@ -6584,9 +6572,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -6661,7 +6649,7 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -7455,7 +7443,7 @@ typedef struct
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -7524,7 +7512,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -7532,7 +7520,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -7540,7 +7528,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -7548,7 +7536,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -7673,7 +7661,7 @@ typedef struct
 
 #define LPTIM_CFGR_TIMOUT_Pos       (19U)
 #define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
-#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timout enable */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
 #define LPTIM_CFGR_WAVE_Pos         (20U)
 #define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
 #define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
@@ -8712,7 +8700,8 @@ typedef struct
 #define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) ((COMMON_INSTANCE) == COMP12_COMMON)
 
 /******************** COMP Instances with window mode capability **************/
-#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) ((INSTANCE) == COMP2)
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                               ((INSTANCE) == COMP2))
 
 /******************************* CRC Instances ********************************/
 #define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
@@ -9007,6 +8996,11 @@ typedef struct
                                                        ((INSTANCE) == TIM2) || \
                                                        ((INSTANCE) == TIM3))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM2)  || \
@@ -9017,9 +9011,6 @@ typedef struct
                                                        ((INSTANCE) == TIM15) || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))

--- a/stm32cube/stm32g0xx/soc/stm32g081xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g081xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -77,7 +77,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
 /******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
-  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt(EXTI line 16)           */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI line 16                                          */
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
   RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
@@ -316,7 +316,7 @@ typedef struct
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
   __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
   __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
-       uint32_t RESERVED3[17];/*!< Reserved3,                                         Address offset: 0x3C */
+       uint32_t RESERVED8[17];/*!< Reserved8,                                         Address offset: 0x3C--0x7C */
   __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
 } FLASH_TypeDef;
 
@@ -678,6 +678,8 @@ typedef struct
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
 #define SRAM_SIZE_MAX         (0x00008000UL)  /*!< maximum SRAM size (up to 32 KBytes) */
 
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x00FFU)) << 10U)
+
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
 #define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000UL)
@@ -989,7 +991,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -2344,7 +2346,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2953,21 +2955,12 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
-#define EXTI_IMR1_IM22_Pos           (22U)
-#define EXTI_IMR1_IM22_Msk           (0x1UL << EXTI_IMR1_IM22_Pos)             /*!< 0x00400000 */
-#define EXTI_IMR1_IM22               EXTI_IMR1_IM22_Msk                        /*!< Interrupt Mask on line 22 */
 #define EXTI_IMR1_IM23_Pos           (23U)
 #define EXTI_IMR1_IM23_Msk           (0x1UL << EXTI_IMR1_IM23_Pos)             /*!< 0x00800000 */
 #define EXTI_IMR1_IM23               EXTI_IMR1_IM23_Msk                        /*!< Interrupt Mask on line 23 */
-#define EXTI_IMR1_IM24_Pos           (24U)
-#define EXTI_IMR1_IM24_Msk           (0x1UL << EXTI_IMR1_IM24_Pos)             /*!< 0x01000000 */
-#define EXTI_IMR1_IM24               EXTI_IMR1_IM24_Msk                        /*!< Interrupt Mask on line 24 */
 #define EXTI_IMR1_IM25_Pos           (25U)
 #define EXTI_IMR1_IM25_Msk           (0x1UL << EXTI_IMR1_IM25_Pos)             /*!< 0x02000000 */
 #define EXTI_IMR1_IM25               EXTI_IMR1_IM25_Msk                        /*!< Interrupt Mask on line 25 */
@@ -3176,135 +3169,135 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)       /*!< 0x000001F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_RDERRIE_Pos                   (26U)
-#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)  /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
 #define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_SEC_PROT_Pos                  (28U)
-#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos) /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
 #define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
 /*******************  Bits definition for FLASH_ECCR register  ****************/
 #define FLASH_ECCR_ADDR_ECC_Pos                (0U)
-#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x00003FFF */
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x3FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00003FFF */
 #define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
 #define FLASH_ECCR_SYSF_ECC_Pos                (20U)
-#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
 #define FLASH_ECCR_ECCCIE_Pos                  (24U)
-#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
 #define FLASH_ECCR_ECCC_Pos                    (30U)
-#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
 #define FLASH_ECCR_ECCD_Pos                    (31U)
-#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_BOR_EN_Pos                  (8U)
-#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos) /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
 #define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
-#define FLASH_OPTR_BORF_LEV_Pos                (9U)
-#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000600 */
-#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
-#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000200 */
-#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000400 */
-#define FLASH_OPTR_BORR_LEV_Pos                (11U)
-#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001800 */
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
 #define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
-#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00000800 */
-#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_nRST_SHDW_Pos               (15U)
-#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
 #define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
 #define FLASH_OPTR_NRST_MODE_Pos               (27U)
-#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
 #define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
-#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x08000000 */
-#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x10000000 */
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
 #define FLASH_OPTR_IRHEN_Pos                   (29U)
-#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos) /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
 #define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
 
 /******************  Bits definition for FLASH_PCROP1ASR register  ************/
 #define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
-#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0xFFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0xFFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)   /*!< 0x000000FF */
 #define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1AER register  ************/
 #define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
-#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0xFFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0xFFUL << FLASH_PCROP1AER_PCROP1A_END_Pos)    /*!< 0x000000FF */
 #define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
 #define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
-#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
 #define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
@@ -3325,13 +3318,14 @@ typedef struct
 
 /******************  Bits definition for FLASH_PCROP1BSR register  ************/
 #define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
-#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0xFFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0xFFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)   /*!< 0x000000FF */
 #define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1BER register  ************/
 #define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
-#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0xFFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)  /*!< 0x000000FF */
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0xFFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)    /*!< 0x000000FF */
 #define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
 
 /******************  Bits definition for FLASH_SECR register  *****************/
 #define FLASH_SECR_SEC_SIZE_Pos                (0U)
@@ -3340,7 +3334,6 @@ typedef struct
 #define FLASH_SECR_BOOT_LOCK_Pos               (16U)
 #define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
 #define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -4958,7 +4951,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
 #define RCC_PLLQ_SUPPORT
 
@@ -5041,12 +5034,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -5064,9 +5051,10 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x07000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
@@ -6520,7 +6508,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -6807,9 +6795,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -6867,12 +6855,12 @@ typedef struct
 #define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
 #define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
 #define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
-#define SYSCFG_ITLINE8_SR_UCPD1_Pos          (0U)
-#define SYSCFG_ITLINE8_SR_UCPD1_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE8_SR_UCPD1              SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
-#define SYSCFG_ITLINE8_SR_UCPD2_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_UCPD2_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_UCPD2              SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD1_Pos           (0U)
+#define SYSCFG_ITLINE8_SR_UCPD1_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE8_SR_UCPD1               SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD2_Pos           (1U)
+#define SYSCFG_ITLINE8_SR_UCPD2_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE8_SR_UCPD2               SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
@@ -6882,9 +6870,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -6959,7 +6947,7 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -7759,7 +7747,7 @@ typedef struct
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -7828,7 +7816,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -7836,7 +7824,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -7844,7 +7832,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -7852,7 +7840,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -7977,7 +7965,7 @@ typedef struct
 
 #define LPTIM_CFGR_TIMOUT_Pos       (19U)
 #define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
-#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timout enable */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
 #define LPTIM_CFGR_WAVE_Pos         (20U)
 #define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
 #define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
@@ -9018,7 +9006,8 @@ typedef struct
 #define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) ((COMMON_INSTANCE) == COMP12_COMMON)
 
 /******************** COMP Instances with window mode capability **************/
-#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) ((INSTANCE) == COMP2)
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                               ((INSTANCE) == COMP2))
 
 /******************************* CRC Instances ********************************/
 #define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
@@ -9315,6 +9304,11 @@ typedef struct
                                                        ((INSTANCE) == TIM2) || \
                                                        ((INSTANCE) == TIM3))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM2)  || \
@@ -9325,9 +9319,6 @@ typedef struct
                                                        ((INSTANCE) == TIM15) || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))

--- a/stm32cube/stm32g0xx/soc/stm32g0b0xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g0b0xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -79,7 +79,7 @@ typedef enum
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
-  RCC_CRS_IRQn                = 4,      /*!< RCC and CRS global Interrupt                                      */
+  RCC_IRQn                    = 4,      /*!< RCC global Interrupt                                              */
   EXTI0_1_IRQn                = 5,      /*!< EXTI 0 and 1 Interrupts                                           */
   EXTI2_3_IRQn                = 6,      /*!< EXTI Line 2 and 3 Interrupts                                      */
   EXTI4_15_IRQn               = 7,      /*!< EXTI Line 4 to 15 Interrupts                                      */
@@ -100,7 +100,7 @@ typedef enum
   I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt  (combined with EXTI 23)                           */
   I2C2_3_IRQn                 = 24,     /*!< I2C2, I2C3 Interrupt (combined with EXTI 24 and EXTI 22)          */
   SPI1_IRQn                   = 25,     /*!< SPI1/I2S1 Interrupt                                               */
-  SPI2_3_IRQn                 = 26,     /*!< SPI2/I2S2, SPI3/I2S3 Interrupt                                         */
+  SPI2_3_IRQn                 = 26,     /*!< SPI2/I2S2, SPI3/I2S3 Interrupt                                    */
   USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
   USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                                  */
   USART3_4_5_6_IRQn           = 29,     /*!< USART3, USART4, USART5, USART6 globlal Interrupts (combined with EXTI 28) */
@@ -165,16 +165,6 @@ typedef struct
   __IO uint32_t POL;            /*!< CRC polynomial register,                   Address offset: 0x14 */
 } CRC_TypeDef;
 
-/**
-  * @brief Clock Recovery System
-  */
-typedef struct
-{
-__IO uint32_t CR;            /*!< CRS ccontrol register,              Address offset: 0x00 */
-__IO uint32_t CFGR;          /*!< CRS configuration register,         Address offset: 0x04 */
-__IO uint32_t ISR;           /*!< CRS interrupt and status register,  Address offset: 0x08 */
-__IO uint32_t ICR;           /*!< CRS interrupt flag clear register,  Address offset: 0x0C */
-} CRS_TypeDef;
 
 /**
   * @brief Debug MCU
@@ -246,6 +236,9 @@ typedef struct
        uint32_t RESERVED4[4];   /*!< Reserved 4,                                                0x70 -- 0x7C */
   __IO uint32_t IMR1;           /*!< EXTI Interrupt Mask Register 1,                  Address offset:   0x80 */
   __IO uint32_t EMR1;           /*!< EXTI Event Mask Register 1,                      Address offset:   0x84 */
+       uint32_t RESERVED5[2];   /*!< Reserved 5,                                                0x88 -- 0x8C */
+  __IO uint32_t IMR2;           /*!< EXTI Interrupt Mask Register 2,                  Address offset:   0x90 */
+  __IO uint32_t EMR2;           /*!< EXTI Event Mask Register 2,                      Address offset:   0x94 */
 } EXTI_TypeDef;
 
 /**
@@ -259,21 +252,17 @@ typedef struct
   __IO uint32_t OPTKEYR;      /*!< FLASH Option Key register,                         Address offset: 0x0C */
   __IO uint32_t SR;           /*!< FLASH Status register,                             Address offset: 0x10 */
   __IO uint32_t CR;           /*!< FLASH Control register,                            Address offset: 0x14 */
-  __IO uint32_t ECC1R;         /*!< FLASH ECC bank 1 register,                        Address offset: 0x18 */
+  __IO uint32_t ECCR;          /*!< FLASH ECC bank 1 register,                        Address offset: 0x18 */
   __IO uint32_t ECC2R;         /*!< FLASH ECC bank 2 register,                        Address offset: 0x1C */
   __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
-       uint32_t RESERVED4[2]; /*!< Reserved4,                                         Address offset: 0x24--0x28 */
+       uint32_t RESERVED3[2]; /*!< Reserved3,                                         Address offset: 0x24--0x28 */
   __IO uint32_t WRP1AR;       /*!< FLASH Bank WRP area A address register,            Address offset: 0x2C */
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
-       uint32_t RESERVED5[2]; /*!< Reserved5,                                         Address offset: 0x34--0x38 */
-       uint32_t RESERVED6[1]; /*!< Reserved6,                                         Address offset: 0x40 */
-  __IO uint32_t PCROP2ASR;    /*!< FLASH Bank2 PCROP area A Start address register,   Address offset: 0x44 */
-  __IO uint32_t PCROP2AER;    /*!< FLASH Bank2 PCROP area A End address register,     Address offset: 0x48 */
+       uint32_t RESERVED4[2]; /*!< Reserved4,                                         Address offset: 0x34--0x38 */
+       uint32_t RESERVED5[2]; /*!< Reserved5,                                         Address offset: 0x3C--0x40 */
+       uint32_t RESERVED6[2]; /*!< Reserved6,                                         Address offset: 0x44--0x48 */
   __IO uint32_t WRP2AR;       /*!< FLASH Bank2 WRP area A address register,           Address offset: 0x4C */
   __IO uint32_t WRP2BR;       /*!< FLASH Bank2 WRP area B address register,           Address offset: 0x50 */
-  __IO uint32_t PCROP2BSR;    /*!< FLASH Bank2 PCROP area B Start address register,   Address offset: 0x54 */
-  __IO uint32_t PCROP2BER;    /*!< FLASH Bank2 PCROP area B End address register,     Address offset: 0x58 */
-       uint32_t RESERVED3[10];/*!< Reserved3,                                         Address offset: 0x5C */
 } FLASH_TypeDef;
 
 /**
@@ -522,41 +511,37 @@ typedef struct
 } USART_TypeDef;
 
 /**
-  * @brief Universal Serial Bus Full Speed Device
+  * @brief Universal Serial Bus Full Speed Dual Role Device
   */
 
 typedef struct
 {
-  __IO uint16_t CHEP0R;          /*!< USB Endpoint 0 register,                Address offset: 0x00 */
-  __IO uint16_t RESERVED0;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP1R;          /*!< USB Endpoint 1 register,                Address offset: 0x04 */
-  __IO uint16_t RESERVED1;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP2R;          /*!< USB Endpoint 2 register,                Address offset: 0x08 */
-  __IO uint16_t RESERVED2;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP3R;          /*!< USB Endpoint 3 register,                Address offset: 0x0C */
-  __IO uint16_t RESERVED3;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP4R;          /*!< USB Endpoint 4 register,                Address offset: 0x10 */
-  __IO uint16_t RESERVED4;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP5R;          /*!< USB Endpoint 5 register,                Address offset: 0x14 */
-  __IO uint16_t RESERVED5;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP6R;          /*!< USB Endpoint 6 register,                Address offset: 0x18 */
-  __IO uint16_t RESERVED6;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP7R;          /*!< USB Endpoint 7 register,                Address offset: 0x1C */
-  __IO uint16_t RESERVED7[17];   /*!< Reserved,                                                    */
-  __IO uint32_t CNTR;            /*!< Control register,                       Address offset: 0x40 */
-  __IO uint16_t ISTR;            /*!< Interrupt status register,              Address offset: 0x44 */
-  __IO uint16_t RESERVED9;       /*!< Reserved,                                                    */
-  __IO uint16_t FNR;             /*!< Frame number register,                  Address offset: 0x48 */
-  __IO uint16_t RESERVEDA;       /*!< Reserved,                                                    */
-  __IO uint16_t DADDR;           /*!< Device address register,                Address offset: 0x4C */
-  __IO uint16_t RESERVEDB;       /*!< Reserved,                                                    */
-  __IO uint16_t BTABLE;          /*!< Buffer Table address register,          Address offset: 0x50 */
-  __IO uint16_t RESERVEDC;       /*!< Reserved,                                                    */
-  __IO uint16_t LPMCSR;          /*!< LPM Control and Status register,        Address offset: 0x54 */
-  __IO uint16_t RESERVEDD;       /*!< Reserved,                                                    */
-  __IO uint16_t BCDR;            /*!< Battery Charging detector register,     Address offset: 0x58 */
-  __IO uint16_t RESERVEDE;       /*!< Reserved,                                                    */
-} USB_DRD_FS_TypeDef;
+  __IO uint32_t CHEP0R;          /*!< USB Channel/Endpoint 0 register,      Address offset: 0x00 */
+  __IO uint32_t CHEP1R;          /*!< USB Channel/Endpoint 1 register,      Address offset: 0x04 */
+  __IO uint32_t CHEP2R;          /*!< USB Channel/Endpoint 2 register,      Address offset: 0x08 */
+  __IO uint32_t CHEP3R;          /*!< USB Channel/Endpoint 3 register,      Address offset: 0x0C */
+  __IO uint32_t CHEP4R;          /*!< USB Channel/Endpoint 4 register,      Address offset: 0x10 */
+  __IO uint32_t CHEP5R;          /*!< USB Channel/Endpoint 5 register,      Address offset: 0x14 */
+  __IO uint32_t CHEP6R;          /*!< USB Channel/Endpoint 6 register,      Address offset: 0x18 */
+  __IO uint32_t CHEP7R;          /*!< USB Channel/Endpoint 7 register,      Address offset: 0x1C */
+  __IO uint32_t RESERVED0[8];    /*!< Reserved,                                                  */
+  __IO uint32_t CNTR;            /*!< Control register,                     Address offset: 0x40 */
+  __IO uint32_t ISTR;            /*!< Interrupt status register,            Address offset: 0x44 */
+  __IO uint32_t FNR;             /*!< Frame number register,                Address offset: 0x48 */
+  __IO uint32_t DADDR;           /*!< Device address register,              Address offset: 0x4C */
+  __IO uint32_t RESERVED1;       /*!< Reserved */
+  __IO uint32_t LPMCSR;          /*!< LPM Control and Status register,      Address offset: 0x54 */
+  __IO uint32_t BCDR;            /*!< Battery Charging detector register,   Address offset: 0x58 */
+} USB_DRD_TypeDef;
+
+/**
+  * @brief Universal Serial Bus PacketMemoryArea Buffer Descriptor Table
+  */
+typedef struct
+{
+  __IO uint32_t TXBD;             /*!<Transmission buffer address*/
+  __IO uint32_t RXBD;             /*!<Reception buffer address */
+} USB_DRD_PMABuffDescTypeDef;
 
 /**
   * @}
@@ -581,7 +566,12 @@ typedef struct
 #define SRAM_BASE             (0x20000000UL)  /*!< SRAM base address */
 #define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
+/*!< USB PMA SIZE */
+#define USB_DRD_PMA_SIZE              2048U   /*!< USB PMA Size 2Kbyte */
+
 #define SRAM_SIZE_MAX         (0x00020000UL)  /*!< maximum SRAM size (up to 128 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x03FFU)) << 10U)
 
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
@@ -606,11 +596,10 @@ typedef struct
 #define I2C1_BASE             (APBPERIPH_BASE + 0x00005400UL)
 #define I2C2_BASE             (APBPERIPH_BASE + 0x00005800UL)
 #define USB_BASE              (APBPERIPH_BASE + 0x00005C00UL)  /*!< USB_IP Peripheral Registers base address */
-#define CRS_BASE              (APBPERIPH_BASE + 0x00006C00UL)
 #define PWR_BASE              (APBPERIPH_BASE + 0x00007000UL)
 #define I2C3_BASE             (APBPERIPH_BASE + 0x00008800UL)
-#define USB_DRD_FS_BASE     (APBPERIPH_BASE + 0x00009800UL) /*!< USB_DRD_FS_IP Peripheral Registers base address */
-#define USB_DRD_FS_PMAADDR  (APBPERIPH_BASE + 0x00009C00UL) /*!< USB_DRD_FS_IP Packet Memory Area base address */
+#define USB_DRD_BASE          (APBPERIPH_BASE + 0x00005C00UL) /*!< USB_DRD_IP Peripheral Registers base address */
+#define USB_DRD_PMAADDR       (APBPERIPH_BASE + 0x00009800UL) /*!< USB_DRD_IP Packet Memory Area base address */
 #define TAMP_BASE             (APBPERIPH_BASE + 0x0000B000UL)
 #define SYSCFG_BASE           (APBPERIPH_BASE + 0x00010000UL)
 #define ADC1_BASE             (APBPERIPH_BASE + 0x00012400UL)
@@ -628,7 +617,7 @@ typedef struct
 
 /*!< AHB peripherals */
 #define DMA1_BASE             (AHBPERIPH_BASE)
-#define DMA2_BASE             (AHBPERIPH_BASE)+ 0x00000400UL
+#define DMA2_BASE             (AHBPERIPH_BASE + 0x00000400UL)
 #define DMAMUX1_BASE          (AHBPERIPH_BASE + 0x00000800UL)
 #define RCC_BASE              (AHBPERIPH_BASE + 0x00001000UL)
 #define EXTI_BASE             (AHBPERIPH_BASE + 0x00001800UL)
@@ -656,6 +645,11 @@ typedef struct
 #define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
 #define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
 #define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+#define DMAMUX1_Channel7_BASE    (DMAMUX1_BASE + 0x0000001CUL)
+#define DMAMUX1_Channel8_BASE    (DMAMUX1_BASE + 0x00000020UL)
+#define DMAMUX1_Channel9_BASE    (DMAMUX1_BASE + 0x00000024UL)
+#define DMAMUX1_Channel10_BASE   (DMAMUX1_BASE + 0x00000028UL)
+#define DMAMUX1_Channel11_BASE   (DMAMUX1_BASE + 0x0000002CUL)
 
 #define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
 #define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
@@ -690,7 +684,6 @@ typedef struct
 #define TIM6                ((TIM_TypeDef *) TIM6_BASE)
 #define TIM7                ((TIM_TypeDef *) TIM7_BASE)
 #define TIM14               ((TIM_TypeDef *) TIM14_BASE)
-#define CRS                 ((CRS_TypeDef *) CRS_BASE)
 #define RTC                 ((RTC_TypeDef *) RTC_BASE)
 #define TAMP                ((TAMP_TypeDef *) TAMP_BASE)
 #define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
@@ -705,7 +698,8 @@ typedef struct
 #define I2C1                ((I2C_TypeDef *) I2C1_BASE)
 #define I2C2                ((I2C_TypeDef *) I2C2_BASE)
 #define I2C3                ((I2C_TypeDef *) I2C3_BASE)
-#define USB_DRD_FS          ((USB_DRD_FS_TypeDef *) USB_DRD_FS_BASE)
+#define USB_DRD_FS          ((USB_DRD_TypeDef *) USB_DRD_BASE)
+#define USB_DRD_PMA_BUFF    ((USB_DRD_PMABuffDescTypeDef*) USB_DRD_PMAADDR)
 #define PWR                 ((PWR_TypeDef *) PWR_BASE)
 #define RCC                 ((RCC_TypeDef *) RCC_BASE)
 #define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
@@ -752,6 +746,11 @@ typedef struct
 #define DMAMUX1_Channel4       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
 #define DMAMUX1_Channel5       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
 #define DMAMUX1_Channel6       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+#define DMAMUX1_Channel7       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel7_BASE)
+#define DMAMUX1_Channel8       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel8_BASE)
+#define DMAMUX1_Channel9       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel9_BASE)
+#define DMAMUX1_Channel10      ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel10_BASE)
+#define DMAMUX1_Channel11      ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel11_BASE)
 
 #define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
 #define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
@@ -894,7 +893,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -1446,104 +1445,6 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                          CRS Clock Recovery System                         */
-/******************************************************************************/
-
-/*******************  Bit definition for CRS_CR register  *********************/
-#define CRS_CR_SYNCOKIE_Pos       (0U)
-#define CRS_CR_SYNCOKIE_Msk       (0x1UL << CRS_CR_SYNCOKIE_Pos)               /*!< 0x00000001 */
-#define CRS_CR_SYNCOKIE           CRS_CR_SYNCOKIE_Msk                          /*!< SYNC event OK interrupt enable */
-#define CRS_CR_SYNCWARNIE_Pos     (1U)
-#define CRS_CR_SYNCWARNIE_Msk     (0x1UL << CRS_CR_SYNCWARNIE_Pos)             /*!< 0x00000002 */
-#define CRS_CR_SYNCWARNIE         CRS_CR_SYNCWARNIE_Msk                        /*!< SYNC warning interrupt enable */
-#define CRS_CR_ERRIE_Pos          (2U)
-#define CRS_CR_ERRIE_Msk          (0x1UL << CRS_CR_ERRIE_Pos)                  /*!< 0x00000004 */
-#define CRS_CR_ERRIE              CRS_CR_ERRIE_Msk                             /*!< SYNC error or trimming error interrupt enable */
-#define CRS_CR_ESYNCIE_Pos        (3U)
-#define CRS_CR_ESYNCIE_Msk        (0x1UL << CRS_CR_ESYNCIE_Pos)                /*!< 0x00000008 */
-#define CRS_CR_ESYNCIE            CRS_CR_ESYNCIE_Msk                           /*!< Expected SYNC interrupt enable */
-#define CRS_CR_CEN_Pos            (5U)
-#define CRS_CR_CEN_Msk            (0x1UL << CRS_CR_CEN_Pos)                    /*!< 0x00000020 */
-#define CRS_CR_CEN                CRS_CR_CEN_Msk                               /*!< Frequency error counter enable */
-#define CRS_CR_AUTOTRIMEN_Pos     (6U)
-#define CRS_CR_AUTOTRIMEN_Msk     (0x1UL << CRS_CR_AUTOTRIMEN_Pos)             /*!< 0x00000040 */
-#define CRS_CR_AUTOTRIMEN         CRS_CR_AUTOTRIMEN_Msk                        /*!< Automatic trimming enable */
-#define CRS_CR_SWSYNC_Pos         (7U)
-#define CRS_CR_SWSYNC_Msk         (0x1UL << CRS_CR_SWSYNC_Pos)                 /*!< 0x00000080 */
-#define CRS_CR_SWSYNC             CRS_CR_SWSYNC_Msk                            /*!< Generate software SYNC event */
-#define CRS_CR_TRIM_Pos           (8U)
-#define CRS_CR_TRIM_Msk           (0x7FUL << CRS_CR_TRIM_Pos)                  /*!< 0x00007F00 */
-#define CRS_CR_TRIM               CRS_CR_TRIM_Msk                              /*!< HSI48 oscillator smooth trimming */
-
-/*******************  Bit definition for CRS_CFGR register  *********************/
-#define CRS_CFGR_RELOAD_Pos       (0U)
-#define CRS_CFGR_RELOAD_Msk       (0xFFFFUL << CRS_CFGR_RELOAD_Pos)            /*!< 0x0000FFFF */
-#define CRS_CFGR_RELOAD           CRS_CFGR_RELOAD_Msk                          /*!< Counter reload value */
-#define CRS_CFGR_FELIM_Pos        (16U)
-#define CRS_CFGR_FELIM_Msk        (0xFFUL << CRS_CFGR_FELIM_Pos)               /*!< 0x00FF0000 */
-#define CRS_CFGR_FELIM            CRS_CFGR_FELIM_Msk                           /*!< Frequency error limit */
-
-#define CRS_CFGR_SYNCDIV_Pos      (24U)
-#define CRS_CFGR_SYNCDIV_Msk      (0x7UL << CRS_CFGR_SYNCDIV_Pos)              /*!< 0x07000000 */
-#define CRS_CFGR_SYNCDIV          CRS_CFGR_SYNCDIV_Msk                         /*!< SYNC divider */
-#define CRS_CFGR_SYNCDIV_0        (0x1UL << CRS_CFGR_SYNCDIV_Pos)              /*!< 0x01000000 */
-#define CRS_CFGR_SYNCDIV_1        (0x2UL << CRS_CFGR_SYNCDIV_Pos)              /*!< 0x02000000 */
-#define CRS_CFGR_SYNCDIV_2        (0x4UL << CRS_CFGR_SYNCDIV_Pos)              /*!< 0x04000000 */
-
-#define CRS_CFGR_SYNCSRC_Pos      (28U)
-#define CRS_CFGR_SYNCSRC_Msk      (0x3UL << CRS_CFGR_SYNCSRC_Pos)              /*!< 0x30000000 */
-#define CRS_CFGR_SYNCSRC          CRS_CFGR_SYNCSRC_Msk                         /*!< SYNC signal source selection */
-#define CRS_CFGR_SYNCSRC_0        (0x1UL << CRS_CFGR_SYNCSRC_Pos)              /*!< 0x10000000 */
-#define CRS_CFGR_SYNCSRC_1        (0x2UL << CRS_CFGR_SYNCSRC_Pos)              /*!< 0x20000000 */
-
-#define CRS_CFGR_SYNCPOL_Pos      (31U)
-#define CRS_CFGR_SYNCPOL_Msk      (0x1UL << CRS_CFGR_SYNCPOL_Pos)              /*!< 0x80000000 */
-#define CRS_CFGR_SYNCPOL          CRS_CFGR_SYNCPOL_Msk                         /*!< SYNC polarity selection */
-
-/*******************  Bit definition for CRS_ISR register  *********************/
-#define CRS_ISR_SYNCOKF_Pos       (0U)
-#define CRS_ISR_SYNCOKF_Msk       (0x1UL << CRS_ISR_SYNCOKF_Pos)               /*!< 0x00000001 */
-#define CRS_ISR_SYNCOKF           CRS_ISR_SYNCOKF_Msk                          /*!< SYNC event OK flag */
-#define CRS_ISR_SYNCWARNF_Pos     (1U)
-#define CRS_ISR_SYNCWARNF_Msk     (0x1UL << CRS_ISR_SYNCWARNF_Pos)             /*!< 0x00000002 */
-#define CRS_ISR_SYNCWARNF         CRS_ISR_SYNCWARNF_Msk                        /*!< SYNC warning flag */
-#define CRS_ISR_ERRF_Pos          (2U)
-#define CRS_ISR_ERRF_Msk          (0x1UL << CRS_ISR_ERRF_Pos)                  /*!< 0x00000004 */
-#define CRS_ISR_ERRF              CRS_ISR_ERRF_Msk                             /*!< Error flag */
-#define CRS_ISR_ESYNCF_Pos        (3U)
-#define CRS_ISR_ESYNCF_Msk        (0x1UL << CRS_ISR_ESYNCF_Pos)                /*!< 0x00000008 */
-#define CRS_ISR_ESYNCF            CRS_ISR_ESYNCF_Msk                           /*!< Expected SYNC flag */
-#define CRS_ISR_SYNCERR_Pos       (8U)
-#define CRS_ISR_SYNCERR_Msk       (0x1UL << CRS_ISR_SYNCERR_Pos)               /*!< 0x00000100 */
-#define CRS_ISR_SYNCERR           CRS_ISR_SYNCERR_Msk                          /*!< SYNC error */
-#define CRS_ISR_SYNCMISS_Pos      (9U)
-#define CRS_ISR_SYNCMISS_Msk      (0x1UL << CRS_ISR_SYNCMISS_Pos)              /*!< 0x00000200 */
-#define CRS_ISR_SYNCMISS          CRS_ISR_SYNCMISS_Msk                         /*!< SYNC missed */
-#define CRS_ISR_TRIMOVF_Pos       (10U)
-#define CRS_ISR_TRIMOVF_Msk       (0x1UL << CRS_ISR_TRIMOVF_Pos)               /*!< 0x00000400 */
-#define CRS_ISR_TRIMOVF           CRS_ISR_TRIMOVF_Msk                          /*!< Trimming overflow or underflow */
-#define CRS_ISR_FEDIR_Pos         (15U)
-#define CRS_ISR_FEDIR_Msk         (0x1UL << CRS_ISR_FEDIR_Pos)                 /*!< 0x00008000 */
-#define CRS_ISR_FEDIR             CRS_ISR_FEDIR_Msk                            /*!< Frequency error direction */
-#define CRS_ISR_FECAP_Pos         (16U)
-#define CRS_ISR_FECAP_Msk         (0xFFFFUL << CRS_ISR_FECAP_Pos)              /*!< 0xFFFF0000 */
-#define CRS_ISR_FECAP             CRS_ISR_FECAP_Msk                            /*!< Frequency error capture */
-
-/*******************  Bit definition for CRS_ICR register  *********************/
-#define CRS_ICR_SYNCOKC_Pos       (0U)
-#define CRS_ICR_SYNCOKC_Msk       (0x1UL << CRS_ICR_SYNCOKC_Pos)               /*!< 0x00000001 */
-#define CRS_ICR_SYNCOKC           CRS_ICR_SYNCOKC_Msk                          /*!< SYNC event OK clear flag */
-#define CRS_ICR_SYNCWARNC_Pos     (1U)
-#define CRS_ICR_SYNCWARNC_Msk     (0x1UL << CRS_ICR_SYNCWARNC_Pos)             /*!< 0x00000002 */
-#define CRS_ICR_SYNCWARNC         CRS_ICR_SYNCWARNC_Msk                        /*!< SYNC warning clear flag */
-#define CRS_ICR_ERRC_Pos          (2U)
-#define CRS_ICR_ERRC_Msk          (0x1UL << CRS_ICR_ERRC_Pos)                  /*!< 0x00000004 */
-#define CRS_ICR_ERRC              CRS_ICR_ERRC_Msk                             /*!< Error clear flag */
-#define CRS_ICR_ESYNCC_Pos        (3U)
-#define CRS_ICR_ESYNCC_Msk        (0x1UL << CRS_ICR_ESYNCC_Pos)                /*!< 0x00000008 */
-#define CRS_ICR_ESYNCC            CRS_ICR_ESYNCC_Msk                           /*!< Expected SYNC clear flag */
-/******************************************************************************/
-/*                                                                            */
 /*                           DMA Controller (DMA)                             */
 /*                                                                            */
 /******************************************************************************/
@@ -1790,7 +1691,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x7FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000007F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -1800,6 +1701,11 @@ typedef struct
 #define DMAMUX_CxCR_DMAREQ_ID_5                (0x20UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
 #define DMAMUX_CxCR_DMAREQ_ID_6                (0x40UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000040 */
 #define DMAMUX_CxCR_DMAREQ_ID_7                (0x80UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000080 */
+#define DMAMUX_CxCR_DMAREQ_ID_8                (0x100UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000100 */
+#define DMAMUX_CxCR_DMAREQ_ID_9                (0x200UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000200 */
+#define DMAMUX_CxCR_DMAREQ_ID_10               (0x400UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000400 */
+#define DMAMUX_CxCR_DMAREQ_ID_11               (0x800UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000800 */
+#define DMAMUX_CxCR_DMAREQ_ID_12               (0x1000UL << DMAMUX_CxCR_DMAREQ_ID_Pos)/*!< 0x00001000 */
 #define DMAMUX_CxCR_SOIE_Pos                   (8U)
 #define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos)  /*!< 0x00000100 */
 #define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk             /*!< Synchro overrun interrupt enable     */
@@ -1853,6 +1759,21 @@ typedef struct
 #define DMAMUX_CSR_SOF6_Pos                    (6U)
 #define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
 #define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+#define DMAMUX_CSR_SOF7_Pos                    (7U)
+#define DMAMUX_CSR_SOF7_Msk                    (0x1UL << DMAMUX_CSR_SOF7_Pos)  /*!< 0x00000080 */
+#define DMAMUX_CSR_SOF7                        DMAMUX_CSR_SOF7_Msk             /*!< Synchronization Overrun Flag 7       */
+#define DMAMUX_CSR_SOF8_Pos                    (8U)
+#define DMAMUX_CSR_SOF8_Msk                    (0x1UL << DMAMUX_CSR_SOF8_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CSR_SOF8                        DMAMUX_CSR_SOF8_Msk             /*!< Synchronization Overrun Flag 8       */
+#define DMAMUX_CSR_SOF9_Pos                    (9U)
+#define DMAMUX_CSR_SOF9_Msk                    (0x1UL << DMAMUX_CSR_SOF9_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CSR_SOF9                        DMAMUX_CSR_SOF9_Msk             /*!< Synchronization Overrun Flag 9       */
+#define DMAMUX_CSR_SOF10_Pos                   (10U)
+#define DMAMUX_CSR_SOF10_Msk                   (0x1UL << DMAMUX_CSR_SOF10_Pos)  /*!< 0x00000400 */
+#define DMAMUX_CSR_SOF10                       DMAMUX_CSR_SOF10_Msk             /*!< Synchronization Overrun Flag 10      */
+#define DMAMUX_CSR_SOF11_Pos                   (11U)
+#define DMAMUX_CSR_SOF11_Msk                   (0x1UL << DMAMUX_CSR_SOF11_Pos)  /*!< 0x00000800 */
+#define DMAMUX_CSR_SOF11                       DMAMUX_CSR_SOF11_Msk             /*!< Synchronization Overrun Flag 11      */
 
 /********************  Bits definition for DMAMUX_CFR register  **************/
 #define DMAMUX_CFR_CSOF0_Pos                   (0U)
@@ -1876,6 +1797,21 @@ typedef struct
 #define DMAMUX_CFR_CSOF6_Pos                   (6U)
 #define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos)  /*!< 0x00000040 */
 #define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk             /*!< Clear Overrun Flag 6                 */
+#define DMAMUX_CFR_CSOF7_Pos                   (7U)
+#define DMAMUX_CFR_CSOF7_Msk                   (0x1UL << DMAMUX_CFR_CSOF7_Pos)  /*!< 0x00000080 */
+#define DMAMUX_CFR_CSOF7                       DMAMUX_CFR_CSOF7_Msk             /*!< Clear Overrun Flag 7                 */
+#define DMAMUX_CFR_CSOF8_Pos                   (8U)
+#define DMAMUX_CFR_CSOF8_Msk                   (0x1UL << DMAMUX_CFR_CSOF8_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CFR_CSOF8                       DMAMUX_CFR_CSOF8_Msk             /*!< Clear Overrun Flag 8                 */
+#define DMAMUX_CFR_CSOF9_Pos                   (9U)
+#define DMAMUX_CFR_CSOF9_Msk                   (0x1UL << DMAMUX_CFR_CSOF9_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CFR_CSOF9                       DMAMUX_CFR_CSOF9_Msk             /*!< Clear Overrun Flag 9                 */
+#define DMAMUX_CFR_CSOF10_Pos                  (10U)
+#define DMAMUX_CFR_CSOF10_Msk                  (0x1UL << DMAMUX_CFR_CSOF10_Pos)  /*!< 0x00000400 */
+#define DMAMUX_CFR_CSOF10                      DMAMUX_CFR_CSOF10_Msk             /*!< Clear Overrun Flag 10               */
+#define DMAMUX_CFR_CSOF11_Pos                  (11U)
+#define DMAMUX_CFR_CSOF11_Msk                  (0x1UL << DMAMUX_CFR_CSOF11_Pos)  /*!< 0x00000800 */
+#define DMAMUX_CFR_CSOF11                      DMAMUX_CFR_CSOF11_Msk             /*!< Clear Overrun Flag 11               */
 
 /********************  Bits definition for DMAMUX_RGxCR register  ************/
 #define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
@@ -2345,9 +2281,6 @@ typedef struct
 #define EXTI_IMR1_IM19_Pos           (19U)
 #define EXTI_IMR1_IM19_Msk           (0x1UL << EXTI_IMR1_IM19_Pos)             /*!< 0x00080000 */
 #define EXTI_IMR1_IM19               EXTI_IMR1_IM19_Msk                        /*!< Interrupt Mask on line 19 */
-#define EXTI_IMR1_IM20_Pos           (20U)
-#define EXTI_IMR1_IM20_Msk           (0x1UL << EXTI_IMR1_IM20_Pos)             /*!< 0x00100000 */
-#define EXTI_IMR1_IM20               EXTI_IMR1_IM20_Msk                        /*!< Interrupt Mask on line 20 */
 #define EXTI_IMR1_IM21_Pos           (21U)
 #define EXTI_IMR1_IM21_Msk           (0x1UL << EXTI_IMR1_IM21_Pos)             /*!< 0x00200000 */
 #define EXTI_IMR1_IM21               EXTI_IMR1_IM21_Msk                        /*!< Interrupt Mask on line 21 */
@@ -2370,14 +2303,15 @@ typedef struct
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0x86A8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x86A8FFFFU */
+#define EXTI_IMR1_IM_Msk             (0x87E8FFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0x87E8FFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
-#define EXTI_IMR2_IM34_Pos           (2U)
-#define EXTI_IMR2_IM34_Msk           (0x1UL << EXTI_IMR2_IM34_Pos)             /*!< 0x00000004 */
-#define EXTI_IMR2_IM34               EXTI_IMR2_IM34_Msk                        /*!< Interrupt Mask on line 34 */
+/*******************  Bit definition for EXTI_IMR2 register  ******************/
+#define EXTI_IMR2_IM36_Pos           (4U)
+#define EXTI_IMR2_IM36_Msk           (0x1UL << EXTI_IMR2_IM36_Pos)             /*!< 0x00000010 */
+#define EXTI_IMR2_IM36               EXTI_IMR2_IM36_Msk                        /*!< Interrupt Mask on line 36 */
 #define EXTI_IMR2_IM_Pos             (0U)
-#define EXTI_IMR2_IM_Msk             (0x3UL << EXTI_IMR2_IM_Pos)               /*!< 0x00000004 */
+#define EXTI_IMR2_IM_Msk             (0x10UL << EXTI_IMR2_IM_Pos)               /*!< 0x00000010 */
 #define EXTI_IMR2_IM                 EXTI_IMR2_IM_Msk                          /*!< Interrupt Mask All */
 
 /*******************  Bit definition for EXTI_EMR1 register  ******************/
@@ -2429,12 +2363,6 @@ typedef struct
 #define EXTI_EMR1_EM15_Pos           (15U)
 #define EXTI_EMR1_EM15_Msk           (0x1UL << EXTI_EMR1_EM15_Pos)             /*!< 0x00008000 */
 #define EXTI_EMR1_EM15               EXTI_EMR1_EM15_Msk                        /*!< Event Mask on line 15 */
-#define EXTI_EMR1_EM17_Pos           (17U)
-#define EXTI_EMR1_EM17_Msk           (0x1UL << EXTI_EMR1_EM17_Pos)             /*!< 0x00020000 */
-#define EXTI_EMR1_EM17               EXTI_EMR1_EM17_Msk                        /*!< Event Mask on line 17 */
-#define EXTI_EMR1_EM18_Pos           (18U)
-#define EXTI_EMR1_EM18_Msk           (0x1UL << EXTI_EMR1_EM18_Pos)             /*!< 0x00040000 */
-#define EXTI_EMR1_EM18               EXTI_EMR1_EM18_Msk                        /*!< Event Mask on line 18 */
 #define EXTI_EMR1_EM19_Pos           (19U)
 #define EXTI_EMR1_EM19_Msk           (0x1UL << EXTI_EMR1_EM19_Pos)             /*!< 0x00080000 */
 #define EXTI_EMR1_EM19               EXTI_EMR1_EM19_Msk                        /*!< Event Mask on line 19 */
@@ -2460,9 +2388,10 @@ typedef struct
 #define EXTI_EMR1_EM31_Msk           (0x1UL << EXTI_EMR1_EM31_Pos)             /*!< 0x80000000 */
 #define EXTI_EMR1_EM31               EXTI_EMR1_EM31_Msk                        /*!< Event Mask on line 31 */
 
-#define EXTI_EMR2_EM34_Pos           (2U)
-#define EXTI_EMR2_EM34_Msk           (0x1UL << EXTI_EMR2_EM34_Pos)             /*!< 0x00000004 */
-#define EXTI_EMR2_EM34               EXTI_EMR2_EM34_Msk                        /*!< Event Mask on line 34 */
+/*******************  Bit definition for EXTI_EMR2 register  ******************/
+#define EXTI_EMR2_EM36_Pos           (4U)
+#define EXTI_EMR2_EM36_Msk           (0x1UL << EXTI_EMR2_EM36_Pos)             /*!< 0x00000010 */
+#define EXTI_EMR2_EM36               EXTI_EMR2_EM36_Msk                        /*!< Event Mask on line 36 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -2493,7 +2422,7 @@ typedef struct
 /*****************  Bit definition for FDCAN_ENDN register  *******************/
 #define FDCAN_ENDN_ETV_Pos        (0U)
 #define FDCAN_ENDN_ETV_Msk        (0xFFFFFFFFUL << FDCAN_ENDN_ETV_Pos)         /*!< 0xFFFFFFFF */
-#define FDCAN_ENDN_ETV            FDCAN_ENDN_ETV_Msk                           /*!<Endiannes Test Value                    */
+#define FDCAN_ENDN_ETV            FDCAN_ENDN_ETV_Msk                           /*!<Endianness Test Value                    */
 
 /*****************  Bit definition for FDCAN_DBTP register  *******************/
 #define FDCAN_DBTP_DSJW_Pos       (0U)
@@ -3117,172 +3046,155 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x7FUL << FLASH_CR_PNB_Pos)       /*!< 0x000003F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_BKER_Pos                      (13U)
-#define FLASH_CR_BKER_Msk                      (0x1UL << FLASH_CR_BKER_Pos)     /*!< 0x00002000 */
+#define FLASH_CR_BKER_Msk                      (0x1UL << FLASH_CR_BKER_Pos)       /*!< 0x00002000 */
 #define FLASH_CR_BKER                          FLASH_CR_BKER_Msk
-#define FLASH_CR_BIFER_Pos                     (14U)
-#define FLASH_CR_BIFER_Msk                     (0x1UL << FLASH_CR_BIFER_Pos)    /*!< 0x00004000 */
-#define FLASH_CR_BIFER                         FLASH_CR_BIFER_Msk
 #define FLASH_CR_MER2_Pos                      (15U)
-#define FLASH_CR_MER2_Msk                      (0x1UL << FLASH_CR_MER2_Pos)     /*!< 0x00008000 */
+#define FLASH_CR_MER2_Msk                      (0x1UL << FLASH_CR_MER2_Pos)       /*!< 0x00008000 */
 #define FLASH_CR_MER2                          FLASH_CR_MER2_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
-/*******************  Bits definition for FLASH_ECC1R register  ****************/
-#define FLASH_ECC1R_ADDR_ECC_Pos                (0U)
-#define FLASH_ECC1R_ADDR_ECC_Msk                (0xFFFFUL << FLASH_ECC1R_ADDR_ECC_Pos) /*!< 0x0000FFFF */
-#define FLASH_ECC1R_ADDR_ECC                    FLASH_ECC1R_ADDR_ECC_Msk
-#define FLASH_ECC1R_SYSF_ECC_Pos                (20U)
-#define FLASH_ECC1R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC1R_SYSF_ECC_Pos) /*!< 0x00100000 */
-#define FLASH_ECC1R_SYSF_ECC                    FLASH_ECC1R_SYSF_ECC_Msk
-#define FLASH_ECC1R_ECCCIE_Pos                  (24U)
-#define FLASH_ECC1R_ECCCIE_Msk                  (0x1UL << FLASH_ECC1R_ECCCIE_Pos) /*!< 0x01000000 */
-#define FLASH_ECC1R_ECCCIE                      FLASH_ECC1R_ECCCIE_Msk
-#define FLASH_ECC1R_ECCC_Pos                    (30U)
-#define FLASH_ECC1R_ECCC_Msk                    (0x1UL << FLASH_ECC1R_ECCC_Pos)   /*!< 0x40000000 */
-#define FLASH_ECC1R_ECCC                        FLASH_ECC1R_ECCC_Msk
-#define FLASH_ECC1R_ECCD_Pos                    (31U)
-#define FLASH_ECC1R_ECCD_Msk                    (0x1UL << FLASH_ECC1R_ECCD_Pos)   /*!< 0x80000000 */
-#define FLASH_ECC1R_ECCD                        FLASH_ECC1R_ECCD_Msk
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos                (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x7FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00007FFF */
+#define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
+#define FLASH_ECCR_SYSF_ECC_Pos                (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
+#define FLASH_ECCR_ECCCIE_Pos                  (24U)
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
+#define FLASH_ECCR_ECCC_Pos                    (30U)
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
+#define FLASH_ECCR_ECCD_Pos                    (31U)
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
+
 /*******************  Bits definition for FLASH_ECC2R register  ****************/
 #define FLASH_ECC2R_ADDR_ECC_Pos                (0U)
-#define FLASH_ECC2R_ADDR_ECC_Msk                (0xFFFFUL << FLASH_ECC2R_ADDR_ECC_Pos) /*!< 0x0000FFFF */
+#define FLASH_ECC2R_ADDR_ECC_Msk                (0x7FFFUL << FLASH_ECC2R_ADDR_ECC_Pos)  /*!< 0x00007FFF */
 #define FLASH_ECC2R_ADDR_ECC                    FLASH_ECC2R_ADDR_ECC_Msk
 #define FLASH_ECC2R_SYSF_ECC_Pos                (20U)
-#define FLASH_ECC2R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC2R_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECC2R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC2R_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECC2R_SYSF_ECC                    FLASH_ECC2R_SYSF_ECC_Msk
 #define FLASH_ECC2R_ECCCIE_Pos                  (24U)
-#define FLASH_ECC2R_ECCCIE_Msk                  (0x1UL << FLASH_ECC2R_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECC2R_ECCCIE_Msk                  (0x1UL << FLASH_ECC2R_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECC2R_ECCCIE                      FLASH_ECC2R_ECCCIE_Msk
 #define FLASH_ECC2R_ECCC_Pos                    (30U)
-#define FLASH_ECC2R_ECCC_Msk                    (0x1UL << FLASH_ECC2R_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECC2R_ECCC_Msk                    (0x1UL << FLASH_ECC2R_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECC2R_ECCC                        FLASH_ECC2R_ECCC_Msk
 #define FLASH_ECC2R_ECCD_Pos                    (31U)
-#define FLASH_ECC2R_ECCD_Msk                    (0x1UL << FLASH_ECC2R_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECC2R_ECCD_Msk                    (0x1UL << FLASH_ECC2R_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECC2R_ECCD                        FLASH_ECC2R_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
+#define FLASH_OPTR_nSWAP_BANK_Pos              (20U)
+#define FLASH_OPTR_nSWAP_BANK_Msk              (0x1UL << FLASH_OPTR_nSWAP_BANK_Pos)        /*!< 0x00100000 */
+#define FLASH_OPTR_nSWAP_BANK                  FLASH_OPTR_nSWAP_BANK_Msk
+#define FLASH_OPTR_DUAL_BANK_Pos               (21U)
+#define FLASH_OPTR_DUAL_BANK_Msk               (0x1UL << FLASH_OPTR_DUAL_BANK_Pos)        /*!< 0x00200000 */
+#define FLASH_OPTR_DUAL_BANK                   FLASH_OPTR_DUAL_BANK_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
-
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
 #define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
-#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x3FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x7FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000007F */
 #define FLASH_WRP1AR_WRP1A_STRT                FLASH_WRP1AR_WRP1A_STRT_Msk
 #define FLASH_WRP1AR_WRP1A_END_Pos             (16U)
-#define FLASH_WRP1AR_WRP1A_END_Msk             (0x3FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP1AR_WRP1A_END_Msk             (0x7FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x007F0000 */
 #define FLASH_WRP1AR_WRP1A_END                 FLASH_WRP1AR_WRP1A_END_Msk
 
 /******************  Bits definition for FLASH_WRP1BR register  ***************/
 #define FLASH_WRP1BR_WRP1B_STRT_Pos            (0U)
-#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x3FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x7FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000007F */
 #define FLASH_WRP1BR_WRP1B_STRT                FLASH_WRP1BR_WRP1B_STRT_Msk
 #define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
-#define FLASH_WRP1BR_WRP1B_END_Msk             (0x3FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP1BR_WRP1B_END_Msk             (0x7FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x007F0000 */
 #define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
 
-/******************  Bits definition for FLASH_PCROP2ASR register  ************/
-#define FLASH_PCROP2ASR_PCROP2A_STRT_Pos       (0U)
-#define FLASH_PCROP2ASR_PCROP2A_STRT_Msk       (0xFFUL << FLASH_PCROP2ASR_PCROP2A_STRT_Pos) /*!< 0x0000FFFF */
-#define FLASH_PCROP2ASR_PCROP2A_STRT           FLASH_PCROP2ASR_PCROP2A_STRT_Msk
-
-/******************  Bits definition for FLASH_PCROP2AER register  ************/
-#define FLASH_PCROP2AER_PCROP2A_END_Pos        (0U)
-#define FLASH_PCROP2AER_PCROP2A_END_Msk        (0xFFUL << FLASH_PCROP2AER_PCROP2A_END_Pos)  /*!< 0x0000FFFF */
-#define FLASH_PCROP2AER_PCROP2A_END            FLASH_PCROP2AER_PCROP2A_END_Msk
 
 /******************  Bits definition for FLASH_WRP2AR register  ***************/
 #define FLASH_WRP2AR_WRP2A_STRT_Pos            (0U)
-#define FLASH_WRP2AR_WRP2A_STRT_Msk            (0x3FUL << FLASH_WRP2AR_WRP2A_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP2AR_WRP2A_STRT_Msk            (0x7FUL << FLASH_WRP2AR_WRP2A_STRT_Pos)  /*!< 0x0000007F */
 #define FLASH_WRP2AR_WRP2A_STRT                FLASH_WRP2AR_WRP2A_STRT_Msk
 #define FLASH_WRP2AR_WRP2A_END_Pos             (16U)
-#define FLASH_WRP2AR_WRP2A_END_Msk             (0x3FUL << FLASH_WRP2AR_WRP2A_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP2AR_WRP2A_END_Msk             (0x7FUL << FLASH_WRP2AR_WRP2A_END_Pos)   /*!< 0x007F0000 */
 #define FLASH_WRP2AR_WRP2A_END                 FLASH_WRP2AR_WRP2A_END_Msk
 
 /******************  Bits definition for FLASH_WRP2BSR register  ***************/
 #define FLASH_WRP2BR_WRP2B_STRT_Pos            (0U)
-#define FLASH_WRP2BR_WRP2B_STRT_Msk            (0x3FUL << FLASH_WRP2BR_WRP2B_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP2BR_WRP2B_STRT_Msk            (0x7FUL << FLASH_WRP2BR_WRP2B_STRT_Pos)  /*!< 0x0000007F */
 #define FLASH_WRP2BR_WRP2B_STRT                FLASH_WRP2BR_WRP2B_STRT_Msk
 #define FLASH_WRP2BR_WRP2B_END_Pos             (16U)
-#define FLASH_WRP2BR_WRP2B_END_Msk             (0x3FUL << FLASH_WRP2BR_WRP2B_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP2BR_WRP2B_END_Msk             (0x7FUL << FLASH_WRP2BR_WRP2B_END_Pos)   /*!< 0x007F0000 */
 #define FLASH_WRP2BR_WRP2B_END                 FLASH_WRP2BR_WRP2B_END_Msk
-
-/******************  Bits definition for FLASH_PCROP2BSR register  ************/
-#define FLASH_PCROP2BSR_PCROP2B_STRT_Pos       (0U)
-#define FLASH_PCROP2BSR_PCROP2B_STRT_Msk       (0xFFUL << FLASH_PCROP2BSR_PCROP2B_STRT_Pos) /*!< 0x000000FF */
-#define FLASH_PCROP2BSR_PCROP2B_STRT           FLASH_PCROP2BSR_PCROP2B_STRT_Msk
-
-/******************  Bits definition for FLASH_PCROP2BER register  ************/
-#define FLASH_PCROP2BER_PCROP2B_END_Pos        (0U)
-#define FLASH_PCROP2BER_PCROP2B_END_Msk        (0xFFUL << FLASH_PCROP2BER_PCROP2B_END_Pos)  /*!< 0x000000FF */
-#define FLASH_PCROP2BER_PCROP2B_END            FLASH_PCROP2BER_PCROP2B_END_Msk
-
 
 /******************************************************************************/
 /*                                                                            */
@@ -4361,7 +4273,7 @@ typedef struct
 
 /********************  Bit definition for PWR_CR3 register  ********************/
 #define PWR_CR3_EWUP_Pos          (0U)
-#define PWR_CR3_EWUP_Msk          (0x3BUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000003B */
+#define PWR_CR3_EWUP_Msk          (0x3FUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000003F */
 #define PWR_CR3_EWUP              PWR_CR3_EWUP_Msk                             /*!< Enable all Wake-Up Pins  */
 #define PWR_CR3_EWUP1_Pos         (0U)
 #define PWR_CR3_EWUP1_Msk         (0x1UL << PWR_CR3_EWUP1_Pos)                 /*!< 0x00000001 */
@@ -4369,6 +4281,9 @@ typedef struct
 #define PWR_CR3_EWUP2_Pos         (1U)
 #define PWR_CR3_EWUP2_Msk         (0x1UL << PWR_CR3_EWUP2_Pos)                 /*!< 0x00000002 */
 #define PWR_CR3_EWUP2             PWR_CR3_EWUP2_Msk                            /*!< Enable WKUP pin 2 */
+#define PWR_CR3_EWUP3_Pos         (2U)
+#define PWR_CR3_EWUP3_Msk         (0x1UL << PWR_CR3_EWUP3_Pos)                 /*!< 0x00000004 */
+#define PWR_CR3_EWUP3             PWR_CR3_EWUP3_Msk                            /*!< Enable WKUP pin 3 */
 #define PWR_CR3_EWUP4_Pos         (3U)
 #define PWR_CR3_EWUP4_Msk         (0x1UL << PWR_CR3_EWUP4_Pos)                 /*!< 0x00000008 */
 #define PWR_CR3_EWUP4             PWR_CR3_EWUP4_Msk                            /*!< Enable WKUP pin 4 */
@@ -4387,7 +4302,7 @@ typedef struct
 
 /********************  Bit definition for PWR_CR4 register  ********************/
 #define PWR_CR4_WP_Pos            (0U)
-#define PWR_CR4_WP_Msk            (0x3BUL << PWR_CR4_WP_Pos)                   /*!< 0x0000003B */
+#define PWR_CR4_WP_Msk            (0x3FUL << PWR_CR4_WP_Pos)                   /*!< 0x0000003F */
 #define PWR_CR4_WP                PWR_CR4_WP_Msk                               /*!< all Wake-Up Pin polarity */
 #define PWR_CR4_WP1_Pos           (0U)
 #define PWR_CR4_WP1_Msk           (0x1UL << PWR_CR4_WP1_Pos)                   /*!< 0x00000001 */
@@ -4395,6 +4310,9 @@ typedef struct
 #define PWR_CR4_WP2_Pos           (1U)
 #define PWR_CR4_WP2_Msk           (0x1UL << PWR_CR4_WP2_Pos)                   /*!< 0x00000002 */
 #define PWR_CR4_WP2               PWR_CR4_WP2_Msk                              /*!< Wake-Up Pin 2 polarity */
+#define PWR_CR4_WP3_Pos           (2U)
+#define PWR_CR4_WP3_Msk           (0x1UL << PWR_CR4_WP3_Pos)                   /*!< 0x00000004 */
+#define PWR_CR4_WP3               PWR_CR4_WP3_Msk                              /*!< Wake-Up Pin 3 polarity */
 #define PWR_CR4_WP4_Pos           (3U)
 #define PWR_CR4_WP4_Msk           (0x1UL << PWR_CR4_WP4_Pos)                   /*!< 0x00000008 */
 #define PWR_CR4_WP4               PWR_CR4_WP4_Msk                              /*!< Wake-Up Pin 4 polarity */
@@ -4413,7 +4331,7 @@ typedef struct
 
 /********************  Bit definition for PWR_SR1 register  ********************/
 #define PWR_SR1_WUF_Pos           (0U)
-#define PWR_SR1_WUF_Msk           (0x3BUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000003B */
+#define PWR_SR1_WUF_Msk           (0x3FUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000003F */
 #define PWR_SR1_WUF               PWR_SR1_WUF_Msk                              /*!< Wakeup Flags  */
 #define PWR_SR1_WUF1_Pos          (0U)
 #define PWR_SR1_WUF1_Msk          (0x1UL << PWR_SR1_WUF1_Pos)                  /*!< 0x00000001 */
@@ -4421,6 +4339,9 @@ typedef struct
 #define PWR_SR1_WUF2_Pos          (1U)
 #define PWR_SR1_WUF2_Msk          (0x1UL << PWR_SR1_WUF2_Pos)                  /*!< 0x00000002 */
 #define PWR_SR1_WUF2              PWR_SR1_WUF2_Msk                             /*!< Wakeup Flag 2 */
+#define PWR_SR1_WUF3_Pos          (2U)
+#define PWR_SR1_WUF3_Msk          (0x1UL << PWR_SR1_WUF3_Pos)                  /*!< 0x00000004 */
+#define PWR_SR1_WUF3              PWR_SR1_WUF3_Msk                             /*!< Wakeup Flag 3 */
 #define PWR_SR1_WUF4_Pos          (3U)
 #define PWR_SR1_WUF4_Msk          (0x1UL << PWR_SR1_WUF4_Pos)                  /*!< 0x00000008 */
 #define PWR_SR1_WUF4              PWR_SR1_WUF4_Msk                             /*!< Wakeup Flag 4 */
@@ -4453,7 +4374,7 @@ typedef struct
 
 /********************  Bit definition for PWR_SCR register  ********************/
 #define PWR_SCR_CWUF_Pos          (0U)
-#define PWR_SCR_CWUF_Msk          (0x3BUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000003B */
+#define PWR_SCR_CWUF_Msk          (0x3FUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000003F */
 #define PWR_SCR_CWUF              PWR_SCR_CWUF_Msk                             /*!< Clear Wake-up Flags  */
 #define PWR_SCR_CWUF1_Pos         (0U)
 #define PWR_SCR_CWUF1_Msk         (0x1UL << PWR_SCR_CWUF1_Pos)                 /*!< 0x00000001 */
@@ -4461,6 +4382,9 @@ typedef struct
 #define PWR_SCR_CWUF2_Pos         (1U)
 #define PWR_SCR_CWUF2_Msk         (0x1UL << PWR_SCR_CWUF2_Pos)                 /*!< 0x00000002 */
 #define PWR_SCR_CWUF2             PWR_SCR_CWUF2_Msk                            /*!< Clear Wake-up Flag 2 */
+#define PWR_SCR_CWUF3_Pos         (2U)
+#define PWR_SCR_CWUF3_Msk         (0x1UL << PWR_SCR_CWUF3_Pos)                 /*!< 0x00000004 */
+#define PWR_SCR_CWUF3             PWR_SCR_CWUF3_Msk                            /*!< Clear Wake-up Flag 3 */
 #define PWR_SCR_CWUF4_Pos         (3U)
 #define PWR_SCR_CWUF4_Msk         (0x1UL << PWR_SCR_CWUF4_Pos)                 /*!< 0x00000008 */
 #define PWR_SCR_CWUF4             PWR_SCR_CWUF4_Msk                            /*!< Clear Wake-up Flag 4 */
@@ -5061,9 +4985,10 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
-#define RCC_HSI48_SUPPORT
+#define RCC_MCO2_SUPPORT
+#define RCC_PLLQ_SUPPORT
 
 /********************  Bit definition for RCC_CR register  *****************/
 #define RCC_CR_HSION_Pos                 (8U)
@@ -5094,12 +5019,6 @@ typedef struct
 #define RCC_CR_CSSON_Msk                 (0x1UL << RCC_CR_CSSON_Pos)           /*!< 0x00080000 */
 #define RCC_CR_CSSON                     RCC_CR_CSSON_Msk                      /*!< HSE Clock Security System enable */
 
-#define RCC_CR_HSI48ON_Pos                (22U)
-#define RCC_CR_HSI48ON_Msk                (0x1UL << RCC_CR_HSI48ON_Pos)           /*!< 0x004000000 */
-#define RCC_CR_HSI48ON                    RCC_CR_HSI48ON_Msk                      /*!< RC48 clock enable */
-#define RCC_CR_HSI48RDY_Pos               (23U)
-#define RCC_CR_HSI48RDY_Msk               (0x1UL << RCC_CR_HSI48RDY_Pos)           /*!< 0x00800000 */
-#define RCC_CR_HSI48RDY                   RCC_CR_HSI48RDY_Msk                      /*!< RC48 clock ready */
 #define RCC_CR_PLLON_Pos                 (24U)
 #define RCC_CR_PLLON_Msk                 (0x1UL << RCC_CR_PLLON_Pos)           /*!< 0x01000000 */
 #define RCC_CR_PLLON                     RCC_CR_PLLON_Msk                      /*!< System PLL clock enable */
@@ -5150,12 +5069,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -5173,21 +5086,41 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+/*!< MCO2SEL configuration */
+#define RCC_CFGR_MCO2SEL_Pos            (16U)
+#define RCC_CFGR_MCO2SEL_Msk            (0xFUL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x000F0000 */
+#define RCC_CFGR_MCO2SEL                RCC_CFGR_MCO2SEL_Msk                     /*!< MCO2SEL [3:0] bits (Clock output selection) */
+#define RCC_CFGR_MCO2SEL_0              (0x1UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00010000 */
+#define RCC_CFGR_MCO2SEL_1              (0x2UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00020000 */
+#define RCC_CFGR_MCO2SEL_2              (0x4UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00040000 */
+#define RCC_CFGR_MCO2SEL_3              (0x8UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00080000 */
+
+/*!< MCO2 Prescaler configuration */
+#define RCC_CFGR_MCO2PRE_Pos            (20U)
+#define RCC_CFGR_MCO2PRE_Msk            (0xFUL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00F00000 */
+#define RCC_CFGR_MCO2PRE                RCC_CFGR_MCO2PRE_Msk                     /*!< MCO2 prescaler [3:0] */
+#define RCC_CFGR_MCO2PRE_0              (0x1UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00100000 */
+#define RCC_CFGR_MCO2PRE_1              (0x2UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00200000 */
+#define RCC_CFGR_MCO2PRE_2              (0x4UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00400000 */
+#define RCC_CFGR_MCO2PRE_3              (0x8UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00800000 */
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0xFUL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
 #define RCC_CFGR_MCOSEL_2              (0x4UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x04000000 */
+#define RCC_CFGR_MCOSEL_3              (0x8UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x08000000 */
 
 /*!< MCO Prescaler configuration */
 #define RCC_CFGR_MCOPRE_Pos            (28U)
-#define RCC_CFGR_MCOPRE_Msk            (0x7UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE_Msk            (0xFUL << RCC_CFGR_MCOPRE_Pos)          /*!< 0xF0000000 */
 #define RCC_CFGR_MCOPRE                RCC_CFGR_MCOPRE_Msk                     /*!< MCO prescaler [2:0] */
 #define RCC_CFGR_MCOPRE_0              (0x1UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x10000000 */
 #define RCC_CFGR_MCOPRE_1              (0x2UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x20000000 */
 #define RCC_CFGR_MCOPRE_2              (0x4UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x40000000 */
+#define RCC_CFGR_MCOPRE_3              (0x8UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x80000000 */
 
 /********************  Bit definition for RCC_PLLCFGR register  ***************/
 #define RCC_PLLCFGR_PLLSRC_Pos           (0U)
@@ -5235,6 +5168,16 @@ typedef struct
 #define RCC_PLLCFGR_PLLP_3                (0x08UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00100000 */
 #define RCC_PLLCFGR_PLLP_4                (0x10UL << RCC_PLLCFGR_PLLP_Pos)     /*!< 0x00200000 */
 
+#define RCC_PLLCFGR_PLLQEN_Pos           (24U)
+#define RCC_PLLCFGR_PLLQEN_Msk           (0x1UL << RCC_PLLCFGR_PLLQEN_Pos)     /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQEN               RCC_PLLCFGR_PLLQEN_Msk
+
+#define RCC_PLLCFGR_PLLQ_Pos             (25U)
+#define RCC_PLLCFGR_PLLQ_Msk             (0x7UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x0E000000 */
+#define RCC_PLLCFGR_PLLQ                 RCC_PLLCFGR_PLLQ_Msk
+#define RCC_PLLCFGR_PLLQ_0               (0x1UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_1               (0x2UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_2               (0x4UL << RCC_PLLCFGR_PLLQ_Pos)       /*!< 0x08000000 */
 
 #define RCC_PLLCFGR_PLLREN_Pos           (28U)
 #define RCC_PLLCFGR_PLLREN_Msk           (0x1UL << RCC_PLLCFGR_PLLREN_Pos)     /*!< 0x10000000 */
@@ -5247,20 +5190,6 @@ typedef struct
 #define RCC_PLLCFGR_PLLR_1               (0x2UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x40000000 */
 #define RCC_PLLCFGR_PLLR_2               (0x4UL << RCC_PLLCFGR_PLLR_Pos)       /*!< 0x80000000 */
 
-/********************  Bit definition for RCC_CRRCR register  ******************/
-/*!< RC48CAL configuration */
-#define RCC_CRRCR_HSI48CAL_Pos            (0U)
-#define RCC_CRRCR_HSI48CAL_Msk            (0x1FFUL << RCC_CRRCR_HSI48CAL_Pos)    /*!< 0x000001FF */
-#define RCC_CRRCR_HSI48CAL                RCC_CRRCR_HSI48CAL_Msk                 /*!< RC48CAL[8:0] bits */
-#define RCC_CRRCR_HSI48CAL_0              (0x01UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000001 */
-#define RCC_CRRCR_HSI48CAL_1              (0x02UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000002 */
-#define RCC_CRRCR_HSI48CAL_2              (0x04UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000004 */
-#define RCC_CRRCR_HSI48CAL_3              (0x08UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000008 */
-#define RCC_CRRCR_HSI48CAL_4              (0x10UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000010 */
-#define RCC_CRRCR_HSI48CAL_5              (0x20UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000020 */
-#define RCC_CRRCR_HSI48CAL_6              (0x40UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000040 */
-#define RCC_CRRCR_HSI48CAL_7              (0x80UL << RCC_CRRCR_HSI48CAL_Pos)     /*!< 0x00000080 */
-#define RCC_CRRCR_HSI48CAL_8              (0x100UL << RCC_CRRCR_HSI48CAL_Pos)    /*!< 0x00000100 */
 /********************  Bit definition for RCC_CIER register  ******************/
 #define RCC_CIER_LSIRDYIE_Pos            (0U)
 #define RCC_CIER_LSIRDYIE_Msk            (0x1UL << RCC_CIER_LSIRDYIE_Pos)      /*!< 0x00000001 */
@@ -5268,9 +5197,6 @@ typedef struct
 #define RCC_CIER_LSERDYIE_Pos            (1U)
 #define RCC_CIER_LSERDYIE_Msk            (0x1UL << RCC_CIER_LSERDYIE_Pos)      /*!< 0x00000002 */
 #define RCC_CIER_LSERDYIE                RCC_CIER_LSERDYIE_Msk
-#define RCC_CIER_HSI48RDYIE_Pos          (2U)
-#define RCC_CIER_HSI48RDYIE_Msk          (0x1UL << RCC_CIER_HSI48RDYIE_Pos)      /*!< 0x00000004 */
-#define RCC_CIER_HSI48RDYIE              RCC_CIER_HSI48RDYIE_Msk
 #define RCC_CIER_HSIRDYIE_Pos            (3U)
 #define RCC_CIER_HSIRDYIE_Msk            (0x1UL << RCC_CIER_HSIRDYIE_Pos)      /*!< 0x00000008 */
 #define RCC_CIER_HSIRDYIE                RCC_CIER_HSIRDYIE_Msk
@@ -5288,9 +5214,6 @@ typedef struct
 #define RCC_CIFR_LSERDYF_Pos             (1U)
 #define RCC_CIFR_LSERDYF_Msk             (0x1UL << RCC_CIFR_LSERDYF_Pos)       /*!< 0x00000002 */
 #define RCC_CIFR_LSERDYF                 RCC_CIFR_LSERDYF_Msk
-#define RCC_CIFR_HSI48RDYF_Pos           (2U)
-#define RCC_CIFR_HSI48RDYF_Msk           (0x1UL << RCC_CIFR_HSI48RDYF_Pos)      /*!< 0x00000004 */
-#define RCC_CIFR_HSI48RDYF                RCC_CIFR_HSI48RDYF_Msk
 #define RCC_CIFR_HSIRDYF_Pos             (3U)
 #define RCC_CIFR_HSIRDYF_Msk             (0x1UL << RCC_CIFR_HSIRDYF_Pos)       /*!< 0x00000008 */
 #define RCC_CIFR_HSIRDYF                 RCC_CIFR_HSIRDYF_Msk
@@ -5314,9 +5237,6 @@ typedef struct
 #define RCC_CICR_LSERDYC_Pos             (1U)
 #define RCC_CICR_LSERDYC_Msk             (0x1UL << RCC_CICR_LSERDYC_Pos)       /*!< 0x00000002 */
 #define RCC_CICR_LSERDYC                 RCC_CICR_LSERDYC_Msk
-#define RCC_CICR_HSI48RDYC_Pos           (2U)
-#define RCC_CICR_HSI48RDYC_Msk           (0x1UL << RCC_CICR_HSI48RDYC_Pos)      /*!< 0x00000004 */
-#define RCC_CICR_HSI48RDYC               RCC_CICR_HSI48RDYC_Msk
 #define RCC_CICR_HSIRDYC_Pos             (3U)
 #define RCC_CICR_HSIRDYC_Msk             (0x1UL << RCC_CICR_HSIRDYC_Pos)       /*!< 0x00000008 */
 #define RCC_CICR_HSIRDYC                 RCC_CICR_HSIRDYC_Msk
@@ -5386,18 +5306,15 @@ typedef struct
 #define RCC_APBRSTR1_USART6RST_Pos       (9U)
 #define RCC_APBRSTR1_USART6RST_Msk       (0x1UL << RCC_APBRSTR1_USART6RST_Pos) /*!< 0x00000200 */
 #define RCC_APBRSTR1_USART6RST           RCC_APBRSTR1_USART6RST_Msk
-#define RCC_APBRSTR1_USBFSRST_Pos        (13U)
-#define RCC_APBRSTR1_USBFSRST_Msk        (0x1UL << RCC_APBRSTR1_USBFSRST_Pos)  /*!< 0x00002000 */
-#define RCC_APBRSTR1_USBFSRST            RCC_APBRSTR1_USBFSRST_Msk
+#define RCC_APBRSTR1_USBRST_Pos          (13U)
+#define RCC_APBRSTR1_USBRST_Msk          (0x1UL << RCC_APBRSTR1_USBRST_Pos)    /*!< 0x00002000 */
+#define RCC_APBRSTR1_USBRST              RCC_APBRSTR1_USBRST_Msk
 #define RCC_APBRSTR1_SPI2RST_Pos         (14U)
 #define RCC_APBRSTR1_SPI2RST_Msk         (0x1UL << RCC_APBRSTR1_SPI2RST_Pos)   /*!< 0x00004000 */
 #define RCC_APBRSTR1_SPI2RST             RCC_APBRSTR1_SPI2RST_Msk
 #define RCC_APBRSTR1_SPI3RST_Pos         (15U)
 #define RCC_APBRSTR1_SPI3RST_Msk         (0x1UL << RCC_APBRSTR1_SPI3RST_Pos)   /*!< 0x00008000 */
 #define RCC_APBRSTR1_SPI3RST             RCC_APBRSTR1_SPI3RST_Msk
-#define RCC_APBRSTR1_CRSRST_Pos          (16U)
-#define RCC_APBRSTR1_CRSRST_Msk          (0x1UL << RCC_APBRSTR1_CRSRST_Pos)    /*!< 0x00010000 */
-#define RCC_APBRSTR1_CRSRST              RCC_APBRSTR1_CRSRST_Msk
 #define RCC_APBRSTR1_USART2RST_Pos       (17U)
 #define RCC_APBRSTR1_USART2RST_Msk       (0x1UL << RCC_APBRSTR1_USART2RST_Pos) /*!< 0x00020000 */
 #define RCC_APBRSTR1_USART2RST           RCC_APBRSTR1_USART2RST_Msk
@@ -5511,18 +5428,15 @@ typedef struct
 #define RCC_APBENR1_WWDGEN_Pos           (11U)
 #define RCC_APBENR1_WWDGEN_Msk           (0x1UL << RCC_APBENR1_WWDGEN_Pos)      /*!< 0x00000800 */
 #define RCC_APBENR1_WWDGEN               RCC_APBENR1_WWDGEN_Msk
-#define RCC_APBENR1_USBFSEN_Pos          (13U)
-#define RCC_APBENR1_USBFSEN_Msk          (0x1UL << RCC_APBENR1_USBFSEN_Pos)     /*!< 0x00002000 */
-#define RCC_APBENR1_USBFSEN              RCC_APBENR1_USBFSEN_Msk
+#define RCC_APBENR1_USBEN_Pos            (13U)
+#define RCC_APBENR1_USBEN_Msk            (0x1UL << RCC_APBENR1_USBEN_Pos)       /*!< 0x00002000 */
+#define RCC_APBENR1_USBEN                RCC_APBENR1_USBEN_Msk
 #define RCC_APBENR1_SPI2EN_Pos           (14U)
 #define RCC_APBENR1_SPI2EN_Msk           (0x1UL << RCC_APBENR1_SPI2EN_Pos)      /*!< 0x00004000 */
 #define RCC_APBENR1_SPI2EN               RCC_APBENR1_SPI2EN_Msk
 #define RCC_APBENR1_SPI3EN_Pos           (15U)
 #define RCC_APBENR1_SPI3EN_Msk           (0x1UL << RCC_APBENR1_SPI3EN_Pos)      /*!< 0x00008000 */
 #define RCC_APBENR1_SPI3EN               RCC_APBENR1_SPI3EN_Msk
-#define RCC_APBENR1_CRSEN_Pos            (16U)
-#define RCC_APBENR1_CRSEN_Msk            (0x1UL << RCC_APBENR1_CRSEN_Pos)       /*!< 0x00010000 */
-#define RCC_APBENR1_CRSEN                RCC_APBENR1_CRSEN_Msk
 #define RCC_APBENR1_USART2EN_Pos         (17U)
 #define RCC_APBENR1_USART2EN_Msk         (0x1UL << RCC_APBENR1_USART2EN_Pos)    /*!< 0x00020000 */
 #define RCC_APBENR1_USART2EN             RCC_APBENR1_USART2EN_Msk
@@ -5639,18 +5553,15 @@ typedef struct
 #define RCC_APBSMENR1_WWDGSMEN_Pos       (11U)
 #define RCC_APBSMENR1_WWDGSMEN_Msk       (0x1UL << RCC_APBSMENR1_WWDGSMEN_Pos)   /*!< 0x00000800 */
 #define RCC_APBSMENR1_WWDGSMEN           RCC_APBSMENR1_WWDGSMEN_Msk
-#define RCC_APBSMENR1_USBFSSMEN_Pos      (13U)
-#define RCC_APBSMENR1_USBFSSMEN_Msk      (0x1UL << RCC_APBSMENR1_USBFSSMEN_Pos)  /*!< 0x00002000 */
-#define RCC_APBSMENR1_USBFSSMEN          RCC_APBSMENR1_USBFSSMEN_Msk
+#define RCC_APBSMENR1_USBSMEN_Pos        (13U)
+#define RCC_APBSMENR1_USBSMEN_Msk        (0x1UL << RCC_APBSMENR1_USBSMEN_Pos)    /*!< 0x00002000 */
+#define RCC_APBSMENR1_USBSMEN            RCC_APBSMENR1_USBSMEN_Msk
 #define RCC_APBSMENR1_SPI2SMEN_Pos       (14U)
 #define RCC_APBSMENR1_SPI2SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI2SMEN_Pos)   /*!< 0x00004000 */
 #define RCC_APBSMENR1_SPI2SMEN           RCC_APBSMENR1_SPI2SMEN_Msk
 #define RCC_APBSMENR1_SPI3SMEN_Pos       (15U)
 #define RCC_APBSMENR1_SPI3SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI3SMEN_Pos)   /*!< 0x00008000 */
 #define RCC_APBSMENR1_SPI3SMEN           RCC_APBSMENR1_SPI3SMEN_Msk
-#define RCC_APBSMENR1_CRSSMEN_Pos        (16U)
-#define RCC_APBSMENR1_CRSSMEN_Msk        (0x1UL << RCC_APBSMENR1_CRSSMEN_Pos)   /*!< 0x00010000 */
-#define RCC_APBSMENR1_CRSSMEN            RCC_APBSMENR1_CRSSMEN_Msk
 #define RCC_APBSMENR1_USART2SMEN_Pos     (17U)
 #define RCC_APBSMENR1_USART2SMEN_Msk     (0x1UL << RCC_APBSMENR1_USART2SMEN_Pos) /*!< 0x00020000 */
 #define RCC_APBSMENR1_USART2SMEN         RCC_APBSMENR1_USART2SMEN_Msk
@@ -5737,11 +5648,6 @@ typedef struct
 #define RCC_CCIPR_I2C2SEL_0             (0x1UL << RCC_CCIPR_I2C2SEL_Pos)        /*!< 0x00004000 */
 #define RCC_CCIPR_I2C2SEL_1             (0x2UL << RCC_CCIPR_I2C2SEL_Pos)        /*!< 0x00008000 */
 
-#define RCC_CCIPR_I2C3SEL_Pos            (16U)
-#define RCC_CCIPR_I2C3SEL_Msk            (0x3UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00030000 */
-#define RCC_CCIPR_I2C3SEL                RCC_CCIPR_I2C3SEL_Msk
-#define RCC_CCIPR_I2C3SEL_0              (0x1UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00010000 */
-#define RCC_CCIPR_I2C3SEL_1              (0x2UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00020000 */
 
 
 
@@ -5762,16 +5668,11 @@ typedef struct
 #define RCC_CCIPR2_I2S2SEL                RCC_CCIPR2_I2S2SEL_Msk
 #define RCC_CCIPR2_I2S2SEL_0              (0x1UL << RCC_CCIPR2_I2S2SEL_Pos)     /*!< 0x00000004 */
 #define RCC_CCIPR2_I2S2SEL_1              (0x2UL << RCC_CCIPR2_I2S2SEL_Pos)     /*!< 0x00000008 */
-#define RCC_CCIPR2_I2S3SEL_Pos            (4U)
-#define RCC_CCIPR2_I2S3SEL_Msk            (0x3UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000030 */
-#define RCC_CCIPR2_I2S3SEL                RCC_CCIPR2_I2S3SEL_Msk
-#define RCC_CCIPR2_I2S3SEL_0              (0x1UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000010 */
-#define RCC_CCIPR2_I2S3SEL_1              (0x2UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000020 */
-#define RCC_CCIPR2_CK48MSEL_Pos           (12U)
-#define RCC_CCIPR2_CK48MSEL_Msk           (0x3UL << RCC_CCIPR2_CK48MSEL_Pos)     /*!< 0x00003000 */
-#define RCC_CCIPR2_CK48MSEL               RCC_CCIPR2_CK48MSEL_Msk
-#define RCC_CCIPR2_CK48MSEL_0             (0x1UL << RCC_CCIPR2_CK48MSEL_Pos)    /*!< 0x00001000 */
-#define RCC_CCIPR2_CK48MSEL_1             (0x2UL << RCC_CCIPR2_CK48MSEL_Pos)    /*!< 0x00002000 */
+#define RCC_CCIPR2_USBSEL_Pos             (12U)
+#define RCC_CCIPR2_USBSEL_Msk             (0x3UL << RCC_CCIPR2_USBSEL_Pos)     /*!< 0x00003000 */
+#define RCC_CCIPR2_USBSEL                 RCC_CCIPR2_USBSEL_Msk
+#define RCC_CCIPR2_USBSEL_0               (0x1UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00001000 */
+#define RCC_CCIPR2_USBSEL_1               (0x2UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00002000 */
 /********************  Bit definition for RCC_BDCR register  ******************/
 #define RCC_BDCR_LSEON_Pos               (0U)
 #define RCC_BDCR_LSEON_Msk               (0x1UL << RCC_BDCR_LSEON_Pos)          /*!< 0x00000001 */
@@ -5859,6 +5760,7 @@ typedef struct
 */
 #define RTC_WAKEUP_SUPPORT
 #define RTC_BACKUP_SUPPORT
+#define RTC_TAMPER3_SUPPORT          /*!< TAMPER3 only available on some devices */
 
 /********************  Bits definition for RTC_TR register  *******************/
 #define RTC_TR_PM_Pos                (22U)
@@ -6429,6 +6331,9 @@ typedef struct
 #define TAMP_CR1_TAMP2E_Pos          (1U)
 #define TAMP_CR1_TAMP2E_Msk          (0x1UL << TAMP_CR1_TAMP2E_Pos)             /*!< 0x00000002 */
 #define TAMP_CR1_TAMP2E              TAMP_CR1_TAMP2E_Msk
+#define TAMP_CR1_TAMP3E_Pos          (2U)
+#define TAMP_CR1_TAMP3E_Msk          (0x1UL << TAMP_CR1_TAMP3E_Pos)             /*!< 0x00000004 */
+#define TAMP_CR1_TAMP3E              TAMP_CR1_TAMP3E_Msk
 #define TAMP_CR1_ITAMP3E_Pos         (18U)
 #define TAMP_CR1_ITAMP3E_Msk         (0x1UL << TAMP_CR1_ITAMP3E_Pos)            /*!< 0x00040000 */
 #define TAMP_CR1_ITAMP3E             TAMP_CR1_ITAMP3E_Msk
@@ -6449,18 +6354,27 @@ typedef struct
 #define TAMP_CR2_TAMP2NOERASE_Pos    (1U)
 #define TAMP_CR2_TAMP2NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP2NOERASE_Pos)       /*!< 0x00000002 */
 #define TAMP_CR2_TAMP2NOERASE        TAMP_CR2_TAMP2NOERASE_Msk
+#define TAMP_CR2_TAMP3NOERASE_Pos    (2U)
+#define TAMP_CR2_TAMP3NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP3NOERASE_Pos)       /*!< 0x00000004 */
+#define TAMP_CR2_TAMP3NOERASE        TAMP_CR2_TAMP3NOERASE_Msk
 #define TAMP_CR2_TAMP1MSK_Pos        (16U)
 #define TAMP_CR2_TAMP1MSK_Msk        (0x1UL << TAMP_CR2_TAMP1MSK_Pos)           /*!< 0x00010000 */
 #define TAMP_CR2_TAMP1MSK            TAMP_CR2_TAMP1MSK_Msk
 #define TAMP_CR2_TAMP2MSK_Pos        (17U)
 #define TAMP_CR2_TAMP2MSK_Msk        (0x1UL << TAMP_CR2_TAMP2MSK_Pos)           /*!< 0x00020000 */
 #define TAMP_CR2_TAMP2MSK            TAMP_CR2_TAMP2MSK_Msk
+#define TAMP_CR2_TAMP3MSK_Pos        (18U)
+#define TAMP_CR2_TAMP3MSK_Msk        (0x1UL << TAMP_CR2_TAMP3MSK_Pos)           /*!< 0x00040000 */
+#define TAMP_CR2_TAMP3MSK            TAMP_CR2_TAMP3MSK_Msk
 #define TAMP_CR2_TAMP1TRG_Pos        (24U)
 #define TAMP_CR2_TAMP1TRG_Msk        (0x1UL << TAMP_CR2_TAMP1TRG_Pos)           /*!< 0x01000000 */
 #define TAMP_CR2_TAMP1TRG            TAMP_CR2_TAMP1TRG_Msk
 #define TAMP_CR2_TAMP2TRG_Pos        (25U)
 #define TAMP_CR2_TAMP2TRG_Msk        (0x1UL << TAMP_CR2_TAMP2TRG_Pos)           /*!< 0x02000000 */
 #define TAMP_CR2_TAMP2TRG            TAMP_CR2_TAMP2TRG_Msk
+#define TAMP_CR2_TAMP3TRG_Pos        (26U)
+#define TAMP_CR2_TAMP3TRG_Msk        (0x1UL << TAMP_CR2_TAMP3TRG_Pos)           /*!< 0x04000000 */
+#define TAMP_CR2_TAMP3TRG            TAMP_CR2_TAMP3TRG_Msk
 
 /********************  Bits definition for TAMP_FLTCR register  ***************/
 #define TAMP_FLTCR_TAMPFREQ_0        0x00000001U
@@ -6490,6 +6404,9 @@ typedef struct
 #define TAMP_IER_TAMP2IE_Pos         (1U)
 #define TAMP_IER_TAMP2IE_Msk         (0x1UL << TAMP_IER_TAMP2IE_Pos)            /*!< 0x00000002 */
 #define TAMP_IER_TAMP2IE             TAMP_IER_TAMP2IE_Msk
+#define TAMP_IER_TAMP3IE_Pos         (2U)
+#define TAMP_IER_TAMP3IE_Msk         (0x1UL << TAMP_IER_TAMP3IE_Pos)            /*!< 0x00000004 */
+#define TAMP_IER_TAMP3IE             TAMP_IER_TAMP3IE_Msk
 #define TAMP_IER_ITAMP3IE_Pos        (18U)
 #define TAMP_IER_ITAMP3IE_Msk        (0x1UL << TAMP_IER_ITAMP3IE_Pos)           /*!< 0x00040000 */
 #define TAMP_IER_ITAMP3IE            TAMP_IER_ITAMP3IE_Msk
@@ -6510,6 +6427,9 @@ typedef struct
 #define TAMP_SR_TAMP2F_Pos           (1U)
 #define TAMP_SR_TAMP2F_Msk           (0x1UL << TAMP_SR_TAMP2F_Pos)              /*!< 0x00000002 */
 #define TAMP_SR_TAMP2F               TAMP_SR_TAMP2F_Msk
+#define TAMP_SR_TAMP3F_Pos           (2U)
+#define TAMP_SR_TAMP3F_Msk           (0x1UL << TAMP_SR_TAMP3F_Pos)              /*!< 0x00000004 */
+#define TAMP_SR_TAMP3F               TAMP_SR_TAMP3F_Msk
 #define TAMP_SR_ITAMP3F_Pos          (18U)
 #define TAMP_SR_ITAMP3F_Msk          (0x1UL << TAMP_SR_ITAMP3F_Pos)             /*!< 0x00040000 */
 #define TAMP_SR_ITAMP3F              TAMP_SR_ITAMP3F_Msk
@@ -6530,6 +6450,9 @@ typedef struct
 #define TAMP_MISR_TAMP2MF_Pos        (1U)
 #define TAMP_MISR_TAMP2MF_Msk        (0x1UL << TAMP_MISR_TAMP2MF_Pos)           /*!< 0x00000002 */
 #define TAMP_MISR_TAMP2MF            TAMP_MISR_TAMP2MF_Msk
+#define TAMP_MISR_TAMP3MF_Pos        (2U)
+#define TAMP_MISR_TAMP3MF_Msk        (0x1UL << TAMP_MISR_TAMP3MF_Pos)           /*!< 0x00000004 */
+#define TAMP_MISR_TAMP3MF            TAMP_MISR_TAMP3MF_Msk
 #define TAMP_MISR_ITAMP3MF_Pos       (18U)
 #define TAMP_MISR_ITAMP3MF_Msk       (0x1UL << TAMP_MISR_ITAMP3MF_Pos)          /*!< 0x00040000 */
 #define TAMP_MISR_ITAMP3MF           TAMP_MISR_ITAMP3MF_Msk
@@ -6550,6 +6473,9 @@ typedef struct
 #define TAMP_SCR_CTAMP2F_Pos         (1U)
 #define TAMP_SCR_CTAMP2F_Msk         (0x1UL << TAMP_SCR_CTAMP2F_Pos)            /*!< 0x00000002 */
 #define TAMP_SCR_CTAMP2F             TAMP_SCR_CTAMP2F_Msk
+#define TAMP_SCR_CTAMP3F_Pos         (2U)
+#define TAMP_SCR_CTAMP3F_Msk         (0x1UL << TAMP_SCR_CTAMP3F_Pos)            /*!< 0x00000004 */
+#define TAMP_SCR_CTAMP3F             TAMP_SCR_CTAMP3F_Msk
 #define TAMP_SCR_CITAMP3F_Pos        (18U)
 #define TAMP_SCR_CITAMP3F_Msk        (0x1UL << TAMP_SCR_CITAMP3F_Pos)           /*!< 0x00040000 */
 #define TAMP_SCR_CITAMP3F            TAMP_SCR_CITAMP3F_Msk
@@ -6594,7 +6520,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -6799,6 +6725,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
 /*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
 #define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
 #define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
@@ -6902,9 +6829,9 @@ typedef struct
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -6914,9 +6841,6 @@ typedef struct
 #define SYSCFG_ITLINE4_SR_CLK_CTRL_Pos        (0U)
 #define SYSCFG_ITLINE4_SR_CLK_CTRL_Msk        (0x1UL << SYSCFG_ITLINE4_SR_CLK_CTRL_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE4_SR_CLK_CTRL            SYSCFG_ITLINE4_SR_CLK_CTRL_Msk   /*!< RCC interrupt */
-#define SYSCFG_ITLINE4_SR_CRS_Pos             (1U)
-#define SYSCFG_ITLINE4_SR_CRS_Msk             (0x1UL << SYSCFG_ITLINE4_SR_CRS_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE4_SR_CRS                 SYSCFG_ITLINE4_SR_CRS_Msk            /*!< CRS interrupt */
 #define SYSCFG_ITLINE5_SR_EXTI0_Pos           (0U)
 #define SYSCFG_ITLINE5_SR_EXTI0_Msk           (0x1UL << SYSCFG_ITLINE5_SR_EXTI0_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE5_SR_EXTI0               SYSCFG_ITLINE5_SR_EXTI0_Msk      /*!< External Interrupt 0 */
@@ -6965,9 +6889,9 @@ typedef struct
 #define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
 #define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
 #define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
-#define SYSCFG_ITLINE8_SR_USBFS_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_USBFS_Msk          (0x1UL << SYSCFG_ITLINE8_SR_USBFS_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_USBFS              SYSCFG_ITLINE8_SR_USBFS_Msk            /*!< USBFS Interrupt */
+#define SYSCFG_ITLINE8_SR_USB_Pos             (2U)
+#define SYSCFG_ITLINE8_SR_USB_Msk             (0x1UL << SYSCFG_ITLINE8_SR_USB_Pos)   /*!< 0x00000004 */
+#define SYSCFG_ITLINE8_SR_USB                 SYSCFG_ITLINE8_SR_USB_Msk              /*!< USB Interrupt */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
@@ -6977,9 +6901,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -7054,10 +6978,10 @@ typedef struct
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE24_SR_I2C3_GLB_Pos       (1U)
 #define SYSCFG_ITLINE24_SR_I2C3_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C3_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE24_SR_I2C3_GLB           SYSCFG_ITLINE24_SR_I2C3_GLB_Msk  /*!< I2C3 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C3_GLB           SYSCFG_ITLINE24_SR_I2C3_GLB_Msk  /*!< I2C3 GLB Interrupt  -> exti[24]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -7838,10 +7762,26 @@ typedef struct
 #define TIM3_AF1_ETRSEL_2         (0x4UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
 #define TIM3_AF1_ETRSEL_3         (0x8UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
 
+/*******************  Bit definition for TIM4_OR1 register  *******************/
+#define TIM4_OR1_OCREF_CLR_Pos     (0U)
+#define TIM4_OR1_OCREF_CLR_Msk     (0x3UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM4_OR1_OCREF_CLR         TIM4_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM4_OR1_OCREF_CLR_0       (0x1UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM4_OR1_OCREF_CLR_1       (0x2UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
+
+/*******************  Bit definition for TIM4_AF1 register  *******************/
+#define TIM4_AF1_ETRSEL_Pos       (14U)
+#define TIM4_AF1_ETRSEL_Msk       (0xFUL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM4_AF1_ETRSEL           TIM4_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM4 ETR source selection) */
+#define TIM4_AF1_ETRSEL_0         (0x1UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM4_AF1_ETRSEL_1         (0x2UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM4_AF1_ETRSEL_2         (0x4UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM4_AF1_ETRSEL_3         (0x8UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -7910,7 +7850,7 @@ typedef struct
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -7918,7 +7858,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -7926,7 +7866,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -7934,7 +7874,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -8440,7 +8380,7 @@ typedef struct
 #define DBG_APB_FZ1_DBG_TIM3_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
 #define DBG_APB_FZ1_DBG_TIM3_STOP                      DBG_APB_FZ1_DBG_TIM3_STOP_Msk
 #define DBG_APB_FZ1_DBG_TIM4_STOP_Pos                  (2U)
-#define DBG_APB_FZ1_DBG_TIM4_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM4_STOP_Pos) /*!< 0x00000003 */
+#define DBG_APB_FZ1_DBG_TIM4_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM4_STOP_Pos) /*!< 0x00000004 */
 #define DBG_APB_FZ1_DBG_TIM4_STOP                      DBG_APB_FZ1_DBG_TIM4_STOP_Msk
 #define DBG_APB_FZ1_DBG_TIM6_STOP_Pos                  (4U)
 #define DBG_APB_FZ1_DBG_TIM6_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM6_STOP_Pos) /*!< 0x00000010 */
@@ -8463,9 +8403,6 @@ typedef struct
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Pos    (22U)
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00400000 */
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Msk
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Pos    (23U)
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00800000 */
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Msk
 
 /********************  Bit definition for DBG_APB_FZ2 register  ************/
 #define DBG_APB_FZ2_DBG_TIM1_STOP_Pos                  (11U)
@@ -8486,177 +8423,351 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                         USB Device FS Endpoint registers                   */
+/*                         USB Dual Role Device FS Endpoint registers         */
 /*                                                                            */
 /******************************************************************************/
-#define USB_DRD_FS_CHEP0R                              USB_DRD_FS_BASE                    /*!< Channel endpoint 0 register address */
-#define USB_DRD_FS_CHEP1R                             (USB_DRD_FS_BASE + 0x0x00000004)   /*!< Channel endpoint 1 register address */
-#define USB_DRD_FS_CHEP2R                             (USB_DRD_FS_BASE + 0x0x00000008)   /*!< Channel endpoint 2 register address */
-#define USB_DRD_FS_CHEP3R                             (USB_DRD_FS_BASE + 0x0x0000000C)   /*!< Channel endpoint 3 register address */
-#define USB_DRD_FS_CHEP4R                             (USB_DRD_FS_BASE + 0x0x00000010)   /*!< Channel endpoint 4 register address */
-#define USB_DRD_FS_CHEP5R                             (USB_DRD_FS_BASE + 0x0x00000014)   /*!< Channel endpoint 5 register address */
-#define USB_DRD_FS_CHEP6R                             (USB_DRD_FS_BASE + 0x0x00000018)   /*!< Channel endpoint 6 register address */
-#define USB_DRD_FS_CHEP7R                             (USB_DRD_FS_BASE + 0x0x0000001C)   /*!< Channel endpoint 7 register address */
 
-/* bit positions */
-//#define USB_DRD_CHEP_CTR_RX                            ((uint16_t)0x8000U)           /*!<  Channel EndPoint Correct TRansfer RX */
-//#define USB_DRD_CHEP_DTOG_RX                           ((uint16_t)0x4000U)           /*!<  Channel EndPoint Data TOGGLE RX */
-//#define USB_DRD_CHEPRX_STAT                            ((uint16_t)0x3000U)           /*!<  Channel EndPoint RX STATus bit field */
-//#define USB_DRD_CHEP_SETUP                             ((uint16_t)0x0800U)           /*!<  Channel EndPoint SETUP */
-//#define USB_DRD_CHEP_T_FIELD                           ((uint16_t)0x0600U)           /*!<  Channel EndPoint TYPE */
-//#define USB_DRD_CHEP_KIND                              ((uint16_t)0x0100U)           /*!<  Channel EndPoint KIND */
-//#define USB_DRD_CHEP_CTR_TX                            ((uint16_t)0x0080U)           /*!<  Channel EndPoint Correct TRansfer TX */
-//#define USB_DRD_CHEP_DTOG_TX                           ((uint16_t)0x0040U)           /*!<  Channel EndPoint Data TOGGLE TX */
-//#define USB_DRD_CHEPTX_STAT                            ((uint16_t)0x0030U)           /*!<  Channel EndPoint TX STATus bit field */
-//#define USB_DRD_CHEPADDR_FIELD                         ((uint16_t)0x000FU)           /*!<  Channel EndPoint ADDRess FIELD */
+/******************  Bits definition for USB_DRD_CNTR register  *******************/
+#define USB_CNTR_HOST_Pos               (31U)
+#define USB_CNTR_HOST_Msk               (0x1UL << USB_CNTR_HOST_Pos)    /*!< 0x80000000 */
+#define USB_CNTR_HOST                   USB_CNTR_HOST_Msk               /*!< Host Mode  */
+#define USB_CNTR_THR512M_Pos            (16U)
+#define USB_CNTR_THR512M_Msk            (0x1UL << USB_CNTR_THR512M_Pos)  /*!< 0x00010000 */
+#define USB_CNTR_THR512M                USB_CNTR_THR512M_Msk             /*!< 512byte Threshold interrupt mask */
+#define USB_CNTR_CTRM_Pos               (15U)
+#define USB_CNTR_CTRM_Msk               (0x1UL << USB_CNTR_CTRM_Pos)    /*!< 0x00008000 */
+#define USB_CNTR_CTRM                   USB_CNTR_CTRM_Msk               /*!< Correct Transfer Mask */
+#define USB_CNTR_PMAOVRM_Pos            (14U)
+#define USB_CNTR_PMAOVRM_Msk            (0x1UL << USB_CNTR_PMAOVRM_Pos) /*!< 0x00004000 */
+#define USB_CNTR_PMAOVRM                USB_CNTR_PMAOVRM_Msk            /*!< DMA OVeR/underrun Mask */
+#define USB_CNTR_ERRM_Pos               (13U)
+#define USB_CNTR_ERRM_Msk               (0x1UL << USB_CNTR_ERRM_Pos)    /*!< 0x00002000 */
+#define USB_CNTR_ERRM                   USB_CNTR_ERRM_Msk               /*!< ERRor Mask */
+#define USB_CNTR_WKUPM_Pos              (12U)
+#define USB_CNTR_WKUPM_Msk              (0x1UL << USB_CNTR_WKUPM_Pos)   /*!< 0x00001000 */
+#define USB_CNTR_WKUPM                  USB_CNTR_WKUPM_Msk              /*!< WaKe UP Mask */
+#define USB_CNTR_SUSPM_Pos              (11U)
+#define USB_CNTR_SUSPM_Msk              (0x1UL << USB_CNTR_SUSPM_Pos)   /*!< 0x00000800 */
+#define USB_CNTR_SUSPM                  USB_CNTR_SUSPM_Msk              /*!< SUSPend Mask */
+#define USB_CNTR_RESETM_Pos             (10U)
+#define USB_CNTR_RESETM_Msk             (0x1UL << USB_CNTR_RESETM_Pos)  /*!< 0x00000400 */
+#define USB_CNTR_RESETM                 USB_CNTR_RESETM_Msk             /*!< RESET Mask */
+#define USB_CNTR_DCON                   USB_CNTR_RESETM_Msk             /*!< Disconnection Connection Mask */
+#define USB_CNTR_SOFM_Pos               (9U)
+#define USB_CNTR_SOFM_Msk               (0x1UL << USB_CNTR_SOFM_Pos)    /*!< 0x00000200 */
+#define USB_CNTR_SOFM                   USB_CNTR_SOFM_Msk               /*!< Start Of Frame Mask */
+#define USB_CNTR_ESOFM_Pos              (8U)
+#define USB_CNTR_ESOFM_Msk              (0x1UL << USB_CNTR_ESOFM_Pos)   /*!< 0x00000100 */
+#define USB_CNTR_ESOFM                  USB_CNTR_ESOFM_Msk              /*!< Expected Start Of Frame Mask */
+#define USB_CNTR_L1REQM_Pos             (7U)
+#define USB_CNTR_L1REQM_Msk             (0x1UL << USB_CNTR_L1REQM_Pos)  /*!< 0x00000080 */
+#define USB_CNTR_L1REQM                 USB_CNTR_L1REQM_Msk             /*!< LPM L1 state request interrupt Mask */
+#define USB_CNTR_L1XACT_Pos             (6U)
+#define USB_CNTR_L1XACT_Msk             (0x1UL << USB_CNTR_L1XACT_Pos)  /*!< 0x00000040 */
+#define USB_CNTR_L1XACT                 USB_CNTR_L1XACT_Msk             /*!< Host LPM L1 transaction request Mask */
+#define USB_CNTR_L1RES_Pos              (5U)
+#define USB_CNTR_L1RES_Msk              (0x1UL << USB_CNTR_L1RES_Pos)   /*!< 0x00000020 */
+#define USB_CNTR_L1RES                  USB_CNTR_L1RES_Msk              /*!< LPM L1 Resume request/ Remote Wakeup Mask */
+#define USB_CNTR_L2RES_Pos              (4U)
+#define USB_CNTR_L2RES_Msk              (0x1UL << USB_CNTR_L2RES_Pos)   /*!< 0x00000010 */
+#define USB_CNTR_L2RES                  USB_CNTR_L2RES_Msk              /*!< L2 Remote Wakeup / Resume driver Mask */
+#define USB_CNTR_SUSPEN_Pos             (3U)
+#define USB_CNTR_SUSPEN_Msk             (0x1UL << USB_CNTR_SUSPEN_Pos)  /*!< 0x00000008 */
+#define USB_CNTR_SUSPEN                 USB_CNTR_SUSPEN_Msk             /*!< Suspend state enable Mask */
+#define USB_CNTR_SUSPRDY_Pos            (2U)
+#define USB_CNTR_SUSPRDY_Msk            (0x1UL << USB_CNTR_SUSPRDY_Pos) /*!< 0x00000004 */
+#define USB_CNTR_SUSPRDY                USB_CNTR_SUSPRDY_Msk            /*!< Suspend state effective Mask */
+#define USB_CNTR_PDWN_Pos               (1U)
+#define USB_CNTR_PDWN_Msk               (0x1UL << USB_CNTR_PDWN_Pos)    /*!< 0x00000002 */
+#define USB_CNTR_PDWN                   USB_CNTR_PDWN_Msk               /*!< Power DoWN Mask */
+#define USB_CNTR_USBRST_Pos             (0U)
+#define USB_CNTR_USBRST_Msk             (0x1UL << USB_CNTR_USBRST_Pos)  /*!< 0x00000001 */
+#define USB_CNTR_USBRST                 USB_CNTR_USBRST_Msk             /*!< USB Reset Mask */
 
-#define USB_DRD_FS_CHEP_VTRX                              ((uint16_t)0x8000U)           /*!<  USB valid transaction received*/
-#define USB_DRD_FS_CHEP_DTOG_RX                           ((uint16_t)0x4000U)           /*!<  Data Toggle, for reception transfers*/
-#define USB_DRD_FS_CHEPRX_STRX                            ((uint16_t)0x3000U)           /*!<  Status bits, for reception transfers*/
-#define USB_DRD_FS_CHEP_SETUP                             ((uint16_t)0x0800U)           /*!<  Setup transaction completed*/
-#define USB_DRD_FS_CHEP_UTYPE                             ((uint16_t)0x0600U)           /*!<  USB type of transaction */
-#define USB_DRD_FS_CHEP_EPKIND                            ((uint16_t)0x0100U)           /*!<  EndPoint KIND */
-#define USB_DRD_FS_CHEP_VTTX                              ((uint16_t)0x0080U)           /*!<  Valid USB transaction transmitted*/
-#define USB_DRD_FS_CHEP_DTOG_TX                           ((uint16_t)0x0040U)           /*!<  Data Toggle, for transmission transfers */
-#define USB_DRD_FS_CHEPTX_STTX                            ((uint16_t)0x0030U)           /*!<  Status bits, for transmission transfers */
-#define USB_DRD_FS_CHEPADDR_FIELD                         ((uint16_t)0x000FU)           /*!<  Endpoint address*/
+/******************  Bits definition for USB_DRD_ISTR register  *******************/
+#define USB_ISTR_IDN_Pos                (0U)
+#define USB_ISTR_IDN_Msk                (0xFUL << USB_ISTR_IDN_Pos)     /*!< 0x0000000F */
+#define USB_ISTR_IDN                    USB_ISTR_IDN_Msk                /*!< EndPoint IDentifier (read-only bit) Mask */
+#define USB_ISTR_DIR_Pos                (4U)
+#define USB_ISTR_DIR_Msk                (0x1UL << USB_ISTR_DIR_Pos)     /*!< 0x00000010 */
+#define USB_ISTR_DIR                    USB_ISTR_DIR_Msk                /*!< DIRection of transaction (read-only bit) Mask */
+#define USB_ISTR_L1REQ_Pos              (7U)
+#define USB_ISTR_L1REQ_Msk              (0x1UL << USB_ISTR_L1REQ_Pos)   /*!< 0x00000080 */
+#define USB_ISTR_L1REQ                  USB_ISTR_L1REQ_Msk              /*!< LPM L1 state request Mask */
+#define USB_ISTR_ESOF_Pos               (8U)
+#define USB_ISTR_ESOF_Msk               (0x1UL << USB_ISTR_ESOF_Pos)    /*!< 0x00000100 */
+#define USB_ISTR_ESOF                   USB_ISTR_ESOF_Msk               /*!< Expected Start Of Frame (clear-only bit) Mask */
+#define USB_ISTR_SOF_Pos                (9U)
+#define USB_ISTR_SOF_Msk                (0x1UL << USB_ISTR_SOF_Pos)     /*!< 0x00000200 */
+#define USB_ISTR_SOF                    USB_ISTR_SOF_Msk                /*!< Start Of Frame (clear-only bit) Mask */
+#define USB_ISTR_RESET_Pos              (10U)
+#define USB_ISTR_RESET_Msk              (0x1UL << USB_ISTR_RESET_Pos)   /*!< 0x00000400 */
+#define USB_ISTR_RESET                  USB_ISTR_RESET_Msk              /*!< RESET Mask */
+#define USB_ISTR_DCON_Pos               (10U)
+#define USB_ISTR_DCON_Msk               (0x1UL << USB_ISTR_DCON_Pos)    /*!< 0x00000400 */
+#define USB_ISTR_DCON                   USB_ISTR_DCON_Msk               /*!< HOST MODE-Device Connection or disconnection Mask */
+#define USB_ISTR_SUSP_Pos               (11U)
+#define USB_ISTR_SUSP_Msk               (0x1UL << USB_ISTR_SUSP_Pos)    /*!< 0x00000800 */
+#define USB_ISTR_SUSP                   USB_ISTR_SUSP_Msk               /*!< SUSPend (clear-only bit) Mask */
+#define USB_ISTR_WKUP_Pos               (12U)
+#define USB_ISTR_WKUP_Msk               (0x1UL << USB_ISTR_WKUP_Pos)    /*!< 0x00001000 */
+#define USB_ISTR_WKUP                   USB_ISTR_WKUP_Msk               /*!< WaKe UP (clear-only bit) Mask */
+#define USB_ISTR_ERR_Pos                (13U)
+#define USB_ISTR_ERR_Msk                (0x1UL << USB_ISTR_ERR_Pos)     /*!< 0x00002000 */
+#define USB_ISTR_ERR                    USB_ISTR_ERR_Msk                /*!< ERRor (clear-only bit) Mask */
+#define USB_ISTR_PMAOVR_Pos             (14U)
+#define USB_ISTR_PMAOVR_Msk             (0x1UL << USB_ISTR_PMAOVR_Pos)  /*!< 0x00004000 */
+#define USB_ISTR_PMAOVR                 USB_ISTR_PMAOVR_Msk             /*!< PMA OVeR/underrun (clear-only bit) Mask */
+#define USB_ISTR_CTR_Pos                (15U)
+#define USB_ISTR_CTR_Msk                (0x1UL << USB_ISTR_CTR_Pos)     /*!< 0x00008000 */
+#define USB_ISTR_CTR                    USB_ISTR_CTR_Msk                /*!< Correct TRansfer (clear-only bit) Mask */
+#define USB_ISTR_THR512_Pos             (16U)
+#define USB_ISTR_THR512_Msk             (0x1UL << USB_ISTR_THR512_Pos)  /*!< 0x00010000 */
+#define USB_ISTR_THR512                 USB_ISTR_THR512_Msk             /*!< 512byte threshold interrupt (used with isochrnous single buffer ) */
+#define USB_ISTR_DCON_STAT_Pos          (29U)
+#define USB_ISTR_DCON_STAT_Msk          (0x1UL << USB_ISTR_DCON_STAT_Pos)/*!< 0x20000000 */
+#define USB_ISTR_DCON_STAT              USB_ISTR_DCON_STAT_Msk           /*!< Device Connection status (connected/Disconnected) don't cause an interrupt */
+#define USB_ISTR_LS_DCONN_Pos           (30U)
+#define USB_ISTR_LS_DCONN_Msk           (0x1UL << USB_ISTR_LS_DCONN_Pos)/*!< 0x40000000 */
+#define USB_ISTR_LS_DCONN               USB_ISTR_LS_DCONN_Msk           /*!< LS_DCONN Mask */
 
+/******************  Bits definition for USB_DRD_FNR register  ********************/
+#define USB_FNR_FN_Pos                  (0U)
+#define USB_FNR_FN_Msk                  (0x7FFUL << USB_FNR_FN_Pos)     /*!< 0x000007FF */
+#define USB_FNR_FN                      USB_FNR_FN_Msk                  /*!< Frame Number Mask */
+#define USB_FNR_LSOF_Pos                (11U)
+#define USB_FNR_LSOF_Msk                (0x3UL << USB_FNR_LSOF_Pos)     /*!< 0x00001800 */
+#define USB_FNR_LSOF                    USB_FNR_LSOF_Msk                /*!< Lost SOF  Mask */
+#define USB_FNR_LCK_Pos                 (13U)
+#define USB_FNR_LCK_Msk                 (0x1UL << USB_FNR_LCK_Pos)      /*!< 0x00002000 */
+#define USB_FNR_LCK                     USB_FNR_LCK_Msk                 /*!< LoCKed Mask */
+#define USB_FNR_RXDM_Pos                (14U)
+#define USB_FNR_RXDM_Msk                (0x1UL << USB_FNR_RXDM_Pos)     /*!< 0x00004000 */
+#define USB_FNR_RXDM                    USB_FNR_RXDM_Msk                /*!< status of D- data line Mask */
+#define USB_FNR_RXDP_Pos                (15U)
+#define USB_FNR_RXDP_Msk                (0x1UL << USB_FNR_RXDP_Pos)     /*!< 0x00008000 */
+#define USB_FNR_RXDP                    USB_FNR_RXDP_Msk                /*!< status of D+ data line Mask */
 
+/******************  Bits definition for USB_DRD_DADDR register    ****************/
+#define USB_DADDR_ADD_Pos               (0U)
+#define USB_DADDR_ADD_Msk               (0x7FUL << USB_DADDR_ADD_Pos)   /*!< 0x0000007F */
+#define USB_DADDR_ADD                   USB_DADDR_ADD_Msk               /*!<  ADD[6:0] bits (Device Address)Mask */
+#define USB_DADDR_ADD0_Pos              (0U)
+#define USB_DADDR_ADD0_Msk              (0x1UL << USB_DADDR_ADD0_Pos)   /*!< 0x00000001 */
+#define USB_DADDR_ADD0                  USB_DADDR_ADD0_Msk              /*!< Bit 0 Mask */
+#define USB_DADDR_ADD1_Pos              (1U)
+#define USB_DADDR_ADD1_Msk              (0x1UL << USB_DADDR_ADD1_Pos)   /*!< 0x00000002 */
+#define USB_DADDR_ADD1                  USB_DADDR_ADD1_Msk              /*!< Bit 1 Mask */
+#define USB_DADDR_ADD2_Pos              (2U)
+#define USB_DADDR_ADD2_Msk              (0x1UL << USB_DADDR_ADD2_Pos)   /*!< 0x00000004 */
+#define USB_DADDR_ADD2                  USB_DADDR_ADD2_Msk              /*!< Bit 2 Mask */
+#define USB_DADDR_ADD3_Pos              (3U)
+#define USB_DADDR_ADD3_Msk              (0x1UL << USB_DADDR_ADD3_Pos)   /*!< 0x00000008 */
+#define USB_DADDR_ADD3                  USB_DADDR_ADD3_Msk              /*!< Bit 3 Mask */
+#define USB_DADDR_ADD4_Pos              (4U)
+#define USB_DADDR_ADD4_Msk              (0x1UL << USB_DADDR_ADD4_Pos)   /*!< 0x00000010 */
+#define USB_DADDR_ADD4                  USB_DADDR_ADD4_Msk              /*!< Bit 4 Mask */
+#define USB_DADDR_ADD5_Pos              (5U)
+#define USB_DADDR_ADD5_Msk              (0x1UL << USB_DADDR_ADD5_Pos)   /*!< 0x00000020 */
+#define USB_DADDR_ADD5                  USB_DADDR_ADD5_Msk              /*!< Bit 5 Mask */
+#define USB_DADDR_ADD6_Pos              (6U)
+#define USB_DADDR_ADD6_Msk              (0x1UL << USB_DADDR_ADD6_Pos)   /*!< 0x00000040 */
+#define USB_DADDR_ADD6                  USB_DADDR_ADD6_Msk              /*!< Bit 6 Mask */
+#define USB_DADDR_EF_Pos                (7U)
+#define USB_DADDR_EF_Msk                (0x1UL << USB_DADDR_EF_Pos)     /*!< 0x00000080 */
+#define USB_DADDR_EF                    USB_DADDR_EF_Msk                /*!< Enable Function Mask */
 
-/* EndPoint REGister MASK (no toggle fields) */
-#define USB_DRD_FS_CHEPREG_MASK                           (USB_DRD_FS_CHEP_VTRX|USB_DRD_FS_CHEP_SETUP|USB_DRD_FS_CHEP_UTYPE|USB_DRD_FS_CHEP_EPKIND|USB_DRD_FS_CHEP_VTTX|USB_DRD_FS_CHEPADDR_FIELD) /*=8f8f*/
-                                                                         /*!< EP_TYPE[1:0] Channel/EndPoint TYPE */
-#define USB_DRD_FS_CHEP_TYPE_MASK                         ((uint16_t)0x0600U)           /*!< Channel/EndPoint TYPE Mask */
-#define USB_DRD_FS_CHEP_BULK                              ((uint16_t)0x0000U)           /*!< Channel/EndPoint BULK */
-#define USB_DRD_FS_CHEP_CONTROL                           ((uint16_t)0x0200U)           /*!< Channel/EndPoint CONTROL */
-#define USB_DRD_FS_CHEP_ISOCHRONOUS                       ((uint16_t)0x0400U)           /*!< Channel/EndPoint ISOCHRONOUS */
-#define USB_DRD_FS_CHEP_INTERRUPT                         ((uint16_t)0x0600U)           /*!< Channel/EndPoint INTERRUPT */
-#define USB_DRD_FS_CHEP_T_MASK                            ((uint16_t) ~USB_DRD_FS_CHEP_UTYPE & USB_DRD_FS_CHEPREG_MASK) /*=0x898F*/
-
-#define USB_DRD_FS_CHEPKIND_MASK                          ((uint16_t)~USB_DRD_FS_CHEP_EPKIND & USB_DRD_FS_CHEPREG_MASK) /*!< EP_KIND EndPoint KIND */
-                                                                         /*!< STAT_TX[1:0] STATus for TX transfer */
-#define USB_DRD_FS_CHEP_TX_DIS                            ((uint16_t)0x0000U)           /*!< EndPoint TX DISabled */
-#define USB_DRD_FS_CHEP_TX_STALL                          ((uint16_t)0x0010U)           /*!< EndPoint TX STALLed */
-#define USB_DRD_FS_CHEP_TX_NAK                            ((uint16_t)0x0020U)           /*!< EndPoint TX NAKed */
-#define USB_DRD_FS_CHEP_TX_VALID                          ((uint16_t)0x0030U)           /*!< EndPoint TX VALID */
-#define USB_DRD_FS_CHEPTX_DTOG1                           ((uint16_t)0x0010U)           /*!< EndPoint TX Data TOGgle bit1 */
-#define USB_DRD_FS_CHEPTX_DTOG2                           ((uint16_t)0x0020U)           /*!< EndPoint TX Data TOGgle bit2 */
-#define USB_DRD_FS_CHEPTX_DTOGMASK                         (USB_DRD_FS_CHEPTX_STTX|USB_DRD_FS_CHEPREG_MASK)
-
-
-                                                                         /*!< STAT_RX[1:0] STATus for RX transfer */
-#define USB_DRD_FS_CHEP_RX_DIS                            ((uint16_t)0x0000U)           /*!< EndPoint RX DISabled */
-#define USB_DRD_FS_CHEP_RX_STALL                          ((uint16_t)0x1000U)           /*!< EndPoint RX STALLed */
-#define USB_DRD_FS_CHEP_RX_NAK                            ((uint16_t)0x2000U)           /*!< EndPoint RX NAKed */
-#define USB_DRD_FS_CHEP_RX_VALID                          ((uint16_t)0x3000U)           /*!< EndPoint RX VALID */
-
-#define USB_DRD_FS_CHEPRX_DTOG1                           ((uint16_t)0x1000U)           /*!< EndPoint RX Data TOGgle bit1 */
-#define USB_DRD_FS_CHEPRX_DTOG2                           ((uint16_t)0x2000U)           /*!< EndPoint RX Data TOGgle bit1 */
-
-#define USB_DRD_FS_CHEPRX_DTOGMASK                        (USB_DRD_FS_CHEPRX_STRX|USB_DRD_FS_CHEPREG_MASK)
-
-/*Buffer Descriprot Mask*/
-#define USB_DRD_FS_CHEPX_TXBD_ADDMSK                       ((uint32_t)0xFFFF0000)
-#define USB_DRD_FS_CHEPX_TXBD_COUNTMSK                     ((uint32_t)0x0000FFFF)
-#define USB_DRD_FS_CHEPX_RXBD_ADDMSK                       ((uint32_t)0xFFFF0000)
-#define USB_DRD_FS_CHEPX_RXBD_COUNTMSK                     ((uint32_t)0x0000FFFF)
-
-
-/******************************************************************************/
-/*                                                                            */
-/*                         USB Device FS General registers                    */
-/*                                                                            */
-/******************************************************************************/
-#define USB_DRD_FS_CNTR                             (USB_DRD_FS_BASE + 0x00000040U)     /*!< Control register */
-#define USB_DRD_FS_ISTR                             (USB_DRD_FS_BASE + 0x00000044U)     /*!< Interrupt status register */
-#define USB_DRD_FS_FNR                              (USB_DRD_FS_BASE + 0x00000048U)     /*!< Frame number register */
-#define USB_DRD_FS_DADDR                            (USB_DRD_FS_BASE + 0x0000004CU)     /*!< Device address register */
-#define USB_DRD_FS_BTABLE                           (USB_DRD_FS_BASE + 0x00000050U)     /*!< Buffer Table address register */
-#define USB_DRD_FS_LPMCSR                           (USB_DRD_FS_BASE + 0x00000054U)     /*!< LPM Control and Status register */
-#define USB_DRD_FS_BCDR                             (USB_DRD_FS_BASE + 0x00000058U)     /*!< Battery Charging detector register*/
-
-/******************  Bits definition for USB_DRD_FS_CNTR register  *******************/
-#define USB_DRD_FS_CNTR_HOST                            ((uint32_t)0x80000000U)           /*!< Host Mode  */
-#define USB_DRD_FS_CNTR_CTRM                            ((uint32_t)0x00008000U)           /*!< Correct TRansfer Mask */
-#define USB_DRD_FS_CNTR_PMAOVRM                         ((uint32_t)0x00004000U)           /*!< DMA OVeR/underrun Mask */
-#define USB_DRD_FS_CNTR_ERRM                            ((uint32_t)0x00002000U)           /*!< ERRor Mask */
-#define USB_DRD_FS_CNTR_WKUPM                           ((uint32_t)0x00001000U)           /*!< WaKe UP Mask */
-#define USB_DRD_FS_CNTR_SUSPM                           ((uint32_t)0x00000800U)           /*!< SUSPend Mask */
-#define USB_DRD_FS_CNTR_RESETM                          ((uint32_t)0x00000400U)           /*!< RESET Mask   */
-#define USB_DRD_FS_CNTR_SOFM                            ((uint32_t)0x00000200U)           /*!< Start Of Frame Mask */
-#define USB_DRD_FS_CNTR_ESOFM                           ((uint32_t)0x00000100U)           /*!< Expected Start Of Frame Mask */
-#define USB_DRD_FS_CNTR_L1REQM                          ((uint32_t)0x00000080U)           /*!< LPM L1 state request interrupt mask */
-#define USB_DRD_FS_CNTR_L1XACT                          ((uint32_t)0x00000040U)           /*!< LPM L1 transaction request */
-#define USB_DRD_FS_CNTR_L1RES                           ((uint32_t)0x00000020U)           /*!< LPM L1 Resume request/ Remote Wakeup  */
-#define USB_DRD_FS_CNTR_L2RES                           ((uint32_t)0x00000010U)           /*!< L2 Remote Wakeup / Resume driver */
-#define USB_DRD_FS_CNTR_SUSPEN                          ((uint32_t)0x00000008U)           /*!< Suspend state enable*/
-#define USB_DRD_FS_CNTR_SYSPRDY                         ((uint32_t)0x00000004U)           /*!< Suspend state effective */
-#define USB_DRD_FS_CNTR_PDWN                            ((uint32_t)0x00000002U)           /*!< Power DoWN */
-#define USB_DRD_FS_CNTR_RST                             ((uint32_t)0x00000001U)           /*!< USB Reset */
-
-/******************  Bits definition for USB_DRD_FS_ISTR register  *******************/
-#define USB_DRD_FS_ISTR_IDN                             ((uint16_t)0x000FU)           /*!< EndPoint IDentifier (read-only bit)  */
-#define USB_DRD_FS_ISTR_DIR                             ((uint16_t)0x0010U)           /*!< DIRection of transaction (read-only bit)  */
-#define USB_DRD_FS_ISTR_L1REQ                           ((uint16_t)0x0080U)           /*!< LPM L1 state request  */
-#define USB_DRD_FS_ISTR_ESOF                            ((uint16_t)0x0100U)           /*!< Expected Start Of Frame (clear-only bit) */
-#define USB_DRD_FS_ISTR_SOF                             ((uint16_t)0x0200U)           /*!< Start Of Frame (clear-only bit) */
-#define USB_DRD_FS_ISTR_RESET                           ((uint16_t)0x0400U)           /*!< RESET (clear-only bit) */
-#define USB_DRD_FS_ISTR_DCON                            ((uint16_t)0x0400U)           /*!< HOST MODE-Device Connection or disconnection  */
-#define USB_DRD_FS_ISTR_SUSP                            ((uint16_t)0x0800U)           /*!< SUSPend (clear-only bit) */
-#define USB_DRD_FS_ISTR_WKUP                            ((uint16_t)0x1000U)           /*!< WaKe UP (clear-only bit) */
-#define USB_DRD_FS_ISTR_ERR                             ((uint16_t)0x2000U)           /*!< ERRor (clear-only bit) */
-#define USB_DRD_FS_ISTR_PMAOVR                          ((uint16_t)0x4000U)           /*!< DMA OVeR/underrun (clear-only bit) */
-#define USB_DRD_FS_ISTR_CTR                             ((uint16_t)0x8000U)           /*!< Correct TRansfer (clear-only bit) */
-
-#define USB_DRD_FS_CLR_L1REQ                            (~USB_DRD_FS_ISTR_L1REQ)           /*!< clear LPM L1  bit */
-#define USB_DRD_FS_CLR_ESOF                             (~USB_DRD_FS_ISTR_ESOF)            /*!< clear Expected Start Of Frame bit */
-#define USB_DRD_FS_CLR_SOF                              (~USB_DRD_FS_ISTR_SOF)             /*!< clear Start Of Frame bit */
-#define USB_DRD_FS_CLR_RESET                            (~USB_DRD_FS_ISTR_RESET)           /*!< clear RESET bit */
-#define USB_DRD_FS_CLR_SUSP                             (~USB_DRD_FS_ISTR_SUSP)            /*!< clear SUSPend bit */
-#define USB_DRD_FS_CLR_WKUP                             (~USB_DRD_FS_ISTR_WKUP)            /*!< clear WaKe UP bit */
-#define USB_DRD_FS_CLR_ERR                              (~USB_DRD_FS_ISTR_ERR)             /*!< clear ERRor bit */
-#define USB_DRD_FS_CLR_PMAOVR                           (~USB_DRD_FS_ISTR_PMAOVR)          /*!< clear DMA OVeR/underrun bit*/
-#define USB_DRD_FS_CLR_CTR                              (~USB_DRD_FS_ISTR_CTR)             /*!< clear Correct TRansfer bit */
-
-/******************  Bits definition for USB_DRD_FS_FNR register  ********************/
-#define USB_DRD_FS_FNR_FN                               ((uint16_t)0x07FFU)           /*!< Frame Number */
-#define USB_DRD_FS_FNR_LSOF                             ((uint16_t)0x1800U)           /*!< Lost SOF */
-#define USB_DRD_FS_FNR_LCK                              ((uint16_t)0x2000U)           /*!< LoCKed */
-#define USB_DRD_FS_FNR_RXDM                             ((uint16_t)0x4000U)           /*!< status of D- data line */
-#define USB_DRD_FS_FNR_RXDP                             ((uint16_t)0x8000U)           /*!< status of D+ data line */
-
-/******************  Bits definition for USB_DRD_FS_DADDR register    ****************/
-#define USB_DRD_FS_DADDR_ADD                            ((uint8_t)0x7FU)              /*!< ADD[6:0] bits (Device Address) */
-#define USB_DRD_FS_DADDR_ADD0                           ((uint8_t)0x01U)              /*!< Bit 0 */
-#define USB_DRD_FS_DADDR_ADD1                           ((uint8_t)0x02U)              /*!< Bit 1 */
-#define USB_DRD_FS_DADDR_ADD2                           ((uint8_t)0x04U)              /*!< Bit 2 */
-#define USB_DRD_FS_DADDR_ADD3                           ((uint8_t)0x08U)              /*!< Bit 3 */
-#define USB_DRD_FS_DADDR_ADD4                           ((uint8_t)0x10U)              /*!< Bit 4 */
-#define USB_DRD_FS_DADDR_ADD5                           ((uint8_t)0x20U)              /*!< Bit 5 */
-#define USB_DRD_FS_DADDR_ADD6                           ((uint8_t)0x40U)              /*!< Bit 6 */
-
-#define USB_DRD_FS_DADDR_EF                             ((uint8_t)0x80U)              /*!< Enable Function */
-
-/******************  Bit definition for USB_DRD_FS_BTABLE register  ******************/
-#define USB_DRD_FS_BTABLE_BTABLE                        ((uint16_t)0xFFF8U)           /*!< Buffer Table */
-
-/******************  Bits definition for USB_DRD_FS_BCDR register  *******************/
-#define USB_DRD_FS_BCDR_BCDEN                           ((uint16_t)0x0001U)           /*!< Battery charging detector (BCD) enable */
-#define USB_DRD_FS_BCDR_DCDEN                           ((uint16_t)0x0002U)           /*!< Data contact detection (DCD) mode enable */
-#define USB_DRD_FS_BCDR_PDEN                            ((uint16_t)0x0004U)           /*!< Primary detection (PD) mode enable */
-#define USB_DRD_FS_BCDR_SDEN                            ((uint16_t)0x0008U)           /*!< Secondary detection (SD) mode enable */
-#define USB_DRD_FS_BCDR_DCDET                           ((uint16_t)0x0010U)           /*!< Data contact detection (DCD) status */
-#define USB_DRD_FS_BCDR_PDET                            ((uint16_t)0x0020U)           /*!< Primary detection (PD) status */
-#define USB_DRD_FS_BCDR_SDET                            ((uint16_t)0x0040U)           /*!< Secondary detection (SD) status */
-#define USB_DRD_FS_BCDR_PS2DET                          ((uint16_t)0x0080U)           /*!< PS2 port or proprietary charger detected */
-#define USB_DRD_FS_BCDR_DPPU                            ((uint16_t)0x8000U)           /*!< DP Pull-up Enable */
-#define USB_DRD_FS_BCDR_DPPD                            ((uint16_t)0x8000U)           /*!< DP Pull-Down Enable */
+/******************  Bit definition for USB_DRD_BTABLE register  ******************/
+#define USB_BTABLE_BTABLE_Pos          (3U)
+#define USB_BTABLE_BTABLE_Msk          (0xFFF8UL << USB_BTABLE_BTABLE_Pos)/*!< 0x00000000 */
+#define USB_BTABLE_BTABLE              USB_BTABLE_BTABLE_Msk              /*!< Buffer Table Mask */
 
 /*******************  Bit definition for LPMCSR register  *********************/
-#define USB_DRD_FS_LPMCSR_LMPEN                         ((uint16_t)0x0001U)           /*!< LPM support enable  */
-#define USB_DRD_FS_LPMCSR_LPMACK                        ((uint16_t)0x0002U)           /*!< LPM Token acknowledge enable*/
-#define USB_DRD_FS_LPMCSR_REMWAKE                       ((uint16_t)0x0008U)           /*!< bRemoteWake value received with last ACKed LPM Token */
-#define USB_DRD_FS_LPMCSR_BESL                          ((uint16_t)0x00F0U)           /*!< BESL value received with last ACKed LPM Token  */
+#define USB_LPMCSR_LMPEN_Pos           (0U)
+#define USB_LPMCSR_LMPEN_Msk           (0x1UL << USB_LPMCSR_LMPEN_Pos)  /*!< 0x00000001 */
+#define USB_LPMCSR_LMPEN               USB_LPMCSR_LMPEN_Msk             /*!< LPM support enable Mask */
+#define USB_LPMCSR_LPMACK_Pos          (1U)
+#define USB_LPMCSR_LPMACK_Msk          (0x1UL << USB_LPMCSR_LPMACK_Pos) /*!< 0x00000002 */
+#define USB_LPMCSR_LPMACK              USB_LPMCSR_LPMACK_Msk            /*!< LPM Token acknowledge enable Mask */
+#define USB_LPMCSR_REMWAKE_Pos         (3U)
+#define USB_LPMCSR_REMWAKE_Msk         (0x1UL << USB_LPMCSR_REMWAKE_Pos)/*!< 0x00000008 */
+#define USB_LPMCSR_REMWAKE             USB_LPMCSR_REMWAKE_Msk           /*!< bRemoteWake value received with last ACKed LPM Token Mask */
+#define USB_LPMCSR_BESL_Pos            (4U)
+#define USB_LPMCSR_BESL_Msk            (0xFUL << USB_LPMCSR_BESL_Pos)   /*!< 0x000000F0 */
+#define USB_LPMCSR_BESL                USB_LPMCSR_BESL_Msk              /*!< BESL value received with last ACKed LPM Token Mask */
+
+/******************  Bits definition for USB_DRD_BCDR register  *******************/
+#define USB_BCDR_BCDEN_Pos             (0U)
+#define USB_BCDR_BCDEN_Msk             (0x1UL << USB_BCDR_BCDEN_Pos)    /*!< 0x00000001 */
+#define USB_BCDR_BCDEN                 USB_BCDR_BCDEN_Msk               /*!< Battery charging detector (BCD) enable Mask */
+#define USB_BCDR_DCDEN_Pos             (1U)
+#define USB_BCDR_DCDEN_Msk             (0x1UL << USB_BCDR_DCDEN_Pos)    /*!< 0x00000002 */
+#define USB_BCDR_DCDEN                 USB_BCDR_DCDEN_Msk               /*!< Data contact detection (DCD) mode enable Mask */
+#define USB_BCDR_PDEN_Pos              (2U)
+#define USB_BCDR_PDEN_Msk              (0x1UL << USB_BCDR_PDEN_Pos)     /*!< 0x00000004 */
+#define USB_BCDR_PDEN                  USB_BCDR_PDEN_Msk                /*!< Primary detection (PD) mode enable Mask */
+#define USB_BCDR_SDEN_Pos              (3U)
+#define USB_BCDR_SDEN_Msk              (0x1UL << USB_BCDR_SDEN_Pos)     /*!< 0x00000008 */
+#define USB_BCDR_SDEN                  USB_BCDR_SDEN_Msk                /*!< Secondary detection (SD) mode enable Mask */
+#define USB_BCDR_DCDET_Pos             (4U)
+#define USB_BCDR_DCDET_Msk             (0x1UL << USB_BCDR_DCDET_Pos)    /*!< 0x00000010 */
+#define USB_BCDR_DCDET                 USB_BCDR_DCDET_Msk               /*!< Data contact detection (DCD) status Mask */
+#define USB_BCDR_PDET_Pos              (5U)
+#define USB_BCDR_PDET_Msk              (0x1UL << USB_BCDR_PDET_Pos)     /*!< 0x00000020 */
+#define USB_BCDR_PDET                  USB_BCDR_PDET_Msk                /*!< Primary detection (PD) status Mask */
+#define USB_BCDR_SDET_Pos              (6U)
+#define USB_BCDR_SDET_Msk              (0x1UL << USB_BCDR_SDET_Pos)     /*!< 0x00000040 */
+#define USB_BCDR_SDET                  USB_BCDR_SDET_Msk                /*!< Secondary detection (SD) status Mask */
+#define USB_BCDR_PS2DET_Pos            (7U)
+#define USB_BCDR_PS2DET_Msk            (0x1UL << USB_BCDR_PS2DET_Pos)   /*!< 0x00000080 */
+#define USB_BCDR_PS2DET                USB_BCDR_PS2DET_Msk              /*!< PS2 port or proprietary charger detected Mask */
+#define USB_BCDR_DPPU_Pos              (15U)
+#define USB_BCDR_DPPU_Msk              (0x1UL << USB_BCDR_DPPU_Pos)     /*!< 0x00008000 */
+#define USB_BCDR_DPPU                  USB_BCDR_DPPU_Msk                /*!< DP Pull-up Enable Mask */
+#define USB_BCDR_DPPD_Pos              (15U)
+#define USB_BCDR_DPPD_Msk              (0x1UL << USB_BCDR_DPPD_Pos)     /*!< 0x00008000 */
+#define USB_BCDR_DPPD                  USB_BCDR_DPPD_Msk                /*!< DP Pull-Down Enable Mask */
+
+/******************  Bits definition for USB_DRD_CHEP register  *******************/
+#define USB_CHEP_ERRRX_Pos             (26U)
+#define USB_CHEP_ERRRX_Msk             (0x01UL << USB_CHEP_ERRRX_Pos)   /*!< 0x04000000 */
+#define USB_CHEP_ERRRX                 USB_CHEP_ERRRX_Msk               /*!< Receive error */
+#define USB_EP_ERRRX                   USB_CHEP_ERRRX_Msk               /*!< EP Receive error */
+#define USB_CH_ERRRX                   USB_CHEP_ERRRX_Msk               /*!< CH Receive error */
+#define USB_CHEP_ERRTX_Pos             (25U)
+#define USB_CHEP_ERRTX_Msk             (0x01UL << USB_CHEP_ERRTX_Pos)   /*!< 0x02000000 */
+#define USB_CHEP_ERRTX                 USB_CHEP_ERRTX_Msk               /*!< Transmit error */
+#define USB_EP_ERRTX                   USB_CHEP_ERRTX_Msk               /*!< EP Transmit error */
+#define USB_CH_ERRTX                   USB_CHEP_ERRTX_Msk               /*!< CH Transmit error */
+#define USB_CHEP_LSEP_Pos              (24U)
+#define USB_CHEP_LSEP_Msk              (0x01UL << USB_CHEP_LSEP_Pos)    /*!< 0x01000000 */
+#define USB_CHEP_LSEP                  USB_CHEP_LSEP_Msk                /*!< Low Speed Endpoint (host with Hub Only) */
+#define USB_CHEP_NAK_Pos               (23U)
+#define USB_CHEP_NAK_Msk               (0x01UL << USB_CHEP_NAK_Pos)     /*!< 0x00800000 */
+#define USB_CHEP_NAK                   USB_CHEP_NAK_Msk                 /*!< Previous NAK detected */
+#define USB_CHEP_DEVADDR_Pos           (16U)
+#define USB_CHEP_DEVADDR_Msk           (0x7FU << USB_CHEP_DEVADDR_Pos)  /*!< 0x7F000000 */
+#define USB_CHEP_DEVADDR               USB_CHEP_DEVADDR_Msk             /* Target Endpoint address*/
+#define USB_CHEP_VTRX_Pos              (15U)
+#define USB_CHEP_VTRX_Msk              (0x1UL << USB_CHEP_VTRX_Pos)     /*!< 0x00008000 */
+#define USB_CHEP_VTRX                  USB_CHEP_VTRX_Msk                /*!< USB valid transaction received Mask */
+#define USB_EP_VTRX                    USB_CHEP_VTRX_Msk                /*!< USB Endpoint valid transaction received Mask */
+#define USB_CH_VTRX                    USB_CHEP_VTRX_Msk                /*!< USB valid Channel transaction received Mask */
+#define USB_CHEP_DTOG_RX_Pos           (14U)
+#define USB_CHEP_DTOG_RX_Msk           (0x1UL << USB_CHEP_DTOG_RX_Pos)  /*!< 0x00004000 */
+#define USB_CHEP_DTOG_RX               USB_CHEP_DTOG_RX_Msk             /*!< Data Toggle, for reception transfers Mask */
+#define USB_EP_DTOG_RX                 USB_CHEP_DTOG_RX_Msk             /*!< EP Data Toggle, for reception transfers Mask */
+#define USB_CH_DTOG_RX                 USB_CHEP_DTOG_RX_Msk             /*!< CH Data Toggle, for reception transfers Mask */
+#define USB_CHEP_RX_STRX_Pos           (12U)
+#define USB_CHEP_RX_STRX_Msk           (0x3UL << USB_CHEP_RX_STRX_Pos)  /*!< 0x00003000 */
+#define USB_CHEP_RX_STRX               USB_CHEP_RX_STRX_Msk             /*!< Status bits, for reception transfers Mask */
+#define USB_EP_RX_STRX                 USB_CHEP_RX_STRX_Msk             /*!< Status bits, for EP reception transfers Mask */
+#define USB_CH_RX_STRX                 USB_CHEP_RX_STRX_Msk             /*!< Status bits, for CH reception transfers Mask */
+#define USB_CHEP_SETUP_Pos             (11U)
+#define USB_CHEP_SETUP_Msk             (0x1UL << USB_CHEP_SETUP_Pos)    /*!< 0x00000800 */
+#define USB_CHEP_SETUP                 USB_CHEP_SETUP_Msk               /*!< Setup transaction completed Mask */
+#define USB_EP_SETUP                   USB_CHEP_SETUP_Msk               /*!< EP Setup transaction completed Mask */
+#define USB_CH_SETUP                   USB_CHEP_SETUP_Msk               /*!< CH Setup transaction completed Mask */
+#define USB_CHEP_UTYPE_Pos             (9U)
+#define USB_CHEP_UTYPE_Msk             (0x3UL << USB_CHEP_UTYPE_Pos)    /*!< 0x00000600 */
+#define USB_CHEP_UTYPE                 USB_CHEP_UTYPE_Msk               /*!< USB type of transaction Mask */
+#define USB_EP_UTYPE                   USB_CHEP_UTYPE_Msk               /*!< USB type of EP transaction Mask */
+#define USB_CH_UTYPE                   USB_CHEP_UTYPE_Msk               /*!< USB type of CH transaction Mask */
+#define USB_CHEP_KIND_Pos              (8U)
+#define USB_CHEP_KIND_Msk              (0x1UL << USB_CHEP_KIND_Pos)     /*!< 0x00000100 */
+#define USB_CHEP_KIND                  USB_CHEP_KIND_Msk                /*!< EndPoint KIND Mask */
+#define USB_EP_KIND                    USB_CHEP_KIND_Msk                /*!< EndPoint KIND Mask */
+#define USB_CH_KIND                    USB_CHEP_KIND_Msk                /*!< Channel KIND Mask */
+#define USB_CHEP_VTTX_Pos              (7U)
+#define USB_CHEP_VTTX_Msk              (0x1UL << USB_CHEP_VTTX_Pos)     /*!< 0x00000080 */
+#define USB_CHEP_VTTX                  USB_CHEP_VTTX_Msk                /*!< Valid USB transaction transmitted Mask */
+#define USB_EP_VTTX                    USB_CHEP_VTTX_Msk                /*!< USB Endpoint valid transaction transmitted Mask */
+#define USB_CH_VTTX                    USB_CHEP_VTTX_Msk                /*!< USB valid Channel transaction transmitted Mask */
+#define USB_CHEP_DTOG_TX_Pos           (6U)
+#define USB_CHEP_DTOG_TX_Msk           (0x1UL << USB_CHEP_DTOG_TX_Pos)  /*!< 0x00000040 */
+#define USB_CHEP_DTOG_TX               USB_CHEP_DTOG_TX_Msk             /*!< Data Toggle, for transmission transfers Mask */
+#define USB_EP_DTOG_TX                 USB_CHEP_DTOG_TX_Msk             /*!< EP Data Toggle, for transmission transfers Mask */
+#define USB_CH_DTOG_TX                 USB_CHEP_DTOG_TX_Msk             /*!< CH Data Toggle, for transmission transfers Mask */
+#define USB_CHEP_TX_STTX_Pos           (4U)
+#define USB_CHEP_TX_STTX_Msk           (0x3UL << USB_CHEP_TX_STTX_Pos)  /*!< 0x00000030 */
+#define USB_CHEP_TX_STTX               USB_CHEP_TX_STTX_Msk             /*!< Status bits, for transmission transfers Mask */
+#define USB_EP_TX_STTX                 USB_CHEP_TX_STTX_Msk             /*!< Status bits, for EP transmission transfers Mask */
+#define USB_CH_TX_STTX                 USB_CHEP_TX_STTX_Msk             /*!< Status bits, for CH transmission transfers Mask */
+#define USB_CHEP_ADDR_Pos              (0U)
+#define USB_CHEP_ADDR_Msk              (0xFUL << USB_CHEP_ADDR_Pos)     /*!< 0x0000000F */
+#define USB_CHEP_ADDR                  USB_CHEP_ADDR_Msk                /*!< Endpoint address Mask */
+
+
+/* EndPoint Register MASK (no toggle fields) */
+#define USB_CHEP_REG_MASK                          (USB_CHEP_ERRRX | USB_CHEP_ERRTX | USB_CHEP_LSEP | \
+                                                    USB_CHEP_DEVADDR | USB_CHEP_VTRX | USB_CHEP_SETUP | \
+                                                    USB_CHEP_UTYPE | USB_CHEP_KIND | USB_CHEP_VTTX | USB_CHEP_ADDR) /* =8f8f */
+
+#define USB_CHEP_TX_DTOGMASK                       (USB_CHEP_TX_STTX | USB_CHEP_REG_MASK)
+#define USB_CHEP_RX_DTOGMASK                       (USB_CHEP_RX_STRX | USB_CHEP_REG_MASK)
+
+#define USB_CHEP_TX_DTOG1                          (0x00000010UL)           /*!< Channel/EndPoint TX Data Toggle bit1 */
+#define USB_CHEP_TX_DTOG2                          (0x00000020UL)           /*!< Channel/EndPoint TX Data Toggle bit2 */
+#define USB_CHEP_RX_DTOG1                          (0x00001000UL)           /*!< Channel/EndPoint RX Data Toggle bit1 */
+#define USB_CHEP_RX_DTOG2                          (0x00002000UL)           /*!< Channel/EndPoint RX Data Toggle bit1 */
+
+/*!< EP_TYPE[1:0] Channel/EndPoint TYPE */
+#define USB_EP_TYPE_MASK                           (0x00000600UL)           /*!< Channel/EndPoint TYPE Mask */
+#define USB_EP_BULK                                (0x00000000UL)           /*!< Channel/EndPoint BULK */
+#define USB_EP_CONTROL                             (0x00000200UL)           /*!< Channel/EndPoint CONTROL */
+#define USB_EP_ISOCHRONOUS                         (0x00000400UL)           /*!< Channel/EndPoint ISOCHRONOUS */
+#define USB_EP_INTERRUPT                           (0x00000600UL)           /*!< Channel/EndPoint INTERRUPT */
+
+#define USB_EP_T_MASK                              ((~USB_EP_UTYPE) & USB_CHEP_REG_MASK) /* =0x898F */
+#define USB_CH_T_MASK                              ((~USB_CH_UTYPE) & USB_CHEP_REG_MASK) /* =0x898F */
+
+#define USB_EP_KIND_MASK                           ((~USB_EP_KIND) & USB_CHEP_REG_MASK) /*!< EP_KIND EndPoint KIND */
+#define USB_CH_KIND_MASK                           ((~USB_CH_KIND) & USB_CHEP_REG_MASK) /*!< EP_KIND EndPoint KIND */
+
+/*!< STAT_TX[1:0] STATus for TX transfer */
+#define USB_EP_TX_DIS                              (0x00000000UL)           /*!< EndPoint TX Disabled */
+#define USB_EP_TX_STALL                            (0x00000010UL)           /*!< EndPoint TX STALLed */
+#define USB_EP_TX_NAK                              (0x00000020UL)           /*!< EndPoint TX NAKed */
+#define USB_EP_TX_VALID                            (0x00000030UL)           /*!< EndPoint TX VALID */
+
+#define USB_CH_TX_DIS                              (0x00000000UL)           /*!< Channel TX Disabled */
+#define USB_CH_TX_STALL                            (0x00000010UL)           /*!< Channel TX STALLed */
+#define USB_CH_TX_NAK                              (0x00000020UL)           /*!< Channel TX NAKed */
+#define USB_CH_TX_VALID                            (0x00000030UL)           /*!< Channel TX VALID */
+
+#define USB_EP_TX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_EP_TX_ACK_DBUF                         (0x00000030UL)           /*!< ACK Double buffer mode */
+
+#define USB_CH_TX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_CH_TX_ACK_DBUF                         (0x00000030UL)           /*!< ACK Double buffer mode */
+
+/*!< STAT_RX[1:0] STATus for RX transfer */
+#define USB_EP_RX_DIS                              (0x00000000UL)           /*!< EndPoint RX Disabled */
+#define USB_EP_RX_STALL                            (0x00001000UL)           /*!< EndPoint RX STALLed */
+#define USB_EP_RX_NAK                              (0x00002000UL)           /*!< EndPoint RX NAKed */
+#define USB_EP_RX_VALID                            (0x00003000UL)           /*!< EndPoint RX VALID */
+
+#define USB_EP_RX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_EP_RX_ACK_DBUF                         (0x00003000UL)           /*!< ACK Double buffer mode */
+
+
+
+#define USB_CH_RX_DIS                              (0x00000000UL)           /*!< EndPoint RX Disabled */
+#define USB_CH_RX_STALL                            (0x00001000UL)           /*!< EndPoint RX STALLed */
+#define USB_CH_RX_NAK                              (0x00002000UL)           /*!< Channel RX NAKed */
+#define USB_CH_RX_VALID                            (0x00003000UL)           /*!< Channel RX VALID */
+
+#define USB_CH_RX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_CH_RX_ACK_DBUF                         (0x00003000UL)           /*!< ACK Double buffer mode */
+
+/*! <used For Double Buffer Enable Disable */
+#define USB_CHEP_DB_MSK                            (0xFFFF0F0FUL)
+
+/*Buffer Descriptor Mask*/
+#define USB_PMA_TXBD_ADDMSK                        (0xFFFF0000UL)
+#define USB_PMA_TXBD_COUNTMSK                      (0x0000FFFFUL)
+#define USB_PMA_RXBD_ADDMSK                        (0xFFFF0000UL)
+#define USB_PMA_RXBD_COUNTMSK                      (0x0000FFFFUL)
 
 
 /** @addtogroup Exported_macros
@@ -8723,13 +8834,11 @@ typedef struct
 
 /****************************** SMBUS Instances *******************************/
 #define IS_SMBUS_ALL_INSTANCE(INSTANCE)(((INSTANCE) == I2C1) || \
-                                        ((INSTANCE) == I2C2) || \
-                                        ((INSTANCE) == I2C3))
+                                        ((INSTANCE) == I2C2))
 
 /****************************** WAKEUP_FROMSTOP Instances *******************************/
 #define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)(((INSTANCE) == I2C1) || \
-                                                  ((INSTANCE) == I2C2) || \
-                                                  ((INSTANCE) == I2C3))
+                                                  ((INSTANCE) == I2C2))
 
 /******************************** SPI Instances *******************************/
 #define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
@@ -8739,8 +8848,7 @@ typedef struct
 
 /******************************** SPI Instances *******************************/
 #define IS_I2S_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
-                                       ((INSTANCE) == SPI2) || \
-                                       ((INSTANCE) == SPI3))
+                                       ((INSTANCE) == SPI2))
 
 
 /****************** TIM Instances : All supported instances *******************/
@@ -8846,13 +8954,13 @@ typedef struct
       ((CHANNEL) == TIM_CHANNEL_5) ||          \
       ((CHANNEL) == TIM_CHANNEL_6)))           \
      ||                                        \
-     (((INSTANCE) == TIM2) &&                  \
+     (((INSTANCE) == TIM3) &&                  \
      (((CHANNEL) == TIM_CHANNEL_1) ||          \
       ((CHANNEL) == TIM_CHANNEL_2) ||          \
       ((CHANNEL) == TIM_CHANNEL_3) ||          \
       ((CHANNEL) == TIM_CHANNEL_4)))           \
      ||                                        \
-     (((INSTANCE) == TIM3) &&                  \
+     (((INSTANCE) == TIM4) &&                  \
      (((CHANNEL) == TIM_CHANNEL_1) ||          \
       ((CHANNEL) == TIM_CHANNEL_2) ||          \
       ((CHANNEL) == TIM_CHANNEL_3) ||          \
@@ -8971,6 +9079,10 @@ typedef struct
                                                        ((INSTANCE) == TIM3) || \
                                                        ((INSTANCE) == TIM4))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM3)  || \
@@ -8981,9 +9093,6 @@ typedef struct
                                                        ((INSTANCE) == TIM15) || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
@@ -9093,15 +9202,13 @@ typedef struct
 
 
 /****************************** USB Instances ********************************/
-#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB)
+#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB_DRD_FS)
 
 /*********************** USB OTG PCD Instances ********************************/
-#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
-                                       ((INSTANCE) == USB_OTG_HS))
+#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS))
 
 /*********************** USB OTG HCD Instances ********************************/
-#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
-                                       ((INSTANCE) == USB_OTG_HS))
+#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS))
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/soc/stm32g0b1xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g0b1xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -77,7 +77,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
 /******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
-  PVD_VDDIO2_IRQn             = 1,      /*!< PVD through EXTI Line detection Interrupt(EXTI line 16), VDDIO2   */
+  PVD_VDDIO2_IRQn             = 1,      /*!< PVD through EXTI line 16, PVM (monit. VDDIO2) through EXTI line 34*/
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
   RCC_CRS_IRQn                = 4,      /*!< RCC and CRS global Interrupt                                      */
@@ -97,15 +97,15 @@ typedef enum
   TIM7_LPTIM2_IRQn            = 18,     /*!< TIM7 and LPTIM2 global Interrupt                                  */
   TIM14_IRQn                  = 19,     /*!< TIM14 global Interrupt                                            */
   TIM15_IRQn                  = 20,     /*!< TIM15 global Interrupt                                            */
-  TIM16_FDCAN1_IRQn           = 21,     /*!< TIM16, FDCAN1 global Interrupt                                    */
-  TIM17_FDCAN2_IRQn           = 22,     /*!< TIM17, FDCAN2 global Interrupt                                    */
+  TIM16_FDCAN_IT0_IRQn        = 21,     /*!< TIM16, FDCAN1_IT0 and FDCAN2_IT0 Interrupt                        */
+  TIM17_FDCAN_IT1_IRQn        = 22,     /*!< TIM17, FDCAN1_IT1 and FDCAN2_IT1 Interrupt                        */
   I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt  (combined with EXTI 23)                           */
   I2C2_3_IRQn                 = 24,     /*!< I2C2, I2C3 Interrupt (combined with EXTI 24 and EXTI 22)          */
   SPI1_IRQn                   = 25,     /*!< SPI1/I2S1 Interrupt                                               */
-  SPI2_3_IRQn                 = 26,     /*!< SPI2/I2S2, SPI3/I2S3 Interrupt                                         */
+  SPI2_3_IRQn                 = 26,     /*!< SPI2/I2S2, SPI3/I2S3 Interrupt                                    */
   USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
-  USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                                  */
-  USART3_4_5_6_LPUART1_2_IRQn = 29,     /*!< USART3, USART4, USART5, USART6, LPUART1 and LPUART2 globlal Interrupts (combined with EXTI 28) */
+  USART2_LPUART2_IRQn         = 28,     /*!< USART2 + LPUART2 Interrupt                                        */
+  USART3_4_5_6_LPUART1_IRQn   = 29,     /*!< USART3, USART4, USART5, USART6, LPUART1 globlal Interrupts (combined with EXTI 28) */
   CEC_IRQn                    = 30,     /*!< CEC Interrupt(combined with EXTI 27)                               */
 } IRQn_Type;
 
@@ -234,8 +234,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CSR_ODD;    /*!< COMP control and status register located in register of comparator instance odd, used for bits common to several COMP instances, Address offset: 0x00 */
-  __IO uint32_t CSR_EVEN;   /*!< COMP control and status register located in register of comparator instance even, used for bits common to several COMP instances, Address offset: 0x04 */
+  __IO uint32_t CSR_ODD;    /*!< COMP control and status register located in register of comparator instance odd (exception for STM32G0 devices featuring ADC3 instance: in common group of COMP2 and COMP3, instances odd and even are inverted), used for bits common to several COMP instances, Address offset: 0x00 */
+  __IO uint32_t CSR_EVEN;   /*!< COMP control and status register located in register of comparator instance even (exception for STM32G0 devices featuring ADC3 instance: in common group of COMP2 and COMP3, instances odd and even are inverted), used for bits common to several COMP instances, Address offset: 0x04 */
 } COMP_Common_TypeDef;
 
 /**
@@ -352,7 +352,11 @@ typedef struct
   __IO uint32_t RPR1;           /*!< EXTI Rising Pending Register 1,                  Address offset:   0x0C */
   __IO uint32_t FPR1;           /*!< EXTI Falling Pending Register 1,                 Address offset:   0x10 */
        uint32_t RESERVED1[3];   /*!< Reserved 1,                                                0x14 -- 0x1C */
-       uint32_t RESERVED2[5];   /*!< Reserved 2,                                                0x20 -- 0x30 */
+  __IO uint32_t RTSR2;          /*!< EXTI Rising Trigger Selection Register 2,        Address offset:   0x20 */
+  __IO uint32_t FTSR2;          /*!< EXTI Falling Trigger Selection Register 2,       Address offset:   0x24 */
+  __IO uint32_t SWIER2;         /*!< EXTI Software Interrupt event Register 2,        Address offset:   0x28 */
+  __IO uint32_t RPR2;           /*!< EXTI Rising Pending Register 2,                  Address offset:   0x2C */
+  __IO uint32_t FPR2;           /*!< EXTI Falling Pending Register 2,                 Address offset:   0x30 */
        uint32_t RESERVED3[11];  /*!< Reserved 3,                                                0x34 -- 0x5C */
   __IO uint32_t EXTICR[4];      /*!< EXTI External Interrupt Configuration Register,            0x60 -- 0x6C */
        uint32_t RESERVED4[4];   /*!< Reserved 4,                                                0x70 -- 0x7C */
@@ -374,7 +378,7 @@ typedef struct
   __IO uint32_t OPTKEYR;      /*!< FLASH Option Key register,                         Address offset: 0x0C */
   __IO uint32_t SR;           /*!< FLASH Status register,                             Address offset: 0x10 */
   __IO uint32_t CR;           /*!< FLASH Control register,                            Address offset: 0x14 */
-  __IO uint32_t ECC1R;         /*!< FLASH ECC bank 1 register,                        Address offset: 0x18 */
+  __IO uint32_t ECCR;          /*!< FLASH ECC bank 1 register,                        Address offset: 0x18 */
   __IO uint32_t ECC2R;         /*!< FLASH ECC bank 2 register,                        Address offset: 0x1C */
   __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
   __IO uint32_t PCROP1ASR;    /*!< FLASH Bank PCROP area A Start address register,    Address offset: 0x24 */
@@ -383,14 +387,14 @@ typedef struct
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
   __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
   __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
-       uint32_t RESERVED6[1]; /*!< Reserved6,                                         Address offset: 0x40 */
+       uint32_t RESERVED5[2]; /*!< Reserved5,                                         Address offset: 0x3C--0x40 */
   __IO uint32_t PCROP2ASR;    /*!< FLASH Bank2 PCROP area A Start address register,   Address offset: 0x44 */
   __IO uint32_t PCROP2AER;    /*!< FLASH Bank2 PCROP area A End address register,     Address offset: 0x48 */
   __IO uint32_t WRP2AR;       /*!< FLASH Bank2 WRP area A address register,           Address offset: 0x4C */
   __IO uint32_t WRP2BR;       /*!< FLASH Bank2 WRP area B address register,           Address offset: 0x50 */
   __IO uint32_t PCROP2BSR;    /*!< FLASH Bank2 PCROP area B Start address register,   Address offset: 0x54 */
   __IO uint32_t PCROP2BER;    /*!< FLASH Bank2 PCROP area B End address register,     Address offset: 0x58 */
-       uint32_t RESERVED3[10];/*!< Reserved3,                                         Address offset: 0x5C */
+       uint32_t RESERVED7[9]; /*!< Reserved7,                                         Address offset: 0x5C--0x7C */
   __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
 } FLASH_TypeDef;
 
@@ -656,41 +660,37 @@ typedef struct
 } USART_TypeDef;
 
 /**
-  * @brief Universal Serial Bus Full Speed Device
+  * @brief Universal Serial Bus Full Speed Dual Role Device
   */
 
 typedef struct
 {
-  __IO uint16_t CHEP0R;          /*!< USB Endpoint 0 register,                Address offset: 0x00 */
-  __IO uint16_t RESERVED0;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP1R;          /*!< USB Endpoint 1 register,                Address offset: 0x04 */
-  __IO uint16_t RESERVED1;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP2R;          /*!< USB Endpoint 2 register,                Address offset: 0x08 */
-  __IO uint16_t RESERVED2;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP3R;          /*!< USB Endpoint 3 register,                Address offset: 0x0C */
-  __IO uint16_t RESERVED3;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP4R;          /*!< USB Endpoint 4 register,                Address offset: 0x10 */
-  __IO uint16_t RESERVED4;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP5R;          /*!< USB Endpoint 5 register,                Address offset: 0x14 */
-  __IO uint16_t RESERVED5;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP6R;          /*!< USB Endpoint 6 register,                Address offset: 0x18 */
-  __IO uint16_t RESERVED6;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP7R;          /*!< USB Endpoint 7 register,                Address offset: 0x1C */
-  __IO uint16_t RESERVED7[17];   /*!< Reserved,                                                    */
-  __IO uint32_t CNTR;            /*!< Control register,                       Address offset: 0x40 */
-  __IO uint16_t ISTR;            /*!< Interrupt status register,              Address offset: 0x44 */
-  __IO uint16_t RESERVED9;       /*!< Reserved,                                                    */
-  __IO uint16_t FNR;             /*!< Frame number register,                  Address offset: 0x48 */
-  __IO uint16_t RESERVEDA;       /*!< Reserved,                                                    */
-  __IO uint16_t DADDR;           /*!< Device address register,                Address offset: 0x4C */
-  __IO uint16_t RESERVEDB;       /*!< Reserved,                                                    */
-  __IO uint16_t BTABLE;          /*!< Buffer Table address register,          Address offset: 0x50 */
-  __IO uint16_t RESERVEDC;       /*!< Reserved,                                                    */
-  __IO uint16_t LPMCSR;          /*!< LPM Control and Status register,        Address offset: 0x54 */
-  __IO uint16_t RESERVEDD;       /*!< Reserved,                                                    */
-  __IO uint16_t BCDR;            /*!< Battery Charging detector register,     Address offset: 0x58 */
-  __IO uint16_t RESERVEDE;       /*!< Reserved,                                                    */
-} USB_DRD_FS_TypeDef;
+  __IO uint32_t CHEP0R;          /*!< USB Channel/Endpoint 0 register,      Address offset: 0x00 */
+  __IO uint32_t CHEP1R;          /*!< USB Channel/Endpoint 1 register,      Address offset: 0x04 */
+  __IO uint32_t CHEP2R;          /*!< USB Channel/Endpoint 2 register,      Address offset: 0x08 */
+  __IO uint32_t CHEP3R;          /*!< USB Channel/Endpoint 3 register,      Address offset: 0x0C */
+  __IO uint32_t CHEP4R;          /*!< USB Channel/Endpoint 4 register,      Address offset: 0x10 */
+  __IO uint32_t CHEP5R;          /*!< USB Channel/Endpoint 5 register,      Address offset: 0x14 */
+  __IO uint32_t CHEP6R;          /*!< USB Channel/Endpoint 6 register,      Address offset: 0x18 */
+  __IO uint32_t CHEP7R;          /*!< USB Channel/Endpoint 7 register,      Address offset: 0x1C */
+  __IO uint32_t RESERVED0[8];    /*!< Reserved,                                                  */
+  __IO uint32_t CNTR;            /*!< Control register,                     Address offset: 0x40 */
+  __IO uint32_t ISTR;            /*!< Interrupt status register,            Address offset: 0x44 */
+  __IO uint32_t FNR;             /*!< Frame number register,                Address offset: 0x48 */
+  __IO uint32_t DADDR;           /*!< Device address register,              Address offset: 0x4C */
+  __IO uint32_t RESERVED1;       /*!< Reserved */
+  __IO uint32_t LPMCSR;          /*!< LPM Control and Status register,      Address offset: 0x54 */
+  __IO uint32_t BCDR;            /*!< Battery Charging detector register,   Address offset: 0x58 */
+} USB_DRD_TypeDef;
+
+/**
+  * @brief Universal Serial Bus PacketMemoryArea Buffer Descriptor Table
+  */
+typedef struct
+{
+  __IO uint32_t TXBD;             /*!<Transmission buffer address*/
+  __IO uint32_t RXBD;             /*!<Reception buffer address */
+} USB_DRD_PMABuffDescTypeDef;
 
 /**
   * @}
@@ -749,7 +749,12 @@ typedef struct
 #define SRAM_BASE             (0x20000000UL)  /*!< SRAM base address */
 #define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
+/*!< USB PMA SIZE */
+#define USB_DRD_PMA_SIZE              2048U   /*!< USB PMA Size 2Kbyte */
+
 #define SRAM_SIZE_MAX         (0x00020000UL)  /*!< maximum SRAM size (up to 128 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x03FFU)) << 10U)
 
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
@@ -788,8 +793,8 @@ typedef struct
 #define LPUART2_BASE          (APBPERIPH_BASE + 0x00008400UL)
 #define I2C3_BASE             (APBPERIPH_BASE + 0x00008800UL)
 #define LPTIM2_BASE           (APBPERIPH_BASE + 0x00009400UL)
-#define USB_DRD_FS_BASE     (APBPERIPH_BASE + 0x00009800UL) /*!< USB_DRD_FS_IP Peripheral Registers base address */
-#define USB_DRD_FS_PMAADDR  (APBPERIPH_BASE + 0x00009C00UL) /*!< USB_DRD_FS_IP Packet Memory Area base address */
+#define USB_DRD_BASE          (APBPERIPH_BASE + 0x00005C00UL) /*!< USB_DRD_IP Peripheral Registers base address */
+#define USB_DRD_PMAADDR       (APBPERIPH_BASE + 0x00009800UL) /*!< USB_DRD_IP Packet Memory Area base address */
 #define UCPD1_BASE            (APBPERIPH_BASE + 0x0000A000UL)
 #define UCPD2_BASE            (APBPERIPH_BASE + 0x0000A400UL)
 #define TAMP_BASE             (APBPERIPH_BASE + 0x0000B000UL)
@@ -814,7 +819,7 @@ typedef struct
 
 /*!< AHB peripherals */
 #define DMA1_BASE             (AHBPERIPH_BASE)
-#define DMA2_BASE             (AHBPERIPH_BASE)+ 0x00000400UL
+#define DMA2_BASE             (AHBPERIPH_BASE + 0x00000400UL)
 #define DMAMUX1_BASE          (AHBPERIPH_BASE + 0x00000800UL)
 #define RCC_BASE              (AHBPERIPH_BASE + 0x00001000UL)
 #define EXTI_BASE             (AHBPERIPH_BASE + 0x00001800UL)
@@ -842,6 +847,11 @@ typedef struct
 #define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
 #define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
 #define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+#define DMAMUX1_Channel7_BASE    (DMAMUX1_BASE + 0x0000001CUL)
+#define DMAMUX1_Channel8_BASE    (DMAMUX1_BASE + 0x00000020UL)
+#define DMAMUX1_Channel9_BASE    (DMAMUX1_BASE + 0x00000024UL)
+#define DMAMUX1_Channel10_BASE   (DMAMUX1_BASE + 0x00000028UL)
+#define DMAMUX1_Channel11_BASE   (DMAMUX1_BASE + 0x0000002CUL)
 
 #define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
 #define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
@@ -892,7 +902,8 @@ typedef struct
 #define I2C1                ((I2C_TypeDef *) I2C1_BASE)
 #define I2C2                ((I2C_TypeDef *) I2C2_BASE)
 #define I2C3                ((I2C_TypeDef *) I2C3_BASE)
-#define USB_DRD_FS          ((USB_DRD_FS_TypeDef *) USB_DRD_FS_BASE)
+#define USB_DRD_FS          ((USB_DRD_TypeDef *) USB_DRD_BASE)
+#define USB_DRD_PMA_BUFF    ((USB_DRD_PMABuffDescTypeDef*) USB_DRD_PMAADDR)
 #define FDCAN1              ((FDCAN_GlobalTypeDef *) FDCAN1_BASE)
 #define FDCAN_CONFIG        ((FDCAN_Config_TypeDef *) FDCAN_CONFIG_BASE)
 #define FDCAN2              ((FDCAN_GlobalTypeDef *) FDCAN2_BASE)
@@ -912,6 +923,7 @@ typedef struct
 #define COMP2               ((COMP_TypeDef *) COMP2_BASE)
 #define COMP12_COMMON       ((COMP_Common_TypeDef *) COMP1_BASE)
 #define COMP3               ((COMP_TypeDef *) COMP3_BASE)
+#define COMP23_COMMON       ((COMP_Common_TypeDef *) COMP2_BASE)
 #define TIM1                ((TIM_TypeDef *) TIM1_BASE)
 #define SPI1                ((SPI_TypeDef *) SPI1_BASE)
 #define USART1              ((USART_TypeDef *) USART1_BASE)
@@ -956,6 +968,11 @@ typedef struct
 #define DMAMUX1_Channel4       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
 #define DMAMUX1_Channel5       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
 #define DMAMUX1_Channel6       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+#define DMAMUX1_Channel7       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel7_BASE)
+#define DMAMUX1_Channel8       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel8_BASE)
+#define DMAMUX1_Channel9       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel9_BASE)
+#define DMAMUX1_Channel10      ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel10_BASE)
+#define DMAMUX1_Channel11      ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel11_BASE)
 
 #define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
 #define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
@@ -1098,7 +1115,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -2362,7 +2379,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x7FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000007F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2372,6 +2389,11 @@ typedef struct
 #define DMAMUX_CxCR_DMAREQ_ID_5                (0x20UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
 #define DMAMUX_CxCR_DMAREQ_ID_6                (0x40UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000040 */
 #define DMAMUX_CxCR_DMAREQ_ID_7                (0x80UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000080 */
+#define DMAMUX_CxCR_DMAREQ_ID_8                (0x100UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000100 */
+#define DMAMUX_CxCR_DMAREQ_ID_9                (0x200UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000200 */
+#define DMAMUX_CxCR_DMAREQ_ID_10               (0x400UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000400 */
+#define DMAMUX_CxCR_DMAREQ_ID_11               (0x800UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000800 */
+#define DMAMUX_CxCR_DMAREQ_ID_12               (0x1000UL << DMAMUX_CxCR_DMAREQ_ID_Pos)/*!< 0x00001000 */
 #define DMAMUX_CxCR_SOIE_Pos                   (8U)
 #define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos)  /*!< 0x00000100 */
 #define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk             /*!< Synchro overrun interrupt enable     */
@@ -2425,6 +2447,21 @@ typedef struct
 #define DMAMUX_CSR_SOF6_Pos                    (6U)
 #define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
 #define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+#define DMAMUX_CSR_SOF7_Pos                    (7U)
+#define DMAMUX_CSR_SOF7_Msk                    (0x1UL << DMAMUX_CSR_SOF7_Pos)  /*!< 0x00000080 */
+#define DMAMUX_CSR_SOF7                        DMAMUX_CSR_SOF7_Msk             /*!< Synchronization Overrun Flag 7       */
+#define DMAMUX_CSR_SOF8_Pos                    (8U)
+#define DMAMUX_CSR_SOF8_Msk                    (0x1UL << DMAMUX_CSR_SOF8_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CSR_SOF8                        DMAMUX_CSR_SOF8_Msk             /*!< Synchronization Overrun Flag 8       */
+#define DMAMUX_CSR_SOF9_Pos                    (9U)
+#define DMAMUX_CSR_SOF9_Msk                    (0x1UL << DMAMUX_CSR_SOF9_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CSR_SOF9                        DMAMUX_CSR_SOF9_Msk             /*!< Synchronization Overrun Flag 9       */
+#define DMAMUX_CSR_SOF10_Pos                   (10U)
+#define DMAMUX_CSR_SOF10_Msk                   (0x1UL << DMAMUX_CSR_SOF10_Pos)  /*!< 0x00000400 */
+#define DMAMUX_CSR_SOF10                       DMAMUX_CSR_SOF10_Msk             /*!< Synchronization Overrun Flag 10      */
+#define DMAMUX_CSR_SOF11_Pos                   (11U)
+#define DMAMUX_CSR_SOF11_Msk                   (0x1UL << DMAMUX_CSR_SOF11_Pos)  /*!< 0x00000800 */
+#define DMAMUX_CSR_SOF11                       DMAMUX_CSR_SOF11_Msk             /*!< Synchronization Overrun Flag 11      */
 
 /********************  Bits definition for DMAMUX_CFR register  **************/
 #define DMAMUX_CFR_CSOF0_Pos                   (0U)
@@ -2448,6 +2485,21 @@ typedef struct
 #define DMAMUX_CFR_CSOF6_Pos                   (6U)
 #define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos)  /*!< 0x00000040 */
 #define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk             /*!< Clear Overrun Flag 6                 */
+#define DMAMUX_CFR_CSOF7_Pos                   (7U)
+#define DMAMUX_CFR_CSOF7_Msk                   (0x1UL << DMAMUX_CFR_CSOF7_Pos)  /*!< 0x00000080 */
+#define DMAMUX_CFR_CSOF7                       DMAMUX_CFR_CSOF7_Msk             /*!< Clear Overrun Flag 7                 */
+#define DMAMUX_CFR_CSOF8_Pos                   (8U)
+#define DMAMUX_CFR_CSOF8_Msk                   (0x1UL << DMAMUX_CFR_CSOF8_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CFR_CSOF8                       DMAMUX_CFR_CSOF8_Msk             /*!< Clear Overrun Flag 8                 */
+#define DMAMUX_CFR_CSOF9_Pos                   (9U)
+#define DMAMUX_CFR_CSOF9_Msk                   (0x1UL << DMAMUX_CFR_CSOF9_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CFR_CSOF9                       DMAMUX_CFR_CSOF9_Msk             /*!< Clear Overrun Flag 9                 */
+#define DMAMUX_CFR_CSOF10_Pos                  (10U)
+#define DMAMUX_CFR_CSOF10_Msk                  (0x1UL << DMAMUX_CFR_CSOF10_Pos)  /*!< 0x00000400 */
+#define DMAMUX_CFR_CSOF10                      DMAMUX_CFR_CSOF10_Msk             /*!< Clear Overrun Flag 10               */
+#define DMAMUX_CFR_CSOF11_Pos                  (11U)
+#define DMAMUX_CFR_CSOF11_Msk                  (0x1UL << DMAMUX_CFR_CSOF11_Pos)  /*!< 0x00000800 */
+#define DMAMUX_CFR_CSOF11                      DMAMUX_CFR_CSOF11_Msk             /*!< Clear Overrun Flag 11               */
 
 /********************  Bits definition for DMAMUX_RGxCR register  ************/
 #define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
@@ -2569,6 +2621,9 @@ typedef struct
 #define EXTI_RTSR1_RT18_Pos          (18U)
 #define EXTI_RTSR1_RT18_Msk          (0x1UL << EXTI_RTSR1_RT18_Pos)            /*!< 0x00040000 */
 #define EXTI_RTSR1_RT18              EXTI_RTSR1_RT18_Msk                       /*!< Rising trigger configuration for input line 18 */
+#define EXTI_RTSR1_RT20_Pos          (20U)
+#define EXTI_RTSR1_RT20_Msk          (0x1UL << EXTI_RTSR1_RT20_Pos)            /*!< 0x00100000 */
+#define EXTI_RTSR1_RT20              EXTI_RTSR1_RT20_Msk                       /*!< Rising trigger configuration for input line 20 */
 
 /******************  Bit definition for EXTI_FTSR1 register  ******************/
 #define EXTI_FTSR1_FT0_Pos           (0U)
@@ -2628,6 +2683,9 @@ typedef struct
 #define EXTI_FTSR1_FT18_Pos          (18U)
 #define EXTI_FTSR1_FT18_Msk          (0x1UL << EXTI_FTSR1_FT18_Pos)            /*!< 0x00040000 */
 #define EXTI_FTSR1_FT18              EXTI_FTSR1_FT18_Msk                       /*!< Falling trigger configuration for input line 18 */
+#define EXTI_FTSR1_FT20_Pos          (20U)
+#define EXTI_FTSR1_FT20_Msk          (0x1UL << EXTI_FTSR1_FT20_Pos)            /*!< 0x00100000 */
+#define EXTI_FTSR1_FT20              EXTI_FTSR1_FT20_Msk                       /*!< Falling trigger configuration for input line 20 */
 
 /******************  Bit definition for EXTI_SWIER1 register  *****************/
 #define EXTI_SWIER1_SWI0_Pos         (0U)
@@ -2687,6 +2745,9 @@ typedef struct
 #define EXTI_SWIER1_SWI18_Pos        (18U)
 #define EXTI_SWIER1_SWI18_Msk        (0x1UL << EXTI_SWIER1_SWI18_Pos)          /*!< 0x00040000 */
 #define EXTI_SWIER1_SWI18            EXTI_SWIER1_SWI18_Msk                     /*!< Software Interrupt on line 18 */
+#define EXTI_SWIER1_SWI20_Pos        (20U)
+#define EXTI_SWIER1_SWI20_Msk        (0x1UL << EXTI_SWIER1_SWI20_Pos)          /*!< 0x00100000 */
+#define EXTI_SWIER1_SWI20            EXTI_SWIER1_SWI20_Msk                     /*!< Software Interrupt on line 20 */
 
 /*******************  Bit definition for EXTI_RPR1 register  ******************/
 #define EXTI_RPR1_RPIF0_Pos          (0U)
@@ -2746,6 +2807,9 @@ typedef struct
 #define EXTI_RPR1_RPIF18_Pos         (18U)
 #define EXTI_RPR1_RPIF18_Msk         (0x1UL << EXTI_RPR1_RPIF18_Pos)           /*!< 0x00040000 */
 #define EXTI_RPR1_RPIF18             EXTI_RPR1_RPIF18_Msk                      /*!< Rising Pending Interrupt Flag on line 18 */
+#define EXTI_RPR1_RPIF20_Pos         (20U)
+#define EXTI_RPR1_RPIF20_Msk         (0x1UL << EXTI_RPR1_RPIF20_Pos)           /*!< 0x00100000 */
+#define EXTI_RPR1_RPIF20             EXTI_RPR1_RPIF20_Msk                      /*!< Rising Pending Interrupt Flag on line 20 */
 
 /*******************  Bit definition for EXTI_FPR1 register  ******************/
 #define EXTI_FPR1_FPIF0_Pos          (0U)
@@ -2805,6 +2869,34 @@ typedef struct
 #define EXTI_FPR1_FPIF18_Pos         (18U)
 #define EXTI_FPR1_FPIF18_Msk         (0x1UL << EXTI_FPR1_FPIF18_Pos)           /*!< 0x00040000 */
 #define EXTI_FPR1_FPIF18             EXTI_FPR1_FPIF18_Msk                      /*!< Falling Pending Interrupt Flag on line 18 */
+#define EXTI_FPR1_FPIF20_Pos         (20U)
+#define EXTI_FPR1_FPIF20_Msk         (0x1UL << EXTI_FPR1_FPIF20_Pos)           /*!< 0x00100000 */
+#define EXTI_FPR1_FPIF20             EXTI_FPR1_FPIF20_Msk                      /*!< Falling Pending Interrupt Flag on line 20 */
+
+/******************  Bit definition for EXTI_RTSR2 register  ******************/
+#define EXTI_RTSR2_RT34_Pos           (2U)
+#define EXTI_RTSR2_RT34_Msk           (0x1UL << EXTI_RTSR2_RT34_Pos)             /*!< 0x00000004 */
+#define EXTI_RTSR2_RT34               EXTI_RTSR2_RT34_Msk                        /*!< Rising trigger configuration for input line 34 */
+
+/******************  Bit definition for EXTI_FTSR2 register  ******************/
+#define EXTI_FTSR2_FT34_Pos           (2U)
+#define EXTI_FTSR2_FT34_Msk           (0x1UL << EXTI_FTSR2_FT34_Pos)             /*!< 0x00000004 */
+#define EXTI_FTSR2_FT34               EXTI_FTSR2_FT34_Msk                        /*!< Falling trigger configuration for input line 34 */
+
+/******************  Bit definition for EXTI_SWIER2 register  *****************/
+#define EXTI_SWIER2_SWI34_Pos         (2U)
+#define EXTI_SWIER2_SWI34_Msk         (0x1UL << EXTI_SWIER2_SWI34_Pos)           /*!< 0x00000004 */
+#define EXTI_SWIER2_SWI34             EXTI_SWIER2_SWI34_Msk                      /*!< Software Interrupt on line 34 */
+
+/*******************  Bit definition for EXTI_RPR2 register  ******************/
+#define EXTI_RPR2_RPIF34_Pos         (2U)
+#define EXTI_RPR2_RPIF34_Msk         (0x1UL << EXTI_RPR2_RPIF34_Pos)            /*!< 0x00000004 */
+#define EXTI_RPR2_RPIF34             EXTI_RPR2_RPIF34_Msk                       /*!< Rising Pending Interrupt Flag on line 34 */
+
+/*******************  Bit definition for EXTI_FPR2 register  ******************/
+#define EXTI_FPR2_RPIF34_Pos         (2U)
+#define EXTI_FPR2_RPIF34_Msk         (0x1UL << EXTI_FPR2_RPIF34_Pos)            /*!< 0x00000004 */
+#define EXTI_FPR2_RPIF34             EXTI_FPR2_RPIF34_Msk                       /*!< Rising Pending Interrupt Flag on line 34 */
 
 /*****************  Bit definition for EXTI_EXTICR1 register  **************/
 #define EXTI_EXTICR1_EXTI0_Pos       (0U)
@@ -3008,7 +3100,7 @@ typedef struct
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0xFEAFFFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xFEAFFFFF */
+#define EXTI_IMR1_IM_Msk             (0xFFFFFFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xFFFFFFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
 /*******************  Bit definition for EXTI_IMR2 register  ******************/
@@ -3021,8 +3113,14 @@ typedef struct
 #define EXTI_IMR2_IM34_Pos           (2U)
 #define EXTI_IMR2_IM34_Msk           (0x1UL << EXTI_IMR2_IM34_Pos)             /*!< 0x00000004 */
 #define EXTI_IMR2_IM34               EXTI_IMR2_IM34_Msk                        /*!< Interrupt Mask on line 34 */
+#define EXTI_IMR2_IM35_Pos           (3U)
+#define EXTI_IMR2_IM35_Msk           (0x1UL << EXTI_IMR2_IM35_Pos)             /*!< 0x00000008 */
+#define EXTI_IMR2_IM35               EXTI_IMR2_IM35_Msk                        /*!< Interrupt Mask on line 35 */
+#define EXTI_IMR2_IM36_Pos           (4U)
+#define EXTI_IMR2_IM36_Msk           (0x1UL << EXTI_IMR2_IM36_Pos)             /*!< 0x00000010 */
+#define EXTI_IMR2_IM36               EXTI_IMR2_IM36_Msk                        /*!< Interrupt Mask on line 36 */
 #define EXTI_IMR2_IM_Pos             (0U)
-#define EXTI_IMR2_IM_Msk             (0x3UL << EXTI_IMR2_IM_Pos)               /*!< 0x00000007 */
+#define EXTI_IMR2_IM_Msk             (0x1FUL << EXTI_IMR2_IM_Pos)               /*!< 0x0000001F */
 #define EXTI_IMR2_IM                 EXTI_IMR2_IM_Msk                          /*!< Interrupt Mask All */
 
 /*******************  Bit definition for EXTI_EMR1 register  ******************/
@@ -3133,6 +3231,12 @@ typedef struct
 #define EXTI_EMR2_EM34_Pos           (2U)
 #define EXTI_EMR2_EM34_Msk           (0x1UL << EXTI_EMR2_EM34_Pos)             /*!< 0x00000004 */
 #define EXTI_EMR2_EM34               EXTI_EMR2_EM34_Msk                        /*!< Event Mask on line 34 */
+#define EXTI_EMR2_EM35_Pos           (3U)
+#define EXTI_EMR2_EM35_Msk           (0x1UL << EXTI_EMR2_EM35_Pos)             /*!< 0x00000008 */
+#define EXTI_EMR2_EM35               EXTI_EMR2_EM35_Msk                        /*!< Event Mask on line 35 */
+#define EXTI_EMR2_EM36_Pos           (4U)
+#define EXTI_EMR2_EM36_Msk           (0x1UL << EXTI_EMR2_EM36_Pos)             /*!< 0x00000010 */
+#define EXTI_EMR2_EM36               EXTI_EMR2_EM36_Msk                        /*!< Event Mask on line 36 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -3163,7 +3267,7 @@ typedef struct
 /*****************  Bit definition for FDCAN_ENDN register  *******************/
 #define FDCAN_ENDN_ETV_Pos        (0U)
 #define FDCAN_ENDN_ETV_Msk        (0xFFFFFFFFUL << FDCAN_ENDN_ETV_Pos)         /*!< 0xFFFFFFFF */
-#define FDCAN_ENDN_ETV            FDCAN_ENDN_ETV_Msk                           /*!<Endiannes Test Value                    */
+#define FDCAN_ENDN_ETV            FDCAN_ENDN_ETV_Msk                           /*!<Endianness Test Value                    */
 
 /*****************  Bit definition for FDCAN_DBTP register  *******************/
 #define FDCAN_DBTP_DSJW_Pos       (0U)
@@ -3795,234 +3899,242 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x7FUL << FLASH_CR_PNB_Pos)       /*!< 0x000003F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_BKER_Pos                      (13U)
-#define FLASH_CR_BKER_Msk                      (0x1UL << FLASH_CR_BKER_Pos)     /*!< 0x00002000 */
+#define FLASH_CR_BKER_Msk                      (0x1UL << FLASH_CR_BKER_Pos)       /*!< 0x00002000 */
 #define FLASH_CR_BKER                          FLASH_CR_BKER_Msk
-#define FLASH_CR_BIFER_Pos                     (14U)
-#define FLASH_CR_BIFER_Msk                     (0x1UL << FLASH_CR_BIFER_Pos)    /*!< 0x00004000 */
-#define FLASH_CR_BIFER                         FLASH_CR_BIFER_Msk
 #define FLASH_CR_MER2_Pos                      (15U)
-#define FLASH_CR_MER2_Msk                      (0x1UL << FLASH_CR_MER2_Pos)     /*!< 0x00008000 */
+#define FLASH_CR_MER2_Msk                      (0x1UL << FLASH_CR_MER2_Pos)       /*!< 0x00008000 */
 #define FLASH_CR_MER2                          FLASH_CR_MER2_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_RDERRIE_Pos                   (26U)
-#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)  /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
 #define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_SEC_PROT_Pos                  (28U)
-#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos) /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
 #define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
+#define FLASH_CR_SEC_PROT2_Pos                 (29U)
+#define FLASH_CR_SEC_PROT2_Msk                 (0x1UL << FLASH_CR_SEC_PROT2_Pos)  /*!< 0x20000000 */
+#define FLASH_CR_SEC_PROT2                     FLASH_CR_SEC_PROT2_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
-/*******************  Bits definition for FLASH_ECC1R register  ****************/
-#define FLASH_ECC1R_ADDR_ECC_Pos                (0U)
-#define FLASH_ECC1R_ADDR_ECC_Msk                (0xFFFFUL << FLASH_ECC1R_ADDR_ECC_Pos) /*!< 0x0000FFFF */
-#define FLASH_ECC1R_ADDR_ECC                    FLASH_ECC1R_ADDR_ECC_Msk
-#define FLASH_ECC1R_SYSF_ECC_Pos                (20U)
-#define FLASH_ECC1R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC1R_SYSF_ECC_Pos) /*!< 0x00100000 */
-#define FLASH_ECC1R_SYSF_ECC                    FLASH_ECC1R_SYSF_ECC_Msk
-#define FLASH_ECC1R_ECCCIE_Pos                  (24U)
-#define FLASH_ECC1R_ECCCIE_Msk                  (0x1UL << FLASH_ECC1R_ECCCIE_Pos) /*!< 0x01000000 */
-#define FLASH_ECC1R_ECCCIE                      FLASH_ECC1R_ECCCIE_Msk
-#define FLASH_ECC1R_ECCC_Pos                    (30U)
-#define FLASH_ECC1R_ECCC_Msk                    (0x1UL << FLASH_ECC1R_ECCC_Pos)   /*!< 0x40000000 */
-#define FLASH_ECC1R_ECCC                        FLASH_ECC1R_ECCC_Msk
-#define FLASH_ECC1R_ECCD_Pos                    (31U)
-#define FLASH_ECC1R_ECCD_Msk                    (0x1UL << FLASH_ECC1R_ECCD_Pos)   /*!< 0x80000000 */
-#define FLASH_ECC1R_ECCD                        FLASH_ECC1R_ECCD_Msk
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos                (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x7FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00007FFF */
+#define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
+#define FLASH_ECCR_SYSF_ECC_Pos                (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
+#define FLASH_ECCR_ECCCIE_Pos                  (24U)
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
+#define FLASH_ECCR_ECCC_Pos                    (30U)
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
+#define FLASH_ECCR_ECCD_Pos                    (31U)
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
+
 /*******************  Bits definition for FLASH_ECC2R register  ****************/
 #define FLASH_ECC2R_ADDR_ECC_Pos                (0U)
-#define FLASH_ECC2R_ADDR_ECC_Msk                (0xFFFFUL << FLASH_ECC2R_ADDR_ECC_Pos) /*!< 0x0000FFFF */
+#define FLASH_ECC2R_ADDR_ECC_Msk                (0x7FFFUL << FLASH_ECC2R_ADDR_ECC_Pos)  /*!< 0x00007FFF */
 #define FLASH_ECC2R_ADDR_ECC                    FLASH_ECC2R_ADDR_ECC_Msk
 #define FLASH_ECC2R_SYSF_ECC_Pos                (20U)
-#define FLASH_ECC2R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC2R_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECC2R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC2R_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECC2R_SYSF_ECC                    FLASH_ECC2R_SYSF_ECC_Msk
 #define FLASH_ECC2R_ECCCIE_Pos                  (24U)
-#define FLASH_ECC2R_ECCCIE_Msk                  (0x1UL << FLASH_ECC2R_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECC2R_ECCCIE_Msk                  (0x1UL << FLASH_ECC2R_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECC2R_ECCCIE                      FLASH_ECC2R_ECCCIE_Msk
 #define FLASH_ECC2R_ECCC_Pos                    (30U)
-#define FLASH_ECC2R_ECCC_Msk                    (0x1UL << FLASH_ECC2R_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECC2R_ECCC_Msk                    (0x1UL << FLASH_ECC2R_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECC2R_ECCC                        FLASH_ECC2R_ECCC_Msk
 #define FLASH_ECC2R_ECCD_Pos                    (31U)
-#define FLASH_ECC2R_ECCD_Msk                    (0x1UL << FLASH_ECC2R_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECC2R_ECCD_Msk                    (0x1UL << FLASH_ECC2R_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECC2R_ECCD                        FLASH_ECC2R_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_BOR_EN_Pos                  (8U)
-#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos) /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
 #define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
-#define FLASH_OPTR_BORF_LEV_Pos                (9U)
-#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000600 */
-#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
-#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000200 */
-#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000400 */
-#define FLASH_OPTR_BORR_LEV_Pos                (11U)
-#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001800 */
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
 #define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
-#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00000800 */
-#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_nRST_SHDW_Pos               (15U)
-#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
 #define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
+#define FLASH_OPTR_nSWAP_BANK_Pos              (20U)
+#define FLASH_OPTR_nSWAP_BANK_Msk              (0x1UL << FLASH_OPTR_nSWAP_BANK_Pos)        /*!< 0x00100000 */
+#define FLASH_OPTR_nSWAP_BANK                  FLASH_OPTR_nSWAP_BANK_Msk
+#define FLASH_OPTR_DUAL_BANK_Pos               (21U)
+#define FLASH_OPTR_DUAL_BANK_Msk               (0x1UL << FLASH_OPTR_DUAL_BANK_Pos)        /*!< 0x00200000 */
+#define FLASH_OPTR_DUAL_BANK                   FLASH_OPTR_DUAL_BANK_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
 #define FLASH_OPTR_NRST_MODE_Pos               (27U)
-#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
 #define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
-#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x08000000 */
-#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x10000000 */
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
 #define FLASH_OPTR_IRHEN_Pos                   (29U)
-#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos) /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
 #define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
 
 /******************  Bits definition for FLASH_PCROP1ASR register  ************/
 #define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
-#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0xFFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x1FFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1AER register  ************/
 #define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
-#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0xFFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x1FFUL << FLASH_PCROP1AER_PCROP1A_END_Pos)   /*!< 0x0000001FF */
 #define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
 #define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
-#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
 #define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
 #define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
-#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x3FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x7FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000007F */
 #define FLASH_WRP1AR_WRP1A_STRT                FLASH_WRP1AR_WRP1A_STRT_Msk
 #define FLASH_WRP1AR_WRP1A_END_Pos             (16U)
-#define FLASH_WRP1AR_WRP1A_END_Msk             (0x3FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP1AR_WRP1A_END_Msk             (0x7FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x007F0000 */
 #define FLASH_WRP1AR_WRP1A_END                 FLASH_WRP1AR_WRP1A_END_Msk
 
 /******************  Bits definition for FLASH_WRP1BR register  ***************/
 #define FLASH_WRP1BR_WRP1B_STRT_Pos            (0U)
-#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x3FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x7FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000007F */
 #define FLASH_WRP1BR_WRP1B_STRT                FLASH_WRP1BR_WRP1B_STRT_Msk
 #define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
-#define FLASH_WRP1BR_WRP1B_END_Msk             (0x3FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP1BR_WRP1B_END_Msk             (0x7FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x007F0000 */
 #define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
 
 /******************  Bits definition for FLASH_PCROP1BSR register  ************/
 #define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
-#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0xFFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x1FFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1BER register  ************/
 #define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
-#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0xFFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)  /*!< 0x000000FF */
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x1FFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)   /*!< 0x0000001FF */
 #define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
 /******************  Bits definition for FLASH_PCROP2ASR register  ************/
 #define FLASH_PCROP2ASR_PCROP2A_STRT_Pos       (0U)
-#define FLASH_PCROP2ASR_PCROP2A_STRT_Msk       (0xFFUL << FLASH_PCROP2ASR_PCROP2A_STRT_Pos) /*!< 0x0000FFFF */
+#define FLASH_PCROP2ASR_PCROP2A_STRT_Msk       (0x1FFUL << FLASH_PCROP2ASR_PCROP2A_STRT_Pos) /*!< 0x0000001FF */
 #define FLASH_PCROP2ASR_PCROP2A_STRT           FLASH_PCROP2ASR_PCROP2A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP2AER register  ************/
 #define FLASH_PCROP2AER_PCROP2A_END_Pos        (0U)
-#define FLASH_PCROP2AER_PCROP2A_END_Msk        (0xFFUL << FLASH_PCROP2AER_PCROP2A_END_Pos)  /*!< 0x0000FFFF */
+#define FLASH_PCROP2AER_PCROP2A_END_Msk        (0x1FFUL << FLASH_PCROP2AER_PCROP2A_END_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP2AER_PCROP2A_END            FLASH_PCROP2AER_PCROP2A_END_Msk
+
 
 /******************  Bits definition for FLASH_WRP2AR register  ***************/
 #define FLASH_WRP2AR_WRP2A_STRT_Pos            (0U)
-#define FLASH_WRP2AR_WRP2A_STRT_Msk            (0x3FUL << FLASH_WRP2AR_WRP2A_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP2AR_WRP2A_STRT_Msk            (0x7FUL << FLASH_WRP2AR_WRP2A_STRT_Pos)  /*!< 0x0000007F */
 #define FLASH_WRP2AR_WRP2A_STRT                FLASH_WRP2AR_WRP2A_STRT_Msk
 #define FLASH_WRP2AR_WRP2A_END_Pos             (16U)
-#define FLASH_WRP2AR_WRP2A_END_Msk             (0x3FUL << FLASH_WRP2AR_WRP2A_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP2AR_WRP2A_END_Msk             (0x7FUL << FLASH_WRP2AR_WRP2A_END_Pos)   /*!< 0x007F0000 */
 #define FLASH_WRP2AR_WRP2A_END                 FLASH_WRP2AR_WRP2A_END_Msk
 
 /******************  Bits definition for FLASH_WRP2BSR register  ***************/
 #define FLASH_WRP2BR_WRP2B_STRT_Pos            (0U)
-#define FLASH_WRP2BR_WRP2B_STRT_Msk            (0x3FUL << FLASH_WRP2BR_WRP2B_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP2BR_WRP2B_STRT_Msk            (0x7FUL << FLASH_WRP2BR_WRP2B_STRT_Pos)  /*!< 0x0000007F */
 #define FLASH_WRP2BR_WRP2B_STRT                FLASH_WRP2BR_WRP2B_STRT_Msk
 #define FLASH_WRP2BR_WRP2B_END_Pos             (16U)
-#define FLASH_WRP2BR_WRP2B_END_Msk             (0x3FUL << FLASH_WRP2BR_WRP2B_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP2BR_WRP2B_END_Msk             (0x7FUL << FLASH_WRP2BR_WRP2B_END_Pos)   /*!< 0x007F0000 */
 #define FLASH_WRP2BR_WRP2B_END                 FLASH_WRP2BR_WRP2B_END_Msk
 
 /******************  Bits definition for FLASH_PCROP2BSR register  ************/
 #define FLASH_PCROP2BSR_PCROP2B_STRT_Pos       (0U)
-#define FLASH_PCROP2BSR_PCROP2B_STRT_Msk       (0xFFUL << FLASH_PCROP2BSR_PCROP2B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP2BSR_PCROP2B_STRT_Msk       (0x1FFUL << FLASH_PCROP2BSR_PCROP2B_STRT_Pos) /*!< 0x0000001FF */
 #define FLASH_PCROP2BSR_PCROP2B_STRT           FLASH_PCROP2BSR_PCROP2B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP2BER register  ************/
 #define FLASH_PCROP2BER_PCROP2B_END_Pos        (0U)
-#define FLASH_PCROP2BER_PCROP2B_END_Msk        (0xFFUL << FLASH_PCROP2BER_PCROP2B_END_Pos)  /*!< 0x000000FF */
+#define FLASH_PCROP2BER_PCROP2B_END_Msk        (0x1FFUL << FLASH_PCROP2BER_PCROP2B_END_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP2BER_PCROP2B_END            FLASH_PCROP2BER_PCROP2B_END_Msk
 
 /******************  Bits definition for FLASH_SECR register  *****************/
-#define FLASH_SECR_SEC_SIZEB1_Pos              (0U)
-#define FLASH_SECR_SEC_SIZEB1_Msk              (0x7FUL << FLASH_SECR_SEC_SIZEB1_Pos) /*!< 0x0000007F */
-#define FLASH_SECR_SEC_SIZEB1                  FLASH_SECR_SEC_SIZEB1_Msk
-#define FLASH_SECR_SEC_SIZEB2_Pos              (20U)
-#define FLASH_SECR_SEC_SIZEB2_Msk              (0xFFUL << FLASH_SECR_SEC_SIZEB2_Pos) /*!< 0x0FF00000 */
-#define FLASH_SECR_SEC_SIZEB2                  FLASH_SECR_SEC_SIZEB2_Msk
+#define FLASH_SECR_SEC_SIZE_Pos                (0U)
+#define FLASH_SECR_SEC_SIZE_Msk                (0xFFUL << FLASH_SECR_SEC_SIZE_Pos) /*!< 0x000000FF */
+#define FLASH_SECR_SEC_SIZE                    FLASH_SECR_SEC_SIZE_Msk
 #define FLASH_SECR_BOOT_LOCK_Pos               (16U)
 #define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
 #define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
-
+#define FLASH_SECR_SEC_SIZE2_Pos               (20U)
+#define FLASH_SECR_SEC_SIZE2_Msk               (0xFFUL << FLASH_SECR_SEC_SIZE2_Pos) /*!< 0x0FF00000 */
+#define FLASH_SECR_SEC_SIZE2                   FLASH_SECR_SEC_SIZE2_Msk
 
 /******************************************************************************/
 /*                                                                            */
@@ -5069,6 +5181,7 @@ typedef struct
 /*                        Power Control                                       */
 /*                                                                            */
 /******************************************************************************/
+#define PWR_PVM_SUPPORT                       /*!< PWR feature available only on specific devices: Power Voltage Monitoring feature */
 #define PWR_PVD_SUPPORT                       /*!< PWR feature available only on specific devices: Power Voltage Detection feature */
 #define PWR_BOR_SUPPORT                       /*!< PWR feature available only on specific devices: Brown-Out Reset feature         */
 #define PWR_SHDW_SUPPORT                      /*!< PWR feature available only on specific devices: Shutdown mode */
@@ -5117,10 +5230,19 @@ typedef struct
 #define PWR_CR2_PVDRT_0           (0x1UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000010 */
 #define PWR_CR2_PVDRT_1           (0x2UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000020 */
 #define PWR_CR2_PVDRT_2           (0x4UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000040 */
+#define PWR_CR2_PVMEN_USB_Pos     (8U)
+#define PWR_CR2_PVMEN_USB_Msk     (0x1UL << PWR_CR2_PVMEN_USB_Pos)             /*!< 0x00000100 */
+#define PWR_CR2_PVMEN_USB         PWR_CR2_PVMEN_USB_Msk                        /*!< USB Peripheral Voltage Monitor Enable */
+#define PWR_CR2_IOSV_Pos          (9U)
+#define PWR_CR2_IOSV_Msk          (0x1UL << PWR_CR2_IOSV_Pos)                  /*!< 0x00000200 */
+#define PWR_CR2_IOSV              PWR_CR2_IOSV_Msk                             /*!< VDDIO2 independent I/Os Supply Valid */
+#define PWR_CR2_USV_Pos           (10U)
+#define PWR_CR2_USV_Msk           (0x1UL << PWR_CR2_USV_Pos)                   /*!< 0x00000400 */
+#define PWR_CR2_USV               PWR_CR2_USV_Msk                              /*!< VDD USB Supply Valid */
 
 /********************  Bit definition for PWR_CR3 register  ********************/
 #define PWR_CR3_EWUP_Pos          (0U)
-#define PWR_CR3_EWUP_Msk          (0x3BUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000003B */
+#define PWR_CR3_EWUP_Msk          (0x3FUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000003F */
 #define PWR_CR3_EWUP              PWR_CR3_EWUP_Msk                             /*!< Enable all Wake-Up Pins  */
 #define PWR_CR3_EWUP1_Pos         (0U)
 #define PWR_CR3_EWUP1_Msk         (0x1UL << PWR_CR3_EWUP1_Pos)                 /*!< 0x00000001 */
@@ -5128,6 +5250,9 @@ typedef struct
 #define PWR_CR3_EWUP2_Pos         (1U)
 #define PWR_CR3_EWUP2_Msk         (0x1UL << PWR_CR3_EWUP2_Pos)                 /*!< 0x00000002 */
 #define PWR_CR3_EWUP2             PWR_CR3_EWUP2_Msk                            /*!< Enable WKUP pin 2 */
+#define PWR_CR3_EWUP3_Pos         (2U)
+#define PWR_CR3_EWUP3_Msk         (0x1UL << PWR_CR3_EWUP3_Pos)                 /*!< 0x00000004 */
+#define PWR_CR3_EWUP3             PWR_CR3_EWUP3_Msk                            /*!< Enable WKUP pin 3 */
 #define PWR_CR3_EWUP4_Pos         (3U)
 #define PWR_CR3_EWUP4_Msk         (0x1UL << PWR_CR3_EWUP4_Pos)                 /*!< 0x00000008 */
 #define PWR_CR3_EWUP4             PWR_CR3_EWUP4_Msk                            /*!< Enable WKUP pin 4 */
@@ -5152,7 +5277,7 @@ typedef struct
 
 /********************  Bit definition for PWR_CR4 register  ********************/
 #define PWR_CR4_WP_Pos            (0U)
-#define PWR_CR4_WP_Msk            (0x3BUL << PWR_CR4_WP_Pos)                   /*!< 0x0000003B */
+#define PWR_CR4_WP_Msk            (0x3FUL << PWR_CR4_WP_Pos)                   /*!< 0x0000003F */
 #define PWR_CR4_WP                PWR_CR4_WP_Msk                               /*!< all Wake-Up Pin polarity */
 #define PWR_CR4_WP1_Pos           (0U)
 #define PWR_CR4_WP1_Msk           (0x1UL << PWR_CR4_WP1_Pos)                   /*!< 0x00000001 */
@@ -5160,6 +5285,9 @@ typedef struct
 #define PWR_CR4_WP2_Pos           (1U)
 #define PWR_CR4_WP2_Msk           (0x1UL << PWR_CR4_WP2_Pos)                   /*!< 0x00000002 */
 #define PWR_CR4_WP2               PWR_CR4_WP2_Msk                              /*!< Wake-Up Pin 2 polarity */
+#define PWR_CR4_WP3_Pos           (2U)
+#define PWR_CR4_WP3_Msk           (0x1UL << PWR_CR4_WP3_Pos)                   /*!< 0x00000004 */
+#define PWR_CR4_WP3               PWR_CR4_WP3_Msk                              /*!< Wake-Up Pin 3 polarity */
 #define PWR_CR4_WP4_Pos           (3U)
 #define PWR_CR4_WP4_Msk           (0x1UL << PWR_CR4_WP4_Pos)                   /*!< 0x00000008 */
 #define PWR_CR4_WP4               PWR_CR4_WP4_Msk                              /*!< Wake-Up Pin 4 polarity */
@@ -5178,7 +5306,7 @@ typedef struct
 
 /********************  Bit definition for PWR_SR1 register  ********************/
 #define PWR_SR1_WUF_Pos           (0U)
-#define PWR_SR1_WUF_Msk           (0x3BUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000003B */
+#define PWR_SR1_WUF_Msk           (0x3FUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000003F */
 #define PWR_SR1_WUF               PWR_SR1_WUF_Msk                              /*!< Wakeup Flags  */
 #define PWR_SR1_WUF1_Pos          (0U)
 #define PWR_SR1_WUF1_Msk          (0x1UL << PWR_SR1_WUF1_Pos)                  /*!< 0x00000001 */
@@ -5186,6 +5314,9 @@ typedef struct
 #define PWR_SR1_WUF2_Pos          (1U)
 #define PWR_SR1_WUF2_Msk          (0x1UL << PWR_SR1_WUF2_Pos)                  /*!< 0x00000002 */
 #define PWR_SR1_WUF2              PWR_SR1_WUF2_Msk                             /*!< Wakeup Flag 2 */
+#define PWR_SR1_WUF3_Pos          (2U)
+#define PWR_SR1_WUF3_Msk          (0x1UL << PWR_SR1_WUF3_Pos)                  /*!< 0x00000004 */
+#define PWR_SR1_WUF3              PWR_SR1_WUF3_Msk                             /*!< Wakeup Flag 3 */
 #define PWR_SR1_WUF4_Pos          (3U)
 #define PWR_SR1_WUF4_Msk          (0x1UL << PWR_SR1_WUF4_Pos)                  /*!< 0x00000008 */
 #define PWR_SR1_WUF4              PWR_SR1_WUF4_Msk                             /*!< Wakeup Flag 4 */
@@ -5218,10 +5349,13 @@ typedef struct
 #define PWR_SR2_PVDO_Pos          (11U)
 #define PWR_SR2_PVDO_Msk          (0x1UL << PWR_SR2_PVDO_Pos)                  /*!< 0x00000800 */
 #define PWR_SR2_PVDO              PWR_SR2_PVDO_Msk                             /*!< Power voltage detector output */
+#define PWR_SR2_PVMO_USB_Pos      (13U)
+#define PWR_SR2_PVMO_USB_Msk      (0x1UL << PWR_SR2_PVMO_USB_Pos)              /*!< 0x00002000 */
+#define PWR_SR2_PVMO_USB          PWR_SR2_PVMO_USB_Msk                         /*!< USB Peripheral Voltage Monitoring Output */
 
 /********************  Bit definition for PWR_SCR register  ********************/
 #define PWR_SCR_CWUF_Pos          (0U)
-#define PWR_SCR_CWUF_Msk          (0x3BUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000003B */
+#define PWR_SCR_CWUF_Msk          (0x3FUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000003F */
 #define PWR_SCR_CWUF              PWR_SCR_CWUF_Msk                             /*!< Clear Wake-up Flags  */
 #define PWR_SCR_CWUF1_Pos         (0U)
 #define PWR_SCR_CWUF1_Msk         (0x1UL << PWR_SCR_CWUF1_Pos)                 /*!< 0x00000001 */
@@ -5229,6 +5363,9 @@ typedef struct
 #define PWR_SCR_CWUF2_Pos         (1U)
 #define PWR_SCR_CWUF2_Msk         (0x1UL << PWR_SCR_CWUF2_Pos)                 /*!< 0x00000002 */
 #define PWR_SCR_CWUF2             PWR_SCR_CWUF2_Msk                            /*!< Clear Wake-up Flag 2 */
+#define PWR_SCR_CWUF3_Pos         (2U)
+#define PWR_SCR_CWUF3_Msk         (0x1UL << PWR_SCR_CWUF3_Pos)                 /*!< 0x00000004 */
+#define PWR_SCR_CWUF3             PWR_SCR_CWUF3_Msk                            /*!< Clear Wake-up Flag 3 */
 #define PWR_SCR_CWUF4_Pos         (3U)
 #define PWR_SCR_CWUF4_Msk         (0x1UL << PWR_SCR_CWUF4_Pos)                 /*!< 0x00000008 */
 #define PWR_SCR_CWUF4             PWR_SCR_CWUF4_Msk                            /*!< Clear Wake-up Flag 4 */
@@ -5829,8 +5966,9 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
+#define RCC_MCO2_SUPPORT
 #define RCC_HSI48_SUPPORT
 #define RCC_PLLQ_SUPPORT
 
@@ -5919,12 +6057,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -5942,21 +6074,41 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+/*!< MCO2SEL configuration */
+#define RCC_CFGR_MCO2SEL_Pos            (16U)
+#define RCC_CFGR_MCO2SEL_Msk            (0xFUL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x000F0000 */
+#define RCC_CFGR_MCO2SEL                RCC_CFGR_MCO2SEL_Msk                     /*!< MCO2SEL [3:0] bits (Clock output selection) */
+#define RCC_CFGR_MCO2SEL_0              (0x1UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00010000 */
+#define RCC_CFGR_MCO2SEL_1              (0x2UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00020000 */
+#define RCC_CFGR_MCO2SEL_2              (0x4UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00040000 */
+#define RCC_CFGR_MCO2SEL_3              (0x8UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00080000 */
+
+/*!< MCO2 Prescaler configuration */
+#define RCC_CFGR_MCO2PRE_Pos            (20U)
+#define RCC_CFGR_MCO2PRE_Msk            (0xFUL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00F00000 */
+#define RCC_CFGR_MCO2PRE                RCC_CFGR_MCO2PRE_Msk                     /*!< MCO2 prescaler [3:0] */
+#define RCC_CFGR_MCO2PRE_0              (0x1UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00100000 */
+#define RCC_CFGR_MCO2PRE_1              (0x2UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00200000 */
+#define RCC_CFGR_MCO2PRE_2              (0x4UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00400000 */
+#define RCC_CFGR_MCO2PRE_3              (0x8UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00800000 */
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0xFUL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
 #define RCC_CFGR_MCOSEL_2              (0x4UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x04000000 */
+#define RCC_CFGR_MCOSEL_3              (0x8UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x08000000 */
 
 /*!< MCO Prescaler configuration */
 #define RCC_CFGR_MCOPRE_Pos            (28U)
-#define RCC_CFGR_MCOPRE_Msk            (0x7UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE_Msk            (0xFUL << RCC_CFGR_MCOPRE_Pos)          /*!< 0xF0000000 */
 #define RCC_CFGR_MCOPRE                RCC_CFGR_MCOPRE_Msk                     /*!< MCO prescaler [2:0] */
 #define RCC_CFGR_MCOPRE_0              (0x1UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x10000000 */
 #define RCC_CFGR_MCOPRE_1              (0x2UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x20000000 */
 #define RCC_CFGR_MCOPRE_2              (0x4UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x40000000 */
+#define RCC_CFGR_MCOPRE_3              (0x8UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x80000000 */
 
 /********************  Bit definition for RCC_PLLCFGR register  ***************/
 #define RCC_PLLCFGR_PLLSRC_Pos           (0U)
@@ -6174,9 +6326,9 @@ typedef struct
 #define RCC_APBRSTR1_FDCANRST_Pos        (12U)
 #define RCC_APBRSTR1_FDCANRST_Msk        (0x1UL << RCC_APBRSTR1_FDCANRST_Pos)  /*!< 0x00001000 */
 #define RCC_APBRSTR1_FDCANRST            RCC_APBRSTR1_FDCANRST_Msk
-#define RCC_APBRSTR1_USBFSRST_Pos        (13U)
-#define RCC_APBRSTR1_USBFSRST_Msk        (0x1UL << RCC_APBRSTR1_USBFSRST_Pos)  /*!< 0x00002000 */
-#define RCC_APBRSTR1_USBFSRST            RCC_APBRSTR1_USBFSRST_Msk
+#define RCC_APBRSTR1_USBRST_Pos          (13U)
+#define RCC_APBRSTR1_USBRST_Msk          (0x1UL << RCC_APBRSTR1_USBRST_Pos)    /*!< 0x00002000 */
+#define RCC_APBRSTR1_USBRST              RCC_APBRSTR1_USBRST_Msk
 #define RCC_APBRSTR1_SPI2RST_Pos         (14U)
 #define RCC_APBRSTR1_SPI2RST_Msk         (0x1UL << RCC_APBRSTR1_SPI2RST_Pos)   /*!< 0x00004000 */
 #define RCC_APBRSTR1_SPI2RST             RCC_APBRSTR1_SPI2RST_Msk
@@ -6329,9 +6481,9 @@ typedef struct
 #define RCC_APBENR1_FDCANEN_Pos          (12U)
 #define RCC_APBENR1_FDCANEN_Msk          (0x1UL << RCC_APBENR1_FDCANEN_Pos)     /*!< 0x00001000 */
 #define RCC_APBENR1_FDCANEN              RCC_APBENR1_FDCANEN_Msk
-#define RCC_APBENR1_USBFSEN_Pos          (13U)
-#define RCC_APBENR1_USBFSEN_Msk          (0x1UL << RCC_APBENR1_USBFSEN_Pos)     /*!< 0x00002000 */
-#define RCC_APBENR1_USBFSEN              RCC_APBENR1_USBFSEN_Msk
+#define RCC_APBENR1_USBEN_Pos            (13U)
+#define RCC_APBENR1_USBEN_Msk            (0x1UL << RCC_APBENR1_USBEN_Pos)       /*!< 0x00002000 */
+#define RCC_APBENR1_USBEN                RCC_APBENR1_USBEN_Msk
 #define RCC_APBENR1_SPI2EN_Pos           (14U)
 #define RCC_APBENR1_SPI2EN_Msk           (0x1UL << RCC_APBENR1_SPI2EN_Pos)      /*!< 0x00004000 */
 #define RCC_APBENR1_SPI2EN               RCC_APBENR1_SPI2EN_Msk
@@ -6487,9 +6639,9 @@ typedef struct
 #define RCC_APBSMENR1_FDCANSMEN_Pos      (12U)
 #define RCC_APBSMENR1_FDCANSMEN_Msk      (0x1UL << RCC_APBSMENR1_FDCANSMEN_Pos)  /*!< 0x00001000 */
 #define RCC_APBSMENR1_FDCANSMEN          RCC_APBSMENR1_FDCANSMEN_Msk
-#define RCC_APBSMENR1_USBFSSMEN_Pos      (13U)
-#define RCC_APBSMENR1_USBFSSMEN_Msk      (0x1UL << RCC_APBSMENR1_USBFSSMEN_Pos)  /*!< 0x00002000 */
-#define RCC_APBSMENR1_USBFSSMEN          RCC_APBSMENR1_USBFSSMEN_Msk
+#define RCC_APBSMENR1_USBSMEN_Pos        (13U)
+#define RCC_APBSMENR1_USBSMEN_Msk        (0x1UL << RCC_APBSMENR1_USBSMEN_Pos)    /*!< 0x00002000 */
+#define RCC_APBSMENR1_USBSMEN            RCC_APBSMENR1_USBSMEN_Msk
 #define RCC_APBSMENR1_SPI2SMEN_Pos       (14U)
 #define RCC_APBSMENR1_SPI2SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI2SMEN_Pos)   /*!< 0x00004000 */
 #define RCC_APBSMENR1_SPI2SMEN           RCC_APBSMENR1_SPI2SMEN_Msk
@@ -6619,11 +6771,6 @@ typedef struct
 #define RCC_CCIPR_I2C2SEL_0             (0x1UL << RCC_CCIPR_I2C2SEL_Pos)        /*!< 0x00004000 */
 #define RCC_CCIPR_I2C2SEL_1             (0x2UL << RCC_CCIPR_I2C2SEL_Pos)        /*!< 0x00008000 */
 
-#define RCC_CCIPR_I2C3SEL_Pos            (16U)
-#define RCC_CCIPR_I2C3SEL_Msk            (0x3UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00030000 */
-#define RCC_CCIPR_I2C3SEL                RCC_CCIPR_I2C3SEL_Msk
-#define RCC_CCIPR_I2C3SEL_0              (0x1UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00010000 */
-#define RCC_CCIPR_I2C3SEL_1              (0x2UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00020000 */
 #define RCC_CCIPR_LPTIM1SEL_Pos          (18U)
 #define RCC_CCIPR_LPTIM1SEL_Msk          (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x000C0000 */
 #define RCC_CCIPR_LPTIM1SEL              RCC_CCIPR_LPTIM1SEL_Msk
@@ -6662,21 +6809,16 @@ typedef struct
 #define RCC_CCIPR2_I2S2SEL                RCC_CCIPR2_I2S2SEL_Msk
 #define RCC_CCIPR2_I2S2SEL_0              (0x1UL << RCC_CCIPR2_I2S2SEL_Pos)     /*!< 0x00000004 */
 #define RCC_CCIPR2_I2S2SEL_1              (0x2UL << RCC_CCIPR2_I2S2SEL_Pos)     /*!< 0x00000008 */
-#define RCC_CCIPR2_I2S3SEL_Pos            (4U)
-#define RCC_CCIPR2_I2S3SEL_Msk            (0x3UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000030 */
-#define RCC_CCIPR2_I2S3SEL                RCC_CCIPR2_I2S3SEL_Msk
-#define RCC_CCIPR2_I2S3SEL_0              (0x1UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000010 */
-#define RCC_CCIPR2_I2S3SEL_1              (0x2UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000020 */
 #define RCC_CCIPR2_FDCANSEL_Pos           (8U)
 #define RCC_CCIPR2_FDCANSEL_Msk           (0x3UL << RCC_CCIPR2_FDCANSEL_Pos)    /*!< 0x00000300 */
 #define RCC_CCIPR2_FDCANSEL               RCC_CCIPR2_FDCANSEL_Msk
 #define RCC_CCIPR2_FDCANSEL_0             (0x1UL << RCC_CCIPR2_FDCANSEL_Pos)    /*!< 0x00000100 */
 #define RCC_CCIPR2_FDCANSEL_1             (0x2UL << RCC_CCIPR2_FDCANSEL_Pos)    /*!< 0x00000200 */
-#define RCC_CCIPR2_CK48MSEL_Pos           (12U)
-#define RCC_CCIPR2_CK48MSEL_Msk           (0x3UL << RCC_CCIPR2_CK48MSEL_Pos)     /*!< 0x00003000 */
-#define RCC_CCIPR2_CK48MSEL               RCC_CCIPR2_CK48MSEL_Msk
-#define RCC_CCIPR2_CK48MSEL_0             (0x1UL << RCC_CCIPR2_CK48MSEL_Pos)    /*!< 0x00001000 */
-#define RCC_CCIPR2_CK48MSEL_1             (0x2UL << RCC_CCIPR2_CK48MSEL_Pos)    /*!< 0x00002000 */
+#define RCC_CCIPR2_USBSEL_Pos             (12U)
+#define RCC_CCIPR2_USBSEL_Msk             (0x3UL << RCC_CCIPR2_USBSEL_Pos)     /*!< 0x00003000 */
+#define RCC_CCIPR2_USBSEL                 RCC_CCIPR2_USBSEL_Msk
+#define RCC_CCIPR2_USBSEL_0               (0x1UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00001000 */
+#define RCC_CCIPR2_USBSEL_1               (0x2UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00002000 */
 /********************  Bit definition for RCC_BDCR register  ******************/
 #define RCC_BDCR_LSEON_Pos               (0U)
 #define RCC_BDCR_LSEON_Msk               (0x1UL << RCC_BDCR_LSEON_Pos)          /*!< 0x00000001 */
@@ -6764,6 +6906,7 @@ typedef struct
 */
 #define RTC_WAKEUP_SUPPORT
 #define RTC_BACKUP_SUPPORT
+#define RTC_TAMPER3_SUPPORT          /*!< TAMPER3 only available on some devices */
 
 /********************  Bits definition for RTC_TR register  *******************/
 #define RTC_TR_PM_Pos                (22U)
@@ -7334,6 +7477,9 @@ typedef struct
 #define TAMP_CR1_TAMP2E_Pos          (1U)
 #define TAMP_CR1_TAMP2E_Msk          (0x1UL << TAMP_CR1_TAMP2E_Pos)             /*!< 0x00000002 */
 #define TAMP_CR1_TAMP2E              TAMP_CR1_TAMP2E_Msk
+#define TAMP_CR1_TAMP3E_Pos          (2U)
+#define TAMP_CR1_TAMP3E_Msk          (0x1UL << TAMP_CR1_TAMP3E_Pos)             /*!< 0x00000004 */
+#define TAMP_CR1_TAMP3E              TAMP_CR1_TAMP3E_Msk
 #define TAMP_CR1_ITAMP3E_Pos         (18U)
 #define TAMP_CR1_ITAMP3E_Msk         (0x1UL << TAMP_CR1_ITAMP3E_Pos)            /*!< 0x00040000 */
 #define TAMP_CR1_ITAMP3E             TAMP_CR1_ITAMP3E_Msk
@@ -7354,18 +7500,27 @@ typedef struct
 #define TAMP_CR2_TAMP2NOERASE_Pos    (1U)
 #define TAMP_CR2_TAMP2NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP2NOERASE_Pos)       /*!< 0x00000002 */
 #define TAMP_CR2_TAMP2NOERASE        TAMP_CR2_TAMP2NOERASE_Msk
+#define TAMP_CR2_TAMP3NOERASE_Pos    (2U)
+#define TAMP_CR2_TAMP3NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP3NOERASE_Pos)       /*!< 0x00000004 */
+#define TAMP_CR2_TAMP3NOERASE        TAMP_CR2_TAMP3NOERASE_Msk
 #define TAMP_CR2_TAMP1MSK_Pos        (16U)
 #define TAMP_CR2_TAMP1MSK_Msk        (0x1UL << TAMP_CR2_TAMP1MSK_Pos)           /*!< 0x00010000 */
 #define TAMP_CR2_TAMP1MSK            TAMP_CR2_TAMP1MSK_Msk
 #define TAMP_CR2_TAMP2MSK_Pos        (17U)
 #define TAMP_CR2_TAMP2MSK_Msk        (0x1UL << TAMP_CR2_TAMP2MSK_Pos)           /*!< 0x00020000 */
 #define TAMP_CR2_TAMP2MSK            TAMP_CR2_TAMP2MSK_Msk
+#define TAMP_CR2_TAMP3MSK_Pos        (18U)
+#define TAMP_CR2_TAMP3MSK_Msk        (0x1UL << TAMP_CR2_TAMP3MSK_Pos)           /*!< 0x00040000 */
+#define TAMP_CR2_TAMP3MSK            TAMP_CR2_TAMP3MSK_Msk
 #define TAMP_CR2_TAMP1TRG_Pos        (24U)
 #define TAMP_CR2_TAMP1TRG_Msk        (0x1UL << TAMP_CR2_TAMP1TRG_Pos)           /*!< 0x01000000 */
 #define TAMP_CR2_TAMP1TRG            TAMP_CR2_TAMP1TRG_Msk
 #define TAMP_CR2_TAMP2TRG_Pos        (25U)
 #define TAMP_CR2_TAMP2TRG_Msk        (0x1UL << TAMP_CR2_TAMP2TRG_Pos)           /*!< 0x02000000 */
 #define TAMP_CR2_TAMP2TRG            TAMP_CR2_TAMP2TRG_Msk
+#define TAMP_CR2_TAMP3TRG_Pos        (26U)
+#define TAMP_CR2_TAMP3TRG_Msk        (0x1UL << TAMP_CR2_TAMP3TRG_Pos)           /*!< 0x04000000 */
+#define TAMP_CR2_TAMP3TRG            TAMP_CR2_TAMP3TRG_Msk
 
 /********************  Bits definition for TAMP_FLTCR register  ***************/
 #define TAMP_FLTCR_TAMPFREQ_0        0x00000001U
@@ -7395,6 +7550,9 @@ typedef struct
 #define TAMP_IER_TAMP2IE_Pos         (1U)
 #define TAMP_IER_TAMP2IE_Msk         (0x1UL << TAMP_IER_TAMP2IE_Pos)            /*!< 0x00000002 */
 #define TAMP_IER_TAMP2IE             TAMP_IER_TAMP2IE_Msk
+#define TAMP_IER_TAMP3IE_Pos         (2U)
+#define TAMP_IER_TAMP3IE_Msk         (0x1UL << TAMP_IER_TAMP3IE_Pos)            /*!< 0x00000004 */
+#define TAMP_IER_TAMP3IE             TAMP_IER_TAMP3IE_Msk
 #define TAMP_IER_ITAMP3IE_Pos        (18U)
 #define TAMP_IER_ITAMP3IE_Msk        (0x1UL << TAMP_IER_ITAMP3IE_Pos)           /*!< 0x00040000 */
 #define TAMP_IER_ITAMP3IE            TAMP_IER_ITAMP3IE_Msk
@@ -7415,6 +7573,9 @@ typedef struct
 #define TAMP_SR_TAMP2F_Pos           (1U)
 #define TAMP_SR_TAMP2F_Msk           (0x1UL << TAMP_SR_TAMP2F_Pos)              /*!< 0x00000002 */
 #define TAMP_SR_TAMP2F               TAMP_SR_TAMP2F_Msk
+#define TAMP_SR_TAMP3F_Pos           (2U)
+#define TAMP_SR_TAMP3F_Msk           (0x1UL << TAMP_SR_TAMP3F_Pos)              /*!< 0x00000004 */
+#define TAMP_SR_TAMP3F               TAMP_SR_TAMP3F_Msk
 #define TAMP_SR_ITAMP3F_Pos          (18U)
 #define TAMP_SR_ITAMP3F_Msk          (0x1UL << TAMP_SR_ITAMP3F_Pos)             /*!< 0x00040000 */
 #define TAMP_SR_ITAMP3F              TAMP_SR_ITAMP3F_Msk
@@ -7435,6 +7596,9 @@ typedef struct
 #define TAMP_MISR_TAMP2MF_Pos        (1U)
 #define TAMP_MISR_TAMP2MF_Msk        (0x1UL << TAMP_MISR_TAMP2MF_Pos)           /*!< 0x00000002 */
 #define TAMP_MISR_TAMP2MF            TAMP_MISR_TAMP2MF_Msk
+#define TAMP_MISR_TAMP3MF_Pos        (2U)
+#define TAMP_MISR_TAMP3MF_Msk        (0x1UL << TAMP_MISR_TAMP3MF_Pos)           /*!< 0x00000004 */
+#define TAMP_MISR_TAMP3MF            TAMP_MISR_TAMP3MF_Msk
 #define TAMP_MISR_ITAMP3MF_Pos       (18U)
 #define TAMP_MISR_ITAMP3MF_Msk       (0x1UL << TAMP_MISR_ITAMP3MF_Pos)          /*!< 0x00040000 */
 #define TAMP_MISR_ITAMP3MF           TAMP_MISR_ITAMP3MF_Msk
@@ -7455,6 +7619,9 @@ typedef struct
 #define TAMP_SCR_CTAMP2F_Pos         (1U)
 #define TAMP_SCR_CTAMP2F_Msk         (0x1UL << TAMP_SCR_CTAMP2F_Pos)            /*!< 0x00000002 */
 #define TAMP_SCR_CTAMP2F             TAMP_SCR_CTAMP2F_Msk
+#define TAMP_SCR_CTAMP3F_Pos         (2U)
+#define TAMP_SCR_CTAMP3F_Msk         (0x1UL << TAMP_SCR_CTAMP3F_Pos)            /*!< 0x00000004 */
+#define TAMP_SCR_CTAMP3F             TAMP_SCR_CTAMP3F_Msk
 #define TAMP_SCR_CITAMP3F_Pos        (18U)
 #define TAMP_SCR_CITAMP3F_Msk        (0x1UL << TAMP_SCR_CITAMP3F_Pos)           /*!< 0x00040000 */
 #define TAMP_SCR_CITAMP3F            TAMP_SCR_CITAMP3F_Msk
@@ -7499,7 +7666,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -7704,6 +7871,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
 /*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
 #define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
 #define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
@@ -7810,12 +7978,15 @@ typedef struct
 #define SYSCFG_ITLINE1_SR_PVDOUT_Pos          (0U)
 #define SYSCFG_ITLINE1_SR_PVDOUT_Msk          (0x1UL << SYSCFG_ITLINE1_SR_PVDOUT_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE1_SR_PVDOUT              SYSCFG_ITLINE1_SR_PVDOUT_Msk     /*!< Power voltage detection -> exti[16] Interrupt */
+#define SYSCFG_ITLINE1_SR_PVMOUT_Pos          (1U)
+#define SYSCFG_ITLINE1_SR_PVMOUT_Msk          (0x1UL << SYSCFG_ITLINE1_SR_PVMOUT_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE1_SR_PVMOUT              SYSCFG_ITLINE1_SR_PVMOUT_Msk     /*!< VDDUSB Power voltage monitor -> exti[34] Interrupt */
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -7876,15 +8047,15 @@ typedef struct
 #define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
 #define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
 #define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
-#define SYSCFG_ITLINE8_SR_UCPD1_Pos          (0U)
-#define SYSCFG_ITLINE8_SR_UCPD1_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE8_SR_UCPD1              SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
-#define SYSCFG_ITLINE8_SR_UCPD2_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_UCPD2_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_UCPD2              SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
-#define SYSCFG_ITLINE8_SR_USBFS_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_USBFS_Msk          (0x1UL << SYSCFG_ITLINE8_SR_USBFS_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_USBFS              SYSCFG_ITLINE8_SR_USBFS_Msk            /*!< USBFS Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD1_Pos           (0U)
+#define SYSCFG_ITLINE8_SR_UCPD1_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE8_SR_UCPD1               SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD2_Pos           (1U)
+#define SYSCFG_ITLINE8_SR_UCPD2_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE8_SR_UCPD2               SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
+#define SYSCFG_ITLINE8_SR_USB_Pos             (2U)
+#define SYSCFG_ITLINE8_SR_USB_Msk             (0x1UL << SYSCFG_ITLINE8_SR_USB_Pos)   /*!< 0x00000004 */
+#define SYSCFG_ITLINE8_SR_USB                 SYSCFG_ITLINE8_SR_USB_Msk              /*!< USB Interrupt */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
@@ -7894,9 +8065,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -7984,24 +8155,30 @@ typedef struct
 #define SYSCFG_ITLINE21_SR_TIM16_GLB_Pos      (0U)
 #define SYSCFG_ITLINE21_SR_TIM16_GLB_Msk      (0x1UL << SYSCFG_ITLINE21_SR_TIM16_GLB_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE21_SR_TIM16_GLB          SYSCFG_ITLINE21_SR_TIM16_GLB_Msk /*!< TIM16 GLB Interrupt */
-#define SYSCFG_ITLINE21_SR_FDCAN1_GLB_Pos     (1U)
-#define SYSCFG_ITLINE21_SR_FDCAN1_GLB_Msk     (0x1UL << SYSCFG_ITLINE21_SR_FDCAN1_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE21_SR_FDCAN1_GLB         SYSCFG_ITLINE21_SR_FDCAN1_GLB_Msk /*!< FDCAN1 GLB Interrupt */
+#define SYSCFG_ITLINE21_SR_FDCAN1_IT0_Pos     (1U)
+#define SYSCFG_ITLINE21_SR_FDCAN1_IT0_Msk     (0x1UL << SYSCFG_ITLINE21_SR_FDCAN1_IT0_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE21_SR_FDCAN1_IT0         SYSCFG_ITLINE21_SR_FDCAN1_IT0_Msk  /*!< FDCAN1 IT0 Interrupt */
+#define SYSCFG_ITLINE21_SR_FDCAN2_IT0_Pos     (2U)
+#define SYSCFG_ITLINE21_SR_FDCAN2_IT0_Msk     (0x1UL << SYSCFG_ITLINE21_SR_FDCAN2_IT0_Pos) /*!< 0x00000003 */
+#define SYSCFG_ITLINE21_SR_FDCAN2_IT0         SYSCFG_ITLINE21_SR_FDCAN2_IT0_Msk  /*!< FDCAN2 IT0 Interrupt */
 #define SYSCFG_ITLINE22_SR_TIM17_GLB_Pos      (0U)
 #define SYSCFG_ITLINE22_SR_TIM17_GLB_Msk      (0x1UL << SYSCFG_ITLINE22_SR_TIM17_GLB_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE22_SR_TIM17_GLB          SYSCFG_ITLINE22_SR_TIM17_GLB_Msk /*!< TIM17 GLB Interrupt */
-#define SYSCFG_ITLINE22_SR_FDCAN2_GLB_Pos     (1U)
-#define SYSCFG_ITLINE22_SR_FDCAN2_GLB_Msk     (0x1UL << SYSCFG_ITLINE22_SR_FDCAN2_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE22_SR_FDCAN2_GLB         SYSCFG_ITLINE22_SR_FDCAN2_GLB_Msk /*!< FDCAN2 GLB Interrupt */
+#define SYSCFG_ITLINE22_SR_FDCAN1_IT1_Pos     (1U)
+#define SYSCFG_ITLINE22_SR_FDCAN1_IT1_Msk     (0x1UL << SYSCFG_ITLINE22_SR_FDCAN1_IT1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE22_SR_FDCAN1_IT1         SYSCFG_ITLINE22_SR_FDCAN1_IT1_Msk  /*!< FDCAN1 IT1 Interrupt */
+#define SYSCFG_ITLINE22_SR_FDCAN2_IT1_Pos     (2U)
+#define SYSCFG_ITLINE22_SR_FDCAN2_IT1_Msk     (0x1UL << SYSCFG_ITLINE22_SR_FDCAN2_IT1_Pos) /*!< 0x00000003 */
+#define SYSCFG_ITLINE22_SR_FDCAN2_IT1         SYSCFG_ITLINE22_SR_FDCAN2_IT1_Msk  /*!< FDCAN2 IT1 Interrupt */
 #define SYSCFG_ITLINE23_SR_I2C1_GLB_Pos       (0U)
 #define SYSCFG_ITLINE23_SR_I2C1_GLB_Msk       (0x1UL << SYSCFG_ITLINE23_SR_I2C1_GLB_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE24_SR_I2C3_GLB_Pos       (1U)
 #define SYSCFG_ITLINE24_SR_I2C3_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C3_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE24_SR_I2C3_GLB           SYSCFG_ITLINE24_SR_I2C3_GLB_Msk  /*!< I2C3 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C3_GLB           SYSCFG_ITLINE24_SR_I2C3_GLB_Msk  /*!< I2C3 GLB Interrupt  -> exti[24]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -8725,8 +8902,10 @@ typedef struct
 
 /*******************  Bit definition for TIM1_OR1 register  *******************/
 #define TIM1_OR1_OCREF_CLR_Pos     (0U)
-#define TIM1_OR1_OCREF_CLR_Msk     (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
-#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+#define TIM1_OR1_OCREF_CLR_Msk     (0x3UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM1_OR1_OCREF_CLR_0       (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM1_OR1_OCREF_CLR_1       (0x2UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
 
 /*******************  Bit definition for TIM1_AF1 register  *******************/
 #define TIM1_AF1_BKINE_Pos        (0U)
@@ -8738,6 +8917,9 @@ typedef struct
 #define TIM1_AF1_BKCMP2E_Pos      (2U)
 #define TIM1_AF1_BKCMP2E_Msk      (0x1UL << TIM1_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM1_AF1_BKCMP2E          TIM1_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM1_AF1_BKCMP3E_Pos      (3U)
+#define TIM1_AF1_BKCMP3E_Msk      (0x1UL << TIM1_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM1_AF1_BKCMP3E          TIM1_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM1_AF1_BKINP_Pos        (9U)
 #define TIM1_AF1_BKINP_Msk        (0x1UL << TIM1_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM1_AF1_BKINP            TIM1_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -8747,6 +8929,9 @@ typedef struct
 #define TIM1_AF1_BKCMP2P_Pos      (11U)
 #define TIM1_AF1_BKCMP2P_Msk      (0x1UL << TIM1_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM1_AF1_BKCMP2P          TIM1_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM1_AF1_BKCMP3P_Pos      (12U)
+#define TIM1_AF1_BKCMP3P_Msk      (0x1UL << TIM1_AF1_BKCMP3P_Pos)              /*!< 0x00001000 */
+#define TIM1_AF1_BKCMP3P          TIM1_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 #define TIM1_AF1_ETRSEL_Pos       (14U)
 #define TIM1_AF1_ETRSEL_Msk       (0xFUL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
@@ -8766,6 +8951,9 @@ typedef struct
 #define TIM1_AF2_BK2CMP2E_Pos     (2U)
 #define TIM1_AF2_BK2CMP2E_Msk     (0x1UL << TIM1_AF2_BK2CMP2E_Pos)             /*!< 0x00000004 */
 #define TIM1_AF2_BK2CMP2E         TIM1_AF2_BK2CMP2E_Msk                        /*!<BRK2 COMP2 enable */
+#define TIM1_AF2_BK2CMP3E_Pos      (3U)
+#define TIM1_AF2_BK2CMP3E_Msk      (0x1UL << TIM1_AF2_BK2CMP3E_Pos)            /*!< 0x00000008 */
+#define TIM1_AF2_BK2CMP3E          TIM1_AF2_BK2CMP3E_Msk                       /*!<BRK2 COMP3 enable */
 #define TIM1_AF2_BK2INP_Pos       (9U)
 #define TIM1_AF2_BK2INP_Msk       (0x1UL << TIM1_AF2_BK2INP_Pos)               /*!< 0x00000200 */
 #define TIM1_AF2_BK2INP           TIM1_AF2_BK2INP_Msk                          /*!<BRK2 BKIN2 input polarity */
@@ -8775,11 +8963,16 @@ typedef struct
 #define TIM1_AF2_BK2CMP2P_Pos     (11U)
 #define TIM1_AF2_BK2CMP2P_Msk     (0x1UL << TIM1_AF2_BK2CMP2P_Pos)             /*!< 0x00000800 */
 #define TIM1_AF2_BK2CMP2P         TIM1_AF2_BK2CMP2P_Msk                        /*!<BRK2 COMP2 input polarity */
+#define TIM1_AF2_BK2CMP3P_Pos      (12U)
+#define TIM1_AF2_BK2CMP3P_Msk      (0x1UL << TIM1_AF2_BK2CMP3P_Pos)            /*!< 0x00001000 */
+#define TIM1_AF2_BK2CMP3P          TIM1_AF2_BK2CMP3P_Msk                       /*!<BRK2 COMP3 input polarity */
 
 /*******************  Bit definition for TIM2_OR1 register  *******************/
 #define TIM2_OR1_OCREF_CLR_Pos     (0U)
-#define TIM2_OR1_OCREF_CLR_Msk     (0x1UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
-#define TIM2_OR1_OCREF_CLR         TIM2_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+#define TIM2_OR1_OCREF_CLR_Msk     (0x3UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM2_OR1_OCREF_CLR         TIM2_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM2_OR1_OCREF_CLR_0       (0x1UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM2_OR1_OCREF_CLR_1       (0x2UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
 
 /*******************  Bit definition for TIM2_AF1 register  *******************/
 #define TIM2_AF1_ETRSEL_Pos       (14U)
@@ -8792,8 +8985,10 @@ typedef struct
 
 /*******************  Bit definition for TIM3_OR1 register  *******************/
 #define TIM3_OR1_OCREF_CLR_Pos     (0U)
-#define TIM3_OR1_OCREF_CLR_Msk     (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
-#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+#define TIM3_OR1_OCREF_CLR_Msk     (0x3UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM3_OR1_OCREF_CLR_0       (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM3_OR1_OCREF_CLR_1       (0x2UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
 
 /*******************  Bit definition for TIM3_AF1 register  *******************/
 #define TIM3_AF1_ETRSEL_Pos       (14U)
@@ -8804,10 +8999,26 @@ typedef struct
 #define TIM3_AF1_ETRSEL_2         (0x4UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
 #define TIM3_AF1_ETRSEL_3         (0x8UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
 
+/*******************  Bit definition for TIM4_OR1 register  *******************/
+#define TIM4_OR1_OCREF_CLR_Pos     (0U)
+#define TIM4_OR1_OCREF_CLR_Msk     (0x3UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM4_OR1_OCREF_CLR         TIM4_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM4_OR1_OCREF_CLR_0       (0x1UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM4_OR1_OCREF_CLR_1       (0x2UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
+
+/*******************  Bit definition for TIM4_AF1 register  *******************/
+#define TIM4_AF1_ETRSEL_Pos       (14U)
+#define TIM4_AF1_ETRSEL_Msk       (0xFUL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM4_AF1_ETRSEL           TIM4_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM4 ETR source selection) */
+#define TIM4_AF1_ETRSEL_0         (0x1UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM4_AF1_ETRSEL_1         (0x2UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM4_AF1_ETRSEL_2         (0x4UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM4_AF1_ETRSEL_3         (0x8UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -8823,6 +9034,9 @@ typedef struct
 #define TIM15_AF1_BKCMP2E_Pos    (2U)
 #define TIM15_AF1_BKCMP2E_Msk    (0x1UL << TIM15_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM15_AF1_BKCMP2E        TIM15_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM15_AF1_BKCMP3E_Pos    (3U)
+#define TIM15_AF1_BKCMP3E_Msk    (0x1UL << TIM15_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM15_AF1_BKCMP3E        TIM15_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM15_AF1_BKINP_Pos      (9U)
 #define TIM15_AF1_BKINP_Msk      (0x1UL << TIM15_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM15_AF1_BKINP          TIM15_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -8832,6 +9046,9 @@ typedef struct
 #define TIM15_AF1_BKCMP2P_Pos    (11U)
 #define TIM15_AF1_BKCMP2P_Msk    (0x1UL << TIM15_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM15_AF1_BKCMP2P        TIM15_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM15_AF1_BKCMP3P_Pos    (12U)
+#define TIM15_AF1_BKCMP3P_Msk    (0x1UL << TIM15_AF1_BKCMP3P_Pos)              /*!< 0x00000010 */
+#define TIM15_AF1_BKCMP3P        TIM15_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 /*******************  Bit definition for TIM16_AF1 register  ******************/
 #define TIM16_AF1_BKINE_Pos      (0U)
@@ -8843,6 +9060,9 @@ typedef struct
 #define TIM16_AF1_BKCMP2E_Pos    (2U)
 #define TIM16_AF1_BKCMP2E_Msk    (0x1UL << TIM16_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM16_AF1_BKCMP2E        TIM16_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM16_AF1_BKCMP3E_Pos    (3U)
+#define TIM16_AF1_BKCMP3E_Msk    (0x1UL << TIM16_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM16_AF1_BKCMP3E        TIM16_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM16_AF1_BKINP_Pos      (9U)
 #define TIM16_AF1_BKINP_Msk      (0x1UL << TIM16_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM16_AF1_BKINP          TIM16_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -8852,6 +9072,9 @@ typedef struct
 #define TIM16_AF1_BKCMP2P_Pos    (11U)
 #define TIM16_AF1_BKCMP2P_Msk    (0x1UL << TIM16_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM16_AF1_BKCMP2P        TIM16_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM16_AF1_BKCMP3P_Pos    (12U)
+#define TIM16_AF1_BKCMP3P_Msk    (0x1UL << TIM16_AF1_BKCMP3P_Pos)              /*!< 0x00000010 */
+#define TIM16_AF1_BKCMP3P        TIM16_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 /*******************  Bit definition for TIM17_AF1 register  ******************/
 #define TIM17_AF1_BKINE_Pos      (0U)
@@ -8863,6 +9086,9 @@ typedef struct
 #define TIM17_AF1_BKCMP2E_Pos    (2U)
 #define TIM17_AF1_BKCMP2E_Msk    (0x1UL << TIM17_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM17_AF1_BKCMP2E        TIM17_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM17_AF1_BKCMP3E_Pos    (3U)
+#define TIM17_AF1_BKCMP3E_Msk    (0x1UL << TIM17_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM17_AF1_BKCMP3E        TIM17_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM17_AF1_BKINP_Pos      (9U)
 #define TIM17_AF1_BKINP_Msk      (0x1UL << TIM17_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM17_AF1_BKINP          TIM17_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -8872,11 +9098,14 @@ typedef struct
 #define TIM17_AF1_BKCMP2P_Pos    (11U)
 #define TIM17_AF1_BKCMP2P_Msk    (0x1UL << TIM17_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM17_AF1_BKCMP2P        TIM17_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM17_AF1_BKCMP3P_Pos    (12U)
+#define TIM17_AF1_BKCMP3P_Msk    (0x1UL << TIM17_AF1_BKCMP3P_Pos)              /*!< 0x00000010 */
+#define TIM17_AF1_BKCMP3P        TIM17_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -8884,7 +9113,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -8892,7 +9121,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -8900,7 +9129,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -9025,7 +9254,7 @@ typedef struct
 
 #define LPTIM_CFGR_TIMOUT_Pos       (19U)
 #define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
-#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timout enable */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
 #define LPTIM_CFGR_WAVE_Pos         (20U)
 #define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
 #define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
@@ -9682,7 +9911,7 @@ typedef struct
 #define DBG_APB_FZ1_DBG_TIM3_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
 #define DBG_APB_FZ1_DBG_TIM3_STOP                      DBG_APB_FZ1_DBG_TIM3_STOP_Msk
 #define DBG_APB_FZ1_DBG_TIM4_STOP_Pos                  (2U)
-#define DBG_APB_FZ1_DBG_TIM4_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM4_STOP_Pos) /*!< 0x00000003 */
+#define DBG_APB_FZ1_DBG_TIM4_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM4_STOP_Pos) /*!< 0x00000004 */
 #define DBG_APB_FZ1_DBG_TIM4_STOP                      DBG_APB_FZ1_DBG_TIM4_STOP_Msk
 #define DBG_APB_FZ1_DBG_TIM6_STOP_Pos                  (4U)
 #define DBG_APB_FZ1_DBG_TIM6_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM6_STOP_Pos) /*!< 0x00000010 */
@@ -9705,9 +9934,6 @@ typedef struct
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Pos    (22U)
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00400000 */
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Msk
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Pos    (23U)
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00800000 */
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Msk
 #define DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos                (30U)
 #define DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk                (0x1UL << DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos) /*!< 0x40000000 */
 #define DBG_APB_FZ1_DBG_LPTIM2_STOP                    DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk
@@ -10054,177 +10280,351 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                         USB Device FS Endpoint registers                   */
+/*                         USB Dual Role Device FS Endpoint registers         */
 /*                                                                            */
 /******************************************************************************/
-#define USB_DRD_FS_CHEP0R                              USB_DRD_FS_BASE                    /*!< Channel endpoint 0 register address */
-#define USB_DRD_FS_CHEP1R                             (USB_DRD_FS_BASE + 0x0x00000004)   /*!< Channel endpoint 1 register address */
-#define USB_DRD_FS_CHEP2R                             (USB_DRD_FS_BASE + 0x0x00000008)   /*!< Channel endpoint 2 register address */
-#define USB_DRD_FS_CHEP3R                             (USB_DRD_FS_BASE + 0x0x0000000C)   /*!< Channel endpoint 3 register address */
-#define USB_DRD_FS_CHEP4R                             (USB_DRD_FS_BASE + 0x0x00000010)   /*!< Channel endpoint 4 register address */
-#define USB_DRD_FS_CHEP5R                             (USB_DRD_FS_BASE + 0x0x00000014)   /*!< Channel endpoint 5 register address */
-#define USB_DRD_FS_CHEP6R                             (USB_DRD_FS_BASE + 0x0x00000018)   /*!< Channel endpoint 6 register address */
-#define USB_DRD_FS_CHEP7R                             (USB_DRD_FS_BASE + 0x0x0000001C)   /*!< Channel endpoint 7 register address */
 
-/* bit positions */
-//#define USB_DRD_CHEP_CTR_RX                            ((uint16_t)0x8000U)           /*!<  Channel EndPoint Correct TRansfer RX */
-//#define USB_DRD_CHEP_DTOG_RX                           ((uint16_t)0x4000U)           /*!<  Channel EndPoint Data TOGGLE RX */
-//#define USB_DRD_CHEPRX_STAT                            ((uint16_t)0x3000U)           /*!<  Channel EndPoint RX STATus bit field */
-//#define USB_DRD_CHEP_SETUP                             ((uint16_t)0x0800U)           /*!<  Channel EndPoint SETUP */
-//#define USB_DRD_CHEP_T_FIELD                           ((uint16_t)0x0600U)           /*!<  Channel EndPoint TYPE */
-//#define USB_DRD_CHEP_KIND                              ((uint16_t)0x0100U)           /*!<  Channel EndPoint KIND */
-//#define USB_DRD_CHEP_CTR_TX                            ((uint16_t)0x0080U)           /*!<  Channel EndPoint Correct TRansfer TX */
-//#define USB_DRD_CHEP_DTOG_TX                           ((uint16_t)0x0040U)           /*!<  Channel EndPoint Data TOGGLE TX */
-//#define USB_DRD_CHEPTX_STAT                            ((uint16_t)0x0030U)           /*!<  Channel EndPoint TX STATus bit field */
-//#define USB_DRD_CHEPADDR_FIELD                         ((uint16_t)0x000FU)           /*!<  Channel EndPoint ADDRess FIELD */
+/******************  Bits definition for USB_DRD_CNTR register  *******************/
+#define USB_CNTR_HOST_Pos               (31U)
+#define USB_CNTR_HOST_Msk               (0x1UL << USB_CNTR_HOST_Pos)    /*!< 0x80000000 */
+#define USB_CNTR_HOST                   USB_CNTR_HOST_Msk               /*!< Host Mode  */
+#define USB_CNTR_THR512M_Pos            (16U)
+#define USB_CNTR_THR512M_Msk            (0x1UL << USB_CNTR_THR512M_Pos)  /*!< 0x00010000 */
+#define USB_CNTR_THR512M                USB_CNTR_THR512M_Msk             /*!< 512byte Threshold interrupt mask */
+#define USB_CNTR_CTRM_Pos               (15U)
+#define USB_CNTR_CTRM_Msk               (0x1UL << USB_CNTR_CTRM_Pos)    /*!< 0x00008000 */
+#define USB_CNTR_CTRM                   USB_CNTR_CTRM_Msk               /*!< Correct Transfer Mask */
+#define USB_CNTR_PMAOVRM_Pos            (14U)
+#define USB_CNTR_PMAOVRM_Msk            (0x1UL << USB_CNTR_PMAOVRM_Pos) /*!< 0x00004000 */
+#define USB_CNTR_PMAOVRM                USB_CNTR_PMAOVRM_Msk            /*!< DMA OVeR/underrun Mask */
+#define USB_CNTR_ERRM_Pos               (13U)
+#define USB_CNTR_ERRM_Msk               (0x1UL << USB_CNTR_ERRM_Pos)    /*!< 0x00002000 */
+#define USB_CNTR_ERRM                   USB_CNTR_ERRM_Msk               /*!< ERRor Mask */
+#define USB_CNTR_WKUPM_Pos              (12U)
+#define USB_CNTR_WKUPM_Msk              (0x1UL << USB_CNTR_WKUPM_Pos)   /*!< 0x00001000 */
+#define USB_CNTR_WKUPM                  USB_CNTR_WKUPM_Msk              /*!< WaKe UP Mask */
+#define USB_CNTR_SUSPM_Pos              (11U)
+#define USB_CNTR_SUSPM_Msk              (0x1UL << USB_CNTR_SUSPM_Pos)   /*!< 0x00000800 */
+#define USB_CNTR_SUSPM                  USB_CNTR_SUSPM_Msk              /*!< SUSPend Mask */
+#define USB_CNTR_RESETM_Pos             (10U)
+#define USB_CNTR_RESETM_Msk             (0x1UL << USB_CNTR_RESETM_Pos)  /*!< 0x00000400 */
+#define USB_CNTR_RESETM                 USB_CNTR_RESETM_Msk             /*!< RESET Mask */
+#define USB_CNTR_DCON                   USB_CNTR_RESETM_Msk             /*!< Disconnection Connection Mask */
+#define USB_CNTR_SOFM_Pos               (9U)
+#define USB_CNTR_SOFM_Msk               (0x1UL << USB_CNTR_SOFM_Pos)    /*!< 0x00000200 */
+#define USB_CNTR_SOFM                   USB_CNTR_SOFM_Msk               /*!< Start Of Frame Mask */
+#define USB_CNTR_ESOFM_Pos              (8U)
+#define USB_CNTR_ESOFM_Msk              (0x1UL << USB_CNTR_ESOFM_Pos)   /*!< 0x00000100 */
+#define USB_CNTR_ESOFM                  USB_CNTR_ESOFM_Msk              /*!< Expected Start Of Frame Mask */
+#define USB_CNTR_L1REQM_Pos             (7U)
+#define USB_CNTR_L1REQM_Msk             (0x1UL << USB_CNTR_L1REQM_Pos)  /*!< 0x00000080 */
+#define USB_CNTR_L1REQM                 USB_CNTR_L1REQM_Msk             /*!< LPM L1 state request interrupt Mask */
+#define USB_CNTR_L1XACT_Pos             (6U)
+#define USB_CNTR_L1XACT_Msk             (0x1UL << USB_CNTR_L1XACT_Pos)  /*!< 0x00000040 */
+#define USB_CNTR_L1XACT                 USB_CNTR_L1XACT_Msk             /*!< Host LPM L1 transaction request Mask */
+#define USB_CNTR_L1RES_Pos              (5U)
+#define USB_CNTR_L1RES_Msk              (0x1UL << USB_CNTR_L1RES_Pos)   /*!< 0x00000020 */
+#define USB_CNTR_L1RES                  USB_CNTR_L1RES_Msk              /*!< LPM L1 Resume request/ Remote Wakeup Mask */
+#define USB_CNTR_L2RES_Pos              (4U)
+#define USB_CNTR_L2RES_Msk              (0x1UL << USB_CNTR_L2RES_Pos)   /*!< 0x00000010 */
+#define USB_CNTR_L2RES                  USB_CNTR_L2RES_Msk              /*!< L2 Remote Wakeup / Resume driver Mask */
+#define USB_CNTR_SUSPEN_Pos             (3U)
+#define USB_CNTR_SUSPEN_Msk             (0x1UL << USB_CNTR_SUSPEN_Pos)  /*!< 0x00000008 */
+#define USB_CNTR_SUSPEN                 USB_CNTR_SUSPEN_Msk             /*!< Suspend state enable Mask */
+#define USB_CNTR_SUSPRDY_Pos            (2U)
+#define USB_CNTR_SUSPRDY_Msk            (0x1UL << USB_CNTR_SUSPRDY_Pos) /*!< 0x00000004 */
+#define USB_CNTR_SUSPRDY                USB_CNTR_SUSPRDY_Msk            /*!< Suspend state effective Mask */
+#define USB_CNTR_PDWN_Pos               (1U)
+#define USB_CNTR_PDWN_Msk               (0x1UL << USB_CNTR_PDWN_Pos)    /*!< 0x00000002 */
+#define USB_CNTR_PDWN                   USB_CNTR_PDWN_Msk               /*!< Power DoWN Mask */
+#define USB_CNTR_USBRST_Pos             (0U)
+#define USB_CNTR_USBRST_Msk             (0x1UL << USB_CNTR_USBRST_Pos)  /*!< 0x00000001 */
+#define USB_CNTR_USBRST                 USB_CNTR_USBRST_Msk             /*!< USB Reset Mask */
 
-#define USB_DRD_FS_CHEP_VTRX                              ((uint16_t)0x8000U)           /*!<  USB valid transaction received*/
-#define USB_DRD_FS_CHEP_DTOG_RX                           ((uint16_t)0x4000U)           /*!<  Data Toggle, for reception transfers*/
-#define USB_DRD_FS_CHEPRX_STRX                            ((uint16_t)0x3000U)           /*!<  Status bits, for reception transfers*/
-#define USB_DRD_FS_CHEP_SETUP                             ((uint16_t)0x0800U)           /*!<  Setup transaction completed*/
-#define USB_DRD_FS_CHEP_UTYPE                             ((uint16_t)0x0600U)           /*!<  USB type of transaction */
-#define USB_DRD_FS_CHEP_EPKIND                            ((uint16_t)0x0100U)           /*!<  EndPoint KIND */
-#define USB_DRD_FS_CHEP_VTTX                              ((uint16_t)0x0080U)           /*!<  Valid USB transaction transmitted*/
-#define USB_DRD_FS_CHEP_DTOG_TX                           ((uint16_t)0x0040U)           /*!<  Data Toggle, for transmission transfers */
-#define USB_DRD_FS_CHEPTX_STTX                            ((uint16_t)0x0030U)           /*!<  Status bits, for transmission transfers */
-#define USB_DRD_FS_CHEPADDR_FIELD                         ((uint16_t)0x000FU)           /*!<  Endpoint address*/
+/******************  Bits definition for USB_DRD_ISTR register  *******************/
+#define USB_ISTR_IDN_Pos                (0U)
+#define USB_ISTR_IDN_Msk                (0xFUL << USB_ISTR_IDN_Pos)     /*!< 0x0000000F */
+#define USB_ISTR_IDN                    USB_ISTR_IDN_Msk                /*!< EndPoint IDentifier (read-only bit) Mask */
+#define USB_ISTR_DIR_Pos                (4U)
+#define USB_ISTR_DIR_Msk                (0x1UL << USB_ISTR_DIR_Pos)     /*!< 0x00000010 */
+#define USB_ISTR_DIR                    USB_ISTR_DIR_Msk                /*!< DIRection of transaction (read-only bit) Mask */
+#define USB_ISTR_L1REQ_Pos              (7U)
+#define USB_ISTR_L1REQ_Msk              (0x1UL << USB_ISTR_L1REQ_Pos)   /*!< 0x00000080 */
+#define USB_ISTR_L1REQ                  USB_ISTR_L1REQ_Msk              /*!< LPM L1 state request Mask */
+#define USB_ISTR_ESOF_Pos               (8U)
+#define USB_ISTR_ESOF_Msk               (0x1UL << USB_ISTR_ESOF_Pos)    /*!< 0x00000100 */
+#define USB_ISTR_ESOF                   USB_ISTR_ESOF_Msk               /*!< Expected Start Of Frame (clear-only bit) Mask */
+#define USB_ISTR_SOF_Pos                (9U)
+#define USB_ISTR_SOF_Msk                (0x1UL << USB_ISTR_SOF_Pos)     /*!< 0x00000200 */
+#define USB_ISTR_SOF                    USB_ISTR_SOF_Msk                /*!< Start Of Frame (clear-only bit) Mask */
+#define USB_ISTR_RESET_Pos              (10U)
+#define USB_ISTR_RESET_Msk              (0x1UL << USB_ISTR_RESET_Pos)   /*!< 0x00000400 */
+#define USB_ISTR_RESET                  USB_ISTR_RESET_Msk              /*!< RESET Mask */
+#define USB_ISTR_DCON_Pos               (10U)
+#define USB_ISTR_DCON_Msk               (0x1UL << USB_ISTR_DCON_Pos)    /*!< 0x00000400 */
+#define USB_ISTR_DCON                   USB_ISTR_DCON_Msk               /*!< HOST MODE-Device Connection or disconnection Mask */
+#define USB_ISTR_SUSP_Pos               (11U)
+#define USB_ISTR_SUSP_Msk               (0x1UL << USB_ISTR_SUSP_Pos)    /*!< 0x00000800 */
+#define USB_ISTR_SUSP                   USB_ISTR_SUSP_Msk               /*!< SUSPend (clear-only bit) Mask */
+#define USB_ISTR_WKUP_Pos               (12U)
+#define USB_ISTR_WKUP_Msk               (0x1UL << USB_ISTR_WKUP_Pos)    /*!< 0x00001000 */
+#define USB_ISTR_WKUP                   USB_ISTR_WKUP_Msk               /*!< WaKe UP (clear-only bit) Mask */
+#define USB_ISTR_ERR_Pos                (13U)
+#define USB_ISTR_ERR_Msk                (0x1UL << USB_ISTR_ERR_Pos)     /*!< 0x00002000 */
+#define USB_ISTR_ERR                    USB_ISTR_ERR_Msk                /*!< ERRor (clear-only bit) Mask */
+#define USB_ISTR_PMAOVR_Pos             (14U)
+#define USB_ISTR_PMAOVR_Msk             (0x1UL << USB_ISTR_PMAOVR_Pos)  /*!< 0x00004000 */
+#define USB_ISTR_PMAOVR                 USB_ISTR_PMAOVR_Msk             /*!< PMA OVeR/underrun (clear-only bit) Mask */
+#define USB_ISTR_CTR_Pos                (15U)
+#define USB_ISTR_CTR_Msk                (0x1UL << USB_ISTR_CTR_Pos)     /*!< 0x00008000 */
+#define USB_ISTR_CTR                    USB_ISTR_CTR_Msk                /*!< Correct TRansfer (clear-only bit) Mask */
+#define USB_ISTR_THR512_Pos             (16U)
+#define USB_ISTR_THR512_Msk             (0x1UL << USB_ISTR_THR512_Pos)  /*!< 0x00010000 */
+#define USB_ISTR_THR512                 USB_ISTR_THR512_Msk             /*!< 512byte threshold interrupt (used with isochrnous single buffer ) */
+#define USB_ISTR_DCON_STAT_Pos          (29U)
+#define USB_ISTR_DCON_STAT_Msk          (0x1UL << USB_ISTR_DCON_STAT_Pos)/*!< 0x20000000 */
+#define USB_ISTR_DCON_STAT              USB_ISTR_DCON_STAT_Msk           /*!< Device Connection status (connected/Disconnected) don't cause an interrupt */
+#define USB_ISTR_LS_DCONN_Pos           (30U)
+#define USB_ISTR_LS_DCONN_Msk           (0x1UL << USB_ISTR_LS_DCONN_Pos)/*!< 0x40000000 */
+#define USB_ISTR_LS_DCONN               USB_ISTR_LS_DCONN_Msk           /*!< LS_DCONN Mask */
 
+/******************  Bits definition for USB_DRD_FNR register  ********************/
+#define USB_FNR_FN_Pos                  (0U)
+#define USB_FNR_FN_Msk                  (0x7FFUL << USB_FNR_FN_Pos)     /*!< 0x000007FF */
+#define USB_FNR_FN                      USB_FNR_FN_Msk                  /*!< Frame Number Mask */
+#define USB_FNR_LSOF_Pos                (11U)
+#define USB_FNR_LSOF_Msk                (0x3UL << USB_FNR_LSOF_Pos)     /*!< 0x00001800 */
+#define USB_FNR_LSOF                    USB_FNR_LSOF_Msk                /*!< Lost SOF  Mask */
+#define USB_FNR_LCK_Pos                 (13U)
+#define USB_FNR_LCK_Msk                 (0x1UL << USB_FNR_LCK_Pos)      /*!< 0x00002000 */
+#define USB_FNR_LCK                     USB_FNR_LCK_Msk                 /*!< LoCKed Mask */
+#define USB_FNR_RXDM_Pos                (14U)
+#define USB_FNR_RXDM_Msk                (0x1UL << USB_FNR_RXDM_Pos)     /*!< 0x00004000 */
+#define USB_FNR_RXDM                    USB_FNR_RXDM_Msk                /*!< status of D- data line Mask */
+#define USB_FNR_RXDP_Pos                (15U)
+#define USB_FNR_RXDP_Msk                (0x1UL << USB_FNR_RXDP_Pos)     /*!< 0x00008000 */
+#define USB_FNR_RXDP                    USB_FNR_RXDP_Msk                /*!< status of D+ data line Mask */
 
+/******************  Bits definition for USB_DRD_DADDR register    ****************/
+#define USB_DADDR_ADD_Pos               (0U)
+#define USB_DADDR_ADD_Msk               (0x7FUL << USB_DADDR_ADD_Pos)   /*!< 0x0000007F */
+#define USB_DADDR_ADD                   USB_DADDR_ADD_Msk               /*!<  ADD[6:0] bits (Device Address)Mask */
+#define USB_DADDR_ADD0_Pos              (0U)
+#define USB_DADDR_ADD0_Msk              (0x1UL << USB_DADDR_ADD0_Pos)   /*!< 0x00000001 */
+#define USB_DADDR_ADD0                  USB_DADDR_ADD0_Msk              /*!< Bit 0 Mask */
+#define USB_DADDR_ADD1_Pos              (1U)
+#define USB_DADDR_ADD1_Msk              (0x1UL << USB_DADDR_ADD1_Pos)   /*!< 0x00000002 */
+#define USB_DADDR_ADD1                  USB_DADDR_ADD1_Msk              /*!< Bit 1 Mask */
+#define USB_DADDR_ADD2_Pos              (2U)
+#define USB_DADDR_ADD2_Msk              (0x1UL << USB_DADDR_ADD2_Pos)   /*!< 0x00000004 */
+#define USB_DADDR_ADD2                  USB_DADDR_ADD2_Msk              /*!< Bit 2 Mask */
+#define USB_DADDR_ADD3_Pos              (3U)
+#define USB_DADDR_ADD3_Msk              (0x1UL << USB_DADDR_ADD3_Pos)   /*!< 0x00000008 */
+#define USB_DADDR_ADD3                  USB_DADDR_ADD3_Msk              /*!< Bit 3 Mask */
+#define USB_DADDR_ADD4_Pos              (4U)
+#define USB_DADDR_ADD4_Msk              (0x1UL << USB_DADDR_ADD4_Pos)   /*!< 0x00000010 */
+#define USB_DADDR_ADD4                  USB_DADDR_ADD4_Msk              /*!< Bit 4 Mask */
+#define USB_DADDR_ADD5_Pos              (5U)
+#define USB_DADDR_ADD5_Msk              (0x1UL << USB_DADDR_ADD5_Pos)   /*!< 0x00000020 */
+#define USB_DADDR_ADD5                  USB_DADDR_ADD5_Msk              /*!< Bit 5 Mask */
+#define USB_DADDR_ADD6_Pos              (6U)
+#define USB_DADDR_ADD6_Msk              (0x1UL << USB_DADDR_ADD6_Pos)   /*!< 0x00000040 */
+#define USB_DADDR_ADD6                  USB_DADDR_ADD6_Msk              /*!< Bit 6 Mask */
+#define USB_DADDR_EF_Pos                (7U)
+#define USB_DADDR_EF_Msk                (0x1UL << USB_DADDR_EF_Pos)     /*!< 0x00000080 */
+#define USB_DADDR_EF                    USB_DADDR_EF_Msk                /*!< Enable Function Mask */
 
-/* EndPoint REGister MASK (no toggle fields) */
-#define USB_DRD_FS_CHEPREG_MASK                           (USB_DRD_FS_CHEP_VTRX|USB_DRD_FS_CHEP_SETUP|USB_DRD_FS_CHEP_UTYPE|USB_DRD_FS_CHEP_EPKIND|USB_DRD_FS_CHEP_VTTX|USB_DRD_FS_CHEPADDR_FIELD) /*=8f8f*/
-                                                                         /*!< EP_TYPE[1:0] Channel/EndPoint TYPE */
-#define USB_DRD_FS_CHEP_TYPE_MASK                         ((uint16_t)0x0600U)           /*!< Channel/EndPoint TYPE Mask */
-#define USB_DRD_FS_CHEP_BULK                              ((uint16_t)0x0000U)           /*!< Channel/EndPoint BULK */
-#define USB_DRD_FS_CHEP_CONTROL                           ((uint16_t)0x0200U)           /*!< Channel/EndPoint CONTROL */
-#define USB_DRD_FS_CHEP_ISOCHRONOUS                       ((uint16_t)0x0400U)           /*!< Channel/EndPoint ISOCHRONOUS */
-#define USB_DRD_FS_CHEP_INTERRUPT                         ((uint16_t)0x0600U)           /*!< Channel/EndPoint INTERRUPT */
-#define USB_DRD_FS_CHEP_T_MASK                            ((uint16_t) ~USB_DRD_FS_CHEP_UTYPE & USB_DRD_FS_CHEPREG_MASK) /*=0x898F*/
-
-#define USB_DRD_FS_CHEPKIND_MASK                          ((uint16_t)~USB_DRD_FS_CHEP_EPKIND & USB_DRD_FS_CHEPREG_MASK) /*!< EP_KIND EndPoint KIND */
-                                                                         /*!< STAT_TX[1:0] STATus for TX transfer */
-#define USB_DRD_FS_CHEP_TX_DIS                            ((uint16_t)0x0000U)           /*!< EndPoint TX DISabled */
-#define USB_DRD_FS_CHEP_TX_STALL                          ((uint16_t)0x0010U)           /*!< EndPoint TX STALLed */
-#define USB_DRD_FS_CHEP_TX_NAK                            ((uint16_t)0x0020U)           /*!< EndPoint TX NAKed */
-#define USB_DRD_FS_CHEP_TX_VALID                          ((uint16_t)0x0030U)           /*!< EndPoint TX VALID */
-#define USB_DRD_FS_CHEPTX_DTOG1                           ((uint16_t)0x0010U)           /*!< EndPoint TX Data TOGgle bit1 */
-#define USB_DRD_FS_CHEPTX_DTOG2                           ((uint16_t)0x0020U)           /*!< EndPoint TX Data TOGgle bit2 */
-#define USB_DRD_FS_CHEPTX_DTOGMASK                         (USB_DRD_FS_CHEPTX_STTX|USB_DRD_FS_CHEPREG_MASK)
-
-
-                                                                         /*!< STAT_RX[1:0] STATus for RX transfer */
-#define USB_DRD_FS_CHEP_RX_DIS                            ((uint16_t)0x0000U)           /*!< EndPoint RX DISabled */
-#define USB_DRD_FS_CHEP_RX_STALL                          ((uint16_t)0x1000U)           /*!< EndPoint RX STALLed */
-#define USB_DRD_FS_CHEP_RX_NAK                            ((uint16_t)0x2000U)           /*!< EndPoint RX NAKed */
-#define USB_DRD_FS_CHEP_RX_VALID                          ((uint16_t)0x3000U)           /*!< EndPoint RX VALID */
-
-#define USB_DRD_FS_CHEPRX_DTOG1                           ((uint16_t)0x1000U)           /*!< EndPoint RX Data TOGgle bit1 */
-#define USB_DRD_FS_CHEPRX_DTOG2                           ((uint16_t)0x2000U)           /*!< EndPoint RX Data TOGgle bit1 */
-
-#define USB_DRD_FS_CHEPRX_DTOGMASK                        (USB_DRD_FS_CHEPRX_STRX|USB_DRD_FS_CHEPREG_MASK)
-
-/*Buffer Descriprot Mask*/
-#define USB_DRD_FS_CHEPX_TXBD_ADDMSK                       ((uint32_t)0xFFFF0000)
-#define USB_DRD_FS_CHEPX_TXBD_COUNTMSK                     ((uint32_t)0x0000FFFF)
-#define USB_DRD_FS_CHEPX_RXBD_ADDMSK                       ((uint32_t)0xFFFF0000)
-#define USB_DRD_FS_CHEPX_RXBD_COUNTMSK                     ((uint32_t)0x0000FFFF)
-
-
-/******************************************************************************/
-/*                                                                            */
-/*                         USB Device FS General registers                    */
-/*                                                                            */
-/******************************************************************************/
-#define USB_DRD_FS_CNTR                             (USB_DRD_FS_BASE + 0x00000040U)     /*!< Control register */
-#define USB_DRD_FS_ISTR                             (USB_DRD_FS_BASE + 0x00000044U)     /*!< Interrupt status register */
-#define USB_DRD_FS_FNR                              (USB_DRD_FS_BASE + 0x00000048U)     /*!< Frame number register */
-#define USB_DRD_FS_DADDR                            (USB_DRD_FS_BASE + 0x0000004CU)     /*!< Device address register */
-#define USB_DRD_FS_BTABLE                           (USB_DRD_FS_BASE + 0x00000050U)     /*!< Buffer Table address register */
-#define USB_DRD_FS_LPMCSR                           (USB_DRD_FS_BASE + 0x00000054U)     /*!< LPM Control and Status register */
-#define USB_DRD_FS_BCDR                             (USB_DRD_FS_BASE + 0x00000058U)     /*!< Battery Charging detector register*/
-
-/******************  Bits definition for USB_DRD_FS_CNTR register  *******************/
-#define USB_DRD_FS_CNTR_HOST                            ((uint32_t)0x80000000U)           /*!< Host Mode  */
-#define USB_DRD_FS_CNTR_CTRM                            ((uint32_t)0x00008000U)           /*!< Correct TRansfer Mask */
-#define USB_DRD_FS_CNTR_PMAOVRM                         ((uint32_t)0x00004000U)           /*!< DMA OVeR/underrun Mask */
-#define USB_DRD_FS_CNTR_ERRM                            ((uint32_t)0x00002000U)           /*!< ERRor Mask */
-#define USB_DRD_FS_CNTR_WKUPM                           ((uint32_t)0x00001000U)           /*!< WaKe UP Mask */
-#define USB_DRD_FS_CNTR_SUSPM                           ((uint32_t)0x00000800U)           /*!< SUSPend Mask */
-#define USB_DRD_FS_CNTR_RESETM                          ((uint32_t)0x00000400U)           /*!< RESET Mask   */
-#define USB_DRD_FS_CNTR_SOFM                            ((uint32_t)0x00000200U)           /*!< Start Of Frame Mask */
-#define USB_DRD_FS_CNTR_ESOFM                           ((uint32_t)0x00000100U)           /*!< Expected Start Of Frame Mask */
-#define USB_DRD_FS_CNTR_L1REQM                          ((uint32_t)0x00000080U)           /*!< LPM L1 state request interrupt mask */
-#define USB_DRD_FS_CNTR_L1XACT                          ((uint32_t)0x00000040U)           /*!< LPM L1 transaction request */
-#define USB_DRD_FS_CNTR_L1RES                           ((uint32_t)0x00000020U)           /*!< LPM L1 Resume request/ Remote Wakeup  */
-#define USB_DRD_FS_CNTR_L2RES                           ((uint32_t)0x00000010U)           /*!< L2 Remote Wakeup / Resume driver */
-#define USB_DRD_FS_CNTR_SUSPEN                          ((uint32_t)0x00000008U)           /*!< Suspend state enable*/
-#define USB_DRD_FS_CNTR_SYSPRDY                         ((uint32_t)0x00000004U)           /*!< Suspend state effective */
-#define USB_DRD_FS_CNTR_PDWN                            ((uint32_t)0x00000002U)           /*!< Power DoWN */
-#define USB_DRD_FS_CNTR_RST                             ((uint32_t)0x00000001U)           /*!< USB Reset */
-
-/******************  Bits definition for USB_DRD_FS_ISTR register  *******************/
-#define USB_DRD_FS_ISTR_IDN                             ((uint16_t)0x000FU)           /*!< EndPoint IDentifier (read-only bit)  */
-#define USB_DRD_FS_ISTR_DIR                             ((uint16_t)0x0010U)           /*!< DIRection of transaction (read-only bit)  */
-#define USB_DRD_FS_ISTR_L1REQ                           ((uint16_t)0x0080U)           /*!< LPM L1 state request  */
-#define USB_DRD_FS_ISTR_ESOF                            ((uint16_t)0x0100U)           /*!< Expected Start Of Frame (clear-only bit) */
-#define USB_DRD_FS_ISTR_SOF                             ((uint16_t)0x0200U)           /*!< Start Of Frame (clear-only bit) */
-#define USB_DRD_FS_ISTR_RESET                           ((uint16_t)0x0400U)           /*!< RESET (clear-only bit) */
-#define USB_DRD_FS_ISTR_DCON                            ((uint16_t)0x0400U)           /*!< HOST MODE-Device Connection or disconnection  */
-#define USB_DRD_FS_ISTR_SUSP                            ((uint16_t)0x0800U)           /*!< SUSPend (clear-only bit) */
-#define USB_DRD_FS_ISTR_WKUP                            ((uint16_t)0x1000U)           /*!< WaKe UP (clear-only bit) */
-#define USB_DRD_FS_ISTR_ERR                             ((uint16_t)0x2000U)           /*!< ERRor (clear-only bit) */
-#define USB_DRD_FS_ISTR_PMAOVR                          ((uint16_t)0x4000U)           /*!< DMA OVeR/underrun (clear-only bit) */
-#define USB_DRD_FS_ISTR_CTR                             ((uint16_t)0x8000U)           /*!< Correct TRansfer (clear-only bit) */
-
-#define USB_DRD_FS_CLR_L1REQ                            (~USB_DRD_FS_ISTR_L1REQ)           /*!< clear LPM L1  bit */
-#define USB_DRD_FS_CLR_ESOF                             (~USB_DRD_FS_ISTR_ESOF)            /*!< clear Expected Start Of Frame bit */
-#define USB_DRD_FS_CLR_SOF                              (~USB_DRD_FS_ISTR_SOF)             /*!< clear Start Of Frame bit */
-#define USB_DRD_FS_CLR_RESET                            (~USB_DRD_FS_ISTR_RESET)           /*!< clear RESET bit */
-#define USB_DRD_FS_CLR_SUSP                             (~USB_DRD_FS_ISTR_SUSP)            /*!< clear SUSPend bit */
-#define USB_DRD_FS_CLR_WKUP                             (~USB_DRD_FS_ISTR_WKUP)            /*!< clear WaKe UP bit */
-#define USB_DRD_FS_CLR_ERR                              (~USB_DRD_FS_ISTR_ERR)             /*!< clear ERRor bit */
-#define USB_DRD_FS_CLR_PMAOVR                           (~USB_DRD_FS_ISTR_PMAOVR)          /*!< clear DMA OVeR/underrun bit*/
-#define USB_DRD_FS_CLR_CTR                              (~USB_DRD_FS_ISTR_CTR)             /*!< clear Correct TRansfer bit */
-
-/******************  Bits definition for USB_DRD_FS_FNR register  ********************/
-#define USB_DRD_FS_FNR_FN                               ((uint16_t)0x07FFU)           /*!< Frame Number */
-#define USB_DRD_FS_FNR_LSOF                             ((uint16_t)0x1800U)           /*!< Lost SOF */
-#define USB_DRD_FS_FNR_LCK                              ((uint16_t)0x2000U)           /*!< LoCKed */
-#define USB_DRD_FS_FNR_RXDM                             ((uint16_t)0x4000U)           /*!< status of D- data line */
-#define USB_DRD_FS_FNR_RXDP                             ((uint16_t)0x8000U)           /*!< status of D+ data line */
-
-/******************  Bits definition for USB_DRD_FS_DADDR register    ****************/
-#define USB_DRD_FS_DADDR_ADD                            ((uint8_t)0x7FU)              /*!< ADD[6:0] bits (Device Address) */
-#define USB_DRD_FS_DADDR_ADD0                           ((uint8_t)0x01U)              /*!< Bit 0 */
-#define USB_DRD_FS_DADDR_ADD1                           ((uint8_t)0x02U)              /*!< Bit 1 */
-#define USB_DRD_FS_DADDR_ADD2                           ((uint8_t)0x04U)              /*!< Bit 2 */
-#define USB_DRD_FS_DADDR_ADD3                           ((uint8_t)0x08U)              /*!< Bit 3 */
-#define USB_DRD_FS_DADDR_ADD4                           ((uint8_t)0x10U)              /*!< Bit 4 */
-#define USB_DRD_FS_DADDR_ADD5                           ((uint8_t)0x20U)              /*!< Bit 5 */
-#define USB_DRD_FS_DADDR_ADD6                           ((uint8_t)0x40U)              /*!< Bit 6 */
-
-#define USB_DRD_FS_DADDR_EF                             ((uint8_t)0x80U)              /*!< Enable Function */
-
-/******************  Bit definition for USB_DRD_FS_BTABLE register  ******************/
-#define USB_DRD_FS_BTABLE_BTABLE                        ((uint16_t)0xFFF8U)           /*!< Buffer Table */
-
-/******************  Bits definition for USB_DRD_FS_BCDR register  *******************/
-#define USB_DRD_FS_BCDR_BCDEN                           ((uint16_t)0x0001U)           /*!< Battery charging detector (BCD) enable */
-#define USB_DRD_FS_BCDR_DCDEN                           ((uint16_t)0x0002U)           /*!< Data contact detection (DCD) mode enable */
-#define USB_DRD_FS_BCDR_PDEN                            ((uint16_t)0x0004U)           /*!< Primary detection (PD) mode enable */
-#define USB_DRD_FS_BCDR_SDEN                            ((uint16_t)0x0008U)           /*!< Secondary detection (SD) mode enable */
-#define USB_DRD_FS_BCDR_DCDET                           ((uint16_t)0x0010U)           /*!< Data contact detection (DCD) status */
-#define USB_DRD_FS_BCDR_PDET                            ((uint16_t)0x0020U)           /*!< Primary detection (PD) status */
-#define USB_DRD_FS_BCDR_SDET                            ((uint16_t)0x0040U)           /*!< Secondary detection (SD) status */
-#define USB_DRD_FS_BCDR_PS2DET                          ((uint16_t)0x0080U)           /*!< PS2 port or proprietary charger detected */
-#define USB_DRD_FS_BCDR_DPPU                            ((uint16_t)0x8000U)           /*!< DP Pull-up Enable */
-#define USB_DRD_FS_BCDR_DPPD                            ((uint16_t)0x8000U)           /*!< DP Pull-Down Enable */
+/******************  Bit definition for USB_DRD_BTABLE register  ******************/
+#define USB_BTABLE_BTABLE_Pos          (3U)
+#define USB_BTABLE_BTABLE_Msk          (0xFFF8UL << USB_BTABLE_BTABLE_Pos)/*!< 0x00000000 */
+#define USB_BTABLE_BTABLE              USB_BTABLE_BTABLE_Msk              /*!< Buffer Table Mask */
 
 /*******************  Bit definition for LPMCSR register  *********************/
-#define USB_DRD_FS_LPMCSR_LMPEN                         ((uint16_t)0x0001U)           /*!< LPM support enable  */
-#define USB_DRD_FS_LPMCSR_LPMACK                        ((uint16_t)0x0002U)           /*!< LPM Token acknowledge enable*/
-#define USB_DRD_FS_LPMCSR_REMWAKE                       ((uint16_t)0x0008U)           /*!< bRemoteWake value received with last ACKed LPM Token */
-#define USB_DRD_FS_LPMCSR_BESL                          ((uint16_t)0x00F0U)           /*!< BESL value received with last ACKed LPM Token  */
+#define USB_LPMCSR_LMPEN_Pos           (0U)
+#define USB_LPMCSR_LMPEN_Msk           (0x1UL << USB_LPMCSR_LMPEN_Pos)  /*!< 0x00000001 */
+#define USB_LPMCSR_LMPEN               USB_LPMCSR_LMPEN_Msk             /*!< LPM support enable Mask */
+#define USB_LPMCSR_LPMACK_Pos          (1U)
+#define USB_LPMCSR_LPMACK_Msk          (0x1UL << USB_LPMCSR_LPMACK_Pos) /*!< 0x00000002 */
+#define USB_LPMCSR_LPMACK              USB_LPMCSR_LPMACK_Msk            /*!< LPM Token acknowledge enable Mask */
+#define USB_LPMCSR_REMWAKE_Pos         (3U)
+#define USB_LPMCSR_REMWAKE_Msk         (0x1UL << USB_LPMCSR_REMWAKE_Pos)/*!< 0x00000008 */
+#define USB_LPMCSR_REMWAKE             USB_LPMCSR_REMWAKE_Msk           /*!< bRemoteWake value received with last ACKed LPM Token Mask */
+#define USB_LPMCSR_BESL_Pos            (4U)
+#define USB_LPMCSR_BESL_Msk            (0xFUL << USB_LPMCSR_BESL_Pos)   /*!< 0x000000F0 */
+#define USB_LPMCSR_BESL                USB_LPMCSR_BESL_Msk              /*!< BESL value received with last ACKed LPM Token Mask */
+
+/******************  Bits definition for USB_DRD_BCDR register  *******************/
+#define USB_BCDR_BCDEN_Pos             (0U)
+#define USB_BCDR_BCDEN_Msk             (0x1UL << USB_BCDR_BCDEN_Pos)    /*!< 0x00000001 */
+#define USB_BCDR_BCDEN                 USB_BCDR_BCDEN_Msk               /*!< Battery charging detector (BCD) enable Mask */
+#define USB_BCDR_DCDEN_Pos             (1U)
+#define USB_BCDR_DCDEN_Msk             (0x1UL << USB_BCDR_DCDEN_Pos)    /*!< 0x00000002 */
+#define USB_BCDR_DCDEN                 USB_BCDR_DCDEN_Msk               /*!< Data contact detection (DCD) mode enable Mask */
+#define USB_BCDR_PDEN_Pos              (2U)
+#define USB_BCDR_PDEN_Msk              (0x1UL << USB_BCDR_PDEN_Pos)     /*!< 0x00000004 */
+#define USB_BCDR_PDEN                  USB_BCDR_PDEN_Msk                /*!< Primary detection (PD) mode enable Mask */
+#define USB_BCDR_SDEN_Pos              (3U)
+#define USB_BCDR_SDEN_Msk              (0x1UL << USB_BCDR_SDEN_Pos)     /*!< 0x00000008 */
+#define USB_BCDR_SDEN                  USB_BCDR_SDEN_Msk                /*!< Secondary detection (SD) mode enable Mask */
+#define USB_BCDR_DCDET_Pos             (4U)
+#define USB_BCDR_DCDET_Msk             (0x1UL << USB_BCDR_DCDET_Pos)    /*!< 0x00000010 */
+#define USB_BCDR_DCDET                 USB_BCDR_DCDET_Msk               /*!< Data contact detection (DCD) status Mask */
+#define USB_BCDR_PDET_Pos              (5U)
+#define USB_BCDR_PDET_Msk              (0x1UL << USB_BCDR_PDET_Pos)     /*!< 0x00000020 */
+#define USB_BCDR_PDET                  USB_BCDR_PDET_Msk                /*!< Primary detection (PD) status Mask */
+#define USB_BCDR_SDET_Pos              (6U)
+#define USB_BCDR_SDET_Msk              (0x1UL << USB_BCDR_SDET_Pos)     /*!< 0x00000040 */
+#define USB_BCDR_SDET                  USB_BCDR_SDET_Msk                /*!< Secondary detection (SD) status Mask */
+#define USB_BCDR_PS2DET_Pos            (7U)
+#define USB_BCDR_PS2DET_Msk            (0x1UL << USB_BCDR_PS2DET_Pos)   /*!< 0x00000080 */
+#define USB_BCDR_PS2DET                USB_BCDR_PS2DET_Msk              /*!< PS2 port or proprietary charger detected Mask */
+#define USB_BCDR_DPPU_Pos              (15U)
+#define USB_BCDR_DPPU_Msk              (0x1UL << USB_BCDR_DPPU_Pos)     /*!< 0x00008000 */
+#define USB_BCDR_DPPU                  USB_BCDR_DPPU_Msk                /*!< DP Pull-up Enable Mask */
+#define USB_BCDR_DPPD_Pos              (15U)
+#define USB_BCDR_DPPD_Msk              (0x1UL << USB_BCDR_DPPD_Pos)     /*!< 0x00008000 */
+#define USB_BCDR_DPPD                  USB_BCDR_DPPD_Msk                /*!< DP Pull-Down Enable Mask */
+
+/******************  Bits definition for USB_DRD_CHEP register  *******************/
+#define USB_CHEP_ERRRX_Pos             (26U)
+#define USB_CHEP_ERRRX_Msk             (0x01UL << USB_CHEP_ERRRX_Pos)   /*!< 0x04000000 */
+#define USB_CHEP_ERRRX                 USB_CHEP_ERRRX_Msk               /*!< Receive error */
+#define USB_EP_ERRRX                   USB_CHEP_ERRRX_Msk               /*!< EP Receive error */
+#define USB_CH_ERRRX                   USB_CHEP_ERRRX_Msk               /*!< CH Receive error */
+#define USB_CHEP_ERRTX_Pos             (25U)
+#define USB_CHEP_ERRTX_Msk             (0x01UL << USB_CHEP_ERRTX_Pos)   /*!< 0x02000000 */
+#define USB_CHEP_ERRTX                 USB_CHEP_ERRTX_Msk               /*!< Transmit error */
+#define USB_EP_ERRTX                   USB_CHEP_ERRTX_Msk               /*!< EP Transmit error */
+#define USB_CH_ERRTX                   USB_CHEP_ERRTX_Msk               /*!< CH Transmit error */
+#define USB_CHEP_LSEP_Pos              (24U)
+#define USB_CHEP_LSEP_Msk              (0x01UL << USB_CHEP_LSEP_Pos)    /*!< 0x01000000 */
+#define USB_CHEP_LSEP                  USB_CHEP_LSEP_Msk                /*!< Low Speed Endpoint (host with Hub Only) */
+#define USB_CHEP_NAK_Pos               (23U)
+#define USB_CHEP_NAK_Msk               (0x01UL << USB_CHEP_NAK_Pos)     /*!< 0x00800000 */
+#define USB_CHEP_NAK                   USB_CHEP_NAK_Msk                 /*!< Previous NAK detected */
+#define USB_CHEP_DEVADDR_Pos           (16U)
+#define USB_CHEP_DEVADDR_Msk           (0x7FU << USB_CHEP_DEVADDR_Pos)  /*!< 0x7F000000 */
+#define USB_CHEP_DEVADDR               USB_CHEP_DEVADDR_Msk             /* Target Endpoint address*/
+#define USB_CHEP_VTRX_Pos              (15U)
+#define USB_CHEP_VTRX_Msk              (0x1UL << USB_CHEP_VTRX_Pos)     /*!< 0x00008000 */
+#define USB_CHEP_VTRX                  USB_CHEP_VTRX_Msk                /*!< USB valid transaction received Mask */
+#define USB_EP_VTRX                    USB_CHEP_VTRX_Msk                /*!< USB Endpoint valid transaction received Mask */
+#define USB_CH_VTRX                    USB_CHEP_VTRX_Msk                /*!< USB valid Channel transaction received Mask */
+#define USB_CHEP_DTOG_RX_Pos           (14U)
+#define USB_CHEP_DTOG_RX_Msk           (0x1UL << USB_CHEP_DTOG_RX_Pos)  /*!< 0x00004000 */
+#define USB_CHEP_DTOG_RX               USB_CHEP_DTOG_RX_Msk             /*!< Data Toggle, for reception transfers Mask */
+#define USB_EP_DTOG_RX                 USB_CHEP_DTOG_RX_Msk             /*!< EP Data Toggle, for reception transfers Mask */
+#define USB_CH_DTOG_RX                 USB_CHEP_DTOG_RX_Msk             /*!< CH Data Toggle, for reception transfers Mask */
+#define USB_CHEP_RX_STRX_Pos           (12U)
+#define USB_CHEP_RX_STRX_Msk           (0x3UL << USB_CHEP_RX_STRX_Pos)  /*!< 0x00003000 */
+#define USB_CHEP_RX_STRX               USB_CHEP_RX_STRX_Msk             /*!< Status bits, for reception transfers Mask */
+#define USB_EP_RX_STRX                 USB_CHEP_RX_STRX_Msk             /*!< Status bits, for EP reception transfers Mask */
+#define USB_CH_RX_STRX                 USB_CHEP_RX_STRX_Msk             /*!< Status bits, for CH reception transfers Mask */
+#define USB_CHEP_SETUP_Pos             (11U)
+#define USB_CHEP_SETUP_Msk             (0x1UL << USB_CHEP_SETUP_Pos)    /*!< 0x00000800 */
+#define USB_CHEP_SETUP                 USB_CHEP_SETUP_Msk               /*!< Setup transaction completed Mask */
+#define USB_EP_SETUP                   USB_CHEP_SETUP_Msk               /*!< EP Setup transaction completed Mask */
+#define USB_CH_SETUP                   USB_CHEP_SETUP_Msk               /*!< CH Setup transaction completed Mask */
+#define USB_CHEP_UTYPE_Pos             (9U)
+#define USB_CHEP_UTYPE_Msk             (0x3UL << USB_CHEP_UTYPE_Pos)    /*!< 0x00000600 */
+#define USB_CHEP_UTYPE                 USB_CHEP_UTYPE_Msk               /*!< USB type of transaction Mask */
+#define USB_EP_UTYPE                   USB_CHEP_UTYPE_Msk               /*!< USB type of EP transaction Mask */
+#define USB_CH_UTYPE                   USB_CHEP_UTYPE_Msk               /*!< USB type of CH transaction Mask */
+#define USB_CHEP_KIND_Pos              (8U)
+#define USB_CHEP_KIND_Msk              (0x1UL << USB_CHEP_KIND_Pos)     /*!< 0x00000100 */
+#define USB_CHEP_KIND                  USB_CHEP_KIND_Msk                /*!< EndPoint KIND Mask */
+#define USB_EP_KIND                    USB_CHEP_KIND_Msk                /*!< EndPoint KIND Mask */
+#define USB_CH_KIND                    USB_CHEP_KIND_Msk                /*!< Channel KIND Mask */
+#define USB_CHEP_VTTX_Pos              (7U)
+#define USB_CHEP_VTTX_Msk              (0x1UL << USB_CHEP_VTTX_Pos)     /*!< 0x00000080 */
+#define USB_CHEP_VTTX                  USB_CHEP_VTTX_Msk                /*!< Valid USB transaction transmitted Mask */
+#define USB_EP_VTTX                    USB_CHEP_VTTX_Msk                /*!< USB Endpoint valid transaction transmitted Mask */
+#define USB_CH_VTTX                    USB_CHEP_VTTX_Msk                /*!< USB valid Channel transaction transmitted Mask */
+#define USB_CHEP_DTOG_TX_Pos           (6U)
+#define USB_CHEP_DTOG_TX_Msk           (0x1UL << USB_CHEP_DTOG_TX_Pos)  /*!< 0x00000040 */
+#define USB_CHEP_DTOG_TX               USB_CHEP_DTOG_TX_Msk             /*!< Data Toggle, for transmission transfers Mask */
+#define USB_EP_DTOG_TX                 USB_CHEP_DTOG_TX_Msk             /*!< EP Data Toggle, for transmission transfers Mask */
+#define USB_CH_DTOG_TX                 USB_CHEP_DTOG_TX_Msk             /*!< CH Data Toggle, for transmission transfers Mask */
+#define USB_CHEP_TX_STTX_Pos           (4U)
+#define USB_CHEP_TX_STTX_Msk           (0x3UL << USB_CHEP_TX_STTX_Pos)  /*!< 0x00000030 */
+#define USB_CHEP_TX_STTX               USB_CHEP_TX_STTX_Msk             /*!< Status bits, for transmission transfers Mask */
+#define USB_EP_TX_STTX                 USB_CHEP_TX_STTX_Msk             /*!< Status bits, for EP transmission transfers Mask */
+#define USB_CH_TX_STTX                 USB_CHEP_TX_STTX_Msk             /*!< Status bits, for CH transmission transfers Mask */
+#define USB_CHEP_ADDR_Pos              (0U)
+#define USB_CHEP_ADDR_Msk              (0xFUL << USB_CHEP_ADDR_Pos)     /*!< 0x0000000F */
+#define USB_CHEP_ADDR                  USB_CHEP_ADDR_Msk                /*!< Endpoint address Mask */
+
+
+/* EndPoint Register MASK (no toggle fields) */
+#define USB_CHEP_REG_MASK                          (USB_CHEP_ERRRX | USB_CHEP_ERRTX | USB_CHEP_LSEP | \
+                                                    USB_CHEP_DEVADDR | USB_CHEP_VTRX | USB_CHEP_SETUP | \
+                                                    USB_CHEP_UTYPE | USB_CHEP_KIND | USB_CHEP_VTTX | USB_CHEP_ADDR) /* =8f8f */
+
+#define USB_CHEP_TX_DTOGMASK                       (USB_CHEP_TX_STTX | USB_CHEP_REG_MASK)
+#define USB_CHEP_RX_DTOGMASK                       (USB_CHEP_RX_STRX | USB_CHEP_REG_MASK)
+
+#define USB_CHEP_TX_DTOG1                          (0x00000010UL)           /*!< Channel/EndPoint TX Data Toggle bit1 */
+#define USB_CHEP_TX_DTOG2                          (0x00000020UL)           /*!< Channel/EndPoint TX Data Toggle bit2 */
+#define USB_CHEP_RX_DTOG1                          (0x00001000UL)           /*!< Channel/EndPoint RX Data Toggle bit1 */
+#define USB_CHEP_RX_DTOG2                          (0x00002000UL)           /*!< Channel/EndPoint RX Data Toggle bit1 */
+
+/*!< EP_TYPE[1:0] Channel/EndPoint TYPE */
+#define USB_EP_TYPE_MASK                           (0x00000600UL)           /*!< Channel/EndPoint TYPE Mask */
+#define USB_EP_BULK                                (0x00000000UL)           /*!< Channel/EndPoint BULK */
+#define USB_EP_CONTROL                             (0x00000200UL)           /*!< Channel/EndPoint CONTROL */
+#define USB_EP_ISOCHRONOUS                         (0x00000400UL)           /*!< Channel/EndPoint ISOCHRONOUS */
+#define USB_EP_INTERRUPT                           (0x00000600UL)           /*!< Channel/EndPoint INTERRUPT */
+
+#define USB_EP_T_MASK                              ((~USB_EP_UTYPE) & USB_CHEP_REG_MASK) /* =0x898F */
+#define USB_CH_T_MASK                              ((~USB_CH_UTYPE) & USB_CHEP_REG_MASK) /* =0x898F */
+
+#define USB_EP_KIND_MASK                           ((~USB_EP_KIND) & USB_CHEP_REG_MASK) /*!< EP_KIND EndPoint KIND */
+#define USB_CH_KIND_MASK                           ((~USB_CH_KIND) & USB_CHEP_REG_MASK) /*!< EP_KIND EndPoint KIND */
+
+/*!< STAT_TX[1:0] STATus for TX transfer */
+#define USB_EP_TX_DIS                              (0x00000000UL)           /*!< EndPoint TX Disabled */
+#define USB_EP_TX_STALL                            (0x00000010UL)           /*!< EndPoint TX STALLed */
+#define USB_EP_TX_NAK                              (0x00000020UL)           /*!< EndPoint TX NAKed */
+#define USB_EP_TX_VALID                            (0x00000030UL)           /*!< EndPoint TX VALID */
+
+#define USB_CH_TX_DIS                              (0x00000000UL)           /*!< Channel TX Disabled */
+#define USB_CH_TX_STALL                            (0x00000010UL)           /*!< Channel TX STALLed */
+#define USB_CH_TX_NAK                              (0x00000020UL)           /*!< Channel TX NAKed */
+#define USB_CH_TX_VALID                            (0x00000030UL)           /*!< Channel TX VALID */
+
+#define USB_EP_TX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_EP_TX_ACK_DBUF                         (0x00000030UL)           /*!< ACK Double buffer mode */
+
+#define USB_CH_TX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_CH_TX_ACK_DBUF                         (0x00000030UL)           /*!< ACK Double buffer mode */
+
+/*!< STAT_RX[1:0] STATus for RX transfer */
+#define USB_EP_RX_DIS                              (0x00000000UL)           /*!< EndPoint RX Disabled */
+#define USB_EP_RX_STALL                            (0x00001000UL)           /*!< EndPoint RX STALLed */
+#define USB_EP_RX_NAK                              (0x00002000UL)           /*!< EndPoint RX NAKed */
+#define USB_EP_RX_VALID                            (0x00003000UL)           /*!< EndPoint RX VALID */
+
+#define USB_EP_RX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_EP_RX_ACK_DBUF                         (0x00003000UL)           /*!< ACK Double buffer mode */
+
+
+
+#define USB_CH_RX_DIS                              (0x00000000UL)           /*!< EndPoint RX Disabled */
+#define USB_CH_RX_STALL                            (0x00001000UL)           /*!< EndPoint RX STALLed */
+#define USB_CH_RX_NAK                              (0x00002000UL)           /*!< Channel RX NAKed */
+#define USB_CH_RX_VALID                            (0x00003000UL)           /*!< Channel RX VALID */
+
+#define USB_CH_RX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_CH_RX_ACK_DBUF                         (0x00003000UL)           /*!< ACK Double buffer mode */
+
+/*! <used For Double Buffer Enable Disable */
+#define USB_CHEP_DB_MSK                            (0xFFFF0F0FUL)
+
+/*Buffer Descriptor Mask*/
+#define USB_PMA_TXBD_ADDMSK                        (0xFFFF0000UL)
+#define USB_PMA_TXBD_COUNTMSK                      (0x0000FFFFUL)
+#define USB_PMA_RXBD_ADDMSK                        (0xFFFF0000UL)
+#define USB_PMA_RXBD_COUNTMSK                      (0x0000FFFFUL)
 
 
 /** @addtogroup Exported_macros
@@ -10245,10 +10645,13 @@ typedef struct
                                         ((INSTANCE) == COMP2) || \
                                         ((INSTANCE) == COMP3))
 
-#define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) ((COMMON_INSTANCE) == COMP12_COMMON)
+#define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) (((COMMON_INSTANCE) == COMP12_COMMON) || \
+                                                  ((COMMON_INSTANCE) == COMP23_COMMON))
 
 /******************** COMP Instances with window mode capability **************/
-#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) ((INSTANCE) == COMP2)
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                               ((INSTANCE) == COMP2) || \
+                                               ((INSTANCE) == COMP3))
 
 /******************************* CRC Instances ********************************/
 #define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
@@ -10308,13 +10711,11 @@ typedef struct
 
 /****************************** SMBUS Instances *******************************/
 #define IS_SMBUS_ALL_INSTANCE(INSTANCE)(((INSTANCE) == I2C1) || \
-                                        ((INSTANCE) == I2C2) || \
-                                        ((INSTANCE) == I2C3))
+                                        ((INSTANCE) == I2C2))
 
 /****************************** WAKEUP_FROMSTOP Instances *******************************/
 #define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)(((INSTANCE) == I2C1) || \
-                                                  ((INSTANCE) == I2C2) || \
-                                                  ((INSTANCE) == I2C3))
+                                                  ((INSTANCE) == I2C2))
 
 /******************************** SPI Instances *******************************/
 #define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
@@ -10324,8 +10725,7 @@ typedef struct
 
 /******************************** SPI Instances *******************************/
 #define IS_I2S_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
-                                       ((INSTANCE) == SPI2) || \
-                                       ((INSTANCE) == SPI3))
+                                       ((INSTANCE) == SPI2))
 
 /****************** LPTIM Instances : All supported instances *****************/
 #define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
@@ -10457,6 +10857,12 @@ typedef struct
       ((CHANNEL) == TIM_CHANNEL_3) ||          \
       ((CHANNEL) == TIM_CHANNEL_4)))           \
      ||                                        \
+     (((INSTANCE) == TIM4) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
      (((INSTANCE) == TIM14) &&                 \
      (((CHANNEL) == TIM_CHANNEL_1)))           \
      ||                                        \
@@ -10583,6 +10989,11 @@ typedef struct
                                                        ((INSTANCE) == TIM3) || \
                                                        ((INSTANCE) == TIM4))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM2)  || \
@@ -10594,9 +11005,6 @@ typedef struct
                                                        ((INSTANCE) == TIM15) || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
@@ -10631,6 +11039,13 @@ typedef struct
 
 
 /******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                     ((INSTANCE) == USART2) || \
+                                     ((INSTANCE) == USART3) || \
+                                     ((INSTANCE) == USART4) || \
+                                     ((INSTANCE) == USART5) || \
+                                     ((INSTANCE) == USART6))
+
 /****************** UART Instances : Hardware Flow control ********************/
 #define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
                                            ((INSTANCE) == USART2) || \
@@ -10703,7 +11118,8 @@ typedef struct
                                     ((INSTANCE) == USART3))
 
 /******************** LPUART Instance *****************************************/
-#define IS_LPUART_INSTANCE(INSTANCE)    ((INSTANCE) == LPUART1)
+#define IS_LPUART_INSTANCE(INSTANCE) (((INSTANCE) == LPUART1) || \
+                                      ((INSTANCE) == LPUART2))
 
 /****************************** IWDG Instances ********************************/
 #define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
@@ -10716,15 +11132,13 @@ typedef struct
                                          ((INSTANCE) == UCPD2))
 
 /****************************** USB Instances ********************************/
-#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB)
+#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB_DRD_FS)
 
 /*********************** USB OTG PCD Instances ********************************/
-#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
-                                       ((INSTANCE) == USB_OTG_HS))
+#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS))
 
 /*********************** USB OTG HCD Instances ********************************/
-#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
-                                       ((INSTANCE) == USB_OTG_HS))
+#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS))
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/soc/stm32g0c1xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g0c1xx.h
@@ -17,10 +17,10 @@
   * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -47,11 +47,11 @@
 /**
   * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals
    */
-#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
-#define __MPU_PRESENT             1 /*!< STM32G0xx  provides an MPU                    */
-#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
-#define __NVIC_PRIO_BITS          2 /*!< STM32G0xx uses 2 Bits for the Priority Levels */
-#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+#define __CM0PLUS_REV             0U /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1U /*!< STM32G0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1U /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2U /*!< STM32G0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
 
 /**
   * @}
@@ -77,7 +77,7 @@ typedef enum
   SysTick_IRQn                = -1,     /*!< 15 Cortex-M System Tick Interrupt                                 */
 /******  STM32G0xxxx specific Interrupt Numbers ****************************************************************/
   WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
-  PVD_VDDIO2_IRQn             = 1,      /*!< PVD through EXTI Line detection Interrupt(EXTI line 16), VDDIO2   */
+  PVD_VDDIO2_IRQn             = 1,      /*!< PVD through EXTI line 16, PVM (monit. VDDIO2) through EXTI line 34*/
   RTC_TAMP_IRQn               = 2,      /*!< RTC interrupt through the EXTI line 19 & 21                       */
   FLASH_IRQn                  = 3,      /*!< FLASH global Interrupt                                            */
   RCC_CRS_IRQn                = 4,      /*!< RCC and CRS global Interrupt                                      */
@@ -97,15 +97,15 @@ typedef enum
   TIM7_LPTIM2_IRQn            = 18,     /*!< TIM7 and LPTIM2 global Interrupt                                  */
   TIM14_IRQn                  = 19,     /*!< TIM14 global Interrupt                                            */
   TIM15_IRQn                  = 20,     /*!< TIM15 global Interrupt                                            */
-  TIM16_FDCAN1_IRQn           = 21,     /*!< TIM16, FDCAN1 global Interrupt                                    */
-  TIM17_FDCAN2_IRQn           = 22,     /*!< TIM17, FDCAN2 global Interrupt                                    */
+  TIM16_FDCAN_IT0_IRQn        = 21,     /*!< TIM16, FDCAN1_IT0 and FDCAN2_IT0 Interrupt                        */
+  TIM17_FDCAN_IT1_IRQn        = 22,     /*!< TIM17, FDCAN1_IT1 and FDCAN2_IT1 Interrupt                        */
   I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt  (combined with EXTI 23)                           */
   I2C2_3_IRQn                 = 24,     /*!< I2C2, I2C3 Interrupt (combined with EXTI 24 and EXTI 22)          */
   SPI1_IRQn                   = 25,     /*!< SPI1/I2S1 Interrupt                                               */
-  SPI2_3_IRQn                 = 26,     /*!< SPI2/I2S2, SPI3/I2S3 Interrupt                                         */
+  SPI2_3_IRQn                 = 26,     /*!< SPI2/I2S2, SPI3/I2S3 Interrupt                                    */
   USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                                  */
-  USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                                  */
-  USART3_4_5_6_LPUART1_2_IRQn = 29,     /*!< USART3, USART4, USART5, USART6, LPUART1 and LPUART2 globlal Interrupts (combined with EXTI 28) */
+  USART2_LPUART2_IRQn         = 28,     /*!< USART2 + LPUART2 Interrupt                                        */
+  USART3_4_5_6_LPUART1_IRQn   = 29,     /*!< USART3, USART4, USART5, USART6, LPUART1 globlal Interrupts (combined with EXTI 28) */
   CEC_IRQn                    = 30,     /*!< CEC Interrupt(combined with EXTI 27)                               */
   AES_RNG_IRQn                = 31,     /*!< AES & RNG Interrupt                                                */
 } IRQn_Type;
@@ -235,8 +235,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CSR_ODD;    /*!< COMP control and status register located in register of comparator instance odd, used for bits common to several COMP instances, Address offset: 0x00 */
-  __IO uint32_t CSR_EVEN;   /*!< COMP control and status register located in register of comparator instance even, used for bits common to several COMP instances, Address offset: 0x04 */
+  __IO uint32_t CSR_ODD;    /*!< COMP control and status register located in register of comparator instance odd (exception for STM32G0 devices featuring ADC3 instance: in common group of COMP2 and COMP3, instances odd and even are inverted), used for bits common to several COMP instances, Address offset: 0x00 */
+  __IO uint32_t CSR_EVEN;   /*!< COMP control and status register located in register of comparator instance even (exception for STM32G0 devices featuring ADC3 instance: in common group of COMP2 and COMP3, instances odd and even are inverted), used for bits common to several COMP instances, Address offset: 0x04 */
 } COMP_Common_TypeDef;
 
 /**
@@ -353,7 +353,11 @@ typedef struct
   __IO uint32_t RPR1;           /*!< EXTI Rising Pending Register 1,                  Address offset:   0x0C */
   __IO uint32_t FPR1;           /*!< EXTI Falling Pending Register 1,                 Address offset:   0x10 */
        uint32_t RESERVED1[3];   /*!< Reserved 1,                                                0x14 -- 0x1C */
-       uint32_t RESERVED2[5];   /*!< Reserved 2,                                                0x20 -- 0x30 */
+  __IO uint32_t RTSR2;          /*!< EXTI Rising Trigger Selection Register 2,        Address offset:   0x20 */
+  __IO uint32_t FTSR2;          /*!< EXTI Falling Trigger Selection Register 2,       Address offset:   0x24 */
+  __IO uint32_t SWIER2;         /*!< EXTI Software Interrupt event Register 2,        Address offset:   0x28 */
+  __IO uint32_t RPR2;           /*!< EXTI Rising Pending Register 2,                  Address offset:   0x2C */
+  __IO uint32_t FPR2;           /*!< EXTI Falling Pending Register 2,                 Address offset:   0x30 */
        uint32_t RESERVED3[11];  /*!< Reserved 3,                                                0x34 -- 0x5C */
   __IO uint32_t EXTICR[4];      /*!< EXTI External Interrupt Configuration Register,            0x60 -- 0x6C */
        uint32_t RESERVED4[4];   /*!< Reserved 4,                                                0x70 -- 0x7C */
@@ -375,7 +379,7 @@ typedef struct
   __IO uint32_t OPTKEYR;      /*!< FLASH Option Key register,                         Address offset: 0x0C */
   __IO uint32_t SR;           /*!< FLASH Status register,                             Address offset: 0x10 */
   __IO uint32_t CR;           /*!< FLASH Control register,                            Address offset: 0x14 */
-  __IO uint32_t ECC1R;         /*!< FLASH ECC bank 1 register,                        Address offset: 0x18 */
+  __IO uint32_t ECCR;          /*!< FLASH ECC bank 1 register,                        Address offset: 0x18 */
   __IO uint32_t ECC2R;         /*!< FLASH ECC bank 2 register,                        Address offset: 0x1C */
   __IO uint32_t OPTR;         /*!< FLASH Option register,                             Address offset: 0x20 */
   __IO uint32_t PCROP1ASR;    /*!< FLASH Bank PCROP area A Start address register,    Address offset: 0x24 */
@@ -384,14 +388,14 @@ typedef struct
   __IO uint32_t WRP1BR;       /*!< FLASH Bank WRP area B address register,            Address offset: 0x30 */
   __IO uint32_t PCROP1BSR;    /*!< FLASH Bank PCROP area B Start address register,    Address offset: 0x34 */
   __IO uint32_t PCROP1BER;    /*!< FLASH Bank PCROP area B End address register,      Address offset: 0x38 */
-       uint32_t RESERVED6[1]; /*!< Reserved6,                                         Address offset: 0x40 */
+       uint32_t RESERVED5[2]; /*!< Reserved5,                                         Address offset: 0x3C--0x40 */
   __IO uint32_t PCROP2ASR;    /*!< FLASH Bank2 PCROP area A Start address register,   Address offset: 0x44 */
   __IO uint32_t PCROP2AER;    /*!< FLASH Bank2 PCROP area A End address register,     Address offset: 0x48 */
   __IO uint32_t WRP2AR;       /*!< FLASH Bank2 WRP area A address register,           Address offset: 0x4C */
   __IO uint32_t WRP2BR;       /*!< FLASH Bank2 WRP area B address register,           Address offset: 0x50 */
   __IO uint32_t PCROP2BSR;    /*!< FLASH Bank2 PCROP area B Start address register,   Address offset: 0x54 */
   __IO uint32_t PCROP2BER;    /*!< FLASH Bank2 PCROP area B End address register,     Address offset: 0x58 */
-       uint32_t RESERVED3[10];/*!< Reserved3,                                         Address offset: 0x5C */
+       uint32_t RESERVED7[9]; /*!< Reserved7,                                         Address offset: 0x5C--0x7C */
   __IO uint32_t SECR;         /*!< FLASH security register ,                          Address offset: 0x80 */
 } FLASH_TypeDef;
 
@@ -657,41 +661,37 @@ typedef struct
 } USART_TypeDef;
 
 /**
-  * @brief Universal Serial Bus Full Speed Device
+  * @brief Universal Serial Bus Full Speed Dual Role Device
   */
 
 typedef struct
 {
-  __IO uint16_t CHEP0R;          /*!< USB Endpoint 0 register,                Address offset: 0x00 */
-  __IO uint16_t RESERVED0;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP1R;          /*!< USB Endpoint 1 register,                Address offset: 0x04 */
-  __IO uint16_t RESERVED1;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP2R;          /*!< USB Endpoint 2 register,                Address offset: 0x08 */
-  __IO uint16_t RESERVED2;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP3R;          /*!< USB Endpoint 3 register,                Address offset: 0x0C */
-  __IO uint16_t RESERVED3;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP4R;          /*!< USB Endpoint 4 register,                Address offset: 0x10 */
-  __IO uint16_t RESERVED4;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP5R;          /*!< USB Endpoint 5 register,                Address offset: 0x14 */
-  __IO uint16_t RESERVED5;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP6R;          /*!< USB Endpoint 6 register,                Address offset: 0x18 */
-  __IO uint16_t RESERVED6;       /*!< Reserved,                                                    */
-  __IO uint16_t CHEP7R;          /*!< USB Endpoint 7 register,                Address offset: 0x1C */
-  __IO uint16_t RESERVED7[17];   /*!< Reserved,                                                    */
-  __IO uint32_t CNTR;            /*!< Control register,                       Address offset: 0x40 */
-  __IO uint16_t ISTR;            /*!< Interrupt status register,              Address offset: 0x44 */
-  __IO uint16_t RESERVED9;       /*!< Reserved,                                                    */
-  __IO uint16_t FNR;             /*!< Frame number register,                  Address offset: 0x48 */
-  __IO uint16_t RESERVEDA;       /*!< Reserved,                                                    */
-  __IO uint16_t DADDR;           /*!< Device address register,                Address offset: 0x4C */
-  __IO uint16_t RESERVEDB;       /*!< Reserved,                                                    */
-  __IO uint16_t BTABLE;          /*!< Buffer Table address register,          Address offset: 0x50 */
-  __IO uint16_t RESERVEDC;       /*!< Reserved,                                                    */
-  __IO uint16_t LPMCSR;          /*!< LPM Control and Status register,        Address offset: 0x54 */
-  __IO uint16_t RESERVEDD;       /*!< Reserved,                                                    */
-  __IO uint16_t BCDR;            /*!< Battery Charging detector register,     Address offset: 0x58 */
-  __IO uint16_t RESERVEDE;       /*!< Reserved,                                                    */
-} USB_DRD_FS_TypeDef;
+  __IO uint32_t CHEP0R;          /*!< USB Channel/Endpoint 0 register,      Address offset: 0x00 */
+  __IO uint32_t CHEP1R;          /*!< USB Channel/Endpoint 1 register,      Address offset: 0x04 */
+  __IO uint32_t CHEP2R;          /*!< USB Channel/Endpoint 2 register,      Address offset: 0x08 */
+  __IO uint32_t CHEP3R;          /*!< USB Channel/Endpoint 3 register,      Address offset: 0x0C */
+  __IO uint32_t CHEP4R;          /*!< USB Channel/Endpoint 4 register,      Address offset: 0x10 */
+  __IO uint32_t CHEP5R;          /*!< USB Channel/Endpoint 5 register,      Address offset: 0x14 */
+  __IO uint32_t CHEP6R;          /*!< USB Channel/Endpoint 6 register,      Address offset: 0x18 */
+  __IO uint32_t CHEP7R;          /*!< USB Channel/Endpoint 7 register,      Address offset: 0x1C */
+  __IO uint32_t RESERVED0[8];    /*!< Reserved,                                                  */
+  __IO uint32_t CNTR;            /*!< Control register,                     Address offset: 0x40 */
+  __IO uint32_t ISTR;            /*!< Interrupt status register,            Address offset: 0x44 */
+  __IO uint32_t FNR;             /*!< Frame number register,                Address offset: 0x48 */
+  __IO uint32_t DADDR;           /*!< Device address register,              Address offset: 0x4C */
+  __IO uint32_t RESERVED1;       /*!< Reserved */
+  __IO uint32_t LPMCSR;          /*!< LPM Control and Status register,      Address offset: 0x54 */
+  __IO uint32_t BCDR;            /*!< Battery Charging detector register,   Address offset: 0x58 */
+} USB_DRD_TypeDef;
+
+/**
+  * @brief Universal Serial Bus PacketMemoryArea Buffer Descriptor Table
+  */
+typedef struct
+{
+  __IO uint32_t TXBD;             /*!<Transmission buffer address*/
+  __IO uint32_t RXBD;             /*!<Reception buffer address */
+} USB_DRD_PMABuffDescTypeDef;
 
 /**
   * @}
@@ -791,7 +791,12 @@ typedef struct
 #define SRAM_BASE             (0x20000000UL)  /*!< SRAM base address */
 #define PERIPH_BASE           (0x40000000UL)  /*!< Peripheral base address */
 #define IOPORT_BASE           (0x50000000UL)  /*!< IOPORT base address */
+/*!< USB PMA SIZE */
+#define USB_DRD_PMA_SIZE              2048U   /*!< USB PMA Size 2Kbyte */
+
 #define SRAM_SIZE_MAX         (0x00020000UL)  /*!< maximum SRAM size (up to 128 KBytes) */
+
+#define FLASH_SIZE            (((*((uint32_t *)FLASHSIZE_BASE)) & (0x03FFU)) << 10U)
 
 /*!< Peripheral memory map */
 #define APBPERIPH_BASE        (PERIPH_BASE)
@@ -830,8 +835,8 @@ typedef struct
 #define LPUART2_BASE          (APBPERIPH_BASE + 0x00008400UL)
 #define I2C3_BASE             (APBPERIPH_BASE + 0x00008800UL)
 #define LPTIM2_BASE           (APBPERIPH_BASE + 0x00009400UL)
-#define USB_DRD_FS_BASE     (APBPERIPH_BASE + 0x00009800UL) /*!< USB_DRD_FS_IP Peripheral Registers base address */
-#define USB_DRD_FS_PMAADDR  (APBPERIPH_BASE + 0x00009C00UL) /*!< USB_DRD_FS_IP Packet Memory Area base address */
+#define USB_DRD_BASE          (APBPERIPH_BASE + 0x00005C00UL) /*!< USB_DRD_IP Peripheral Registers base address */
+#define USB_DRD_PMAADDR       (APBPERIPH_BASE + 0x00009800UL) /*!< USB_DRD_IP Packet Memory Area base address */
 #define UCPD1_BASE            (APBPERIPH_BASE + 0x0000A000UL)
 #define UCPD2_BASE            (APBPERIPH_BASE + 0x0000A400UL)
 #define TAMP_BASE             (APBPERIPH_BASE + 0x0000B000UL)
@@ -856,7 +861,7 @@ typedef struct
 
 /*!< AHB peripherals */
 #define DMA1_BASE             (AHBPERIPH_BASE)
-#define DMA2_BASE             (AHBPERIPH_BASE)+ 0x00000400UL
+#define DMA2_BASE             (AHBPERIPH_BASE + 0x00000400UL)
 #define DMAMUX1_BASE          (AHBPERIPH_BASE + 0x00000800UL)
 #define RCC_BASE              (AHBPERIPH_BASE + 0x00001000UL)
 #define EXTI_BASE             (AHBPERIPH_BASE + 0x00001800UL)
@@ -886,6 +891,11 @@ typedef struct
 #define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
 #define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
 #define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+#define DMAMUX1_Channel7_BASE    (DMAMUX1_BASE + 0x0000001CUL)
+#define DMAMUX1_Channel8_BASE    (DMAMUX1_BASE + 0x00000020UL)
+#define DMAMUX1_Channel9_BASE    (DMAMUX1_BASE + 0x00000024UL)
+#define DMAMUX1_Channel10_BASE   (DMAMUX1_BASE + 0x00000028UL)
+#define DMAMUX1_Channel11_BASE   (DMAMUX1_BASE + 0x0000002CUL)
 
 #define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
 #define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
@@ -936,7 +946,8 @@ typedef struct
 #define I2C1                ((I2C_TypeDef *) I2C1_BASE)
 #define I2C2                ((I2C_TypeDef *) I2C2_BASE)
 #define I2C3                ((I2C_TypeDef *) I2C3_BASE)
-#define USB_DRD_FS          ((USB_DRD_FS_TypeDef *) USB_DRD_FS_BASE)
+#define USB_DRD_FS          ((USB_DRD_TypeDef *) USB_DRD_BASE)
+#define USB_DRD_PMA_BUFF    ((USB_DRD_PMABuffDescTypeDef*) USB_DRD_PMAADDR)
 #define FDCAN1              ((FDCAN_GlobalTypeDef *) FDCAN1_BASE)
 #define FDCAN_CONFIG        ((FDCAN_Config_TypeDef *) FDCAN_CONFIG_BASE)
 #define FDCAN2              ((FDCAN_GlobalTypeDef *) FDCAN2_BASE)
@@ -956,6 +967,7 @@ typedef struct
 #define COMP2               ((COMP_TypeDef *) COMP2_BASE)
 #define COMP12_COMMON       ((COMP_Common_TypeDef *) COMP1_BASE)
 #define COMP3               ((COMP_TypeDef *) COMP3_BASE)
+#define COMP23_COMMON       ((COMP_Common_TypeDef *) COMP2_BASE)
 #define TIM1                ((TIM_TypeDef *) TIM1_BASE)
 #define SPI1                ((SPI_TypeDef *) SPI1_BASE)
 #define USART1              ((USART_TypeDef *) USART1_BASE)
@@ -1003,6 +1015,11 @@ typedef struct
 #define DMAMUX1_Channel4       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
 #define DMAMUX1_Channel5       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
 #define DMAMUX1_Channel6       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+#define DMAMUX1_Channel7       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel7_BASE)
+#define DMAMUX1_Channel8       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel8_BASE)
+#define DMAMUX1_Channel9       ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel9_BASE)
+#define DMAMUX1_Channel10      ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel10_BASE)
+#define DMAMUX1_Channel11      ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel11_BASE)
 
 #define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
 #define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
@@ -1145,7 +1162,7 @@ typedef struct
 
 #define ADC_CFGR1_ALIGN_Pos            (5U)
 #define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
-#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignement */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
 
 #define ADC_CFGR1_EXTSEL_Pos           (6U)
 #define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
@@ -2598,7 +2615,7 @@ typedef struct
 /******************************************************************************/
 /********************  Bits definition for DMAMUX_CxCR register  **************/
 #define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
-#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0xFFUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x000000FF */
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x7FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000007F */
 #define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk             /*!< DMA Request ID   */
 #define DMAMUX_CxCR_DMAREQ_ID_0                (0x01UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
 #define DMAMUX_CxCR_DMAREQ_ID_1                (0x02UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
@@ -2608,6 +2625,11 @@ typedef struct
 #define DMAMUX_CxCR_DMAREQ_ID_5                (0x20UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
 #define DMAMUX_CxCR_DMAREQ_ID_6                (0x40UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000040 */
 #define DMAMUX_CxCR_DMAREQ_ID_7                (0x80UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000080 */
+#define DMAMUX_CxCR_DMAREQ_ID_8                (0x100UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000100 */
+#define DMAMUX_CxCR_DMAREQ_ID_9                (0x200UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000200 */
+#define DMAMUX_CxCR_DMAREQ_ID_10               (0x400UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000400 */
+#define DMAMUX_CxCR_DMAREQ_ID_11               (0x800UL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000800 */
+#define DMAMUX_CxCR_DMAREQ_ID_12               (0x1000UL << DMAMUX_CxCR_DMAREQ_ID_Pos)/*!< 0x00001000 */
 #define DMAMUX_CxCR_SOIE_Pos                   (8U)
 #define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos)  /*!< 0x00000100 */
 #define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk             /*!< Synchro overrun interrupt enable     */
@@ -2661,6 +2683,21 @@ typedef struct
 #define DMAMUX_CSR_SOF6_Pos                    (6U)
 #define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
 #define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+#define DMAMUX_CSR_SOF7_Pos                    (7U)
+#define DMAMUX_CSR_SOF7_Msk                    (0x1UL << DMAMUX_CSR_SOF7_Pos)  /*!< 0x00000080 */
+#define DMAMUX_CSR_SOF7                        DMAMUX_CSR_SOF7_Msk             /*!< Synchronization Overrun Flag 7       */
+#define DMAMUX_CSR_SOF8_Pos                    (8U)
+#define DMAMUX_CSR_SOF8_Msk                    (0x1UL << DMAMUX_CSR_SOF8_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CSR_SOF8                        DMAMUX_CSR_SOF8_Msk             /*!< Synchronization Overrun Flag 8       */
+#define DMAMUX_CSR_SOF9_Pos                    (9U)
+#define DMAMUX_CSR_SOF9_Msk                    (0x1UL << DMAMUX_CSR_SOF9_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CSR_SOF9                        DMAMUX_CSR_SOF9_Msk             /*!< Synchronization Overrun Flag 9       */
+#define DMAMUX_CSR_SOF10_Pos                   (10U)
+#define DMAMUX_CSR_SOF10_Msk                   (0x1UL << DMAMUX_CSR_SOF10_Pos)  /*!< 0x00000400 */
+#define DMAMUX_CSR_SOF10                       DMAMUX_CSR_SOF10_Msk             /*!< Synchronization Overrun Flag 10      */
+#define DMAMUX_CSR_SOF11_Pos                   (11U)
+#define DMAMUX_CSR_SOF11_Msk                   (0x1UL << DMAMUX_CSR_SOF11_Pos)  /*!< 0x00000800 */
+#define DMAMUX_CSR_SOF11                       DMAMUX_CSR_SOF11_Msk             /*!< Synchronization Overrun Flag 11      */
 
 /********************  Bits definition for DMAMUX_CFR register  **************/
 #define DMAMUX_CFR_CSOF0_Pos                   (0U)
@@ -2684,6 +2721,21 @@ typedef struct
 #define DMAMUX_CFR_CSOF6_Pos                   (6U)
 #define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos)  /*!< 0x00000040 */
 #define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk             /*!< Clear Overrun Flag 6                 */
+#define DMAMUX_CFR_CSOF7_Pos                   (7U)
+#define DMAMUX_CFR_CSOF7_Msk                   (0x1UL << DMAMUX_CFR_CSOF7_Pos)  /*!< 0x00000080 */
+#define DMAMUX_CFR_CSOF7                       DMAMUX_CFR_CSOF7_Msk             /*!< Clear Overrun Flag 7                 */
+#define DMAMUX_CFR_CSOF8_Pos                   (8U)
+#define DMAMUX_CFR_CSOF8_Msk                   (0x1UL << DMAMUX_CFR_CSOF8_Pos)  /*!< 0x00000100 */
+#define DMAMUX_CFR_CSOF8                       DMAMUX_CFR_CSOF8_Msk             /*!< Clear Overrun Flag 8                 */
+#define DMAMUX_CFR_CSOF9_Pos                   (9U)
+#define DMAMUX_CFR_CSOF9_Msk                   (0x1UL << DMAMUX_CFR_CSOF9_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CFR_CSOF9                       DMAMUX_CFR_CSOF9_Msk             /*!< Clear Overrun Flag 9                 */
+#define DMAMUX_CFR_CSOF10_Pos                  (10U)
+#define DMAMUX_CFR_CSOF10_Msk                  (0x1UL << DMAMUX_CFR_CSOF10_Pos)  /*!< 0x00000400 */
+#define DMAMUX_CFR_CSOF10                      DMAMUX_CFR_CSOF10_Msk             /*!< Clear Overrun Flag 10               */
+#define DMAMUX_CFR_CSOF11_Pos                  (11U)
+#define DMAMUX_CFR_CSOF11_Msk                  (0x1UL << DMAMUX_CFR_CSOF11_Pos)  /*!< 0x00000800 */
+#define DMAMUX_CFR_CSOF11                      DMAMUX_CFR_CSOF11_Msk             /*!< Clear Overrun Flag 11               */
 
 /********************  Bits definition for DMAMUX_RGxCR register  ************/
 #define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
@@ -2805,6 +2857,9 @@ typedef struct
 #define EXTI_RTSR1_RT18_Pos          (18U)
 #define EXTI_RTSR1_RT18_Msk          (0x1UL << EXTI_RTSR1_RT18_Pos)            /*!< 0x00040000 */
 #define EXTI_RTSR1_RT18              EXTI_RTSR1_RT18_Msk                       /*!< Rising trigger configuration for input line 18 */
+#define EXTI_RTSR1_RT20_Pos          (20U)
+#define EXTI_RTSR1_RT20_Msk          (0x1UL << EXTI_RTSR1_RT20_Pos)            /*!< 0x00100000 */
+#define EXTI_RTSR1_RT20              EXTI_RTSR1_RT20_Msk                       /*!< Rising trigger configuration for input line 20 */
 
 /******************  Bit definition for EXTI_FTSR1 register  ******************/
 #define EXTI_FTSR1_FT0_Pos           (0U)
@@ -2864,6 +2919,9 @@ typedef struct
 #define EXTI_FTSR1_FT18_Pos          (18U)
 #define EXTI_FTSR1_FT18_Msk          (0x1UL << EXTI_FTSR1_FT18_Pos)            /*!< 0x00040000 */
 #define EXTI_FTSR1_FT18              EXTI_FTSR1_FT18_Msk                       /*!< Falling trigger configuration for input line 18 */
+#define EXTI_FTSR1_FT20_Pos          (20U)
+#define EXTI_FTSR1_FT20_Msk          (0x1UL << EXTI_FTSR1_FT20_Pos)            /*!< 0x00100000 */
+#define EXTI_FTSR1_FT20              EXTI_FTSR1_FT20_Msk                       /*!< Falling trigger configuration for input line 20 */
 
 /******************  Bit definition for EXTI_SWIER1 register  *****************/
 #define EXTI_SWIER1_SWI0_Pos         (0U)
@@ -2923,6 +2981,9 @@ typedef struct
 #define EXTI_SWIER1_SWI18_Pos        (18U)
 #define EXTI_SWIER1_SWI18_Msk        (0x1UL << EXTI_SWIER1_SWI18_Pos)          /*!< 0x00040000 */
 #define EXTI_SWIER1_SWI18            EXTI_SWIER1_SWI18_Msk                     /*!< Software Interrupt on line 18 */
+#define EXTI_SWIER1_SWI20_Pos        (20U)
+#define EXTI_SWIER1_SWI20_Msk        (0x1UL << EXTI_SWIER1_SWI20_Pos)          /*!< 0x00100000 */
+#define EXTI_SWIER1_SWI20            EXTI_SWIER1_SWI20_Msk                     /*!< Software Interrupt on line 20 */
 
 /*******************  Bit definition for EXTI_RPR1 register  ******************/
 #define EXTI_RPR1_RPIF0_Pos          (0U)
@@ -2982,6 +3043,9 @@ typedef struct
 #define EXTI_RPR1_RPIF18_Pos         (18U)
 #define EXTI_RPR1_RPIF18_Msk         (0x1UL << EXTI_RPR1_RPIF18_Pos)           /*!< 0x00040000 */
 #define EXTI_RPR1_RPIF18             EXTI_RPR1_RPIF18_Msk                      /*!< Rising Pending Interrupt Flag on line 18 */
+#define EXTI_RPR1_RPIF20_Pos         (20U)
+#define EXTI_RPR1_RPIF20_Msk         (0x1UL << EXTI_RPR1_RPIF20_Pos)           /*!< 0x00100000 */
+#define EXTI_RPR1_RPIF20             EXTI_RPR1_RPIF20_Msk                      /*!< Rising Pending Interrupt Flag on line 20 */
 
 /*******************  Bit definition for EXTI_FPR1 register  ******************/
 #define EXTI_FPR1_FPIF0_Pos          (0U)
@@ -3041,6 +3105,34 @@ typedef struct
 #define EXTI_FPR1_FPIF18_Pos         (18U)
 #define EXTI_FPR1_FPIF18_Msk         (0x1UL << EXTI_FPR1_FPIF18_Pos)           /*!< 0x00040000 */
 #define EXTI_FPR1_FPIF18             EXTI_FPR1_FPIF18_Msk                      /*!< Falling Pending Interrupt Flag on line 18 */
+#define EXTI_FPR1_FPIF20_Pos         (20U)
+#define EXTI_FPR1_FPIF20_Msk         (0x1UL << EXTI_FPR1_FPIF20_Pos)           /*!< 0x00100000 */
+#define EXTI_FPR1_FPIF20             EXTI_FPR1_FPIF20_Msk                      /*!< Falling Pending Interrupt Flag on line 20 */
+
+/******************  Bit definition for EXTI_RTSR2 register  ******************/
+#define EXTI_RTSR2_RT34_Pos           (2U)
+#define EXTI_RTSR2_RT34_Msk           (0x1UL << EXTI_RTSR2_RT34_Pos)             /*!< 0x00000004 */
+#define EXTI_RTSR2_RT34               EXTI_RTSR2_RT34_Msk                        /*!< Rising trigger configuration for input line 34 */
+
+/******************  Bit definition for EXTI_FTSR2 register  ******************/
+#define EXTI_FTSR2_FT34_Pos           (2U)
+#define EXTI_FTSR2_FT34_Msk           (0x1UL << EXTI_FTSR2_FT34_Pos)             /*!< 0x00000004 */
+#define EXTI_FTSR2_FT34               EXTI_FTSR2_FT34_Msk                        /*!< Falling trigger configuration for input line 34 */
+
+/******************  Bit definition for EXTI_SWIER2 register  *****************/
+#define EXTI_SWIER2_SWI34_Pos         (2U)
+#define EXTI_SWIER2_SWI34_Msk         (0x1UL << EXTI_SWIER2_SWI34_Pos)           /*!< 0x00000004 */
+#define EXTI_SWIER2_SWI34             EXTI_SWIER2_SWI34_Msk                      /*!< Software Interrupt on line 34 */
+
+/*******************  Bit definition for EXTI_RPR2 register  ******************/
+#define EXTI_RPR2_RPIF34_Pos         (2U)
+#define EXTI_RPR2_RPIF34_Msk         (0x1UL << EXTI_RPR2_RPIF34_Pos)            /*!< 0x00000004 */
+#define EXTI_RPR2_RPIF34             EXTI_RPR2_RPIF34_Msk                       /*!< Rising Pending Interrupt Flag on line 34 */
+
+/*******************  Bit definition for EXTI_FPR2 register  ******************/
+#define EXTI_FPR2_RPIF34_Pos         (2U)
+#define EXTI_FPR2_RPIF34_Msk         (0x1UL << EXTI_FPR2_RPIF34_Pos)            /*!< 0x00000004 */
+#define EXTI_FPR2_RPIF34             EXTI_FPR2_RPIF34_Msk                       /*!< Rising Pending Interrupt Flag on line 34 */
 
 /*****************  Bit definition for EXTI_EXTICR1 register  **************/
 #define EXTI_EXTICR1_EXTI0_Pos       (0U)
@@ -3244,7 +3336,7 @@ typedef struct
 #define EXTI_IMR1_IM31_Msk           (0x1UL << EXTI_IMR1_IM31_Pos)              /*!< 0x80000000 */
 #define EXTI_IMR1_IM31               EXTI_IMR1_IM31_Msk                        /*!< Interrupt Mask on line 31 */
 #define EXTI_IMR1_IM_Pos             (0U)
-#define EXTI_IMR1_IM_Msk             (0xFEAFFFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xFEAFFFFF */
+#define EXTI_IMR1_IM_Msk             (0xFFFFFFFFUL << EXTI_IMR1_IM_Pos)        /*!< 0xFFFFFFFF */
 #define EXTI_IMR1_IM                 EXTI_IMR1_IM_Msk                          /*!< Interrupt Mask All */
 
 /*******************  Bit definition for EXTI_IMR2 register  ******************/
@@ -3257,8 +3349,14 @@ typedef struct
 #define EXTI_IMR2_IM34_Pos           (2U)
 #define EXTI_IMR2_IM34_Msk           (0x1UL << EXTI_IMR2_IM34_Pos)             /*!< 0x00000004 */
 #define EXTI_IMR2_IM34               EXTI_IMR2_IM34_Msk                        /*!< Interrupt Mask on line 34 */
+#define EXTI_IMR2_IM35_Pos           (3U)
+#define EXTI_IMR2_IM35_Msk           (0x1UL << EXTI_IMR2_IM35_Pos)             /*!< 0x00000008 */
+#define EXTI_IMR2_IM35               EXTI_IMR2_IM35_Msk                        /*!< Interrupt Mask on line 35 */
+#define EXTI_IMR2_IM36_Pos           (4U)
+#define EXTI_IMR2_IM36_Msk           (0x1UL << EXTI_IMR2_IM36_Pos)             /*!< 0x00000010 */
+#define EXTI_IMR2_IM36               EXTI_IMR2_IM36_Msk                        /*!< Interrupt Mask on line 36 */
 #define EXTI_IMR2_IM_Pos             (0U)
-#define EXTI_IMR2_IM_Msk             (0x3UL << EXTI_IMR2_IM_Pos)               /*!< 0x00000007 */
+#define EXTI_IMR2_IM_Msk             (0x1FUL << EXTI_IMR2_IM_Pos)               /*!< 0x0000001F */
 #define EXTI_IMR2_IM                 EXTI_IMR2_IM_Msk                          /*!< Interrupt Mask All */
 
 /*******************  Bit definition for EXTI_EMR1 register  ******************/
@@ -3369,6 +3467,12 @@ typedef struct
 #define EXTI_EMR2_EM34_Pos           (2U)
 #define EXTI_EMR2_EM34_Msk           (0x1UL << EXTI_EMR2_EM34_Pos)             /*!< 0x00000004 */
 #define EXTI_EMR2_EM34               EXTI_EMR2_EM34_Msk                        /*!< Event Mask on line 34 */
+#define EXTI_EMR2_EM35_Pos           (3U)
+#define EXTI_EMR2_EM35_Msk           (0x1UL << EXTI_EMR2_EM35_Pos)             /*!< 0x00000008 */
+#define EXTI_EMR2_EM35               EXTI_EMR2_EM35_Msk                        /*!< Event Mask on line 35 */
+#define EXTI_EMR2_EM36_Pos           (4U)
+#define EXTI_EMR2_EM36_Msk           (0x1UL << EXTI_EMR2_EM36_Pos)             /*!< 0x00000010 */
+#define EXTI_EMR2_EM36               EXTI_EMR2_EM36_Msk                        /*!< Event Mask on line 36 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -3399,7 +3503,7 @@ typedef struct
 /*****************  Bit definition for FDCAN_ENDN register  *******************/
 #define FDCAN_ENDN_ETV_Pos        (0U)
 #define FDCAN_ENDN_ETV_Msk        (0xFFFFFFFFUL << FDCAN_ENDN_ETV_Pos)         /*!< 0xFFFFFFFF */
-#define FDCAN_ENDN_ETV            FDCAN_ENDN_ETV_Msk                           /*!<Endiannes Test Value                    */
+#define FDCAN_ENDN_ETV            FDCAN_ENDN_ETV_Msk                           /*!<Endianness Test Value                    */
 
 /*****************  Bit definition for FDCAN_DBTP register  *******************/
 #define FDCAN_DBTP_DSJW_Pos       (0U)
@@ -4031,234 +4135,242 @@ typedef struct
 
 /*******************  Bits definition for FLASH_CR register  ******************/
 #define FLASH_CR_PG_Pos                        (0U)
-#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)       /*!< 0x00000001 */
+#define FLASH_CR_PG_Msk                        (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
 #define FLASH_CR_PG                            FLASH_CR_PG_Msk
 #define FLASH_CR_PER_Pos                       (1U)
-#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)      /*!< 0x00000002 */
+#define FLASH_CR_PER_Msk                       (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
 #define FLASH_CR_PER                           FLASH_CR_PER_Msk
 #define FLASH_CR_MER1_Pos                      (2U)
-#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)     /*!< 0x00000004 */
+#define FLASH_CR_MER1_Msk                      (0x1UL << FLASH_CR_MER1_Pos)       /*!< 0x00000004 */
 #define FLASH_CR_MER1                          FLASH_CR_MER1_Msk
 #define FLASH_CR_PNB_Pos                       (3U)
-#define FLASH_CR_PNB_Msk                       (0x3FUL << FLASH_CR_PNB_Pos)     /*!< 0x000001F8 */
+#define FLASH_CR_PNB_Msk                       (0x7FUL << FLASH_CR_PNB_Pos)       /*!< 0x000003F8 */
 #define FLASH_CR_PNB                           FLASH_CR_PNB_Msk
 #define FLASH_CR_BKER_Pos                      (13U)
-#define FLASH_CR_BKER_Msk                      (0x1UL << FLASH_CR_BKER_Pos)     /*!< 0x00002000 */
+#define FLASH_CR_BKER_Msk                      (0x1UL << FLASH_CR_BKER_Pos)       /*!< 0x00002000 */
 #define FLASH_CR_BKER                          FLASH_CR_BKER_Msk
-#define FLASH_CR_BIFER_Pos                     (14U)
-#define FLASH_CR_BIFER_Msk                     (0x1UL << FLASH_CR_BIFER_Pos)    /*!< 0x00004000 */
-#define FLASH_CR_BIFER                         FLASH_CR_BIFER_Msk
 #define FLASH_CR_MER2_Pos                      (15U)
-#define FLASH_CR_MER2_Msk                      (0x1UL << FLASH_CR_MER2_Pos)     /*!< 0x00008000 */
+#define FLASH_CR_MER2_Msk                      (0x1UL << FLASH_CR_MER2_Pos)       /*!< 0x00008000 */
 #define FLASH_CR_MER2                          FLASH_CR_MER2_Msk
 #define FLASH_CR_STRT_Pos                      (16U)
-#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)     /*!< 0x00010000 */
+#define FLASH_CR_STRT_Msk                      (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
 #define FLASH_CR_STRT                          FLASH_CR_STRT_Msk
 #define FLASH_CR_OPTSTRT_Pos                   (17U)
-#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)  /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT_Msk                   (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
 #define FLASH_CR_OPTSTRT                       FLASH_CR_OPTSTRT_Msk
 #define FLASH_CR_FSTPG_Pos                     (18U)
-#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)    /*!< 0x00040000 */
+#define FLASH_CR_FSTPG_Msk                     (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
 #define FLASH_CR_FSTPG                         FLASH_CR_FSTPG_Msk
 #define FLASH_CR_EOPIE_Pos                     (24U)
-#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)    /*!< 0x01000000 */
+#define FLASH_CR_EOPIE_Msk                     (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
 #define FLASH_CR_EOPIE                         FLASH_CR_EOPIE_Msk
 #define FLASH_CR_ERRIE_Pos                     (25U)
-#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)    /*!< 0x02000000 */
+#define FLASH_CR_ERRIE_Msk                     (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
 #define FLASH_CR_ERRIE                         FLASH_CR_ERRIE_Msk
 #define FLASH_CR_RDERRIE_Pos                   (26U)
-#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)  /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE_Msk                   (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
 #define FLASH_CR_RDERRIE                       FLASH_CR_RDERRIE_Msk
 #define FLASH_CR_OBL_LAUNCH_Pos                (27U)
 #define FLASH_CR_OBL_LAUNCH_Msk                (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
 #define FLASH_CR_OBL_LAUNCH                    FLASH_CR_OBL_LAUNCH_Msk
 #define FLASH_CR_SEC_PROT_Pos                  (28U)
-#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos) /*!< 0x10000000 */
+#define FLASH_CR_SEC_PROT_Msk                  (0x1UL << FLASH_CR_SEC_PROT_Pos)   /*!< 0x10000000 */
 #define FLASH_CR_SEC_PROT                      FLASH_CR_SEC_PROT_Msk
+#define FLASH_CR_SEC_PROT2_Pos                 (29U)
+#define FLASH_CR_SEC_PROT2_Msk                 (0x1UL << FLASH_CR_SEC_PROT2_Pos)  /*!< 0x20000000 */
+#define FLASH_CR_SEC_PROT2                     FLASH_CR_SEC_PROT2_Msk
 #define FLASH_CR_OPTLOCK_Pos                   (30U)
-#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)  /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK_Msk                   (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
 #define FLASH_CR_OPTLOCK                       FLASH_CR_OPTLOCK_Msk
 #define FLASH_CR_LOCK_Pos                      (31U)
-#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)     /*!< 0x80000000 */
+#define FLASH_CR_LOCK_Msk                      (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
 #define FLASH_CR_LOCK                          FLASH_CR_LOCK_Msk
 
-/*******************  Bits definition for FLASH_ECC1R register  ****************/
-#define FLASH_ECC1R_ADDR_ECC_Pos                (0U)
-#define FLASH_ECC1R_ADDR_ECC_Msk                (0xFFFFUL << FLASH_ECC1R_ADDR_ECC_Pos) /*!< 0x0000FFFF */
-#define FLASH_ECC1R_ADDR_ECC                    FLASH_ECC1R_ADDR_ECC_Msk
-#define FLASH_ECC1R_SYSF_ECC_Pos                (20U)
-#define FLASH_ECC1R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC1R_SYSF_ECC_Pos) /*!< 0x00100000 */
-#define FLASH_ECC1R_SYSF_ECC                    FLASH_ECC1R_SYSF_ECC_Msk
-#define FLASH_ECC1R_ECCCIE_Pos                  (24U)
-#define FLASH_ECC1R_ECCCIE_Msk                  (0x1UL << FLASH_ECC1R_ECCCIE_Pos) /*!< 0x01000000 */
-#define FLASH_ECC1R_ECCCIE                      FLASH_ECC1R_ECCCIE_Msk
-#define FLASH_ECC1R_ECCC_Pos                    (30U)
-#define FLASH_ECC1R_ECCC_Msk                    (0x1UL << FLASH_ECC1R_ECCC_Pos)   /*!< 0x40000000 */
-#define FLASH_ECC1R_ECCC                        FLASH_ECC1R_ECCC_Msk
-#define FLASH_ECC1R_ECCD_Pos                    (31U)
-#define FLASH_ECC1R_ECCD_Msk                    (0x1UL << FLASH_ECC1R_ECCD_Pos)   /*!< 0x80000000 */
-#define FLASH_ECC1R_ECCD                        FLASH_ECC1R_ECCD_Msk
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos                (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk                (0x7FFFUL << FLASH_ECCR_ADDR_ECC_Pos)  /*!< 0x00007FFF */
+#define FLASH_ECCR_ADDR_ECC                    FLASH_ECCR_ADDR_ECC_Msk
+#define FLASH_ECCR_SYSF_ECC_Pos                (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk                (0x1UL << FLASH_ECCR_SYSF_ECC_Pos)     /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                    FLASH_ECCR_SYSF_ECC_Msk
+#define FLASH_ECCR_ECCCIE_Pos                  (24U)
+#define FLASH_ECCR_ECCCIE_Msk                  (0x1UL << FLASH_ECCR_ECCCIE_Pos)       /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                      FLASH_ECCR_ECCCIE_Msk
+#define FLASH_ECCR_ECCC_Pos                    (30U)
+#define FLASH_ECCR_ECCC_Msk                    (0x1UL << FLASH_ECCR_ECCC_Pos)         /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                        FLASH_ECCR_ECCC_Msk
+#define FLASH_ECCR_ECCD_Pos                    (31U)
+#define FLASH_ECCR_ECCD_Msk                    (0x1UL << FLASH_ECCR_ECCD_Pos)         /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                        FLASH_ECCR_ECCD_Msk
+
 /*******************  Bits definition for FLASH_ECC2R register  ****************/
 #define FLASH_ECC2R_ADDR_ECC_Pos                (0U)
-#define FLASH_ECC2R_ADDR_ECC_Msk                (0xFFFFUL << FLASH_ECC2R_ADDR_ECC_Pos) /*!< 0x0000FFFF */
+#define FLASH_ECC2R_ADDR_ECC_Msk                (0x7FFFUL << FLASH_ECC2R_ADDR_ECC_Pos)  /*!< 0x00007FFF */
 #define FLASH_ECC2R_ADDR_ECC                    FLASH_ECC2R_ADDR_ECC_Msk
 #define FLASH_ECC2R_SYSF_ECC_Pos                (20U)
-#define FLASH_ECC2R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC2R_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECC2R_SYSF_ECC_Msk                (0x1UL << FLASH_ECC2R_SYSF_ECC_Pos)     /*!< 0x00100000 */
 #define FLASH_ECC2R_SYSF_ECC                    FLASH_ECC2R_SYSF_ECC_Msk
 #define FLASH_ECC2R_ECCCIE_Pos                  (24U)
-#define FLASH_ECC2R_ECCCIE_Msk                  (0x1UL << FLASH_ECC2R_ECCCIE_Pos) /*!< 0x01000000 */
+#define FLASH_ECC2R_ECCCIE_Msk                  (0x1UL << FLASH_ECC2R_ECCCIE_Pos)       /*!< 0x01000000 */
 #define FLASH_ECC2R_ECCCIE                      FLASH_ECC2R_ECCCIE_Msk
 #define FLASH_ECC2R_ECCC_Pos                    (30U)
-#define FLASH_ECC2R_ECCC_Msk                    (0x1UL << FLASH_ECC2R_ECCC_Pos)   /*!< 0x40000000 */
+#define FLASH_ECC2R_ECCC_Msk                    (0x1UL << FLASH_ECC2R_ECCC_Pos)         /*!< 0x40000000 */
 #define FLASH_ECC2R_ECCC                        FLASH_ECC2R_ECCC_Msk
 #define FLASH_ECC2R_ECCD_Pos                    (31U)
-#define FLASH_ECC2R_ECCD_Msk                    (0x1UL << FLASH_ECC2R_ECCD_Pos)   /*!< 0x80000000 */
+#define FLASH_ECC2R_ECCD_Msk                    (0x1UL << FLASH_ECC2R_ECCD_Pos)         /*!< 0x80000000 */
 #define FLASH_ECC2R_ECCD                        FLASH_ECC2R_ECCD_Msk
 
 /*******************  Bits definition for FLASH_OPTR register  ****************/
 #define FLASH_OPTR_RDP_Pos                     (0U)
-#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)   /*!< 0x000000FF */
+#define FLASH_OPTR_RDP_Msk                     (0xFFUL << FLASH_OPTR_RDP_Pos)             /*!< 0x000000FF */
 #define FLASH_OPTR_RDP                         FLASH_OPTR_RDP_Msk
 #define FLASH_OPTR_BOR_EN_Pos                  (8U)
-#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos) /*!< 0x00000100 */
+#define FLASH_OPTR_BOR_EN_Msk                  (0x1UL << FLASH_OPTR_BOR_EN_Pos)           /*!< 0x00000100 */
 #define FLASH_OPTR_BOR_EN                      FLASH_OPTR_BOR_EN_Msk
-#define FLASH_OPTR_BORF_LEV_Pos                (9U)
-#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000600 */
-#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
-#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000200 */
-#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos) /*!< 0x00000400 */
-#define FLASH_OPTR_BORR_LEV_Pos                (11U)
-#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001800 */
+#define FLASH_OPTR_BORR_LEV_Pos                (9U)
+#define FLASH_OPTR_BORR_LEV_Msk                (0x3UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000600 */
 #define FLASH_OPTR_BORR_LEV                    FLASH_OPTR_BORR_LEV_Msk
-#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00000800 */
-#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_BORR_LEV_0                  (0x1UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000200 */
+#define FLASH_OPTR_BORR_LEV_1                  (0x2UL << FLASH_OPTR_BORR_LEV_Pos)         /*!< 0x00000400 */
+#define FLASH_OPTR_BORF_LEV_Pos                (11U)
+#define FLASH_OPTR_BORF_LEV_Msk                (0x3UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001800 */
+#define FLASH_OPTR_BORF_LEV                    FLASH_OPTR_BORF_LEV_Msk
+#define FLASH_OPTR_BORF_LEV_0                  (0x1UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00000800 */
+#define FLASH_OPTR_BORF_LEV_1                  (0x2UL << FLASH_OPTR_BORF_LEV_Pos)         /*!< 0x00001000 */
 #define FLASH_OPTR_nRST_STOP_Pos               (13U)
-#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STOP_Msk               (0x1UL << FLASH_OPTR_nRST_STOP_Pos)        /*!< 0x00002000 */
 #define FLASH_OPTR_nRST_STOP                   FLASH_OPTR_nRST_STOP_Msk
 #define FLASH_OPTR_nRST_STDBY_Pos              (14U)
-#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_STDBY_Msk              (0x1UL << FLASH_OPTR_nRST_STDBY_Pos)       /*!< 0x00004000 */
 #define FLASH_OPTR_nRST_STDBY                  FLASH_OPTR_nRST_STDBY_Msk
 #define FLASH_OPTR_nRST_SHDW_Pos               (15U)
-#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00008000 */
+#define FLASH_OPTR_nRST_SHDW_Msk               (0x1UL << FLASH_OPTR_nRST_SHDW_Pos)        /*!< 0x00008000 */
 #define FLASH_OPTR_nRST_SHDW                   FLASH_OPTR_nRST_SHDW_Msk
 #define FLASH_OPTR_IWDG_SW_Pos                 (16U)
-#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)   /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW_Msk                 (0x1UL << FLASH_OPTR_IWDG_SW_Pos)          /*!< 0x00010000 */
 #define FLASH_OPTR_IWDG_SW                     FLASH_OPTR_IWDG_SW_Msk
 #define FLASH_OPTR_IWDG_STOP_Pos               (17U)
-#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP_Msk               (0x1UL << FLASH_OPTR_IWDG_STOP_Pos)        /*!< 0x00020000 */
 #define FLASH_OPTR_IWDG_STOP                   FLASH_OPTR_IWDG_STOP_Msk
 #define FLASH_OPTR_IWDG_STDBY_Pos              (18U)
-#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY_Msk              (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos)       /*!< 0x00040000 */
 #define FLASH_OPTR_IWDG_STDBY                  FLASH_OPTR_IWDG_STDBY_Msk
 #define FLASH_OPTR_WWDG_SW_Pos                 (19U)
-#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos) /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW_Msk                 (0x1UL << FLASH_OPTR_WWDG_SW_Pos)          /*!< 0x00080000 */
 #define FLASH_OPTR_WWDG_SW                     FLASH_OPTR_WWDG_SW_Msk
+#define FLASH_OPTR_nSWAP_BANK_Pos              (20U)
+#define FLASH_OPTR_nSWAP_BANK_Msk              (0x1UL << FLASH_OPTR_nSWAP_BANK_Pos)        /*!< 0x00100000 */
+#define FLASH_OPTR_nSWAP_BANK                  FLASH_OPTR_nSWAP_BANK_Msk
+#define FLASH_OPTR_DUAL_BANK_Pos               (21U)
+#define FLASH_OPTR_DUAL_BANK_Msk               (0x1UL << FLASH_OPTR_DUAL_BANK_Pos)        /*!< 0x00200000 */
+#define FLASH_OPTR_DUAL_BANK                   FLASH_OPTR_DUAL_BANK_Msk
 #define FLASH_OPTR_RAM_PARITY_CHECK_Pos        (22U)
 #define FLASH_OPTR_RAM_PARITY_CHECK_Msk        (0x1UL << FLASH_OPTR_RAM_PARITY_CHECK_Pos) /*!< 0x00400000 */
 #define FLASH_OPTR_RAM_PARITY_CHECK            FLASH_OPTR_RAM_PARITY_CHECK_Msk
 #define FLASH_OPTR_nBOOT_SEL_Pos               (24U)
-#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos) /*!< 0x01000000 */
+#define FLASH_OPTR_nBOOT_SEL_Msk               (0x1UL << FLASH_OPTR_nBOOT_SEL_Pos)        /*!< 0x01000000 */
 #define FLASH_OPTR_nBOOT_SEL                   FLASH_OPTR_nBOOT_SEL_Msk
 #define FLASH_OPTR_nBOOT1_Pos                  (25U)
-#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_nBOOT1_Msk                  (0x1UL << FLASH_OPTR_nBOOT1_Pos)           /*!< 0x02000000 */
 #define FLASH_OPTR_nBOOT1                      FLASH_OPTR_nBOOT1_Msk
 #define FLASH_OPTR_nBOOT0_Pos                  (26U)
-#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nBOOT0_Msk                  (0x1UL << FLASH_OPTR_nBOOT0_Pos)           /*!< 0x04000000 */
 #define FLASH_OPTR_nBOOT0                      FLASH_OPTR_nBOOT0_Msk
 #define FLASH_OPTR_NRST_MODE_Pos               (27U)
-#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x18000000 */
+#define FLASH_OPTR_NRST_MODE_Msk               (0x3UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x18000000 */
 #define FLASH_OPTR_NRST_MODE                   FLASH_OPTR_NRST_MODE_Msk
-#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x08000000 */
-#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos) /*!< 0x10000000 */
+#define FLASH_OPTR_NRST_MODE_0                 (0x1UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x08000000 */
+#define FLASH_OPTR_NRST_MODE_1                 (0x2UL << FLASH_OPTR_NRST_MODE_Pos)        /*!< 0x10000000 */
 #define FLASH_OPTR_IRHEN_Pos                   (29U)
-#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos) /*!< 0x20000000 */
+#define FLASH_OPTR_IRHEN_Msk                   (0x1UL << FLASH_OPTR_IRHEN_Pos)            /*!< 0x20000000 */
 #define FLASH_OPTR_IRHEN                       FLASH_OPTR_IRHEN_Msk
 
 /******************  Bits definition for FLASH_PCROP1ASR register  ************/
 #define FLASH_PCROP1ASR_PCROP1A_STRT_Pos       (0U)
-#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0xFFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk       (0x1FFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP1ASR_PCROP1A_STRT           FLASH_PCROP1ASR_PCROP1A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1AER register  ************/
 #define FLASH_PCROP1AER_PCROP1A_END_Pos        (0U)
-#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0xFFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1AER_PCROP1A_END_Msk        (0x1FFUL << FLASH_PCROP1AER_PCROP1A_END_Pos)   /*!< 0x0000001FF */
 #define FLASH_PCROP1AER_PCROP1A_END            FLASH_PCROP1AER_PCROP1A_END_Msk
 #define FLASH_PCROP1AER_PCROP_RDP_Pos          (31U)
-#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP_Msk          (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos)       /*!< 0x80000000 */
 #define FLASH_PCROP1AER_PCROP_RDP              FLASH_PCROP1AER_PCROP_RDP_Msk
 
 /******************  Bits definition for FLASH_WRP1AR register  ***************/
 #define FLASH_WRP1AR_WRP1A_STRT_Pos            (0U)
-#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x3FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP1AR_WRP1A_STRT_Msk            (0x7FUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x0000007F */
 #define FLASH_WRP1AR_WRP1A_STRT                FLASH_WRP1AR_WRP1A_STRT_Msk
 #define FLASH_WRP1AR_WRP1A_END_Pos             (16U)
-#define FLASH_WRP1AR_WRP1A_END_Msk             (0x3FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP1AR_WRP1A_END_Msk             (0x7FUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x007F0000 */
 #define FLASH_WRP1AR_WRP1A_END                 FLASH_WRP1AR_WRP1A_END_Msk
 
 /******************  Bits definition for FLASH_WRP1BR register  ***************/
 #define FLASH_WRP1BR_WRP1B_STRT_Pos            (0U)
-#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x3FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP1BR_WRP1B_STRT_Msk            (0x7FUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x0000007F */
 #define FLASH_WRP1BR_WRP1B_STRT                FLASH_WRP1BR_WRP1B_STRT_Msk
 #define FLASH_WRP1BR_WRP1B_END_Pos             (16U)
-#define FLASH_WRP1BR_WRP1B_END_Msk             (0x3FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP1BR_WRP1B_END_Msk             (0x7FUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x007F0000 */
 #define FLASH_WRP1BR_WRP1B_END                 FLASH_WRP1BR_WRP1B_END_Msk
 
 /******************  Bits definition for FLASH_PCROP1BSR register  ************/
 #define FLASH_PCROP1BSR_PCROP1B_STRT_Pos       (0U)
-#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0xFFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk       (0x1FFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP1BSR_PCROP1B_STRT           FLASH_PCROP1BSR_PCROP1B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP1BER register  ************/
 #define FLASH_PCROP1BER_PCROP1B_END_Pos        (0U)
-#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0xFFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)  /*!< 0x000000FF */
+#define FLASH_PCROP1BER_PCROP1B_END_Msk        (0x1FFUL << FLASH_PCROP1BER_PCROP1B_END_Pos)   /*!< 0x0000001FF */
 #define FLASH_PCROP1BER_PCROP1B_END            FLASH_PCROP1BER_PCROP1B_END_Msk
+
 /******************  Bits definition for FLASH_PCROP2ASR register  ************/
 #define FLASH_PCROP2ASR_PCROP2A_STRT_Pos       (0U)
-#define FLASH_PCROP2ASR_PCROP2A_STRT_Msk       (0xFFUL << FLASH_PCROP2ASR_PCROP2A_STRT_Pos) /*!< 0x0000FFFF */
+#define FLASH_PCROP2ASR_PCROP2A_STRT_Msk       (0x1FFUL << FLASH_PCROP2ASR_PCROP2A_STRT_Pos) /*!< 0x0000001FF */
 #define FLASH_PCROP2ASR_PCROP2A_STRT           FLASH_PCROP2ASR_PCROP2A_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP2AER register  ************/
 #define FLASH_PCROP2AER_PCROP2A_END_Pos        (0U)
-#define FLASH_PCROP2AER_PCROP2A_END_Msk        (0xFFUL << FLASH_PCROP2AER_PCROP2A_END_Pos)  /*!< 0x0000FFFF */
+#define FLASH_PCROP2AER_PCROP2A_END_Msk        (0x1FFUL << FLASH_PCROP2AER_PCROP2A_END_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP2AER_PCROP2A_END            FLASH_PCROP2AER_PCROP2A_END_Msk
+
 
 /******************  Bits definition for FLASH_WRP2AR register  ***************/
 #define FLASH_WRP2AR_WRP2A_STRT_Pos            (0U)
-#define FLASH_WRP2AR_WRP2A_STRT_Msk            (0x3FUL << FLASH_WRP2AR_WRP2A_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP2AR_WRP2A_STRT_Msk            (0x7FUL << FLASH_WRP2AR_WRP2A_STRT_Pos)  /*!< 0x0000007F */
 #define FLASH_WRP2AR_WRP2A_STRT                FLASH_WRP2AR_WRP2A_STRT_Msk
 #define FLASH_WRP2AR_WRP2A_END_Pos             (16U)
-#define FLASH_WRP2AR_WRP2A_END_Msk             (0x3FUL << FLASH_WRP2AR_WRP2A_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP2AR_WRP2A_END_Msk             (0x7FUL << FLASH_WRP2AR_WRP2A_END_Pos)   /*!< 0x007F0000 */
 #define FLASH_WRP2AR_WRP2A_END                 FLASH_WRP2AR_WRP2A_END_Msk
 
 /******************  Bits definition for FLASH_WRP2BSR register  ***************/
 #define FLASH_WRP2BR_WRP2B_STRT_Pos            (0U)
-#define FLASH_WRP2BR_WRP2B_STRT_Msk            (0x3FUL << FLASH_WRP2BR_WRP2B_STRT_Pos) /*!< 0x0000003F */
+#define FLASH_WRP2BR_WRP2B_STRT_Msk            (0x7FUL << FLASH_WRP2BR_WRP2B_STRT_Pos)  /*!< 0x0000007F */
 #define FLASH_WRP2BR_WRP2B_STRT                FLASH_WRP2BR_WRP2B_STRT_Msk
 #define FLASH_WRP2BR_WRP2B_END_Pos             (16U)
-#define FLASH_WRP2BR_WRP2B_END_Msk             (0x3FUL << FLASH_WRP2BR_WRP2B_END_Pos) /*!< 0x003F0000 */
+#define FLASH_WRP2BR_WRP2B_END_Msk             (0x7FUL << FLASH_WRP2BR_WRP2B_END_Pos)   /*!< 0x007F0000 */
 #define FLASH_WRP2BR_WRP2B_END                 FLASH_WRP2BR_WRP2B_END_Msk
 
 /******************  Bits definition for FLASH_PCROP2BSR register  ************/
 #define FLASH_PCROP2BSR_PCROP2B_STRT_Pos       (0U)
-#define FLASH_PCROP2BSR_PCROP2B_STRT_Msk       (0xFFUL << FLASH_PCROP2BSR_PCROP2B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_PCROP2BSR_PCROP2B_STRT_Msk       (0x1FFUL << FLASH_PCROP2BSR_PCROP2B_STRT_Pos) /*!< 0x0000001FF */
 #define FLASH_PCROP2BSR_PCROP2B_STRT           FLASH_PCROP2BSR_PCROP2B_STRT_Msk
 
 /******************  Bits definition for FLASH_PCROP2BER register  ************/
 #define FLASH_PCROP2BER_PCROP2B_END_Pos        (0U)
-#define FLASH_PCROP2BER_PCROP2B_END_Msk        (0xFFUL << FLASH_PCROP2BER_PCROP2B_END_Pos)  /*!< 0x000000FF */
+#define FLASH_PCROP2BER_PCROP2B_END_Msk        (0x1FFUL << FLASH_PCROP2BER_PCROP2B_END_Pos)  /*!< 0x0000001FF */
 #define FLASH_PCROP2BER_PCROP2B_END            FLASH_PCROP2BER_PCROP2B_END_Msk
 
 /******************  Bits definition for FLASH_SECR register  *****************/
-#define FLASH_SECR_SEC_SIZEB1_Pos              (0U)
-#define FLASH_SECR_SEC_SIZEB1_Msk              (0x7FUL << FLASH_SECR_SEC_SIZEB1_Pos) /*!< 0x0000007F */
-#define FLASH_SECR_SEC_SIZEB1                  FLASH_SECR_SEC_SIZEB1_Msk
-#define FLASH_SECR_SEC_SIZEB2_Pos              (20U)
-#define FLASH_SECR_SEC_SIZEB2_Msk              (0xFFUL << FLASH_SECR_SEC_SIZEB2_Pos) /*!< 0x0FF00000 */
-#define FLASH_SECR_SEC_SIZEB2                  FLASH_SECR_SEC_SIZEB2_Msk
+#define FLASH_SECR_SEC_SIZE_Pos                (0U)
+#define FLASH_SECR_SEC_SIZE_Msk                (0xFFUL << FLASH_SECR_SEC_SIZE_Pos) /*!< 0x000000FF */
+#define FLASH_SECR_SEC_SIZE                    FLASH_SECR_SEC_SIZE_Msk
 #define FLASH_SECR_BOOT_LOCK_Pos               (16U)
 #define FLASH_SECR_BOOT_LOCK_Msk               (0x1UL << FLASH_SECR_BOOT_LOCK_Pos) /*!< 0x00010000 */
 #define FLASH_SECR_BOOT_LOCK                   FLASH_SECR_BOOT_LOCK_Msk
-
+#define FLASH_SECR_SEC_SIZE2_Pos               (20U)
+#define FLASH_SECR_SEC_SIZE2_Msk               (0xFFUL << FLASH_SECR_SEC_SIZE2_Pos) /*!< 0x0FF00000 */
+#define FLASH_SECR_SEC_SIZE2                   FLASH_SECR_SEC_SIZE2_Msk
 
 /******************************************************************************/
 /*                                                                            */
@@ -5305,6 +5417,7 @@ typedef struct
 /*                        Power Control                                       */
 /*                                                                            */
 /******************************************************************************/
+#define PWR_PVM_SUPPORT                       /*!< PWR feature available only on specific devices: Power Voltage Monitoring feature */
 #define PWR_PVD_SUPPORT                       /*!< PWR feature available only on specific devices: Power Voltage Detection feature */
 #define PWR_BOR_SUPPORT                       /*!< PWR feature available only on specific devices: Brown-Out Reset feature         */
 #define PWR_SHDW_SUPPORT                      /*!< PWR feature available only on specific devices: Shutdown mode */
@@ -5353,10 +5466,19 @@ typedef struct
 #define PWR_CR2_PVDRT_0           (0x1UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000010 */
 #define PWR_CR2_PVDRT_1           (0x2UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000020 */
 #define PWR_CR2_PVDRT_2           (0x4UL << PWR_CR2_PVDRT_Pos)                 /*!< 0x00000040 */
+#define PWR_CR2_PVMEN_USB_Pos     (8U)
+#define PWR_CR2_PVMEN_USB_Msk     (0x1UL << PWR_CR2_PVMEN_USB_Pos)             /*!< 0x00000100 */
+#define PWR_CR2_PVMEN_USB         PWR_CR2_PVMEN_USB_Msk                        /*!< USB Peripheral Voltage Monitor Enable */
+#define PWR_CR2_IOSV_Pos          (9U)
+#define PWR_CR2_IOSV_Msk          (0x1UL << PWR_CR2_IOSV_Pos)                  /*!< 0x00000200 */
+#define PWR_CR2_IOSV              PWR_CR2_IOSV_Msk                             /*!< VDDIO2 independent I/Os Supply Valid */
+#define PWR_CR2_USV_Pos           (10U)
+#define PWR_CR2_USV_Msk           (0x1UL << PWR_CR2_USV_Pos)                   /*!< 0x00000400 */
+#define PWR_CR2_USV               PWR_CR2_USV_Msk                              /*!< VDD USB Supply Valid */
 
 /********************  Bit definition for PWR_CR3 register  ********************/
 #define PWR_CR3_EWUP_Pos          (0U)
-#define PWR_CR3_EWUP_Msk          (0x3BUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000003B */
+#define PWR_CR3_EWUP_Msk          (0x3FUL << PWR_CR3_EWUP_Pos)                 /*!< 0x0000003F */
 #define PWR_CR3_EWUP              PWR_CR3_EWUP_Msk                             /*!< Enable all Wake-Up Pins  */
 #define PWR_CR3_EWUP1_Pos         (0U)
 #define PWR_CR3_EWUP1_Msk         (0x1UL << PWR_CR3_EWUP1_Pos)                 /*!< 0x00000001 */
@@ -5364,6 +5486,9 @@ typedef struct
 #define PWR_CR3_EWUP2_Pos         (1U)
 #define PWR_CR3_EWUP2_Msk         (0x1UL << PWR_CR3_EWUP2_Pos)                 /*!< 0x00000002 */
 #define PWR_CR3_EWUP2             PWR_CR3_EWUP2_Msk                            /*!< Enable WKUP pin 2 */
+#define PWR_CR3_EWUP3_Pos         (2U)
+#define PWR_CR3_EWUP3_Msk         (0x1UL << PWR_CR3_EWUP3_Pos)                 /*!< 0x00000004 */
+#define PWR_CR3_EWUP3             PWR_CR3_EWUP3_Msk                            /*!< Enable WKUP pin 3 */
 #define PWR_CR3_EWUP4_Pos         (3U)
 #define PWR_CR3_EWUP4_Msk         (0x1UL << PWR_CR3_EWUP4_Pos)                 /*!< 0x00000008 */
 #define PWR_CR3_EWUP4             PWR_CR3_EWUP4_Msk                            /*!< Enable WKUP pin 4 */
@@ -5388,7 +5513,7 @@ typedef struct
 
 /********************  Bit definition for PWR_CR4 register  ********************/
 #define PWR_CR4_WP_Pos            (0U)
-#define PWR_CR4_WP_Msk            (0x3BUL << PWR_CR4_WP_Pos)                   /*!< 0x0000003B */
+#define PWR_CR4_WP_Msk            (0x3FUL << PWR_CR4_WP_Pos)                   /*!< 0x0000003F */
 #define PWR_CR4_WP                PWR_CR4_WP_Msk                               /*!< all Wake-Up Pin polarity */
 #define PWR_CR4_WP1_Pos           (0U)
 #define PWR_CR4_WP1_Msk           (0x1UL << PWR_CR4_WP1_Pos)                   /*!< 0x00000001 */
@@ -5396,6 +5521,9 @@ typedef struct
 #define PWR_CR4_WP2_Pos           (1U)
 #define PWR_CR4_WP2_Msk           (0x1UL << PWR_CR4_WP2_Pos)                   /*!< 0x00000002 */
 #define PWR_CR4_WP2               PWR_CR4_WP2_Msk                              /*!< Wake-Up Pin 2 polarity */
+#define PWR_CR4_WP3_Pos           (2U)
+#define PWR_CR4_WP3_Msk           (0x1UL << PWR_CR4_WP3_Pos)                   /*!< 0x00000004 */
+#define PWR_CR4_WP3               PWR_CR4_WP3_Msk                              /*!< Wake-Up Pin 3 polarity */
 #define PWR_CR4_WP4_Pos           (3U)
 #define PWR_CR4_WP4_Msk           (0x1UL << PWR_CR4_WP4_Pos)                   /*!< 0x00000008 */
 #define PWR_CR4_WP4               PWR_CR4_WP4_Msk                              /*!< Wake-Up Pin 4 polarity */
@@ -5414,7 +5542,7 @@ typedef struct
 
 /********************  Bit definition for PWR_SR1 register  ********************/
 #define PWR_SR1_WUF_Pos           (0U)
-#define PWR_SR1_WUF_Msk           (0x3BUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000003B */
+#define PWR_SR1_WUF_Msk           (0x3FUL << PWR_SR1_WUF_Pos)                  /*!< 0x0000003F */
 #define PWR_SR1_WUF               PWR_SR1_WUF_Msk                              /*!< Wakeup Flags  */
 #define PWR_SR1_WUF1_Pos          (0U)
 #define PWR_SR1_WUF1_Msk          (0x1UL << PWR_SR1_WUF1_Pos)                  /*!< 0x00000001 */
@@ -5422,6 +5550,9 @@ typedef struct
 #define PWR_SR1_WUF2_Pos          (1U)
 #define PWR_SR1_WUF2_Msk          (0x1UL << PWR_SR1_WUF2_Pos)                  /*!< 0x00000002 */
 #define PWR_SR1_WUF2              PWR_SR1_WUF2_Msk                             /*!< Wakeup Flag 2 */
+#define PWR_SR1_WUF3_Pos          (2U)
+#define PWR_SR1_WUF3_Msk          (0x1UL << PWR_SR1_WUF3_Pos)                  /*!< 0x00000004 */
+#define PWR_SR1_WUF3              PWR_SR1_WUF3_Msk                             /*!< Wakeup Flag 3 */
 #define PWR_SR1_WUF4_Pos          (3U)
 #define PWR_SR1_WUF4_Msk          (0x1UL << PWR_SR1_WUF4_Pos)                  /*!< 0x00000008 */
 #define PWR_SR1_WUF4              PWR_SR1_WUF4_Msk                             /*!< Wakeup Flag 4 */
@@ -5454,10 +5585,13 @@ typedef struct
 #define PWR_SR2_PVDO_Pos          (11U)
 #define PWR_SR2_PVDO_Msk          (0x1UL << PWR_SR2_PVDO_Pos)                  /*!< 0x00000800 */
 #define PWR_SR2_PVDO              PWR_SR2_PVDO_Msk                             /*!< Power voltage detector output */
+#define PWR_SR2_PVMO_USB_Pos      (13U)
+#define PWR_SR2_PVMO_USB_Msk      (0x1UL << PWR_SR2_PVMO_USB_Pos)              /*!< 0x00002000 */
+#define PWR_SR2_PVMO_USB          PWR_SR2_PVMO_USB_Msk                         /*!< USB Peripheral Voltage Monitoring Output */
 
 /********************  Bit definition for PWR_SCR register  ********************/
 #define PWR_SCR_CWUF_Pos          (0U)
-#define PWR_SCR_CWUF_Msk          (0x3BUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000003B */
+#define PWR_SCR_CWUF_Msk          (0x3FUL << PWR_SCR_CWUF_Pos)                 /*!< 0x0000003F */
 #define PWR_SCR_CWUF              PWR_SCR_CWUF_Msk                             /*!< Clear Wake-up Flags  */
 #define PWR_SCR_CWUF1_Pos         (0U)
 #define PWR_SCR_CWUF1_Msk         (0x1UL << PWR_SCR_CWUF1_Pos)                 /*!< 0x00000001 */
@@ -5465,6 +5599,9 @@ typedef struct
 #define PWR_SCR_CWUF2_Pos         (1U)
 #define PWR_SCR_CWUF2_Msk         (0x1UL << PWR_SCR_CWUF2_Pos)                 /*!< 0x00000002 */
 #define PWR_SCR_CWUF2             PWR_SCR_CWUF2_Msk                            /*!< Clear Wake-up Flag 2 */
+#define PWR_SCR_CWUF3_Pos         (2U)
+#define PWR_SCR_CWUF3_Msk         (0x1UL << PWR_SCR_CWUF3_Pos)                 /*!< 0x00000004 */
+#define PWR_SCR_CWUF3             PWR_SCR_CWUF3_Msk                            /*!< Clear Wake-up Flag 3 */
 #define PWR_SCR_CWUF4_Pos         (3U)
 #define PWR_SCR_CWUF4_Msk         (0x1UL << PWR_SCR_CWUF4_Pos)                 /*!< 0x00000008 */
 #define PWR_SCR_CWUF4             PWR_SCR_CWUF4_Msk                            /*!< Clear Wake-up Flag 4 */
@@ -6065,8 +6202,9 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions  (not present on all devices in the STM32G0 serie)
+* @brief Specific device feature definitions  (not present on all devices in the STM32G0 series)
 */
+#define RCC_MCO2_SUPPORT
 #define RCC_HSI48_SUPPORT
 #define RCC_PLLQ_SUPPORT
 
@@ -6155,12 +6293,6 @@ typedef struct
 #define RCC_CFGR_SWS_1                 (0x2UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000010 */
 #define RCC_CFGR_SWS_2                 (0x4UL << RCC_CFGR_SWS_Pos)             /*!< 0x00000020 */
 
-#define RCC_CFGR_SWS_HSI               (0UL)                                   /*!< HSI used as system clock */
-#define RCC_CFGR_SWS_HSE               (0x00000008UL)                          /*!< HSE used as system clock */
-#define RCC_CFGR_SWS_PLL               (0x00000010UL)                          /*!< PLL used as system clock */
-#define RCC_CFGR_SWS_LSI               (0x00000018UL)                          /*!< LSI used as system clock */
-#define RCC_CFGR_SWS_LSE               (0x00000020UL)                          /*!< LSE used as system clock */
-
 /*!< HPRE configuration */
 #define RCC_CFGR_HPRE_Pos              (8U)
 #define RCC_CFGR_HPRE_Msk              (0xFUL << RCC_CFGR_HPRE_Pos)            /*!< 0x00000F00 */
@@ -6178,21 +6310,41 @@ typedef struct
 #define RCC_CFGR_PPRE_1                (0x2UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00002000 */
 #define RCC_CFGR_PPRE_2                (0x4UL << RCC_CFGR_PPRE_Pos)            /*!< 0x00004000 */
 
+/*!< MCO2SEL configuration */
+#define RCC_CFGR_MCO2SEL_Pos            (16U)
+#define RCC_CFGR_MCO2SEL_Msk            (0xFUL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x000F0000 */
+#define RCC_CFGR_MCO2SEL                RCC_CFGR_MCO2SEL_Msk                     /*!< MCO2SEL [3:0] bits (Clock output selection) */
+#define RCC_CFGR_MCO2SEL_0              (0x1UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00010000 */
+#define RCC_CFGR_MCO2SEL_1              (0x2UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00020000 */
+#define RCC_CFGR_MCO2SEL_2              (0x4UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00040000 */
+#define RCC_CFGR_MCO2SEL_3              (0x8UL << RCC_CFGR_MCO2SEL_Pos)          /*!< 0x00080000 */
+
+/*!< MCO2 Prescaler configuration */
+#define RCC_CFGR_MCO2PRE_Pos            (20U)
+#define RCC_CFGR_MCO2PRE_Msk            (0xFUL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00F00000 */
+#define RCC_CFGR_MCO2PRE                RCC_CFGR_MCO2PRE_Msk                     /*!< MCO2 prescaler [3:0] */
+#define RCC_CFGR_MCO2PRE_0              (0x1UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00100000 */
+#define RCC_CFGR_MCO2PRE_1              (0x2UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00200000 */
+#define RCC_CFGR_MCO2PRE_2              (0x4UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00400000 */
+#define RCC_CFGR_MCO2PRE_3              (0x8UL << RCC_CFGR_MCO2PRE_Pos)          /*!< 0x00800000 */
+
 /*!< MCOSEL configuration */
 #define RCC_CFGR_MCOSEL_Pos            (24U)
-#define RCC_CFGR_MCOSEL_Msk            (0x7UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL_Msk            (0xFUL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x0F000000 */
 #define RCC_CFGR_MCOSEL                RCC_CFGR_MCOSEL_Msk                     /*!< MCOSEL [2:0] bits (Clock output selection) */
 #define RCC_CFGR_MCOSEL_0              (0x1UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x01000000 */
 #define RCC_CFGR_MCOSEL_1              (0x2UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x02000000 */
 #define RCC_CFGR_MCOSEL_2              (0x4UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x04000000 */
+#define RCC_CFGR_MCOSEL_3              (0x8UL << RCC_CFGR_MCOSEL_Pos)          /*!< 0x08000000 */
 
 /*!< MCO Prescaler configuration */
 #define RCC_CFGR_MCOPRE_Pos            (28U)
-#define RCC_CFGR_MCOPRE_Msk            (0x7UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE_Msk            (0xFUL << RCC_CFGR_MCOPRE_Pos)          /*!< 0xF0000000 */
 #define RCC_CFGR_MCOPRE                RCC_CFGR_MCOPRE_Msk                     /*!< MCO prescaler [2:0] */
 #define RCC_CFGR_MCOPRE_0              (0x1UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x10000000 */
 #define RCC_CFGR_MCOPRE_1              (0x2UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x20000000 */
 #define RCC_CFGR_MCOPRE_2              (0x4UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x40000000 */
+#define RCC_CFGR_MCOPRE_3              (0x8UL << RCC_CFGR_MCOPRE_Pos)          /*!< 0x80000000 */
 
 /********************  Bit definition for RCC_PLLCFGR register  ***************/
 #define RCC_PLLCFGR_PLLSRC_Pos           (0U)
@@ -6416,9 +6568,9 @@ typedef struct
 #define RCC_APBRSTR1_FDCANRST_Pos        (12U)
 #define RCC_APBRSTR1_FDCANRST_Msk        (0x1UL << RCC_APBRSTR1_FDCANRST_Pos)  /*!< 0x00001000 */
 #define RCC_APBRSTR1_FDCANRST            RCC_APBRSTR1_FDCANRST_Msk
-#define RCC_APBRSTR1_USBFSRST_Pos        (13U)
-#define RCC_APBRSTR1_USBFSRST_Msk        (0x1UL << RCC_APBRSTR1_USBFSRST_Pos)  /*!< 0x00002000 */
-#define RCC_APBRSTR1_USBFSRST            RCC_APBRSTR1_USBFSRST_Msk
+#define RCC_APBRSTR1_USBRST_Pos          (13U)
+#define RCC_APBRSTR1_USBRST_Msk          (0x1UL << RCC_APBRSTR1_USBRST_Pos)    /*!< 0x00002000 */
+#define RCC_APBRSTR1_USBRST              RCC_APBRSTR1_USBRST_Msk
 #define RCC_APBRSTR1_SPI2RST_Pos         (14U)
 #define RCC_APBRSTR1_SPI2RST_Msk         (0x1UL << RCC_APBRSTR1_SPI2RST_Pos)   /*!< 0x00004000 */
 #define RCC_APBRSTR1_SPI2RST             RCC_APBRSTR1_SPI2RST_Msk
@@ -6577,9 +6729,9 @@ typedef struct
 #define RCC_APBENR1_FDCANEN_Pos          (12U)
 #define RCC_APBENR1_FDCANEN_Msk          (0x1UL << RCC_APBENR1_FDCANEN_Pos)     /*!< 0x00001000 */
 #define RCC_APBENR1_FDCANEN              RCC_APBENR1_FDCANEN_Msk
-#define RCC_APBENR1_USBFSEN_Pos          (13U)
-#define RCC_APBENR1_USBFSEN_Msk          (0x1UL << RCC_APBENR1_USBFSEN_Pos)     /*!< 0x00002000 */
-#define RCC_APBENR1_USBFSEN              RCC_APBENR1_USBFSEN_Msk
+#define RCC_APBENR1_USBEN_Pos            (13U)
+#define RCC_APBENR1_USBEN_Msk            (0x1UL << RCC_APBENR1_USBEN_Pos)       /*!< 0x00002000 */
+#define RCC_APBENR1_USBEN                RCC_APBENR1_USBEN_Msk
 #define RCC_APBENR1_SPI2EN_Pos           (14U)
 #define RCC_APBENR1_SPI2EN_Msk           (0x1UL << RCC_APBENR1_SPI2EN_Pos)      /*!< 0x00004000 */
 #define RCC_APBENR1_SPI2EN               RCC_APBENR1_SPI2EN_Msk
@@ -6741,9 +6893,9 @@ typedef struct
 #define RCC_APBSMENR1_FDCANSMEN_Pos      (12U)
 #define RCC_APBSMENR1_FDCANSMEN_Msk      (0x1UL << RCC_APBSMENR1_FDCANSMEN_Pos)  /*!< 0x00001000 */
 #define RCC_APBSMENR1_FDCANSMEN          RCC_APBSMENR1_FDCANSMEN_Msk
-#define RCC_APBSMENR1_USBFSSMEN_Pos      (13U)
-#define RCC_APBSMENR1_USBFSSMEN_Msk      (0x1UL << RCC_APBSMENR1_USBFSSMEN_Pos)  /*!< 0x00002000 */
-#define RCC_APBSMENR1_USBFSSMEN          RCC_APBSMENR1_USBFSSMEN_Msk
+#define RCC_APBSMENR1_USBSMEN_Pos        (13U)
+#define RCC_APBSMENR1_USBSMEN_Msk        (0x1UL << RCC_APBSMENR1_USBSMEN_Pos)    /*!< 0x00002000 */
+#define RCC_APBSMENR1_USBSMEN            RCC_APBSMENR1_USBSMEN_Msk
 #define RCC_APBSMENR1_SPI2SMEN_Pos       (14U)
 #define RCC_APBSMENR1_SPI2SMEN_Msk       (0x1UL << RCC_APBSMENR1_SPI2SMEN_Pos)   /*!< 0x00004000 */
 #define RCC_APBSMENR1_SPI2SMEN           RCC_APBSMENR1_SPI2SMEN_Msk
@@ -6873,11 +7025,6 @@ typedef struct
 #define RCC_CCIPR_I2C2SEL_0             (0x1UL << RCC_CCIPR_I2C2SEL_Pos)        /*!< 0x00004000 */
 #define RCC_CCIPR_I2C2SEL_1             (0x2UL << RCC_CCIPR_I2C2SEL_Pos)        /*!< 0x00008000 */
 
-#define RCC_CCIPR_I2C3SEL_Pos            (16U)
-#define RCC_CCIPR_I2C3SEL_Msk            (0x3UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00030000 */
-#define RCC_CCIPR_I2C3SEL                RCC_CCIPR_I2C3SEL_Msk
-#define RCC_CCIPR_I2C3SEL_0              (0x1UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00010000 */
-#define RCC_CCIPR_I2C3SEL_1              (0x2UL << RCC_CCIPR_I2C3SEL_Pos)       /*!< 0x00020000 */
 #define RCC_CCIPR_LPTIM1SEL_Pos          (18U)
 #define RCC_CCIPR_LPTIM1SEL_Msk          (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos)     /*!< 0x000C0000 */
 #define RCC_CCIPR_LPTIM1SEL              RCC_CCIPR_LPTIM1SEL_Msk
@@ -6927,21 +7074,16 @@ typedef struct
 #define RCC_CCIPR2_I2S2SEL                RCC_CCIPR2_I2S2SEL_Msk
 #define RCC_CCIPR2_I2S2SEL_0              (0x1UL << RCC_CCIPR2_I2S2SEL_Pos)     /*!< 0x00000004 */
 #define RCC_CCIPR2_I2S2SEL_1              (0x2UL << RCC_CCIPR2_I2S2SEL_Pos)     /*!< 0x00000008 */
-#define RCC_CCIPR2_I2S3SEL_Pos            (4U)
-#define RCC_CCIPR2_I2S3SEL_Msk            (0x3UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000030 */
-#define RCC_CCIPR2_I2S3SEL                RCC_CCIPR2_I2S3SEL_Msk
-#define RCC_CCIPR2_I2S3SEL_0              (0x1UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000010 */
-#define RCC_CCIPR2_I2S3SEL_1              (0x2UL << RCC_CCIPR2_I2S3SEL_Pos)     /*!< 0x00000020 */
 #define RCC_CCIPR2_FDCANSEL_Pos           (8U)
 #define RCC_CCIPR2_FDCANSEL_Msk           (0x3UL << RCC_CCIPR2_FDCANSEL_Pos)    /*!< 0x00000300 */
 #define RCC_CCIPR2_FDCANSEL               RCC_CCIPR2_FDCANSEL_Msk
 #define RCC_CCIPR2_FDCANSEL_0             (0x1UL << RCC_CCIPR2_FDCANSEL_Pos)    /*!< 0x00000100 */
 #define RCC_CCIPR2_FDCANSEL_1             (0x2UL << RCC_CCIPR2_FDCANSEL_Pos)    /*!< 0x00000200 */
-#define RCC_CCIPR2_CK48MSEL_Pos           (12U)
-#define RCC_CCIPR2_CK48MSEL_Msk           (0x3UL << RCC_CCIPR2_CK48MSEL_Pos)     /*!< 0x00003000 */
-#define RCC_CCIPR2_CK48MSEL               RCC_CCIPR2_CK48MSEL_Msk
-#define RCC_CCIPR2_CK48MSEL_0             (0x1UL << RCC_CCIPR2_CK48MSEL_Pos)    /*!< 0x00001000 */
-#define RCC_CCIPR2_CK48MSEL_1             (0x2UL << RCC_CCIPR2_CK48MSEL_Pos)    /*!< 0x00002000 */
+#define RCC_CCIPR2_USBSEL_Pos             (12U)
+#define RCC_CCIPR2_USBSEL_Msk             (0x3UL << RCC_CCIPR2_USBSEL_Pos)     /*!< 0x00003000 */
+#define RCC_CCIPR2_USBSEL                 RCC_CCIPR2_USBSEL_Msk
+#define RCC_CCIPR2_USBSEL_0               (0x1UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00001000 */
+#define RCC_CCIPR2_USBSEL_1               (0x2UL << RCC_CCIPR2_USBSEL_Pos)      /*!< 0x00002000 */
 /********************  Bit definition for RCC_BDCR register  ******************/
 #define RCC_BDCR_LSEON_Pos               (0U)
 #define RCC_BDCR_LSEON_Msk               (0x1UL << RCC_BDCR_LSEON_Pos)          /*!< 0x00000001 */
@@ -7062,6 +7204,7 @@ typedef struct
 */
 #define RTC_WAKEUP_SUPPORT
 #define RTC_BACKUP_SUPPORT
+#define RTC_TAMPER3_SUPPORT          /*!< TAMPER3 only available on some devices */
 
 /********************  Bits definition for RTC_TR register  *******************/
 #define RTC_TR_PM_Pos                (22U)
@@ -7632,6 +7775,9 @@ typedef struct
 #define TAMP_CR1_TAMP2E_Pos          (1U)
 #define TAMP_CR1_TAMP2E_Msk          (0x1UL << TAMP_CR1_TAMP2E_Pos)             /*!< 0x00000002 */
 #define TAMP_CR1_TAMP2E              TAMP_CR1_TAMP2E_Msk
+#define TAMP_CR1_TAMP3E_Pos          (2U)
+#define TAMP_CR1_TAMP3E_Msk          (0x1UL << TAMP_CR1_TAMP3E_Pos)             /*!< 0x00000004 */
+#define TAMP_CR1_TAMP3E              TAMP_CR1_TAMP3E_Msk
 #define TAMP_CR1_ITAMP3E_Pos         (18U)
 #define TAMP_CR1_ITAMP3E_Msk         (0x1UL << TAMP_CR1_ITAMP3E_Pos)            /*!< 0x00040000 */
 #define TAMP_CR1_ITAMP3E             TAMP_CR1_ITAMP3E_Msk
@@ -7652,18 +7798,27 @@ typedef struct
 #define TAMP_CR2_TAMP2NOERASE_Pos    (1U)
 #define TAMP_CR2_TAMP2NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP2NOERASE_Pos)       /*!< 0x00000002 */
 #define TAMP_CR2_TAMP2NOERASE        TAMP_CR2_TAMP2NOERASE_Msk
+#define TAMP_CR2_TAMP3NOERASE_Pos    (2U)
+#define TAMP_CR2_TAMP3NOERASE_Msk    (0x1UL << TAMP_CR2_TAMP3NOERASE_Pos)       /*!< 0x00000004 */
+#define TAMP_CR2_TAMP3NOERASE        TAMP_CR2_TAMP3NOERASE_Msk
 #define TAMP_CR2_TAMP1MSK_Pos        (16U)
 #define TAMP_CR2_TAMP1MSK_Msk        (0x1UL << TAMP_CR2_TAMP1MSK_Pos)           /*!< 0x00010000 */
 #define TAMP_CR2_TAMP1MSK            TAMP_CR2_TAMP1MSK_Msk
 #define TAMP_CR2_TAMP2MSK_Pos        (17U)
 #define TAMP_CR2_TAMP2MSK_Msk        (0x1UL << TAMP_CR2_TAMP2MSK_Pos)           /*!< 0x00020000 */
 #define TAMP_CR2_TAMP2MSK            TAMP_CR2_TAMP2MSK_Msk
+#define TAMP_CR2_TAMP3MSK_Pos        (18U)
+#define TAMP_CR2_TAMP3MSK_Msk        (0x1UL << TAMP_CR2_TAMP3MSK_Pos)           /*!< 0x00040000 */
+#define TAMP_CR2_TAMP3MSK            TAMP_CR2_TAMP3MSK_Msk
 #define TAMP_CR2_TAMP1TRG_Pos        (24U)
 #define TAMP_CR2_TAMP1TRG_Msk        (0x1UL << TAMP_CR2_TAMP1TRG_Pos)           /*!< 0x01000000 */
 #define TAMP_CR2_TAMP1TRG            TAMP_CR2_TAMP1TRG_Msk
 #define TAMP_CR2_TAMP2TRG_Pos        (25U)
 #define TAMP_CR2_TAMP2TRG_Msk        (0x1UL << TAMP_CR2_TAMP2TRG_Pos)           /*!< 0x02000000 */
 #define TAMP_CR2_TAMP2TRG            TAMP_CR2_TAMP2TRG_Msk
+#define TAMP_CR2_TAMP3TRG_Pos        (26U)
+#define TAMP_CR2_TAMP3TRG_Msk        (0x1UL << TAMP_CR2_TAMP3TRG_Pos)           /*!< 0x04000000 */
+#define TAMP_CR2_TAMP3TRG            TAMP_CR2_TAMP3TRG_Msk
 
 /********************  Bits definition for TAMP_FLTCR register  ***************/
 #define TAMP_FLTCR_TAMPFREQ_0        0x00000001U
@@ -7693,6 +7848,9 @@ typedef struct
 #define TAMP_IER_TAMP2IE_Pos         (1U)
 #define TAMP_IER_TAMP2IE_Msk         (0x1UL << TAMP_IER_TAMP2IE_Pos)            /*!< 0x00000002 */
 #define TAMP_IER_TAMP2IE             TAMP_IER_TAMP2IE_Msk
+#define TAMP_IER_TAMP3IE_Pos         (2U)
+#define TAMP_IER_TAMP3IE_Msk         (0x1UL << TAMP_IER_TAMP3IE_Pos)            /*!< 0x00000004 */
+#define TAMP_IER_TAMP3IE             TAMP_IER_TAMP3IE_Msk
 #define TAMP_IER_ITAMP3IE_Pos        (18U)
 #define TAMP_IER_ITAMP3IE_Msk        (0x1UL << TAMP_IER_ITAMP3IE_Pos)           /*!< 0x00040000 */
 #define TAMP_IER_ITAMP3IE            TAMP_IER_ITAMP3IE_Msk
@@ -7713,6 +7871,9 @@ typedef struct
 #define TAMP_SR_TAMP2F_Pos           (1U)
 #define TAMP_SR_TAMP2F_Msk           (0x1UL << TAMP_SR_TAMP2F_Pos)              /*!< 0x00000002 */
 #define TAMP_SR_TAMP2F               TAMP_SR_TAMP2F_Msk
+#define TAMP_SR_TAMP3F_Pos           (2U)
+#define TAMP_SR_TAMP3F_Msk           (0x1UL << TAMP_SR_TAMP3F_Pos)              /*!< 0x00000004 */
+#define TAMP_SR_TAMP3F               TAMP_SR_TAMP3F_Msk
 #define TAMP_SR_ITAMP3F_Pos          (18U)
 #define TAMP_SR_ITAMP3F_Msk          (0x1UL << TAMP_SR_ITAMP3F_Pos)             /*!< 0x00040000 */
 #define TAMP_SR_ITAMP3F              TAMP_SR_ITAMP3F_Msk
@@ -7733,6 +7894,9 @@ typedef struct
 #define TAMP_MISR_TAMP2MF_Pos        (1U)
 #define TAMP_MISR_TAMP2MF_Msk        (0x1UL << TAMP_MISR_TAMP2MF_Pos)           /*!< 0x00000002 */
 #define TAMP_MISR_TAMP2MF            TAMP_MISR_TAMP2MF_Msk
+#define TAMP_MISR_TAMP3MF_Pos        (2U)
+#define TAMP_MISR_TAMP3MF_Msk        (0x1UL << TAMP_MISR_TAMP3MF_Pos)           /*!< 0x00000004 */
+#define TAMP_MISR_TAMP3MF            TAMP_MISR_TAMP3MF_Msk
 #define TAMP_MISR_ITAMP3MF_Pos       (18U)
 #define TAMP_MISR_ITAMP3MF_Msk       (0x1UL << TAMP_MISR_ITAMP3MF_Pos)          /*!< 0x00040000 */
 #define TAMP_MISR_ITAMP3MF           TAMP_MISR_ITAMP3MF_Msk
@@ -7753,6 +7917,9 @@ typedef struct
 #define TAMP_SCR_CTAMP2F_Pos         (1U)
 #define TAMP_SCR_CTAMP2F_Msk         (0x1UL << TAMP_SCR_CTAMP2F_Pos)            /*!< 0x00000002 */
 #define TAMP_SCR_CTAMP2F             TAMP_SCR_CTAMP2F_Msk
+#define TAMP_SCR_CTAMP3F_Pos         (2U)
+#define TAMP_SCR_CTAMP3F_Msk         (0x1UL << TAMP_SCR_CTAMP3F_Pos)            /*!< 0x00000004 */
+#define TAMP_SCR_CTAMP3F             TAMP_SCR_CTAMP3F_Msk
 #define TAMP_SCR_CITAMP3F_Pos        (18U)
 #define TAMP_SCR_CITAMP3F_Msk        (0x1UL << TAMP_SCR_CITAMP3F_Pos)           /*!< 0x00040000 */
 #define TAMP_SCR_CITAMP3F            TAMP_SCR_CITAMP3F_Msk
@@ -7797,7 +7964,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32G0 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32G0 series)
  */
 #define SPI_I2S_SUPPORT                       /*!< I2S support */
 
@@ -8002,6 +8169,7 @@ typedef struct
 /*                                 SYSCFG                                     */
 /*                                                                            */
 /******************************************************************************/
+#define SYSCFG_CDEN_SUPPORT
 /*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
 #define SYSCFG_CFGR1_MEM_MODE_Pos             (0U)
 #define SYSCFG_CFGR1_MEM_MODE_Msk             (0x3UL << SYSCFG_CFGR1_MEM_MODE_Pos) /*!< 0x00000003 */
@@ -8108,12 +8276,15 @@ typedef struct
 #define SYSCFG_ITLINE1_SR_PVDOUT_Pos          (0U)
 #define SYSCFG_ITLINE1_SR_PVDOUT_Msk          (0x1UL << SYSCFG_ITLINE1_SR_PVDOUT_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE1_SR_PVDOUT              SYSCFG_ITLINE1_SR_PVDOUT_Msk     /*!< Power voltage detection -> exti[16] Interrupt */
+#define SYSCFG_ITLINE1_SR_PVMOUT_Pos          (1U)
+#define SYSCFG_ITLINE1_SR_PVMOUT_Msk          (0x1UL << SYSCFG_ITLINE1_SR_PVMOUT_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE1_SR_PVMOUT              SYSCFG_ITLINE1_SR_PVMOUT_Msk     /*!< VDDUSB Power voltage monitor -> exti[34] Interrupt */
 #define SYSCFG_ITLINE2_SR_TAMPER_Pos          (0U)
 #define SYSCFG_ITLINE2_SR_TAMPER_Msk          (0x1UL << SYSCFG_ITLINE2_SR_TAMPER_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE2_SR_TAMPER              SYSCFG_ITLINE2_SR_TAMPER_Msk     /*!< TAMPER -> exti[21] interrupt */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos      (1U)
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk      (0x1UL << SYSCFG_ITLINE2_SR_RTC_WAKEUP_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE2_SR_RTC_WAKEUP          SYSCFG_ITLINE2_SR_RTC_WAKEUP_Msk /*!< RTC_WAKEUP -> exti[19] interrupt .... */
+#define SYSCFG_ITLINE2_SR_RTC_Pos             (1U)
+#define SYSCFG_ITLINE2_SR_RTC_Msk             (0x1UL << SYSCFG_ITLINE2_SR_RTC_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE2_SR_RTC                 SYSCFG_ITLINE2_SR_RTC_Msk /*!< RTC -> exti[19] interrupt .... */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Pos       (0U)
 #define SYSCFG_ITLINE3_SR_FLASH_ECC_Msk       (0x1UL << SYSCFG_ITLINE3_SR_FLASH_ECC_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE3_SR_FLASH_ECC           SYSCFG_ITLINE3_SR_FLASH_ECC_Msk  /*!< Flash ITF ECC interrupt */
@@ -8174,15 +8345,15 @@ typedef struct
 #define SYSCFG_ITLINE7_SR_EXTI15_Pos          (11U)
 #define SYSCFG_ITLINE7_SR_EXTI15_Msk          (0x1UL << SYSCFG_ITLINE7_SR_EXTI15_Pos) /*!< 0x00000800 */
 #define SYSCFG_ITLINE7_SR_EXTI15              SYSCFG_ITLINE7_SR_EXTI15_Msk     /*!< External Interrupt 15 */
-#define SYSCFG_ITLINE8_SR_UCPD1_Pos          (0U)
-#define SYSCFG_ITLINE8_SR_UCPD1_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE8_SR_UCPD1              SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
-#define SYSCFG_ITLINE8_SR_UCPD2_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_UCPD2_Msk          (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_UCPD2              SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
-#define SYSCFG_ITLINE8_SR_USBFS_Pos          (1U)
-#define SYSCFG_ITLINE8_SR_USBFS_Msk          (0x1UL << SYSCFG_ITLINE8_SR_USBFS_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE8_SR_USBFS              SYSCFG_ITLINE8_SR_USBFS_Msk            /*!< USBFS Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD1_Pos           (0U)
+#define SYSCFG_ITLINE8_SR_UCPD1_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE8_SR_UCPD1               SYSCFG_ITLINE8_SR_UCPD1_Msk       /*!< UCPD1 -> exti[32] Interrupt */
+#define SYSCFG_ITLINE8_SR_UCPD2_Pos           (1U)
+#define SYSCFG_ITLINE8_SR_UCPD2_Msk           (0x1UL << SYSCFG_ITLINE8_SR_UCPD2_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE8_SR_UCPD2               SYSCFG_ITLINE8_SR_UCPD2_Msk       /*!< UCPD2 -> exti[33] Interrupt */
+#define SYSCFG_ITLINE8_SR_USB_Pos             (2U)
+#define SYSCFG_ITLINE8_SR_USB_Msk             (0x1UL << SYSCFG_ITLINE8_SR_USB_Pos)   /*!< 0x00000004 */
+#define SYSCFG_ITLINE8_SR_USB                 SYSCFG_ITLINE8_SR_USB_Msk              /*!< USB Interrupt */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Pos        (0U)
 #define SYSCFG_ITLINE9_SR_DMA1_CH1_Msk        (0x1UL << SYSCFG_ITLINE9_SR_DMA1_CH1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE9_SR_DMA1_CH1            SYSCFG_ITLINE9_SR_DMA1_CH1_Msk   /*!< DMA1 Channel 1 Interrupt */
@@ -8192,9 +8363,9 @@ typedef struct
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Pos       (1U)
 #define SYSCFG_ITLINE10_SR_DMA1_CH3_Msk       (0x1UL << SYSCFG_ITLINE10_SR_DMA1_CH3_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE10_SR_DMA1_CH3           SYSCFG_ITLINE10_SR_DMA1_CH3_Msk  /*!< DMA2 Channel 3 Interrupt */
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos         (0U)
-#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk         (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE11_SR_DMAMUX1             SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Pos        (0U)
+#define SYSCFG_ITLINE11_SR_DMAMUX1_Msk        (0x1UL << SYSCFG_ITLINE11_SR_DMAMUX1_Pos) /*!< 0x00000001 */
+#define SYSCFG_ITLINE11_SR_DMAMUX1            SYSCFG_ITLINE11_SR_DMAMUX1_Msk    /*!< DMAMUX Interrupt */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Pos       (1U)
 #define SYSCFG_ITLINE11_SR_DMA1_CH4_Msk       (0x1UL << SYSCFG_ITLINE11_SR_DMA1_CH4_Pos) /*!< 0x00000002 */
 #define SYSCFG_ITLINE11_SR_DMA1_CH4           SYSCFG_ITLINE11_SR_DMA1_CH4_Msk  /*!< DMA1 Channel 4 Interrupt */
@@ -8282,24 +8453,30 @@ typedef struct
 #define SYSCFG_ITLINE21_SR_TIM16_GLB_Pos      (0U)
 #define SYSCFG_ITLINE21_SR_TIM16_GLB_Msk      (0x1UL << SYSCFG_ITLINE21_SR_TIM16_GLB_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE21_SR_TIM16_GLB          SYSCFG_ITLINE21_SR_TIM16_GLB_Msk /*!< TIM16 GLB Interrupt */
-#define SYSCFG_ITLINE21_SR_FDCAN1_GLB_Pos     (1U)
-#define SYSCFG_ITLINE21_SR_FDCAN1_GLB_Msk     (0x1UL << SYSCFG_ITLINE21_SR_FDCAN1_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE21_SR_FDCAN1_GLB         SYSCFG_ITLINE21_SR_FDCAN1_GLB_Msk /*!< FDCAN1 GLB Interrupt */
+#define SYSCFG_ITLINE21_SR_FDCAN1_IT0_Pos     (1U)
+#define SYSCFG_ITLINE21_SR_FDCAN1_IT0_Msk     (0x1UL << SYSCFG_ITLINE21_SR_FDCAN1_IT0_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE21_SR_FDCAN1_IT0         SYSCFG_ITLINE21_SR_FDCAN1_IT0_Msk  /*!< FDCAN1 IT0 Interrupt */
+#define SYSCFG_ITLINE21_SR_FDCAN2_IT0_Pos     (2U)
+#define SYSCFG_ITLINE21_SR_FDCAN2_IT0_Msk     (0x1UL << SYSCFG_ITLINE21_SR_FDCAN2_IT0_Pos) /*!< 0x00000003 */
+#define SYSCFG_ITLINE21_SR_FDCAN2_IT0         SYSCFG_ITLINE21_SR_FDCAN2_IT0_Msk  /*!< FDCAN2 IT0 Interrupt */
 #define SYSCFG_ITLINE22_SR_TIM17_GLB_Pos      (0U)
 #define SYSCFG_ITLINE22_SR_TIM17_GLB_Msk      (0x1UL << SYSCFG_ITLINE22_SR_TIM17_GLB_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE22_SR_TIM17_GLB          SYSCFG_ITLINE22_SR_TIM17_GLB_Msk /*!< TIM17 GLB Interrupt */
-#define SYSCFG_ITLINE22_SR_FDCAN2_GLB_Pos     (1U)
-#define SYSCFG_ITLINE22_SR_FDCAN2_GLB_Msk     (0x1UL << SYSCFG_ITLINE22_SR_FDCAN2_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE22_SR_FDCAN2_GLB         SYSCFG_ITLINE22_SR_FDCAN2_GLB_Msk /*!< FDCAN2 GLB Interrupt */
+#define SYSCFG_ITLINE22_SR_FDCAN1_IT1_Pos     (1U)
+#define SYSCFG_ITLINE22_SR_FDCAN1_IT1_Msk     (0x1UL << SYSCFG_ITLINE22_SR_FDCAN1_IT1_Pos) /*!< 0x00000002 */
+#define SYSCFG_ITLINE22_SR_FDCAN1_IT1         SYSCFG_ITLINE22_SR_FDCAN1_IT1_Msk  /*!< FDCAN1 IT1 Interrupt */
+#define SYSCFG_ITLINE22_SR_FDCAN2_IT1_Pos     (2U)
+#define SYSCFG_ITLINE22_SR_FDCAN2_IT1_Msk     (0x1UL << SYSCFG_ITLINE22_SR_FDCAN2_IT1_Pos) /*!< 0x00000003 */
+#define SYSCFG_ITLINE22_SR_FDCAN2_IT1         SYSCFG_ITLINE22_SR_FDCAN2_IT1_Msk  /*!< FDCAN2 IT1 Interrupt */
 #define SYSCFG_ITLINE23_SR_I2C1_GLB_Pos       (0U)
 #define SYSCFG_ITLINE23_SR_I2C1_GLB_Msk       (0x1UL << SYSCFG_ITLINE23_SR_I2C1_GLB_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE23_SR_I2C1_GLB           SYSCFG_ITLINE23_SR_I2C1_GLB_Msk  /*!< I2C1 GLB Interrupt -> exti[23] */
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Pos       (0U)
 #define SYSCFG_ITLINE24_SR_I2C2_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C2_GLB_Pos) /*!< 0x00000001 */
-#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C2_GLB           SYSCFG_ITLINE24_SR_I2C2_GLB_Msk  /*!< I2C2 GLB Interrupt  -> exti[22]*/
 #define SYSCFG_ITLINE24_SR_I2C3_GLB_Pos       (1U)
 #define SYSCFG_ITLINE24_SR_I2C3_GLB_Msk       (0x1UL << SYSCFG_ITLINE24_SR_I2C3_GLB_Pos) /*!< 0x00000002 */
-#define SYSCFG_ITLINE24_SR_I2C3_GLB           SYSCFG_ITLINE24_SR_I2C3_GLB_Msk  /*!< I2C3 GLB Interrupt */
+#define SYSCFG_ITLINE24_SR_I2C3_GLB           SYSCFG_ITLINE24_SR_I2C3_GLB_Msk  /*!< I2C3 GLB Interrupt  -> exti[24]*/
 #define SYSCFG_ITLINE25_SR_SPI1_Pos           (0U)
 #define SYSCFG_ITLINE25_SR_SPI1_Msk           (0x1UL << SYSCFG_ITLINE25_SR_SPI1_Pos) /*!< 0x00000001 */
 #define SYSCFG_ITLINE25_SR_SPI1               SYSCFG_ITLINE25_SR_SPI1_Msk      /*!< SPI1 Interrupt */
@@ -9029,8 +9206,10 @@ typedef struct
 
 /*******************  Bit definition for TIM1_OR1 register  *******************/
 #define TIM1_OR1_OCREF_CLR_Pos     (0U)
-#define TIM1_OR1_OCREF_CLR_Msk     (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
-#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+#define TIM1_OR1_OCREF_CLR_Msk     (0x3UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM1_OR1_OCREF_CLR         TIM1_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM1_OR1_OCREF_CLR_0       (0x1UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM1_OR1_OCREF_CLR_1       (0x2UL << TIM1_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
 
 /*******************  Bit definition for TIM1_AF1 register  *******************/
 #define TIM1_AF1_BKINE_Pos        (0U)
@@ -9042,6 +9221,9 @@ typedef struct
 #define TIM1_AF1_BKCMP2E_Pos      (2U)
 #define TIM1_AF1_BKCMP2E_Msk      (0x1UL << TIM1_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM1_AF1_BKCMP2E          TIM1_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM1_AF1_BKCMP3E_Pos      (3U)
+#define TIM1_AF1_BKCMP3E_Msk      (0x1UL << TIM1_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM1_AF1_BKCMP3E          TIM1_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM1_AF1_BKINP_Pos        (9U)
 #define TIM1_AF1_BKINP_Msk        (0x1UL << TIM1_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM1_AF1_BKINP            TIM1_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -9051,6 +9233,9 @@ typedef struct
 #define TIM1_AF1_BKCMP2P_Pos      (11U)
 #define TIM1_AF1_BKCMP2P_Msk      (0x1UL << TIM1_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM1_AF1_BKCMP2P          TIM1_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM1_AF1_BKCMP3P_Pos      (12U)
+#define TIM1_AF1_BKCMP3P_Msk      (0x1UL << TIM1_AF1_BKCMP3P_Pos)              /*!< 0x00001000 */
+#define TIM1_AF1_BKCMP3P          TIM1_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 #define TIM1_AF1_ETRSEL_Pos       (14U)
 #define TIM1_AF1_ETRSEL_Msk       (0xFUL << TIM1_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
@@ -9070,6 +9255,9 @@ typedef struct
 #define TIM1_AF2_BK2CMP2E_Pos     (2U)
 #define TIM1_AF2_BK2CMP2E_Msk     (0x1UL << TIM1_AF2_BK2CMP2E_Pos)             /*!< 0x00000004 */
 #define TIM1_AF2_BK2CMP2E         TIM1_AF2_BK2CMP2E_Msk                        /*!<BRK2 COMP2 enable */
+#define TIM1_AF2_BK2CMP3E_Pos      (3U)
+#define TIM1_AF2_BK2CMP3E_Msk      (0x1UL << TIM1_AF2_BK2CMP3E_Pos)            /*!< 0x00000008 */
+#define TIM1_AF2_BK2CMP3E          TIM1_AF2_BK2CMP3E_Msk                       /*!<BRK2 COMP3 enable */
 #define TIM1_AF2_BK2INP_Pos       (9U)
 #define TIM1_AF2_BK2INP_Msk       (0x1UL << TIM1_AF2_BK2INP_Pos)               /*!< 0x00000200 */
 #define TIM1_AF2_BK2INP           TIM1_AF2_BK2INP_Msk                          /*!<BRK2 BKIN2 input polarity */
@@ -9079,11 +9267,16 @@ typedef struct
 #define TIM1_AF2_BK2CMP2P_Pos     (11U)
 #define TIM1_AF2_BK2CMP2P_Msk     (0x1UL << TIM1_AF2_BK2CMP2P_Pos)             /*!< 0x00000800 */
 #define TIM1_AF2_BK2CMP2P         TIM1_AF2_BK2CMP2P_Msk                        /*!<BRK2 COMP2 input polarity */
+#define TIM1_AF2_BK2CMP3P_Pos      (12U)
+#define TIM1_AF2_BK2CMP3P_Msk      (0x1UL << TIM1_AF2_BK2CMP3P_Pos)            /*!< 0x00001000 */
+#define TIM1_AF2_BK2CMP3P          TIM1_AF2_BK2CMP3P_Msk                       /*!<BRK2 COMP3 input polarity */
 
 /*******************  Bit definition for TIM2_OR1 register  *******************/
 #define TIM2_OR1_OCREF_CLR_Pos     (0U)
-#define TIM2_OR1_OCREF_CLR_Msk     (0x1UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
-#define TIM2_OR1_OCREF_CLR         TIM2_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+#define TIM2_OR1_OCREF_CLR_Msk     (0x3UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM2_OR1_OCREF_CLR         TIM2_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM2_OR1_OCREF_CLR_0       (0x1UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM2_OR1_OCREF_CLR_1       (0x2UL << TIM2_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
 
 /*******************  Bit definition for TIM2_AF1 register  *******************/
 #define TIM2_AF1_ETRSEL_Pos       (14U)
@@ -9096,8 +9289,10 @@ typedef struct
 
 /*******************  Bit definition for TIM3_OR1 register  *******************/
 #define TIM3_OR1_OCREF_CLR_Pos     (0U)
-#define TIM3_OR1_OCREF_CLR_Msk     (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
-#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!<OCREF clear input selection */
+#define TIM3_OR1_OCREF_CLR_Msk     (0x3UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM3_OR1_OCREF_CLR         TIM3_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM3_OR1_OCREF_CLR_0       (0x1UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM3_OR1_OCREF_CLR_1       (0x2UL << TIM3_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
 
 /*******************  Bit definition for TIM3_AF1 register  *******************/
 #define TIM3_AF1_ETRSEL_Pos       (14U)
@@ -9108,10 +9303,26 @@ typedef struct
 #define TIM3_AF1_ETRSEL_2         (0x4UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
 #define TIM3_AF1_ETRSEL_3         (0x8UL << TIM3_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
 
+/*******************  Bit definition for TIM4_OR1 register  *******************/
+#define TIM4_OR1_OCREF_CLR_Pos     (0U)
+#define TIM4_OR1_OCREF_CLR_Msk     (0x3UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000003 */
+#define TIM4_OR1_OCREF_CLR         TIM4_OR1_OCREF_CLR_Msk                      /*!< OCREF_CLR[1:0] input selection */
+#define TIM4_OR1_OCREF_CLR_0       (0x1UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000001 */
+#define TIM4_OR1_OCREF_CLR_1       (0x2UL << TIM4_OR1_OCREF_CLR_Pos)           /*!< 0x00000002 */
+
+/*******************  Bit definition for TIM4_AF1 register  *******************/
+#define TIM4_AF1_ETRSEL_Pos       (14U)
+#define TIM4_AF1_ETRSEL_Msk       (0xFUL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x0003C000 */
+#define TIM4_AF1_ETRSEL           TIM4_AF1_ETRSEL_Msk                          /*!<ETRSEL[3:0] bits (TIM4 ETR source selection) */
+#define TIM4_AF1_ETRSEL_0         (0x1UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00004000 */
+#define TIM4_AF1_ETRSEL_1         (0x2UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00008000 */
+#define TIM4_AF1_ETRSEL_2         (0x4UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00010000 */
+#define TIM4_AF1_ETRSEL_3         (0x8UL << TIM4_AF1_ETRSEL_Pos)               /*!< 0x00020000 */
+
 /*******************  Bit definition for TIM14_AF1 register  *******************/
 #define TIM14_AF1_ETRSEL_Pos      (14U)
 #define TIM14_AF1_ETRSEL_Msk      (0xFUL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x0003C000 */
-#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM3 ETR source selection) */
+#define TIM14_AF1_ETRSEL          TIM14_AF1_ETRSEL_Msk                         /*!<ETRSEL[3:0] bits (TIM14 ETR source selection) */
 #define TIM14_AF1_ETRSEL_0        (0x1UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00004000 */
 #define TIM14_AF1_ETRSEL_1        (0x2UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00008000 */
 #define TIM14_AF1_ETRSEL_2        (0x4UL << TIM14_AF1_ETRSEL_Pos)              /*!< 0x00010000 */
@@ -9127,6 +9338,9 @@ typedef struct
 #define TIM15_AF1_BKCMP2E_Pos    (2U)
 #define TIM15_AF1_BKCMP2E_Msk    (0x1UL << TIM15_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM15_AF1_BKCMP2E        TIM15_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM15_AF1_BKCMP3E_Pos    (3U)
+#define TIM15_AF1_BKCMP3E_Msk    (0x1UL << TIM15_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM15_AF1_BKCMP3E        TIM15_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM15_AF1_BKINP_Pos      (9U)
 #define TIM15_AF1_BKINP_Msk      (0x1UL << TIM15_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM15_AF1_BKINP          TIM15_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -9136,6 +9350,9 @@ typedef struct
 #define TIM15_AF1_BKCMP2P_Pos    (11U)
 #define TIM15_AF1_BKCMP2P_Msk    (0x1UL << TIM15_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM15_AF1_BKCMP2P        TIM15_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM15_AF1_BKCMP3P_Pos    (12U)
+#define TIM15_AF1_BKCMP3P_Msk    (0x1UL << TIM15_AF1_BKCMP3P_Pos)              /*!< 0x00000010 */
+#define TIM15_AF1_BKCMP3P        TIM15_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 /*******************  Bit definition for TIM16_AF1 register  ******************/
 #define TIM16_AF1_BKINE_Pos      (0U)
@@ -9147,6 +9364,9 @@ typedef struct
 #define TIM16_AF1_BKCMP2E_Pos    (2U)
 #define TIM16_AF1_BKCMP2E_Msk    (0x1UL << TIM16_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM16_AF1_BKCMP2E        TIM16_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM16_AF1_BKCMP3E_Pos    (3U)
+#define TIM16_AF1_BKCMP3E_Msk    (0x1UL << TIM16_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM16_AF1_BKCMP3E        TIM16_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM16_AF1_BKINP_Pos      (9U)
 #define TIM16_AF1_BKINP_Msk      (0x1UL << TIM16_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM16_AF1_BKINP          TIM16_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -9156,6 +9376,9 @@ typedef struct
 #define TIM16_AF1_BKCMP2P_Pos    (11U)
 #define TIM16_AF1_BKCMP2P_Msk    (0x1UL << TIM16_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM16_AF1_BKCMP2P        TIM16_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM16_AF1_BKCMP3P_Pos    (12U)
+#define TIM16_AF1_BKCMP3P_Msk    (0x1UL << TIM16_AF1_BKCMP3P_Pos)              /*!< 0x00000010 */
+#define TIM16_AF1_BKCMP3P        TIM16_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 /*******************  Bit definition for TIM17_AF1 register  ******************/
 #define TIM17_AF1_BKINE_Pos      (0U)
@@ -9167,6 +9390,9 @@ typedef struct
 #define TIM17_AF1_BKCMP2E_Pos    (2U)
 #define TIM17_AF1_BKCMP2E_Msk    (0x1UL << TIM17_AF1_BKCMP2E_Pos)              /*!< 0x00000004 */
 #define TIM17_AF1_BKCMP2E        TIM17_AF1_BKCMP2E_Msk                         /*!<BRK COMP2 enable */
+#define TIM17_AF1_BKCMP3E_Pos    (3U)
+#define TIM17_AF1_BKCMP3E_Msk    (0x1UL << TIM17_AF1_BKCMP3E_Pos)              /*!< 0x00000008 */
+#define TIM17_AF1_BKCMP3E        TIM17_AF1_BKCMP3E_Msk                         /*!<BRK COMP3 enable */
 #define TIM17_AF1_BKINP_Pos      (9U)
 #define TIM17_AF1_BKINP_Msk      (0x1UL << TIM17_AF1_BKINP_Pos)                /*!< 0x00000200 */
 #define TIM17_AF1_BKINP          TIM17_AF1_BKINP_Msk                           /*!<BRK BKIN input polarity */
@@ -9176,11 +9402,14 @@ typedef struct
 #define TIM17_AF1_BKCMP2P_Pos    (11U)
 #define TIM17_AF1_BKCMP2P_Msk    (0x1UL << TIM17_AF1_BKCMP2P_Pos)              /*!< 0x00000800 */
 #define TIM17_AF1_BKCMP2P        TIM17_AF1_BKCMP2P_Msk                         /*!<BRK COMP2 input polarity */
+#define TIM17_AF1_BKCMP3P_Pos    (12U)
+#define TIM17_AF1_BKCMP3P_Msk    (0x1UL << TIM17_AF1_BKCMP3P_Pos)              /*!< 0x00000010 */
+#define TIM17_AF1_BKCMP3P        TIM17_AF1_BKCMP3P_Msk                         /*!<BRK COMP3 input polarity */
 
 /*******************  Bit definition for TIM_TISEL register  *********************/
 #define TIM_TISEL_TI1SEL_Pos      (0U)
 #define TIM_TISEL_TI1SEL_Msk      (0xFUL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x0000000F */
-#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM1 TI1 SEL)*/
+#define TIM_TISEL_TI1SEL          TIM_TISEL_TI1SEL_Msk                         /*!<TI1SEL[3:0] bits (TIM TI1 SEL)*/
 #define TIM_TISEL_TI1SEL_0        (0x1UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000001 */
 #define TIM_TISEL_TI1SEL_1        (0x2UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000002 */
 #define TIM_TISEL_TI1SEL_2        (0x4UL << TIM_TISEL_TI1SEL_Pos)              /*!< 0x00000004 */
@@ -9188,7 +9417,7 @@ typedef struct
 
 #define TIM_TISEL_TI2SEL_Pos      (8U)
 #define TIM_TISEL_TI2SEL_Msk      (0xFUL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000F00 */
-#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM1 TI2 SEL)*/
+#define TIM_TISEL_TI2SEL          TIM_TISEL_TI2SEL_Msk                         /*!<TI2SEL[3:0] bits (TIM TI2 SEL)*/
 #define TIM_TISEL_TI2SEL_0        (0x1UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000100 */
 #define TIM_TISEL_TI2SEL_1        (0x2UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000200 */
 #define TIM_TISEL_TI2SEL_2        (0x4UL << TIM_TISEL_TI2SEL_Pos)              /*!< 0x00000400 */
@@ -9196,7 +9425,7 @@ typedef struct
 
 #define TIM_TISEL_TI3SEL_Pos      (16U)
 #define TIM_TISEL_TI3SEL_Msk      (0xFUL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x000F0000 */
-#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM1 TI3 SEL)*/
+#define TIM_TISEL_TI3SEL          TIM_TISEL_TI3SEL_Msk                         /*!<TI3SEL[3:0] bits (TIM TI3 SEL)*/
 #define TIM_TISEL_TI3SEL_0        (0x1UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00010000 */
 #define TIM_TISEL_TI3SEL_1        (0x2UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00020000 */
 #define TIM_TISEL_TI3SEL_2        (0x4UL << TIM_TISEL_TI3SEL_Pos)              /*!< 0x00040000 */
@@ -9204,7 +9433,7 @@ typedef struct
 
 #define TIM_TISEL_TI4SEL_Pos      (24U)
 #define TIM_TISEL_TI4SEL_Msk      (0xFUL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x0F000000 */
-#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM1 TI4 SEL)*/
+#define TIM_TISEL_TI4SEL          TIM_TISEL_TI4SEL_Msk                         /*!<TI4SEL[3:0] bits (TIM TI4 SEL)*/
 #define TIM_TISEL_TI4SEL_0        (0x1UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x01000000 */
 #define TIM_TISEL_TI4SEL_1        (0x2UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x02000000 */
 #define TIM_TISEL_TI4SEL_2        (0x4UL << TIM_TISEL_TI4SEL_Pos)              /*!< 0x04000000 */
@@ -9329,7 +9558,7 @@ typedef struct
 
 #define LPTIM_CFGR_TIMOUT_Pos       (19U)
 #define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
-#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timout enable */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
 #define LPTIM_CFGR_WAVE_Pos         (20U)
 #define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
 #define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
@@ -9986,7 +10215,7 @@ typedef struct
 #define DBG_APB_FZ1_DBG_TIM3_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM3_STOP_Pos) /*!< 0x00000002 */
 #define DBG_APB_FZ1_DBG_TIM3_STOP                      DBG_APB_FZ1_DBG_TIM3_STOP_Msk
 #define DBG_APB_FZ1_DBG_TIM4_STOP_Pos                  (2U)
-#define DBG_APB_FZ1_DBG_TIM4_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM4_STOP_Pos) /*!< 0x00000003 */
+#define DBG_APB_FZ1_DBG_TIM4_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM4_STOP_Pos) /*!< 0x00000004 */
 #define DBG_APB_FZ1_DBG_TIM4_STOP                      DBG_APB_FZ1_DBG_TIM4_STOP_Msk
 #define DBG_APB_FZ1_DBG_TIM6_STOP_Pos                  (4U)
 #define DBG_APB_FZ1_DBG_TIM6_STOP_Msk                  (0x1UL << DBG_APB_FZ1_DBG_TIM6_STOP_Pos) /*!< 0x00000010 */
@@ -10009,9 +10238,6 @@ typedef struct
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Pos    (22U)
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00400000 */
 #define DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C2_SMBUS_TIMEOUT_STOP_Msk
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Pos    (23U)
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Msk    (0x1UL << DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Pos) /*!< 0x00800000 */
-#define DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP        DBG_APB_FZ1_DBG_I2C3_SMBUS_TIMEOUT_STOP_Msk
 #define DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos                (30U)
 #define DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk                (0x1UL << DBG_APB_FZ1_DBG_LPTIM2_STOP_Pos) /*!< 0x40000000 */
 #define DBG_APB_FZ1_DBG_LPTIM2_STOP                    DBG_APB_FZ1_DBG_LPTIM2_STOP_Msk
@@ -10358,177 +10584,351 @@ typedef struct
 
 /******************************************************************************/
 /*                                                                            */
-/*                         USB Device FS Endpoint registers                   */
+/*                         USB Dual Role Device FS Endpoint registers         */
 /*                                                                            */
 /******************************************************************************/
-#define USB_DRD_FS_CHEP0R                              USB_DRD_FS_BASE                    /*!< Channel endpoint 0 register address */
-#define USB_DRD_FS_CHEP1R                             (USB_DRD_FS_BASE + 0x0x00000004)   /*!< Channel endpoint 1 register address */
-#define USB_DRD_FS_CHEP2R                             (USB_DRD_FS_BASE + 0x0x00000008)   /*!< Channel endpoint 2 register address */
-#define USB_DRD_FS_CHEP3R                             (USB_DRD_FS_BASE + 0x0x0000000C)   /*!< Channel endpoint 3 register address */
-#define USB_DRD_FS_CHEP4R                             (USB_DRD_FS_BASE + 0x0x00000010)   /*!< Channel endpoint 4 register address */
-#define USB_DRD_FS_CHEP5R                             (USB_DRD_FS_BASE + 0x0x00000014)   /*!< Channel endpoint 5 register address */
-#define USB_DRD_FS_CHEP6R                             (USB_DRD_FS_BASE + 0x0x00000018)   /*!< Channel endpoint 6 register address */
-#define USB_DRD_FS_CHEP7R                             (USB_DRD_FS_BASE + 0x0x0000001C)   /*!< Channel endpoint 7 register address */
 
-/* bit positions */
-//#define USB_DRD_CHEP_CTR_RX                            ((uint16_t)0x8000U)           /*!<  Channel EndPoint Correct TRansfer RX */
-//#define USB_DRD_CHEP_DTOG_RX                           ((uint16_t)0x4000U)           /*!<  Channel EndPoint Data TOGGLE RX */
-//#define USB_DRD_CHEPRX_STAT                            ((uint16_t)0x3000U)           /*!<  Channel EndPoint RX STATus bit field */
-//#define USB_DRD_CHEP_SETUP                             ((uint16_t)0x0800U)           /*!<  Channel EndPoint SETUP */
-//#define USB_DRD_CHEP_T_FIELD                           ((uint16_t)0x0600U)           /*!<  Channel EndPoint TYPE */
-//#define USB_DRD_CHEP_KIND                              ((uint16_t)0x0100U)           /*!<  Channel EndPoint KIND */
-//#define USB_DRD_CHEP_CTR_TX                            ((uint16_t)0x0080U)           /*!<  Channel EndPoint Correct TRansfer TX */
-//#define USB_DRD_CHEP_DTOG_TX                           ((uint16_t)0x0040U)           /*!<  Channel EndPoint Data TOGGLE TX */
-//#define USB_DRD_CHEPTX_STAT                            ((uint16_t)0x0030U)           /*!<  Channel EndPoint TX STATus bit field */
-//#define USB_DRD_CHEPADDR_FIELD                         ((uint16_t)0x000FU)           /*!<  Channel EndPoint ADDRess FIELD */
+/******************  Bits definition for USB_DRD_CNTR register  *******************/
+#define USB_CNTR_HOST_Pos               (31U)
+#define USB_CNTR_HOST_Msk               (0x1UL << USB_CNTR_HOST_Pos)    /*!< 0x80000000 */
+#define USB_CNTR_HOST                   USB_CNTR_HOST_Msk               /*!< Host Mode  */
+#define USB_CNTR_THR512M_Pos            (16U)
+#define USB_CNTR_THR512M_Msk            (0x1UL << USB_CNTR_THR512M_Pos)  /*!< 0x00010000 */
+#define USB_CNTR_THR512M                USB_CNTR_THR512M_Msk             /*!< 512byte Threshold interrupt mask */
+#define USB_CNTR_CTRM_Pos               (15U)
+#define USB_CNTR_CTRM_Msk               (0x1UL << USB_CNTR_CTRM_Pos)    /*!< 0x00008000 */
+#define USB_CNTR_CTRM                   USB_CNTR_CTRM_Msk               /*!< Correct Transfer Mask */
+#define USB_CNTR_PMAOVRM_Pos            (14U)
+#define USB_CNTR_PMAOVRM_Msk            (0x1UL << USB_CNTR_PMAOVRM_Pos) /*!< 0x00004000 */
+#define USB_CNTR_PMAOVRM                USB_CNTR_PMAOVRM_Msk            /*!< DMA OVeR/underrun Mask */
+#define USB_CNTR_ERRM_Pos               (13U)
+#define USB_CNTR_ERRM_Msk               (0x1UL << USB_CNTR_ERRM_Pos)    /*!< 0x00002000 */
+#define USB_CNTR_ERRM                   USB_CNTR_ERRM_Msk               /*!< ERRor Mask */
+#define USB_CNTR_WKUPM_Pos              (12U)
+#define USB_CNTR_WKUPM_Msk              (0x1UL << USB_CNTR_WKUPM_Pos)   /*!< 0x00001000 */
+#define USB_CNTR_WKUPM                  USB_CNTR_WKUPM_Msk              /*!< WaKe UP Mask */
+#define USB_CNTR_SUSPM_Pos              (11U)
+#define USB_CNTR_SUSPM_Msk              (0x1UL << USB_CNTR_SUSPM_Pos)   /*!< 0x00000800 */
+#define USB_CNTR_SUSPM                  USB_CNTR_SUSPM_Msk              /*!< SUSPend Mask */
+#define USB_CNTR_RESETM_Pos             (10U)
+#define USB_CNTR_RESETM_Msk             (0x1UL << USB_CNTR_RESETM_Pos)  /*!< 0x00000400 */
+#define USB_CNTR_RESETM                 USB_CNTR_RESETM_Msk             /*!< RESET Mask */
+#define USB_CNTR_DCON                   USB_CNTR_RESETM_Msk             /*!< Disconnection Connection Mask */
+#define USB_CNTR_SOFM_Pos               (9U)
+#define USB_CNTR_SOFM_Msk               (0x1UL << USB_CNTR_SOFM_Pos)    /*!< 0x00000200 */
+#define USB_CNTR_SOFM                   USB_CNTR_SOFM_Msk               /*!< Start Of Frame Mask */
+#define USB_CNTR_ESOFM_Pos              (8U)
+#define USB_CNTR_ESOFM_Msk              (0x1UL << USB_CNTR_ESOFM_Pos)   /*!< 0x00000100 */
+#define USB_CNTR_ESOFM                  USB_CNTR_ESOFM_Msk              /*!< Expected Start Of Frame Mask */
+#define USB_CNTR_L1REQM_Pos             (7U)
+#define USB_CNTR_L1REQM_Msk             (0x1UL << USB_CNTR_L1REQM_Pos)  /*!< 0x00000080 */
+#define USB_CNTR_L1REQM                 USB_CNTR_L1REQM_Msk             /*!< LPM L1 state request interrupt Mask */
+#define USB_CNTR_L1XACT_Pos             (6U)
+#define USB_CNTR_L1XACT_Msk             (0x1UL << USB_CNTR_L1XACT_Pos)  /*!< 0x00000040 */
+#define USB_CNTR_L1XACT                 USB_CNTR_L1XACT_Msk             /*!< Host LPM L1 transaction request Mask */
+#define USB_CNTR_L1RES_Pos              (5U)
+#define USB_CNTR_L1RES_Msk              (0x1UL << USB_CNTR_L1RES_Pos)   /*!< 0x00000020 */
+#define USB_CNTR_L1RES                  USB_CNTR_L1RES_Msk              /*!< LPM L1 Resume request/ Remote Wakeup Mask */
+#define USB_CNTR_L2RES_Pos              (4U)
+#define USB_CNTR_L2RES_Msk              (0x1UL << USB_CNTR_L2RES_Pos)   /*!< 0x00000010 */
+#define USB_CNTR_L2RES                  USB_CNTR_L2RES_Msk              /*!< L2 Remote Wakeup / Resume driver Mask */
+#define USB_CNTR_SUSPEN_Pos             (3U)
+#define USB_CNTR_SUSPEN_Msk             (0x1UL << USB_CNTR_SUSPEN_Pos)  /*!< 0x00000008 */
+#define USB_CNTR_SUSPEN                 USB_CNTR_SUSPEN_Msk             /*!< Suspend state enable Mask */
+#define USB_CNTR_SUSPRDY_Pos            (2U)
+#define USB_CNTR_SUSPRDY_Msk            (0x1UL << USB_CNTR_SUSPRDY_Pos) /*!< 0x00000004 */
+#define USB_CNTR_SUSPRDY                USB_CNTR_SUSPRDY_Msk            /*!< Suspend state effective Mask */
+#define USB_CNTR_PDWN_Pos               (1U)
+#define USB_CNTR_PDWN_Msk               (0x1UL << USB_CNTR_PDWN_Pos)    /*!< 0x00000002 */
+#define USB_CNTR_PDWN                   USB_CNTR_PDWN_Msk               /*!< Power DoWN Mask */
+#define USB_CNTR_USBRST_Pos             (0U)
+#define USB_CNTR_USBRST_Msk             (0x1UL << USB_CNTR_USBRST_Pos)  /*!< 0x00000001 */
+#define USB_CNTR_USBRST                 USB_CNTR_USBRST_Msk             /*!< USB Reset Mask */
 
-#define USB_DRD_FS_CHEP_VTRX                              ((uint16_t)0x8000U)           /*!<  USB valid transaction received*/
-#define USB_DRD_FS_CHEP_DTOG_RX                           ((uint16_t)0x4000U)           /*!<  Data Toggle, for reception transfers*/
-#define USB_DRD_FS_CHEPRX_STRX                            ((uint16_t)0x3000U)           /*!<  Status bits, for reception transfers*/
-#define USB_DRD_FS_CHEP_SETUP                             ((uint16_t)0x0800U)           /*!<  Setup transaction completed*/
-#define USB_DRD_FS_CHEP_UTYPE                             ((uint16_t)0x0600U)           /*!<  USB type of transaction */
-#define USB_DRD_FS_CHEP_EPKIND                            ((uint16_t)0x0100U)           /*!<  EndPoint KIND */
-#define USB_DRD_FS_CHEP_VTTX                              ((uint16_t)0x0080U)           /*!<  Valid USB transaction transmitted*/
-#define USB_DRD_FS_CHEP_DTOG_TX                           ((uint16_t)0x0040U)           /*!<  Data Toggle, for transmission transfers */
-#define USB_DRD_FS_CHEPTX_STTX                            ((uint16_t)0x0030U)           /*!<  Status bits, for transmission transfers */
-#define USB_DRD_FS_CHEPADDR_FIELD                         ((uint16_t)0x000FU)           /*!<  Endpoint address*/
+/******************  Bits definition for USB_DRD_ISTR register  *******************/
+#define USB_ISTR_IDN_Pos                (0U)
+#define USB_ISTR_IDN_Msk                (0xFUL << USB_ISTR_IDN_Pos)     /*!< 0x0000000F */
+#define USB_ISTR_IDN                    USB_ISTR_IDN_Msk                /*!< EndPoint IDentifier (read-only bit) Mask */
+#define USB_ISTR_DIR_Pos                (4U)
+#define USB_ISTR_DIR_Msk                (0x1UL << USB_ISTR_DIR_Pos)     /*!< 0x00000010 */
+#define USB_ISTR_DIR                    USB_ISTR_DIR_Msk                /*!< DIRection of transaction (read-only bit) Mask */
+#define USB_ISTR_L1REQ_Pos              (7U)
+#define USB_ISTR_L1REQ_Msk              (0x1UL << USB_ISTR_L1REQ_Pos)   /*!< 0x00000080 */
+#define USB_ISTR_L1REQ                  USB_ISTR_L1REQ_Msk              /*!< LPM L1 state request Mask */
+#define USB_ISTR_ESOF_Pos               (8U)
+#define USB_ISTR_ESOF_Msk               (0x1UL << USB_ISTR_ESOF_Pos)    /*!< 0x00000100 */
+#define USB_ISTR_ESOF                   USB_ISTR_ESOF_Msk               /*!< Expected Start Of Frame (clear-only bit) Mask */
+#define USB_ISTR_SOF_Pos                (9U)
+#define USB_ISTR_SOF_Msk                (0x1UL << USB_ISTR_SOF_Pos)     /*!< 0x00000200 */
+#define USB_ISTR_SOF                    USB_ISTR_SOF_Msk                /*!< Start Of Frame (clear-only bit) Mask */
+#define USB_ISTR_RESET_Pos              (10U)
+#define USB_ISTR_RESET_Msk              (0x1UL << USB_ISTR_RESET_Pos)   /*!< 0x00000400 */
+#define USB_ISTR_RESET                  USB_ISTR_RESET_Msk              /*!< RESET Mask */
+#define USB_ISTR_DCON_Pos               (10U)
+#define USB_ISTR_DCON_Msk               (0x1UL << USB_ISTR_DCON_Pos)    /*!< 0x00000400 */
+#define USB_ISTR_DCON                   USB_ISTR_DCON_Msk               /*!< HOST MODE-Device Connection or disconnection Mask */
+#define USB_ISTR_SUSP_Pos               (11U)
+#define USB_ISTR_SUSP_Msk               (0x1UL << USB_ISTR_SUSP_Pos)    /*!< 0x00000800 */
+#define USB_ISTR_SUSP                   USB_ISTR_SUSP_Msk               /*!< SUSPend (clear-only bit) Mask */
+#define USB_ISTR_WKUP_Pos               (12U)
+#define USB_ISTR_WKUP_Msk               (0x1UL << USB_ISTR_WKUP_Pos)    /*!< 0x00001000 */
+#define USB_ISTR_WKUP                   USB_ISTR_WKUP_Msk               /*!< WaKe UP (clear-only bit) Mask */
+#define USB_ISTR_ERR_Pos                (13U)
+#define USB_ISTR_ERR_Msk                (0x1UL << USB_ISTR_ERR_Pos)     /*!< 0x00002000 */
+#define USB_ISTR_ERR                    USB_ISTR_ERR_Msk                /*!< ERRor (clear-only bit) Mask */
+#define USB_ISTR_PMAOVR_Pos             (14U)
+#define USB_ISTR_PMAOVR_Msk             (0x1UL << USB_ISTR_PMAOVR_Pos)  /*!< 0x00004000 */
+#define USB_ISTR_PMAOVR                 USB_ISTR_PMAOVR_Msk             /*!< PMA OVeR/underrun (clear-only bit) Mask */
+#define USB_ISTR_CTR_Pos                (15U)
+#define USB_ISTR_CTR_Msk                (0x1UL << USB_ISTR_CTR_Pos)     /*!< 0x00008000 */
+#define USB_ISTR_CTR                    USB_ISTR_CTR_Msk                /*!< Correct TRansfer (clear-only bit) Mask */
+#define USB_ISTR_THR512_Pos             (16U)
+#define USB_ISTR_THR512_Msk             (0x1UL << USB_ISTR_THR512_Pos)  /*!< 0x00010000 */
+#define USB_ISTR_THR512                 USB_ISTR_THR512_Msk             /*!< 512byte threshold interrupt (used with isochrnous single buffer ) */
+#define USB_ISTR_DCON_STAT_Pos          (29U)
+#define USB_ISTR_DCON_STAT_Msk          (0x1UL << USB_ISTR_DCON_STAT_Pos)/*!< 0x20000000 */
+#define USB_ISTR_DCON_STAT              USB_ISTR_DCON_STAT_Msk           /*!< Device Connection status (connected/Disconnected) don't cause an interrupt */
+#define USB_ISTR_LS_DCONN_Pos           (30U)
+#define USB_ISTR_LS_DCONN_Msk           (0x1UL << USB_ISTR_LS_DCONN_Pos)/*!< 0x40000000 */
+#define USB_ISTR_LS_DCONN               USB_ISTR_LS_DCONN_Msk           /*!< LS_DCONN Mask */
 
+/******************  Bits definition for USB_DRD_FNR register  ********************/
+#define USB_FNR_FN_Pos                  (0U)
+#define USB_FNR_FN_Msk                  (0x7FFUL << USB_FNR_FN_Pos)     /*!< 0x000007FF */
+#define USB_FNR_FN                      USB_FNR_FN_Msk                  /*!< Frame Number Mask */
+#define USB_FNR_LSOF_Pos                (11U)
+#define USB_FNR_LSOF_Msk                (0x3UL << USB_FNR_LSOF_Pos)     /*!< 0x00001800 */
+#define USB_FNR_LSOF                    USB_FNR_LSOF_Msk                /*!< Lost SOF  Mask */
+#define USB_FNR_LCK_Pos                 (13U)
+#define USB_FNR_LCK_Msk                 (0x1UL << USB_FNR_LCK_Pos)      /*!< 0x00002000 */
+#define USB_FNR_LCK                     USB_FNR_LCK_Msk                 /*!< LoCKed Mask */
+#define USB_FNR_RXDM_Pos                (14U)
+#define USB_FNR_RXDM_Msk                (0x1UL << USB_FNR_RXDM_Pos)     /*!< 0x00004000 */
+#define USB_FNR_RXDM                    USB_FNR_RXDM_Msk                /*!< status of D- data line Mask */
+#define USB_FNR_RXDP_Pos                (15U)
+#define USB_FNR_RXDP_Msk                (0x1UL << USB_FNR_RXDP_Pos)     /*!< 0x00008000 */
+#define USB_FNR_RXDP                    USB_FNR_RXDP_Msk                /*!< status of D+ data line Mask */
 
+/******************  Bits definition for USB_DRD_DADDR register    ****************/
+#define USB_DADDR_ADD_Pos               (0U)
+#define USB_DADDR_ADD_Msk               (0x7FUL << USB_DADDR_ADD_Pos)   /*!< 0x0000007F */
+#define USB_DADDR_ADD                   USB_DADDR_ADD_Msk               /*!<  ADD[6:0] bits (Device Address)Mask */
+#define USB_DADDR_ADD0_Pos              (0U)
+#define USB_DADDR_ADD0_Msk              (0x1UL << USB_DADDR_ADD0_Pos)   /*!< 0x00000001 */
+#define USB_DADDR_ADD0                  USB_DADDR_ADD0_Msk              /*!< Bit 0 Mask */
+#define USB_DADDR_ADD1_Pos              (1U)
+#define USB_DADDR_ADD1_Msk              (0x1UL << USB_DADDR_ADD1_Pos)   /*!< 0x00000002 */
+#define USB_DADDR_ADD1                  USB_DADDR_ADD1_Msk              /*!< Bit 1 Mask */
+#define USB_DADDR_ADD2_Pos              (2U)
+#define USB_DADDR_ADD2_Msk              (0x1UL << USB_DADDR_ADD2_Pos)   /*!< 0x00000004 */
+#define USB_DADDR_ADD2                  USB_DADDR_ADD2_Msk              /*!< Bit 2 Mask */
+#define USB_DADDR_ADD3_Pos              (3U)
+#define USB_DADDR_ADD3_Msk              (0x1UL << USB_DADDR_ADD3_Pos)   /*!< 0x00000008 */
+#define USB_DADDR_ADD3                  USB_DADDR_ADD3_Msk              /*!< Bit 3 Mask */
+#define USB_DADDR_ADD4_Pos              (4U)
+#define USB_DADDR_ADD4_Msk              (0x1UL << USB_DADDR_ADD4_Pos)   /*!< 0x00000010 */
+#define USB_DADDR_ADD4                  USB_DADDR_ADD4_Msk              /*!< Bit 4 Mask */
+#define USB_DADDR_ADD5_Pos              (5U)
+#define USB_DADDR_ADD5_Msk              (0x1UL << USB_DADDR_ADD5_Pos)   /*!< 0x00000020 */
+#define USB_DADDR_ADD5                  USB_DADDR_ADD5_Msk              /*!< Bit 5 Mask */
+#define USB_DADDR_ADD6_Pos              (6U)
+#define USB_DADDR_ADD6_Msk              (0x1UL << USB_DADDR_ADD6_Pos)   /*!< 0x00000040 */
+#define USB_DADDR_ADD6                  USB_DADDR_ADD6_Msk              /*!< Bit 6 Mask */
+#define USB_DADDR_EF_Pos                (7U)
+#define USB_DADDR_EF_Msk                (0x1UL << USB_DADDR_EF_Pos)     /*!< 0x00000080 */
+#define USB_DADDR_EF                    USB_DADDR_EF_Msk                /*!< Enable Function Mask */
 
-/* EndPoint REGister MASK (no toggle fields) */
-#define USB_DRD_FS_CHEPREG_MASK                           (USB_DRD_FS_CHEP_VTRX|USB_DRD_FS_CHEP_SETUP|USB_DRD_FS_CHEP_UTYPE|USB_DRD_FS_CHEP_EPKIND|USB_DRD_FS_CHEP_VTTX|USB_DRD_FS_CHEPADDR_FIELD) /*=8f8f*/
-                                                                         /*!< EP_TYPE[1:0] Channel/EndPoint TYPE */
-#define USB_DRD_FS_CHEP_TYPE_MASK                         ((uint16_t)0x0600U)           /*!< Channel/EndPoint TYPE Mask */
-#define USB_DRD_FS_CHEP_BULK                              ((uint16_t)0x0000U)           /*!< Channel/EndPoint BULK */
-#define USB_DRD_FS_CHEP_CONTROL                           ((uint16_t)0x0200U)           /*!< Channel/EndPoint CONTROL */
-#define USB_DRD_FS_CHEP_ISOCHRONOUS                       ((uint16_t)0x0400U)           /*!< Channel/EndPoint ISOCHRONOUS */
-#define USB_DRD_FS_CHEP_INTERRUPT                         ((uint16_t)0x0600U)           /*!< Channel/EndPoint INTERRUPT */
-#define USB_DRD_FS_CHEP_T_MASK                            ((uint16_t) ~USB_DRD_FS_CHEP_UTYPE & USB_DRD_FS_CHEPREG_MASK) /*=0x898F*/
-
-#define USB_DRD_FS_CHEPKIND_MASK                          ((uint16_t)~USB_DRD_FS_CHEP_EPKIND & USB_DRD_FS_CHEPREG_MASK) /*!< EP_KIND EndPoint KIND */
-                                                                         /*!< STAT_TX[1:0] STATus for TX transfer */
-#define USB_DRD_FS_CHEP_TX_DIS                            ((uint16_t)0x0000U)           /*!< EndPoint TX DISabled */
-#define USB_DRD_FS_CHEP_TX_STALL                          ((uint16_t)0x0010U)           /*!< EndPoint TX STALLed */
-#define USB_DRD_FS_CHEP_TX_NAK                            ((uint16_t)0x0020U)           /*!< EndPoint TX NAKed */
-#define USB_DRD_FS_CHEP_TX_VALID                          ((uint16_t)0x0030U)           /*!< EndPoint TX VALID */
-#define USB_DRD_FS_CHEPTX_DTOG1                           ((uint16_t)0x0010U)           /*!< EndPoint TX Data TOGgle bit1 */
-#define USB_DRD_FS_CHEPTX_DTOG2                           ((uint16_t)0x0020U)           /*!< EndPoint TX Data TOGgle bit2 */
-#define USB_DRD_FS_CHEPTX_DTOGMASK                         (USB_DRD_FS_CHEPTX_STTX|USB_DRD_FS_CHEPREG_MASK)
-
-
-                                                                         /*!< STAT_RX[1:0] STATus for RX transfer */
-#define USB_DRD_FS_CHEP_RX_DIS                            ((uint16_t)0x0000U)           /*!< EndPoint RX DISabled */
-#define USB_DRD_FS_CHEP_RX_STALL                          ((uint16_t)0x1000U)           /*!< EndPoint RX STALLed */
-#define USB_DRD_FS_CHEP_RX_NAK                            ((uint16_t)0x2000U)           /*!< EndPoint RX NAKed */
-#define USB_DRD_FS_CHEP_RX_VALID                          ((uint16_t)0x3000U)           /*!< EndPoint RX VALID */
-
-#define USB_DRD_FS_CHEPRX_DTOG1                           ((uint16_t)0x1000U)           /*!< EndPoint RX Data TOGgle bit1 */
-#define USB_DRD_FS_CHEPRX_DTOG2                           ((uint16_t)0x2000U)           /*!< EndPoint RX Data TOGgle bit1 */
-
-#define USB_DRD_FS_CHEPRX_DTOGMASK                        (USB_DRD_FS_CHEPRX_STRX|USB_DRD_FS_CHEPREG_MASK)
-
-/*Buffer Descriprot Mask*/
-#define USB_DRD_FS_CHEPX_TXBD_ADDMSK                       ((uint32_t)0xFFFF0000)
-#define USB_DRD_FS_CHEPX_TXBD_COUNTMSK                     ((uint32_t)0x0000FFFF)
-#define USB_DRD_FS_CHEPX_RXBD_ADDMSK                       ((uint32_t)0xFFFF0000)
-#define USB_DRD_FS_CHEPX_RXBD_COUNTMSK                     ((uint32_t)0x0000FFFF)
-
-
-/******************************************************************************/
-/*                                                                            */
-/*                         USB Device FS General registers                    */
-/*                                                                            */
-/******************************************************************************/
-#define USB_DRD_FS_CNTR                             (USB_DRD_FS_BASE + 0x00000040U)     /*!< Control register */
-#define USB_DRD_FS_ISTR                             (USB_DRD_FS_BASE + 0x00000044U)     /*!< Interrupt status register */
-#define USB_DRD_FS_FNR                              (USB_DRD_FS_BASE + 0x00000048U)     /*!< Frame number register */
-#define USB_DRD_FS_DADDR                            (USB_DRD_FS_BASE + 0x0000004CU)     /*!< Device address register */
-#define USB_DRD_FS_BTABLE                           (USB_DRD_FS_BASE + 0x00000050U)     /*!< Buffer Table address register */
-#define USB_DRD_FS_LPMCSR                           (USB_DRD_FS_BASE + 0x00000054U)     /*!< LPM Control and Status register */
-#define USB_DRD_FS_BCDR                             (USB_DRD_FS_BASE + 0x00000058U)     /*!< Battery Charging detector register*/
-
-/******************  Bits definition for USB_DRD_FS_CNTR register  *******************/
-#define USB_DRD_FS_CNTR_HOST                            ((uint32_t)0x80000000U)           /*!< Host Mode  */
-#define USB_DRD_FS_CNTR_CTRM                            ((uint32_t)0x00008000U)           /*!< Correct TRansfer Mask */
-#define USB_DRD_FS_CNTR_PMAOVRM                         ((uint32_t)0x00004000U)           /*!< DMA OVeR/underrun Mask */
-#define USB_DRD_FS_CNTR_ERRM                            ((uint32_t)0x00002000U)           /*!< ERRor Mask */
-#define USB_DRD_FS_CNTR_WKUPM                           ((uint32_t)0x00001000U)           /*!< WaKe UP Mask */
-#define USB_DRD_FS_CNTR_SUSPM                           ((uint32_t)0x00000800U)           /*!< SUSPend Mask */
-#define USB_DRD_FS_CNTR_RESETM                          ((uint32_t)0x00000400U)           /*!< RESET Mask   */
-#define USB_DRD_FS_CNTR_SOFM                            ((uint32_t)0x00000200U)           /*!< Start Of Frame Mask */
-#define USB_DRD_FS_CNTR_ESOFM                           ((uint32_t)0x00000100U)           /*!< Expected Start Of Frame Mask */
-#define USB_DRD_FS_CNTR_L1REQM                          ((uint32_t)0x00000080U)           /*!< LPM L1 state request interrupt mask */
-#define USB_DRD_FS_CNTR_L1XACT                          ((uint32_t)0x00000040U)           /*!< LPM L1 transaction request */
-#define USB_DRD_FS_CNTR_L1RES                           ((uint32_t)0x00000020U)           /*!< LPM L1 Resume request/ Remote Wakeup  */
-#define USB_DRD_FS_CNTR_L2RES                           ((uint32_t)0x00000010U)           /*!< L2 Remote Wakeup / Resume driver */
-#define USB_DRD_FS_CNTR_SUSPEN                          ((uint32_t)0x00000008U)           /*!< Suspend state enable*/
-#define USB_DRD_FS_CNTR_SYSPRDY                         ((uint32_t)0x00000004U)           /*!< Suspend state effective */
-#define USB_DRD_FS_CNTR_PDWN                            ((uint32_t)0x00000002U)           /*!< Power DoWN */
-#define USB_DRD_FS_CNTR_RST                             ((uint32_t)0x00000001U)           /*!< USB Reset */
-
-/******************  Bits definition for USB_DRD_FS_ISTR register  *******************/
-#define USB_DRD_FS_ISTR_IDN                             ((uint16_t)0x000FU)           /*!< EndPoint IDentifier (read-only bit)  */
-#define USB_DRD_FS_ISTR_DIR                             ((uint16_t)0x0010U)           /*!< DIRection of transaction (read-only bit)  */
-#define USB_DRD_FS_ISTR_L1REQ                           ((uint16_t)0x0080U)           /*!< LPM L1 state request  */
-#define USB_DRD_FS_ISTR_ESOF                            ((uint16_t)0x0100U)           /*!< Expected Start Of Frame (clear-only bit) */
-#define USB_DRD_FS_ISTR_SOF                             ((uint16_t)0x0200U)           /*!< Start Of Frame (clear-only bit) */
-#define USB_DRD_FS_ISTR_RESET                           ((uint16_t)0x0400U)           /*!< RESET (clear-only bit) */
-#define USB_DRD_FS_ISTR_DCON                            ((uint16_t)0x0400U)           /*!< HOST MODE-Device Connection or disconnection  */
-#define USB_DRD_FS_ISTR_SUSP                            ((uint16_t)0x0800U)           /*!< SUSPend (clear-only bit) */
-#define USB_DRD_FS_ISTR_WKUP                            ((uint16_t)0x1000U)           /*!< WaKe UP (clear-only bit) */
-#define USB_DRD_FS_ISTR_ERR                             ((uint16_t)0x2000U)           /*!< ERRor (clear-only bit) */
-#define USB_DRD_FS_ISTR_PMAOVR                          ((uint16_t)0x4000U)           /*!< DMA OVeR/underrun (clear-only bit) */
-#define USB_DRD_FS_ISTR_CTR                             ((uint16_t)0x8000U)           /*!< Correct TRansfer (clear-only bit) */
-
-#define USB_DRD_FS_CLR_L1REQ                            (~USB_DRD_FS_ISTR_L1REQ)           /*!< clear LPM L1  bit */
-#define USB_DRD_FS_CLR_ESOF                             (~USB_DRD_FS_ISTR_ESOF)            /*!< clear Expected Start Of Frame bit */
-#define USB_DRD_FS_CLR_SOF                              (~USB_DRD_FS_ISTR_SOF)             /*!< clear Start Of Frame bit */
-#define USB_DRD_FS_CLR_RESET                            (~USB_DRD_FS_ISTR_RESET)           /*!< clear RESET bit */
-#define USB_DRD_FS_CLR_SUSP                             (~USB_DRD_FS_ISTR_SUSP)            /*!< clear SUSPend bit */
-#define USB_DRD_FS_CLR_WKUP                             (~USB_DRD_FS_ISTR_WKUP)            /*!< clear WaKe UP bit */
-#define USB_DRD_FS_CLR_ERR                              (~USB_DRD_FS_ISTR_ERR)             /*!< clear ERRor bit */
-#define USB_DRD_FS_CLR_PMAOVR                           (~USB_DRD_FS_ISTR_PMAOVR)          /*!< clear DMA OVeR/underrun bit*/
-#define USB_DRD_FS_CLR_CTR                              (~USB_DRD_FS_ISTR_CTR)             /*!< clear Correct TRansfer bit */
-
-/******************  Bits definition for USB_DRD_FS_FNR register  ********************/
-#define USB_DRD_FS_FNR_FN                               ((uint16_t)0x07FFU)           /*!< Frame Number */
-#define USB_DRD_FS_FNR_LSOF                             ((uint16_t)0x1800U)           /*!< Lost SOF */
-#define USB_DRD_FS_FNR_LCK                              ((uint16_t)0x2000U)           /*!< LoCKed */
-#define USB_DRD_FS_FNR_RXDM                             ((uint16_t)0x4000U)           /*!< status of D- data line */
-#define USB_DRD_FS_FNR_RXDP                             ((uint16_t)0x8000U)           /*!< status of D+ data line */
-
-/******************  Bits definition for USB_DRD_FS_DADDR register    ****************/
-#define USB_DRD_FS_DADDR_ADD                            ((uint8_t)0x7FU)              /*!< ADD[6:0] bits (Device Address) */
-#define USB_DRD_FS_DADDR_ADD0                           ((uint8_t)0x01U)              /*!< Bit 0 */
-#define USB_DRD_FS_DADDR_ADD1                           ((uint8_t)0x02U)              /*!< Bit 1 */
-#define USB_DRD_FS_DADDR_ADD2                           ((uint8_t)0x04U)              /*!< Bit 2 */
-#define USB_DRD_FS_DADDR_ADD3                           ((uint8_t)0x08U)              /*!< Bit 3 */
-#define USB_DRD_FS_DADDR_ADD4                           ((uint8_t)0x10U)              /*!< Bit 4 */
-#define USB_DRD_FS_DADDR_ADD5                           ((uint8_t)0x20U)              /*!< Bit 5 */
-#define USB_DRD_FS_DADDR_ADD6                           ((uint8_t)0x40U)              /*!< Bit 6 */
-
-#define USB_DRD_FS_DADDR_EF                             ((uint8_t)0x80U)              /*!< Enable Function */
-
-/******************  Bit definition for USB_DRD_FS_BTABLE register  ******************/
-#define USB_DRD_FS_BTABLE_BTABLE                        ((uint16_t)0xFFF8U)           /*!< Buffer Table */
-
-/******************  Bits definition for USB_DRD_FS_BCDR register  *******************/
-#define USB_DRD_FS_BCDR_BCDEN                           ((uint16_t)0x0001U)           /*!< Battery charging detector (BCD) enable */
-#define USB_DRD_FS_BCDR_DCDEN                           ((uint16_t)0x0002U)           /*!< Data contact detection (DCD) mode enable */
-#define USB_DRD_FS_BCDR_PDEN                            ((uint16_t)0x0004U)           /*!< Primary detection (PD) mode enable */
-#define USB_DRD_FS_BCDR_SDEN                            ((uint16_t)0x0008U)           /*!< Secondary detection (SD) mode enable */
-#define USB_DRD_FS_BCDR_DCDET                           ((uint16_t)0x0010U)           /*!< Data contact detection (DCD) status */
-#define USB_DRD_FS_BCDR_PDET                            ((uint16_t)0x0020U)           /*!< Primary detection (PD) status */
-#define USB_DRD_FS_BCDR_SDET                            ((uint16_t)0x0040U)           /*!< Secondary detection (SD) status */
-#define USB_DRD_FS_BCDR_PS2DET                          ((uint16_t)0x0080U)           /*!< PS2 port or proprietary charger detected */
-#define USB_DRD_FS_BCDR_DPPU                            ((uint16_t)0x8000U)           /*!< DP Pull-up Enable */
-#define USB_DRD_FS_BCDR_DPPD                            ((uint16_t)0x8000U)           /*!< DP Pull-Down Enable */
+/******************  Bit definition for USB_DRD_BTABLE register  ******************/
+#define USB_BTABLE_BTABLE_Pos          (3U)
+#define USB_BTABLE_BTABLE_Msk          (0xFFF8UL << USB_BTABLE_BTABLE_Pos)/*!< 0x00000000 */
+#define USB_BTABLE_BTABLE              USB_BTABLE_BTABLE_Msk              /*!< Buffer Table Mask */
 
 /*******************  Bit definition for LPMCSR register  *********************/
-#define USB_DRD_FS_LPMCSR_LMPEN                         ((uint16_t)0x0001U)           /*!< LPM support enable  */
-#define USB_DRD_FS_LPMCSR_LPMACK                        ((uint16_t)0x0002U)           /*!< LPM Token acknowledge enable*/
-#define USB_DRD_FS_LPMCSR_REMWAKE                       ((uint16_t)0x0008U)           /*!< bRemoteWake value received with last ACKed LPM Token */
-#define USB_DRD_FS_LPMCSR_BESL                          ((uint16_t)0x00F0U)           /*!< BESL value received with last ACKed LPM Token  */
+#define USB_LPMCSR_LMPEN_Pos           (0U)
+#define USB_LPMCSR_LMPEN_Msk           (0x1UL << USB_LPMCSR_LMPEN_Pos)  /*!< 0x00000001 */
+#define USB_LPMCSR_LMPEN               USB_LPMCSR_LMPEN_Msk             /*!< LPM support enable Mask */
+#define USB_LPMCSR_LPMACK_Pos          (1U)
+#define USB_LPMCSR_LPMACK_Msk          (0x1UL << USB_LPMCSR_LPMACK_Pos) /*!< 0x00000002 */
+#define USB_LPMCSR_LPMACK              USB_LPMCSR_LPMACK_Msk            /*!< LPM Token acknowledge enable Mask */
+#define USB_LPMCSR_REMWAKE_Pos         (3U)
+#define USB_LPMCSR_REMWAKE_Msk         (0x1UL << USB_LPMCSR_REMWAKE_Pos)/*!< 0x00000008 */
+#define USB_LPMCSR_REMWAKE             USB_LPMCSR_REMWAKE_Msk           /*!< bRemoteWake value received with last ACKed LPM Token Mask */
+#define USB_LPMCSR_BESL_Pos            (4U)
+#define USB_LPMCSR_BESL_Msk            (0xFUL << USB_LPMCSR_BESL_Pos)   /*!< 0x000000F0 */
+#define USB_LPMCSR_BESL                USB_LPMCSR_BESL_Msk              /*!< BESL value received with last ACKed LPM Token Mask */
+
+/******************  Bits definition for USB_DRD_BCDR register  *******************/
+#define USB_BCDR_BCDEN_Pos             (0U)
+#define USB_BCDR_BCDEN_Msk             (0x1UL << USB_BCDR_BCDEN_Pos)    /*!< 0x00000001 */
+#define USB_BCDR_BCDEN                 USB_BCDR_BCDEN_Msk               /*!< Battery charging detector (BCD) enable Mask */
+#define USB_BCDR_DCDEN_Pos             (1U)
+#define USB_BCDR_DCDEN_Msk             (0x1UL << USB_BCDR_DCDEN_Pos)    /*!< 0x00000002 */
+#define USB_BCDR_DCDEN                 USB_BCDR_DCDEN_Msk               /*!< Data contact detection (DCD) mode enable Mask */
+#define USB_BCDR_PDEN_Pos              (2U)
+#define USB_BCDR_PDEN_Msk              (0x1UL << USB_BCDR_PDEN_Pos)     /*!< 0x00000004 */
+#define USB_BCDR_PDEN                  USB_BCDR_PDEN_Msk                /*!< Primary detection (PD) mode enable Mask */
+#define USB_BCDR_SDEN_Pos              (3U)
+#define USB_BCDR_SDEN_Msk              (0x1UL << USB_BCDR_SDEN_Pos)     /*!< 0x00000008 */
+#define USB_BCDR_SDEN                  USB_BCDR_SDEN_Msk                /*!< Secondary detection (SD) mode enable Mask */
+#define USB_BCDR_DCDET_Pos             (4U)
+#define USB_BCDR_DCDET_Msk             (0x1UL << USB_BCDR_DCDET_Pos)    /*!< 0x00000010 */
+#define USB_BCDR_DCDET                 USB_BCDR_DCDET_Msk               /*!< Data contact detection (DCD) status Mask */
+#define USB_BCDR_PDET_Pos              (5U)
+#define USB_BCDR_PDET_Msk              (0x1UL << USB_BCDR_PDET_Pos)     /*!< 0x00000020 */
+#define USB_BCDR_PDET                  USB_BCDR_PDET_Msk                /*!< Primary detection (PD) status Mask */
+#define USB_BCDR_SDET_Pos              (6U)
+#define USB_BCDR_SDET_Msk              (0x1UL << USB_BCDR_SDET_Pos)     /*!< 0x00000040 */
+#define USB_BCDR_SDET                  USB_BCDR_SDET_Msk                /*!< Secondary detection (SD) status Mask */
+#define USB_BCDR_PS2DET_Pos            (7U)
+#define USB_BCDR_PS2DET_Msk            (0x1UL << USB_BCDR_PS2DET_Pos)   /*!< 0x00000080 */
+#define USB_BCDR_PS2DET                USB_BCDR_PS2DET_Msk              /*!< PS2 port or proprietary charger detected Mask */
+#define USB_BCDR_DPPU_Pos              (15U)
+#define USB_BCDR_DPPU_Msk              (0x1UL << USB_BCDR_DPPU_Pos)     /*!< 0x00008000 */
+#define USB_BCDR_DPPU                  USB_BCDR_DPPU_Msk                /*!< DP Pull-up Enable Mask */
+#define USB_BCDR_DPPD_Pos              (15U)
+#define USB_BCDR_DPPD_Msk              (0x1UL << USB_BCDR_DPPD_Pos)     /*!< 0x00008000 */
+#define USB_BCDR_DPPD                  USB_BCDR_DPPD_Msk                /*!< DP Pull-Down Enable Mask */
+
+/******************  Bits definition for USB_DRD_CHEP register  *******************/
+#define USB_CHEP_ERRRX_Pos             (26U)
+#define USB_CHEP_ERRRX_Msk             (0x01UL << USB_CHEP_ERRRX_Pos)   /*!< 0x04000000 */
+#define USB_CHEP_ERRRX                 USB_CHEP_ERRRX_Msk               /*!< Receive error */
+#define USB_EP_ERRRX                   USB_CHEP_ERRRX_Msk               /*!< EP Receive error */
+#define USB_CH_ERRRX                   USB_CHEP_ERRRX_Msk               /*!< CH Receive error */
+#define USB_CHEP_ERRTX_Pos             (25U)
+#define USB_CHEP_ERRTX_Msk             (0x01UL << USB_CHEP_ERRTX_Pos)   /*!< 0x02000000 */
+#define USB_CHEP_ERRTX                 USB_CHEP_ERRTX_Msk               /*!< Transmit error */
+#define USB_EP_ERRTX                   USB_CHEP_ERRTX_Msk               /*!< EP Transmit error */
+#define USB_CH_ERRTX                   USB_CHEP_ERRTX_Msk               /*!< CH Transmit error */
+#define USB_CHEP_LSEP_Pos              (24U)
+#define USB_CHEP_LSEP_Msk              (0x01UL << USB_CHEP_LSEP_Pos)    /*!< 0x01000000 */
+#define USB_CHEP_LSEP                  USB_CHEP_LSEP_Msk                /*!< Low Speed Endpoint (host with Hub Only) */
+#define USB_CHEP_NAK_Pos               (23U)
+#define USB_CHEP_NAK_Msk               (0x01UL << USB_CHEP_NAK_Pos)     /*!< 0x00800000 */
+#define USB_CHEP_NAK                   USB_CHEP_NAK_Msk                 /*!< Previous NAK detected */
+#define USB_CHEP_DEVADDR_Pos           (16U)
+#define USB_CHEP_DEVADDR_Msk           (0x7FU << USB_CHEP_DEVADDR_Pos)  /*!< 0x7F000000 */
+#define USB_CHEP_DEVADDR               USB_CHEP_DEVADDR_Msk             /* Target Endpoint address*/
+#define USB_CHEP_VTRX_Pos              (15U)
+#define USB_CHEP_VTRX_Msk              (0x1UL << USB_CHEP_VTRX_Pos)     /*!< 0x00008000 */
+#define USB_CHEP_VTRX                  USB_CHEP_VTRX_Msk                /*!< USB valid transaction received Mask */
+#define USB_EP_VTRX                    USB_CHEP_VTRX_Msk                /*!< USB Endpoint valid transaction received Mask */
+#define USB_CH_VTRX                    USB_CHEP_VTRX_Msk                /*!< USB valid Channel transaction received Mask */
+#define USB_CHEP_DTOG_RX_Pos           (14U)
+#define USB_CHEP_DTOG_RX_Msk           (0x1UL << USB_CHEP_DTOG_RX_Pos)  /*!< 0x00004000 */
+#define USB_CHEP_DTOG_RX               USB_CHEP_DTOG_RX_Msk             /*!< Data Toggle, for reception transfers Mask */
+#define USB_EP_DTOG_RX                 USB_CHEP_DTOG_RX_Msk             /*!< EP Data Toggle, for reception transfers Mask */
+#define USB_CH_DTOG_RX                 USB_CHEP_DTOG_RX_Msk             /*!< CH Data Toggle, for reception transfers Mask */
+#define USB_CHEP_RX_STRX_Pos           (12U)
+#define USB_CHEP_RX_STRX_Msk           (0x3UL << USB_CHEP_RX_STRX_Pos)  /*!< 0x00003000 */
+#define USB_CHEP_RX_STRX               USB_CHEP_RX_STRX_Msk             /*!< Status bits, for reception transfers Mask */
+#define USB_EP_RX_STRX                 USB_CHEP_RX_STRX_Msk             /*!< Status bits, for EP reception transfers Mask */
+#define USB_CH_RX_STRX                 USB_CHEP_RX_STRX_Msk             /*!< Status bits, for CH reception transfers Mask */
+#define USB_CHEP_SETUP_Pos             (11U)
+#define USB_CHEP_SETUP_Msk             (0x1UL << USB_CHEP_SETUP_Pos)    /*!< 0x00000800 */
+#define USB_CHEP_SETUP                 USB_CHEP_SETUP_Msk               /*!< Setup transaction completed Mask */
+#define USB_EP_SETUP                   USB_CHEP_SETUP_Msk               /*!< EP Setup transaction completed Mask */
+#define USB_CH_SETUP                   USB_CHEP_SETUP_Msk               /*!< CH Setup transaction completed Mask */
+#define USB_CHEP_UTYPE_Pos             (9U)
+#define USB_CHEP_UTYPE_Msk             (0x3UL << USB_CHEP_UTYPE_Pos)    /*!< 0x00000600 */
+#define USB_CHEP_UTYPE                 USB_CHEP_UTYPE_Msk               /*!< USB type of transaction Mask */
+#define USB_EP_UTYPE                   USB_CHEP_UTYPE_Msk               /*!< USB type of EP transaction Mask */
+#define USB_CH_UTYPE                   USB_CHEP_UTYPE_Msk               /*!< USB type of CH transaction Mask */
+#define USB_CHEP_KIND_Pos              (8U)
+#define USB_CHEP_KIND_Msk              (0x1UL << USB_CHEP_KIND_Pos)     /*!< 0x00000100 */
+#define USB_CHEP_KIND                  USB_CHEP_KIND_Msk                /*!< EndPoint KIND Mask */
+#define USB_EP_KIND                    USB_CHEP_KIND_Msk                /*!< EndPoint KIND Mask */
+#define USB_CH_KIND                    USB_CHEP_KIND_Msk                /*!< Channel KIND Mask */
+#define USB_CHEP_VTTX_Pos              (7U)
+#define USB_CHEP_VTTX_Msk              (0x1UL << USB_CHEP_VTTX_Pos)     /*!< 0x00000080 */
+#define USB_CHEP_VTTX                  USB_CHEP_VTTX_Msk                /*!< Valid USB transaction transmitted Mask */
+#define USB_EP_VTTX                    USB_CHEP_VTTX_Msk                /*!< USB Endpoint valid transaction transmitted Mask */
+#define USB_CH_VTTX                    USB_CHEP_VTTX_Msk                /*!< USB valid Channel transaction transmitted Mask */
+#define USB_CHEP_DTOG_TX_Pos           (6U)
+#define USB_CHEP_DTOG_TX_Msk           (0x1UL << USB_CHEP_DTOG_TX_Pos)  /*!< 0x00000040 */
+#define USB_CHEP_DTOG_TX               USB_CHEP_DTOG_TX_Msk             /*!< Data Toggle, for transmission transfers Mask */
+#define USB_EP_DTOG_TX                 USB_CHEP_DTOG_TX_Msk             /*!< EP Data Toggle, for transmission transfers Mask */
+#define USB_CH_DTOG_TX                 USB_CHEP_DTOG_TX_Msk             /*!< CH Data Toggle, for transmission transfers Mask */
+#define USB_CHEP_TX_STTX_Pos           (4U)
+#define USB_CHEP_TX_STTX_Msk           (0x3UL << USB_CHEP_TX_STTX_Pos)  /*!< 0x00000030 */
+#define USB_CHEP_TX_STTX               USB_CHEP_TX_STTX_Msk             /*!< Status bits, for transmission transfers Mask */
+#define USB_EP_TX_STTX                 USB_CHEP_TX_STTX_Msk             /*!< Status bits, for EP transmission transfers Mask */
+#define USB_CH_TX_STTX                 USB_CHEP_TX_STTX_Msk             /*!< Status bits, for CH transmission transfers Mask */
+#define USB_CHEP_ADDR_Pos              (0U)
+#define USB_CHEP_ADDR_Msk              (0xFUL << USB_CHEP_ADDR_Pos)     /*!< 0x0000000F */
+#define USB_CHEP_ADDR                  USB_CHEP_ADDR_Msk                /*!< Endpoint address Mask */
+
+
+/* EndPoint Register MASK (no toggle fields) */
+#define USB_CHEP_REG_MASK                          (USB_CHEP_ERRRX | USB_CHEP_ERRTX | USB_CHEP_LSEP | \
+                                                    USB_CHEP_DEVADDR | USB_CHEP_VTRX | USB_CHEP_SETUP | \
+                                                    USB_CHEP_UTYPE | USB_CHEP_KIND | USB_CHEP_VTTX | USB_CHEP_ADDR) /* =8f8f */
+
+#define USB_CHEP_TX_DTOGMASK                       (USB_CHEP_TX_STTX | USB_CHEP_REG_MASK)
+#define USB_CHEP_RX_DTOGMASK                       (USB_CHEP_RX_STRX | USB_CHEP_REG_MASK)
+
+#define USB_CHEP_TX_DTOG1                          (0x00000010UL)           /*!< Channel/EndPoint TX Data Toggle bit1 */
+#define USB_CHEP_TX_DTOG2                          (0x00000020UL)           /*!< Channel/EndPoint TX Data Toggle bit2 */
+#define USB_CHEP_RX_DTOG1                          (0x00001000UL)           /*!< Channel/EndPoint RX Data Toggle bit1 */
+#define USB_CHEP_RX_DTOG2                          (0x00002000UL)           /*!< Channel/EndPoint RX Data Toggle bit1 */
+
+/*!< EP_TYPE[1:0] Channel/EndPoint TYPE */
+#define USB_EP_TYPE_MASK                           (0x00000600UL)           /*!< Channel/EndPoint TYPE Mask */
+#define USB_EP_BULK                                (0x00000000UL)           /*!< Channel/EndPoint BULK */
+#define USB_EP_CONTROL                             (0x00000200UL)           /*!< Channel/EndPoint CONTROL */
+#define USB_EP_ISOCHRONOUS                         (0x00000400UL)           /*!< Channel/EndPoint ISOCHRONOUS */
+#define USB_EP_INTERRUPT                           (0x00000600UL)           /*!< Channel/EndPoint INTERRUPT */
+
+#define USB_EP_T_MASK                              ((~USB_EP_UTYPE) & USB_CHEP_REG_MASK) /* =0x898F */
+#define USB_CH_T_MASK                              ((~USB_CH_UTYPE) & USB_CHEP_REG_MASK) /* =0x898F */
+
+#define USB_EP_KIND_MASK                           ((~USB_EP_KIND) & USB_CHEP_REG_MASK) /*!< EP_KIND EndPoint KIND */
+#define USB_CH_KIND_MASK                           ((~USB_CH_KIND) & USB_CHEP_REG_MASK) /*!< EP_KIND EndPoint KIND */
+
+/*!< STAT_TX[1:0] STATus for TX transfer */
+#define USB_EP_TX_DIS                              (0x00000000UL)           /*!< EndPoint TX Disabled */
+#define USB_EP_TX_STALL                            (0x00000010UL)           /*!< EndPoint TX STALLed */
+#define USB_EP_TX_NAK                              (0x00000020UL)           /*!< EndPoint TX NAKed */
+#define USB_EP_TX_VALID                            (0x00000030UL)           /*!< EndPoint TX VALID */
+
+#define USB_CH_TX_DIS                              (0x00000000UL)           /*!< Channel TX Disabled */
+#define USB_CH_TX_STALL                            (0x00000010UL)           /*!< Channel TX STALLed */
+#define USB_CH_TX_NAK                              (0x00000020UL)           /*!< Channel TX NAKed */
+#define USB_CH_TX_VALID                            (0x00000030UL)           /*!< Channel TX VALID */
+
+#define USB_EP_TX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_EP_TX_ACK_DBUF                         (0x00000030UL)           /*!< ACK Double buffer mode */
+
+#define USB_CH_TX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_CH_TX_ACK_DBUF                         (0x00000030UL)           /*!< ACK Double buffer mode */
+
+/*!< STAT_RX[1:0] STATus for RX transfer */
+#define USB_EP_RX_DIS                              (0x00000000UL)           /*!< EndPoint RX Disabled */
+#define USB_EP_RX_STALL                            (0x00001000UL)           /*!< EndPoint RX STALLed */
+#define USB_EP_RX_NAK                              (0x00002000UL)           /*!< EndPoint RX NAKed */
+#define USB_EP_RX_VALID                            (0x00003000UL)           /*!< EndPoint RX VALID */
+
+#define USB_EP_RX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_EP_RX_ACK_DBUF                         (0x00003000UL)           /*!< ACK Double buffer mode */
+
+
+
+#define USB_CH_RX_DIS                              (0x00000000UL)           /*!< EndPoint RX Disabled */
+#define USB_CH_RX_STALL                            (0x00001000UL)           /*!< EndPoint RX STALLed */
+#define USB_CH_RX_NAK                              (0x00002000UL)           /*!< Channel RX NAKed */
+#define USB_CH_RX_VALID                            (0x00003000UL)           /*!< Channel RX VALID */
+
+#define USB_CH_RX_ACK_SBUF                         (0x00000000UL)           /*!< ACK single buffer mode */
+#define USB_CH_RX_ACK_DBUF                         (0x00003000UL)           /*!< ACK Double buffer mode */
+
+/*! <used For Double Buffer Enable Disable */
+#define USB_CHEP_DB_MSK                            (0xFFFF0F0FUL)
+
+/*Buffer Descriptor Mask*/
+#define USB_PMA_TXBD_ADDMSK                        (0xFFFF0000UL)
+#define USB_PMA_TXBD_COUNTMSK                      (0x0000FFFFUL)
+#define USB_PMA_RXBD_ADDMSK                        (0xFFFF0000UL)
+#define USB_PMA_RXBD_COUNTMSK                      (0x0000FFFFUL)
 
 
 /** @addtogroup Exported_macros
@@ -10551,10 +10951,13 @@ typedef struct
                                         ((INSTANCE) == COMP2) || \
                                         ((INSTANCE) == COMP3))
 
-#define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) ((COMMON_INSTANCE) == COMP12_COMMON)
+#define IS_COMP_COMMON_INSTANCE(COMMON_INSTANCE) (((COMMON_INSTANCE) == COMP12_COMMON) || \
+                                                  ((COMMON_INSTANCE) == COMP23_COMMON))
 
 /******************** COMP Instances with window mode capability **************/
-#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) ((INSTANCE) == COMP2)
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                               ((INSTANCE) == COMP2) || \
+                                               ((INSTANCE) == COMP3))
 
 /******************************* CRC Instances ********************************/
 #define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
@@ -10616,13 +11019,11 @@ typedef struct
 
 /****************************** SMBUS Instances *******************************/
 #define IS_SMBUS_ALL_INSTANCE(INSTANCE)(((INSTANCE) == I2C1) || \
-                                        ((INSTANCE) == I2C2) || \
-                                        ((INSTANCE) == I2C3))
+                                        ((INSTANCE) == I2C2))
 
 /****************************** WAKEUP_FROMSTOP Instances *******************************/
 #define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)(((INSTANCE) == I2C1) || \
-                                                  ((INSTANCE) == I2C2) || \
-                                                  ((INSTANCE) == I2C3))
+                                                  ((INSTANCE) == I2C2))
 
 /******************************** SPI Instances *******************************/
 #define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
@@ -10632,8 +11033,7 @@ typedef struct
 
 /******************************** SPI Instances *******************************/
 #define IS_I2S_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
-                                       ((INSTANCE) == SPI2) || \
-                                       ((INSTANCE) == SPI3))
+                                       ((INSTANCE) == SPI2))
 
 /****************** LPTIM Instances : All supported instances *****************/
 #define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
@@ -10765,6 +11165,12 @@ typedef struct
       ((CHANNEL) == TIM_CHANNEL_3) ||          \
       ((CHANNEL) == TIM_CHANNEL_4)))           \
      ||                                        \
+     (((INSTANCE) == TIM4) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
      (((INSTANCE) == TIM14) &&                 \
      (((CHANNEL) == TIM_CHANNEL_1)))           \
      ||                                        \
@@ -10779,7 +11185,6 @@ typedef struct
       (((CHANNEL) == TIM_CHANNEL_1))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
-#if  STM32G0C1xx
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
    ((((INSTANCE) == TIM1) &&                    \
      (((CHANNEL) == TIM_CHANNEL_1) ||           \
@@ -10795,7 +11200,6 @@ typedef struct
     (((INSTANCE) == TIM17) &&                   \
      ((CHANNEL) == TIM_CHANNEL_1)))
 
-#endif
 /****************** TIM Instances : supporting clock division *****************/
 #define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
                                                     ((INSTANCE) == TIM2)    || \
@@ -10893,6 +11297,11 @@ typedef struct
                                                        ((INSTANCE) == TIM3) || \
                                                        ((INSTANCE) == TIM4))
 
+/****************** TIM Instances : supporting bitfield OCCS in SMCR register *******************/
+#define IS_TIM_OCCS_INSTANCE(INSTANCE)                (((INSTANCE) == TIM1)  || \
+                                                       ((INSTANCE) == TIM2)  || \
+                                                       ((INSTANCE) == TIM3))
+
 /****************** TIM Instances : remapping capability **********************/
 #define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
                                             ((INSTANCE) == TIM2)  || \
@@ -10904,9 +11313,6 @@ typedef struct
                                                        ((INSTANCE) == TIM15) || \
                                                        ((INSTANCE) == TIM16) || \
                                                        ((INSTANCE) == TIM17))
-
-/****************** TIM Instances : supporting synchronization ****************/
-#define IS_TIM_SYNCHRO_INSTANCE(INSTANCE)  IS_TIM_MASTER_INSTANCE(INSTANCE)
 
 /****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
 #define IS_TIM_TRGO2_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
@@ -11020,7 +11426,8 @@ typedef struct
                                     ((INSTANCE) == USART3))
 
 /******************** LPUART Instance *****************************************/
-#define IS_LPUART_INSTANCE(INSTANCE)    ((INSTANCE) == LPUART1)
+#define IS_LPUART_INSTANCE(INSTANCE) (((INSTANCE) == LPUART1) || \
+                                      ((INSTANCE) == LPUART2))
 
 /****************************** IWDG Instances ********************************/
 #define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
@@ -11033,15 +11440,13 @@ typedef struct
                                          ((INSTANCE) == UCPD2))
 
 /****************************** USB Instances ********************************/
-#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB)
+#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB_DRD_FS)
 
 /*********************** USB OTG PCD Instances ********************************/
-#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
-                                       ((INSTANCE) == USB_OTG_HS))
+#define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS))
 
 /*********************** USB OTG HCD Instances ********************************/
-#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
-                                       ((INSTANCE) == USB_OTG_HS))
+#define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_DRD_FS))
 
 /**
   * @}

--- a/stm32cube/stm32g0xx/soc/stm32g0xx.h
+++ b/stm32cube/stm32g0xx/soc/stm32g0xx.h
@@ -19,10 +19,10 @@
   * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -57,10 +57,19 @@
    application
   */
 
-#if !defined (STM32G071xx) && !defined (STM32G081xx) && !defined (STM32G070xx) && !defined (STM32G030xx) && !defined (STM32G031xx) && !defined (STM32G041xx)
+#if !defined (STM32G071xx) && !defined (STM32G081xx) && !defined (STM32G070xx) \
+ && !defined (STM32G030xx) && !defined (STM32G031xx) && !defined (STM32G041xx) \
+ && !defined (STM32G0B0xx) && !defined (STM32G0B1xx) && !defined (STM32G0C1xx) \
+ && !defined (STM32G050xx) && !defined (STM32G051xx) && !defined (STM32G061xx)
+  /* #define STM32G0B0xx */   /*!< STM32G0B0xx Devices */
+  /* #define STM32G0B1xx */   /*!< STM32G0B1xx Devices */
+  /* #define STM32G0C1xx */   /*!< STM32G0C1xx Devices */
   /* #define STM32G070xx */   /*!< STM32G070xx Devices */
   /* #define STM32G071xx */   /*!< STM32G071xx Devices */
   /* #define STM32G081xx */   /*!< STM32G081xx Devices */
+  /* #define STM32G050xx */   /*!< STM32G050xx Devices */
+  /* #define STM32G051xx */   /*!< STM32G051xx Devices */
+  /* #define STM32G061xx */   /*!< STM32G061xx Devices */
   /* #define STM32G030xx */   /*!< STM32G030xx Devices */
   /* #define STM32G031xx */   /*!< STM32G031xx Devices */
   /* #define STM32G041xx */   /*!< STM32G041xx Devices */
@@ -82,7 +91,7 @@
   * @brief CMSIS Device version number $VERSION$
   */
 #define __STM32G0_CMSIS_VERSION_MAIN   (0x01U) /*!< [31:24] main version */
-#define __STM32G0_CMSIS_VERSION_SUB1   (0x03U) /*!< [23:16] sub1 version */
+#define __STM32G0_CMSIS_VERSION_SUB1   (0x04U) /*!< [23:16] sub1 version */
 #define __STM32G0_CMSIS_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
 #define __STM32G0_CMSIS_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
 #define __STM32G0_CMSIS_VERSION        ((__STM32G0_CMSIS_VERSION_MAIN << 24)\
@@ -98,7 +107,13 @@
   * @{
   */
 
-#if defined(STM32G071xx)
+#if defined(STM32G0B1xx)
+  #include "stm32g0b1xx.h"
+#elif defined(STM32G0C1xx)
+  #include "stm32g0c1xx.h"
+#elif defined(STM32G0B0xx)
+  #include "stm32g0b0xx.h"
+#elif defined(STM32G071xx)
   #include "stm32g071xx.h"
 #elif defined(STM32G081xx)
   #include "stm32g081xx.h"
@@ -110,6 +125,12 @@
   #include "stm32g041xx.h"
 #elif defined(STM32G030xx)
   #include "stm32g030xx.h"
+#elif defined(STM32G051xx)
+  #include "stm32g051xx.h"
+#elif defined(STM32G061xx)
+  #include "stm32g061xx.h"
+#elif defined(STM32G050xx)
+  #include "stm32g050xx.h"
 #else
  #error "Please select first the target STM32G0xx device used in your application (in stm32g0xx.h file)"
 #endif

--- a/stm32cube/stm32g0xx/soc/system_stm32g0xx.c
+++ b/stm32cube/stm32g0xx/soc/system_stm32g0xx.c
@@ -56,10 +56,10 @@
   * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */
@@ -228,30 +228,30 @@ void SystemCoreClockUpdate(void)
   /* Get SYSCLK source -------------------------------------------------------*/
   switch (RCC->CFGR & RCC_CFGR_SWS)
   {
-    case RCC_CFGR_SWS_HSE:  /* HSE used as system clock */
+    case RCC_CFGR_SWS_0:                /* HSE used as system clock */
       SystemCoreClock = HSE_VALUE;
       break;
 
-    case RCC_CFGR_SWS_LSI:  /* LSI used as system clock */
+    case (RCC_CFGR_SWS_1 | RCC_CFGR_SWS_0):  /* LSI used as system clock */
       SystemCoreClock = LSI_VALUE;
       break;
 
-    case RCC_CFGR_SWS_LSE:  /* LSE used as system clock */
+    case RCC_CFGR_SWS_2:                /* LSE used as system clock */
       SystemCoreClock = LSE_VALUE;
       break;
 
-    case RCC_CFGR_SWS_PLL:  /* PLL used as system clock */
+    case RCC_CFGR_SWS_1:  /* PLL used as system clock */
       /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLLM) * PLLN
          SYSCLK = PLL_VCO / PLLR
          */
       pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
       pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> RCC_PLLCFGR_PLLM_Pos) + 1UL;
 
-      if(pllsource == 0x03UL) /* HSE used as PLL clock source */
+      if(pllsource == 0x03UL)           /* HSE used as PLL clock source */
       {
         pllvco = (HSE_VALUE / pllm);
       }
-      else /* HSI used as PLL clock source */
+      else                              /* HSI used as PLL clock source */
       {
           pllvco = (HSI_VALUE / pllm);
       }
@@ -261,8 +261,8 @@ void SystemCoreClockUpdate(void)
       SystemCoreClock = pllvco/pllr;
       break;
 
-    case RCC_CFGR_SWS_HSI:  /* HSI used as system clock */
-    default:                /* HSI used as system clock */
+    case 0x00000000U:                   /* HSI used as system clock */
+    default:                            /* HSI used as system clock */
       hsidiv = (1UL << ((READ_BIT(RCC->CR, RCC_CR_HSIDIV))>> RCC_CR_HSIDIV_Pos));
       SystemCoreClock = (HSI_VALUE/hsidiv);
       break;

--- a/stm32cube/stm32g0xx/soc/system_stm32g0xx.h
+++ b/stm32cube/stm32g0xx/soc/system_stm32g0xx.h
@@ -9,10 +9,10 @@
   * <h2><center>&copy; Copyright (c) 2018 STMicroelectronics.
   * All rights reserved.</center></h2>
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
+  * This software component is licensed by ST under Apache License, Version 2.0,
   * the "License"; You may not use this file except in compliance with the
   * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  *                        opensource.org/licenses/Apache-2.0
   *
   ******************************************************************************
   */


### PR DESCRIPTION
Update Cube version for STM32G0xx series to V1.4.0

This introduces the STM32G050xx, STM32G051xx, STM32G061xx,  STM32G0C1xx, STM32G0B1xx, and STM32G0B0xx devices.

- Extend public SetFlashLatency API to all families: This patch is no longer necessary, as it is already fixed in the HAL.
- Adds trivial patch in stm32g0xx_hal_hcd.h file, for which I have opened an issue in STMicroelectronics/STM32CubeG0/issues/13