### PR TITLE
dts: add HRTIM pinctrl

### DIFF
--- a/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c(4-6-8)tx-pinctrl.dtsi
@@ -108,6 +108,88 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334c8yx-pinctrl.dtsi
@@ -124,6 +124,88 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)tx-pinctrl.dtsi
@@ -79,6 +79,60 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334k(4-6-8)ux-pinctrl.dtsi
@@ -75,6 +75,56 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
+++ b/dts/st/f3/stm32f334r(6-8)tx-pinctrl.dtsi
@@ -148,6 +148,108 @@
 				pinmux = <STM32_PINMUX('A', 6, ANALOG)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa15: i2c1_scl_pa15 {

--- a/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)tx-pinctrl.dtsi
@@ -190,6 +190,88 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474c(b-c-e)ux-pinctrl.dtsi
@@ -194,6 +194,100 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474m(b-c-e)tx-pinctrl.dtsi
@@ -334,6 +334,120 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474meyx-pinctrl.dtsi
@@ -346,6 +346,120 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474p(b-c-e)ix-pinctrl.dtsi
@@ -690,6 +690,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474q(b-c-e)tx-pinctrl.dtsi
@@ -726,6 +726,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474r(b-c-e)tx-pinctrl.dtsi
@@ -230,6 +230,120 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)hx-pinctrl.dtsi
@@ -600,6 +600,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)ix-pinctrl.dtsi
@@ -600,6 +600,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g474v(b-c-e)tx-pinctrl.dtsi
@@ -600,6 +600,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484cetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484cetx-pinctrl.dtsi
@@ -190,6 +190,88 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484ceux-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484ceux-pinctrl.dtsi
@@ -194,6 +194,100 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484metx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484metx-pinctrl.dtsi
@@ -334,6 +334,120 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484meyx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484meyx-pinctrl.dtsi
@@ -346,6 +346,120 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484peix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484peix-pinctrl.dtsi
@@ -690,6 +690,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484qetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484qetx-pinctrl.dtsi
@@ -726,6 +726,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484retx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484retx-pinctrl.dtsi
@@ -230,6 +230,120 @@
 				pinmux = <STM32_PINMUX('B', 4, AF11)>;
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484vehx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vehx-pinctrl.dtsi
@@ -600,6 +600,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484veix-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484veix-pinctrl.dtsi
@@ -600,6 +600,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/dts/st/g4/stm32g484vetx-pinctrl.dtsi
+++ b/dts/st/g4/stm32g484vetx-pinctrl.dtsi
@@ -600,6 +600,120 @@
 				slew-rate = "very-high-speed";
 			};
 
+			/* HRTIM_CH */
+
+			hrtim1_cha1_pa8: hrtim1_cha1_pa8 {
+				pinmux = <STM32_PINMUX('A', 8, AF13)>;
+			};
+
+			hrtim1_cha2_pa9: hrtim1_cha2_pa9 {
+				pinmux = <STM32_PINMUX('A', 9, AF13)>;
+			};
+
+			hrtim1_chb1_pa10: hrtim1_chb1_pa10 {
+				pinmux = <STM32_PINMUX('A', 10, AF13)>;
+			};
+
+			hrtim1_chb2_pa11: hrtim1_chb2_pa11 {
+				pinmux = <STM32_PINMUX('A', 11, AF13)>;
+			};
+
+			hrtim1_chc1_pb12: hrtim1_chc1_pb12 {
+				pinmux = <STM32_PINMUX('B', 12, AF13)>;
+			};
+
+			hrtim1_chc2_pb13: hrtim1_chc2_pb13 {
+				pinmux = <STM32_PINMUX('B', 13, AF13)>;
+			};
+
+			hrtim1_chd1_pb14: hrtim1_chd1_pb14 {
+				pinmux = <STM32_PINMUX('B', 14, AF13)>;
+			};
+
+			hrtim1_chd2_pb15: hrtim1_chd2_pb15 {
+				pinmux = <STM32_PINMUX('B', 15, AF13)>;
+			};
+
+			hrtim1_chf1_pc6: hrtim1_chf1_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF13)>;
+			};
+
+			hrtim1_chf2_pc7: hrtim1_chf2_pc7 {
+				pinmux = <STM32_PINMUX('C', 7, AF13)>;
+			};
+
+			hrtim1_che1_pc8: hrtim1_che1_pc8 {
+				pinmux = <STM32_PINMUX('C', 8, AF3)>;
+			};
+
+			hrtim1_che2_pc9: hrtim1_che2_pc9 {
+				pinmux = <STM32_PINMUX('C', 9, AF3)>;
+			};
+
+			/* HRTIM_EEV */
+
+			hrtim1_eev9_pb3: hrtim1_eev9_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF13)>;
+			};
+
+			hrtim1_eev7_pb4: hrtim1_eev7_pb4 {
+				pinmux = <STM32_PINMUX('B', 4, AF13)>;
+			};
+
+			hrtim1_eev6_pb5: hrtim1_eev6_pb5 {
+				pinmux = <STM32_PINMUX('B', 5, AF13)>;
+			};
+
+			hrtim1_eev4_pb6: hrtim1_eev4_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF13)>;
+			};
+
+			hrtim1_eev3_pb7: hrtim1_eev3_pb7 {
+				pinmux = <STM32_PINMUX('B', 7, AF13)>;
+			};
+
+			hrtim1_eev8_pb8: hrtim1_eev8_pb8 {
+				pinmux = <STM32_PINMUX('B', 8, AF13)>;
+			};
+
+			hrtim1_eev5_pb9: hrtim1_eev5_pb9 {
+				pinmux = <STM32_PINMUX('B', 9, AF13)>;
+			};
+
+			hrtim1_eev10_pc5: hrtim1_eev10_pc5 {
+				pinmux = <STM32_PINMUX('C', 5, AF13)>;
+			};
+
+			hrtim1_eev10_pc6: hrtim1_eev10_pc6 {
+				pinmux = <STM32_PINMUX('C', 6, AF3)>;
+			};
+
+			hrtim1_eev2_pc11: hrtim1_eev2_pc11 {
+				pinmux = <STM32_PINMUX('C', 11, AF3)>;
+			};
+
+			hrtim1_eev1_pc12: hrtim1_eev1_pc12 {
+				pinmux = <STM32_PINMUX('C', 12, AF3)>;
+			};
+
+			/* HRTIM_SCIN / HRTIM_SCOUT */
+
+			hrtim1_scout_pb1: hrtim1_scout_pb1 {
+				pinmux = <STM32_PINMUX('B', 1, AF13)>;
+			};
+
+			hrtim1_scin_pb2: hrtim1_scin_pb2 {
+				pinmux = <STM32_PINMUX('B', 2, AF13)>;
+			};
+
+			hrtim1_scout_pb3: hrtim1_scout_pb3 {
+				pinmux = <STM32_PINMUX('B', 3, AF12)>;
+			};
+
+			hrtim1_scin_pb6: hrtim1_scin_pb6 {
+				pinmux = <STM32_PINMUX('B', 6, AF12)>;
+			};
+
 			/* I2C_SCL */
 
 			i2c1_scl_pa13: i2c1_scl_pa13 {

--- a/scripts/genpinctrl/stm32-pinctrl-config.yaml
+++ b/scripts/genpinctrl/stm32-pinctrl-config.yaml
@@ -137,6 +137,18 @@
   bias: pull-up
   slew-rate: very-high-speed
 
+- name: HRTIM_CH
+  match: "^HRTIM\\d+_CH[A-F]\\d+$"
+
+- name: HRTIM_EEV
+  match: "^HRTIM\\d+_EEV\\d+$"
+
+- name: HRTIM_FLT
+  match: "^HRTIM\\d+_FLT[A-F]\\d+$"
+
+- name: HRTIM_SCIN / HRTIM_SCOUT
+  match: "^HRTIM\\d+_SC(IN|OUT)$"
+
 - name: I2C_SCL
   match: "^I2C\\d+_SCL$"
   drive: open-drain


### PR DESCRIPTION
Add options for high-resolution timer HRTIM to pinctrl-config and generate new pinctrl DTS files.

I know that the HRTIM peripheral is not yet supported by Zephyr, but I'm working on a driver and would like to use the pinctrl properly already.